### PR TITLE
Unified export dialog with naming macros, JPEG quality, and size estimate

### DIFF
--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -420,10 +420,12 @@ class CCRBackend:
             except Exception as e:
                 print(f"Failed to convert image at index {idx}: {e}")
 
-    def export_image_by_index(self, idx: int, output_path: str, jpg_output: bool = False):
+    def export_image_by_index(self, idx: int, output_path: str, jpg_output: bool = False,
+                              jpg_quality: int = 95, max_long_side: int = None) -> bool:
         """
         Exports the processed image at the given index to the specified output path.
         Routes to bwpoint or reference-frame pipeline depending on how the image was converted.
+        Returns True on success.
         """
         if idx is not None and 0 <= idx < len(self.images):
             image_obj = self.images[idx]
@@ -432,89 +434,114 @@ class CCRBackend:
                     # B/W point conversion — re-process from original full-res file
                     ccr_normalize_with_bwpoint(image_obj, self.black_point_bgr, self.white_point_bgr,
                                                output_path=output_path, water_mark=not self.software_activated,
-                                               jpg_out=jpg_output)
+                                               jpg_out=jpg_output, jpg_quality=jpg_quality,
+                                               max_long_side=max_long_side)
                 else:
                     ccr_normalize_with_reference(image_obj, output_path=output_path,
-                                                 water_mark=not self.software_activated, jpg_out=jpg_output)
+                                                 water_mark=not self.software_activated, jpg_out=jpg_output,
+                                                 jpg_quality=jpg_quality, max_long_side=max_long_side)
+                return True
             except Exception as e:
                 print(f"Failed to export image at index {idx}: {e}")
-            
-    def export_all_images(self, output_folder: str, jpg_output: bool = False, progress_callback=None):
+        return False
+
+    def export_items(self, items, jpg_output: bool = False, jpg_quality: int = 95,
+                     max_long_side: int = None, progress_callback=None, cancel_check=None) -> dict:
         """
-        Exports all processed images to the specified output folder using parallel processing.
+        Exports specific images to explicit output paths using parallel processing.
+
+        Args:
+            items: list of (idx, absolute_output_path) tuples; filename building is
+                   owned by the caller
+            progress_callback: optional callable(current, total)
+            cancel_check: optional zero-arg callable; once it returns True, queued
+                          exports are abandoned (in-flight ones finish)
+
+        Returns:
+            dict with "exported", "failed", "cancelled" counts/flag and
+            "failures" as a list of (idx, message) tuples.
         """
         import time
         total_start_time = time.time()
-        
-        if not os.path.exists(output_folder):
-            os.makedirs(output_folder)
-        
-        # Count converted images for progress tracking
-        converted_images = [(idx, img) for idx, img in enumerate(self.images) if img.converted]
-        total_images = len(converted_images)
-        
-        print(f"Starting export of {total_images} images...")
-        
-        if total_images == 0:
-            return
-        
-        def export_single_image(idx_img_tuple):
-            idx, img = idx_img_tuple
-            import time
+
+        result = {"exported": 0, "failed": 0, "cancelled": False, "failures": []}
+        total_items = len(items)
+        if total_items == 0:
+            return result
+
+        print(f"Starting export of {total_items} images...")
+
+        def cancelled():
+            return cancel_check is not None and cancel_check()
+
+        def export_single_image(idx, output_path):
+            if cancelled():
+                return idx, None, None  # None success = not attempted
             start_time = time.time()
-            try:                
-                base_name = os.path.splitext(os.path.basename(img.file_path))[0]
-                if jpg_output:
-                    output_path = os.path.join(output_folder, f"{base_name}_ccr.jpg")
-                else:
-                    output_path = os.path.join(output_folder, f"{base_name}_ccr.tiff")
-                self.export_image_by_index(idx, output_path, jpg_output=jpg_output)
-                elapsed = time.time() - start_time
+            success = self.export_image_by_index(idx, output_path, jpg_output=jpg_output,
+                                                 jpg_quality=jpg_quality, max_long_side=max_long_side)
+            elapsed = time.time() - start_time
+            base_name = os.path.basename(output_path)
+            if success:
                 print(f"Export completed for {base_name} in {elapsed:.2f}s")
                 return idx, True, None
-            except Exception as e:
-                elapsed = time.time() - start_time
-                print(f"Export failed for image {idx} after {elapsed:.2f}s: {e}")
-                return idx, False, str(e)
-        
+            print(f"Export failed for image {idx} after {elapsed:.2f}s")
+            return idx, False, "export failed (see log)"
+
         # Use parallel processing for exports
         max_workers = min(4, os.cpu_count() or 1)  # Use very few workers for export to avoid I/O contention
         completed_count = 0
-        
+
         if progress_callback:
-            progress_callback(0, total_images)
-        
+            progress_callback(0, total_items)
+
         if max_workers == 1:
             # Sequential fallback
-            for idx, img in converted_images:
-                try:                
-                    base_name = os.path.splitext(os.path.basename(img.file_path))[0]
-                    if jpg_output:
-                        output_path = os.path.join(output_folder, f"{base_name}_ccr.jpg")
-                    else:
-                        output_path = os.path.join(output_folder, f"{base_name}_ccr.tiff")
-                    self.export_image_by_index(idx, output_path, jpg_output=jpg_output)
-                except Exception as e:
-                    print(f"Failed to export image at index {idx}: {e}")
+            for idx, output_path in items:
+                if cancelled():
+                    result["cancelled"] = True
+                    break
+                idx, success, error = export_single_image(idx, output_path)
+                if success:
+                    result["exported"] += 1
+                else:
+                    result["failed"] += 1
+                    result["failures"].append((idx, error))
                 completed_count += 1
                 if progress_callback:
-                    progress_callback(completed_count, total_images)
+                    progress_callback(completed_count, total_items)
         else:
             # Parallel export
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-                future_to_idx = {executor.submit(export_single_image, (idx, img)): idx 
-                                for idx, img in converted_images}
-                
+                future_to_idx = {executor.submit(export_single_image, idx, path): idx
+                                 for idx, path in items}
+
                 for future in concurrent.futures.as_completed(future_to_idx):
-                    idx, success, error = future.result()
-                    if not success:
-                        print(f"Failed to export image at index {idx}: {error}")
+                    try:
+                        idx, success, error = future.result()
+                    except concurrent.futures.CancelledError:
+                        result["cancelled"] = True
+                        continue
+                    if success is None:
+                        result["cancelled"] = True
+                    elif success:
+                        result["exported"] += 1
+                    else:
+                        result["failed"] += 1
+                        result["failures"].append((idx, error))
                     completed_count += 1
                     if progress_callback:
-                        progress_callback(completed_count, total_images)
-        
+                        progress_callback(completed_count, total_items)
+                    if cancelled() and not result["cancelled"]:
+                        result["cancelled"] = True
+                        # Cancel anything not yet started; in-flight exports finish
+                        for f in future_to_idx:
+                            f.cancel()
+
         total_elapsed = time.time() - total_start_time
-        print(f"Export completed! Total time: {total_elapsed:.2f}s for {total_images} images ({total_elapsed/total_images:.2f}s per image)")
+        print(f"Export finished in {total_elapsed:.2f}s: {result['exported']} exported, "
+              f"{result['failed']} failed{', cancelled' if result['cancelled'] else ''}")
+        return result
     
     def remove_image_by_index(self, idx: int):
         """

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -56,6 +56,7 @@ class CCRImage:
         self.temperature_base: int = 0   # Non-destructive base temperature offset; slider shows 0
         self.brightness_base: int = -8   # Non-destructive base brightness offset; slider shows 0
         self.histogram_image = None
+        self.original_full_size: Optional[tuple[int, int]] = None  # (height, width) of the full-res source, set by read_image
 
         self.info = self.get_camera_and_lens_for_lensfun(self.file_path)  # Extract camera and lens info for lensfun
         
@@ -148,6 +149,9 @@ class CCRImage:
                 with rawpy.imread(file_path) as raw:
                     # Capture sensor ceiling before postprocess (e.g. 16383 for 14-bit)
                     white_level = raw.white_level
+
+                    # Full processed output size, valid even when half_size=True
+                    self.original_full_size = (raw.sizes.height, raw.sizes.width)
 
                     # Check if this is a monochrome sensor
                     is_monochrome = False
@@ -293,6 +297,8 @@ class CCRImage:
             # Convert to 16-bit if needed
             if img.dtype != np.uint16:
                 img = img.astype(np.uint16) * 257 if img.dtype == np.uint8 else img
+            # This branch always reads at full resolution regardless of `preview`
+            self.original_full_size = (img.shape[0], img.shape[1])
             return img
         
     def update_thumbnail_and_preview(self, thumbnail_size: int = 156, preview_size: int = 1080) -> None:

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -429,23 +429,25 @@ def safe_unicode_path(file_path: str) -> str:
     return os.path.normpath(file_path)
 
 
-def safe_cv2_imwrite(output_path: str, image: np.ndarray) -> bool:
+def safe_cv2_imwrite(output_path: str, image: np.ndarray, params=None) -> bool:
     """
     Safe image writing that handles Unicode file paths.
+    params: optional cv2 encode parameters, e.g. [cv2.IMWRITE_JPEG_QUALITY, 92]
     """
     output_path = safe_unicode_path(output_path)
+    params = params or []
     try:
         # Try normal cv2.imwrite first
-        success = cv2.imwrite(output_path, image)
+        success = cv2.imwrite(output_path, image, params)
         if success:
             return True
-        
+
         # If that fails, try encoding to bytes and using alternative method
         try:
             # Get file extension
             _, ext = os.path.splitext(output_path)
             # Encode image to memory buffer
-            success, buffer = cv2.imencode(ext, image)
+            success, buffer = cv2.imencode(ext, image, params)
             if success:
                 # Write buffer to file
                 with open(output_path, 'wb') as f:
@@ -477,7 +479,7 @@ def safe_tifffile_imwrite(output_path: str, image: np.ndarray, **kwargs) -> bool
 
 
 
-def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_out=False) -> np.ndarray:
+def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_out=False,jpg_quality=95,max_long_side=None) -> np.ndarray:
     """
     Normalize and align the image using the CCR algorithm, using a reference rectangle
     for percentile calculations instead of a crop factor.
@@ -812,13 +814,16 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
         # Ensure output_path has proper extension and handle Unicode
         step_start = time.time()
         output_path = safe_unicode_path(output_path)
+        if max_long_side:
+            rgb_brightness_normalized = ccr_image.resize_image_to_max_pixel(rgb_brightness_normalized, max_long_side)
         if jpg_out:
             output_path = os.path.splitext(output_path)[0] + ".jpg"
             # Convert to 8-bit for JPEG output
             rgb_brightness_normalized_8 = to_8bit(rgb_brightness_normalized)
             # Ensure output is RGB, not BGR
             rgb_brightness_normalized_8 = cv2.cvtColor(rgb_brightness_normalized_8, cv2.COLOR_RGB2BGR)
-            success = safe_cv2_imwrite(output_path, rgb_brightness_normalized_8)
+            success = safe_cv2_imwrite(output_path, rgb_brightness_normalized_8,
+                                       [cv2.IMWRITE_JPEG_QUALITY, int(jpg_quality)])
             del rgb_brightness_normalized_8  # Clean up 8-bit copy
             if success:
                 print(f"Normalized image saved to {output_path}")
@@ -855,7 +860,8 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
     return rgb_brightness_normalized
 
 def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
-                               output_path=None, water_mark=True, jpg_out=False):
+                               output_path=None, water_mark=True, jpg_out=False,
+                               jpg_quality=95, max_long_side=None):
     """
     Film negative conversion using the same pipeline as ccr_normalize_with_reference
     but with explicit per-channel B/W points instead of auto-detected percentiles.
@@ -1014,11 +1020,14 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
 
         # Write file
         output_path = safe_unicode_path(output_path)
+        if max_long_side:
+            rgb_result = ccr_image.resize_image_to_max_pixel(rgb_result, max_long_side)
         if jpg_out:
             output_path = os.path.splitext(output_path)[0] + ".jpg"
             img_8 = to_8bit(rgb_result)
             img_8 = cv2.cvtColor(img_8, cv2.COLOR_RGB2BGR)
-            if not safe_cv2_imwrite(output_path, img_8):
+            if not safe_cv2_imwrite(output_path, img_8,
+                                    [cv2.IMWRITE_JPEG_QUALITY, int(jpg_quality)]):
                 raise IOError(f"Failed to save image to {output_path}")
         else:
             output_path = os.path.splitext(output_path)[0] + ".tiff"

--- a/src/core/export_estimator.py
+++ b/src/core/export_estimator.py
@@ -1,0 +1,129 @@
+"""
+Output-size estimation for the export dialog: cheap original-dimension probing
+and JPEG/TIFF size approximation from the in-memory converted preview.
+
+No Qt imports here; the dialog drives this module.
+"""
+import logging
+import os
+
+import cv2
+import numpy as np
+
+RAW_EXTS = {".cr3", ".cr2", ".nef", ".arw", ".dng", ".rw2", ".orf", ".raf", ".srw", ".pef", ".3fr"}
+
+# Typical deflate compression ratio observed on 16-bit photographic TIFFs
+TIFF_DEFLATE_FACTOR = 0.6
+
+
+def get_original_dims(ccr_img):
+    """
+    Return (height, width) of the image's full-resolution source.
+
+    Uses the cached CCRImage.original_full_size (captured during read_image);
+    falls back to a cheap header probe and caches the result back onto the
+    instance. Returns None when nothing works.
+    """
+    dims = getattr(ccr_img, "original_full_size", None)
+    if dims:
+        return dims
+
+    file_path = ccr_img.file_path
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext == ".fff":
+        ext = ".tiff"
+    try:
+        if ext in RAW_EXTS:
+            import rawpy
+            with rawpy.imread(file_path) as raw:
+                dims = (raw.sizes.height, raw.sizes.width)
+        elif ext in (".tif", ".tiff"):
+            import tifffile
+            with tifffile.TiffFile(file_path) as tif:
+                shape = tif.pages[0].shape
+                dims = (shape[0], shape[1])
+        else:
+            img = cv2.imread(file_path, cv2.IMREAD_UNCHANGED)
+            if img is not None:
+                dims = (img.shape[0], img.shape[1])
+    except Exception as e:
+        logging.warning(f"Could not probe dimensions of {file_path}: {e}")
+        dims = None
+
+    if dims is None and ccr_img.resized_raw is not None:
+        # Last resort: the preview's dims (underestimates large originals)
+        dims = (ccr_img.resized_raw.shape[0], ccr_img.resized_raw.shape[1])
+
+    if dims:
+        ccr_img.original_full_size = dims
+    return dims
+
+
+def effective_pixels(h: int, w: int, max_long_side=None) -> int:
+    """Pixel count after an optional long-edge cap, preserving aspect ratio."""
+    if max_long_side and max(h, w) > max_long_side:
+        scale = max_long_side / max(h, w)
+        h, w = int(h * scale), int(w * scale)
+    return h * w
+
+
+def jpeg_bytes_per_pixel(sample_rgb16: np.ndarray, quality: int):
+    """
+    Encode a 16-bit RGB sample (the converted preview) as JPEG at the given
+    quality and return the resulting bytes-per-pixel, or None on failure.
+    """
+    try:
+        img8 = (np.clip(sample_rgb16, 0, 65535) / 257).astype(np.uint8)
+        img8 = cv2.cvtColor(img8, cv2.COLOR_RGB2BGR)
+        ok, buffer = cv2.imencode(".jpg", img8, [cv2.IMWRITE_JPEG_QUALITY, int(quality)])
+        if not ok:
+            return None
+        pixels = img8.shape[0] * img8.shape[1]
+        return len(buffer) / pixels if pixels else None
+    except Exception as e:
+        logging.warning(f"JPEG size sampling failed: {e}")
+        return None
+
+
+def tiff_bytes(h: int, w: int) -> int:
+    """Approximate size of a 16-bit RGB deflate-compressed TIFF."""
+    return int(h * w * 3 * 2 * TIFF_DEFLATE_FACTOR)
+
+
+def estimate_total_bytes(dims_list, fmt: str, *, bpp=None, max_long_side=None) -> int:
+    """
+    Estimate the total output size for a batch.
+
+    Args:
+        dims_list: iterable of (height, width) per image (None entries skipped)
+        fmt: "jpeg" or "tiff"
+        bpp: bytes-per-pixel sample from jpeg_bytes_per_pixel (jpeg only)
+        max_long_side: optional resize cap applied on export
+    """
+    total = 0
+    for dims in dims_list:
+        if not dims:
+            continue
+        h, w = dims
+        if fmt == "jpeg":
+            if bpp is None:
+                continue
+            total += int(effective_pixels(h, w, max_long_side) * bpp)
+        else:
+            if max_long_side and max(h, w) > max_long_side:
+                scale = max_long_side / max(h, w)
+                h, w = int(h * scale), int(w * scale)
+            total += tiff_bytes(h, w)
+    return total
+
+
+def format_size(num_bytes: float) -> str:
+    """Human-readable size with a leading ~ (estimates are approximate)."""
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            if unit == "B":
+                return f"~{int(size)} {unit}"
+            return f"~{size:.1f} {unit}"
+        size /= 1024
+    return f"~{size:.1f} GB"

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -100,6 +100,11 @@ class MainWindow(QMainWindow):
         open_folder_action = file_menu.addAction("Open Folder")
         open_folder_action.triggered.connect(self.open_folder)
 
+        file_menu.addSeparator()
+        export_action = file_menu.addAction("Export…")
+        export_action.setShortcut("Ctrl+E")
+        export_action.triggered.connect(self.image_preview.open_export_dialog)
+
         # Add Help menu with About, Licenses, Activation, and Help actions
         help_menu = menu_bar.addMenu("Help")
         about_action = help_menu.addAction("About")

--- a/src/utils/export_naming.py
+++ b/src/utils/export_naming.py
@@ -1,0 +1,160 @@
+"""
+Pure filename-building logic for the export dialog: macro expansion,
+sanitization, in-batch uniquification, and on-disk conflict resolution.
+
+This module must stay free of Qt/cv2 imports so it remains testable headless.
+"""
+import os
+import re
+from datetime import datetime
+from typing import Callable, List, Optional, Sequence
+
+MACRO_RE = re.compile(r"\{(date|time|seq|name)\}")
+
+# Windows-reserved filename characters plus ASCII control characters
+_INVALID_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+
+def expand_macros(template: str, *, base_name: str, seq: int, seq_width: int, now: datetime) -> str:
+    """
+    Expand {date}, {time}, {seq} and {name} macros in a prefix/suffix template.
+    Unknown {...} tokens are left literal.
+
+    Args:
+        template (str): The prefix or suffix template
+        base_name (str): Original file base name (no extension)
+        seq (int): 1-based sequence number of this file in the batch
+        seq_width (int): Zero-padding width for {seq}
+        now (datetime): Timestamp used for {date} and {time}
+
+    Returns:
+        str: The expanded string
+    """
+    values = {
+        "date": now.strftime("%Y-%m-%d"),
+        "time": now.strftime("%H%M%S"),
+        "seq": str(seq).zfill(seq_width),
+        "name": base_name,
+    }
+    return MACRO_RE.sub(lambda m: values[m.group(1)], template)
+
+
+def sanitize_filename(name: str) -> str:
+    """
+    Replace characters that are invalid in Windows filenames with underscores
+    and strip trailing dots/spaces (invalid at the end of a Windows name).
+    """
+    return _INVALID_CHARS_RE.sub("_", name).rstrip(". ")
+
+
+def build_filename(base_name: str, prefix: str, suffix: str, ext: str, *,
+                   seq: int, seq_width: int, now: datetime) -> str:
+    """
+    Build a single output filename: expanded prefix + base name + expanded
+    suffix + extension, sanitized for the filesystem.
+
+    Args:
+        ext (str): Extension including the leading dot, e.g. ".tiff"
+    """
+    stem = (
+        expand_macros(prefix, base_name=base_name, seq=seq, seq_width=seq_width, now=now)
+        + base_name
+        + expand_macros(suffix, base_name=base_name, seq=seq, seq_width=seq_width, now=now)
+    )
+    stem = sanitize_filename(stem)
+    if not stem:
+        stem = base_name or "image"
+    return stem + ext
+
+
+def uniquify_in_batch(names: Sequence[str]) -> List[str]:
+    """
+    Make a list of filenames unique within itself (case-insensitive). The
+    first occurrence keeps its name; later duplicates get -1, -2, ... before
+    the extension. Always applied regardless of conflict policy, since a
+    macro-only suffix (e.g. just {date}) would otherwise collide every file.
+    """
+    seen = set()
+    result = []
+    for name in names:
+        key = os.path.normcase(name)
+        if key not in seen:
+            seen.add(key)
+            result.append(name)
+            continue
+        stem, ext = os.path.splitext(name)
+        n = 0
+        while True:
+            n += 1
+            candidate = f"{stem}-{n}{ext}"
+            candidate_key = os.path.normcase(candidate)
+            if candidate_key not in seen:
+                break
+        seen.add(candidate_key)
+        result.append(candidate)
+    return result
+
+
+def build_export_names(base_names: Sequence[str], prefix: str, suffix: str, ext: str,
+                       now: Optional[datetime] = None) -> List[str]:
+    """
+    Build the full list of output filenames for a batch, expanding macros and
+    guaranteeing in-batch uniqueness.
+
+    Args:
+        base_names: Original file base names (no extension), in export order
+        ext (str): Extension including the leading dot, e.g. ".jpg"
+        now: Timestamp for {date}/{time}; defaults to datetime.now()
+
+    Returns:
+        list[str]: Output filenames (no directory component)
+    """
+    if now is None:
+        now = datetime.now()
+    seq_width = max(3, len(str(len(base_names))))
+    names = [
+        build_filename(base, prefix, suffix, ext, seq=i + 1, seq_width=seq_width, now=now)
+        for i, base in enumerate(base_names)
+    ]
+    return uniquify_in_batch(names)
+
+
+def resolve_conflicts(names: Sequence[str], policy: str,
+                      exists: Callable[[str], bool]) -> List[Optional[str]]:
+    """
+    Apply the file-conflict policy against existing files on disk.
+
+    Args:
+        names: In-batch-unique filenames (or full paths; `exists` receives
+               the same strings)
+        policy: "overwrite" | "skip" | "rename"
+        exists: Predicate checking whether a name is already taken on disk
+                (injected so tests don't need a real filesystem)
+
+    Returns:
+        list: Same order as input; entries are the (possibly renamed) name,
+              or None when the file is skipped under the "skip" policy.
+    """
+    if policy == "overwrite":
+        return list(names)
+    if policy == "skip":
+        return [None if exists(name) else name for name in names]
+    if policy == "rename":
+        claimed = {os.path.normcase(name) for name in names}
+        result = []
+        for name in names:
+            if not exists(name):
+                result.append(name)
+                continue
+            stem, ext = os.path.splitext(name)
+            n = 0
+            while True:
+                n += 1
+                candidate = f"{stem}-{n}{ext}"
+                key = os.path.normcase(candidate)
+                if key not in claimed and not exists(candidate):
+                    break
+            claimed.add(key)
+            result.append(candidate)
+        return result
+    raise ValueError(f"Unknown conflict policy: {policy!r}")

--- a/src/utils/export_naming.py
+++ b/src/utils/export_naming.py
@@ -17,11 +17,11 @@ _INVALID_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 
 def expand_macros(template: str, *, base_name: str, seq: int, seq_width: int, now: datetime) -> str:
     """
-    Expand {date}, {time}, {seq} and {name} macros in a prefix/suffix template.
+    Expand {date}, {time}, {seq} and {name} macros in a filename template.
     Unknown {...} tokens are left literal.
 
     Args:
-        template (str): The prefix or suffix template
+        template (str): The filename stem template, e.g. "{name}_ccr"
         base_name (str): Original file base name (no extension)
         seq (int): 1-based sequence number of this file in the batch
         seq_width (int): Zero-padding width for {seq}
@@ -47,20 +47,16 @@ def sanitize_filename(name: str) -> str:
     return _INVALID_CHARS_RE.sub("_", name).rstrip(". ")
 
 
-def build_filename(base_name: str, prefix: str, suffix: str, ext: str, *,
+def build_filename(base_name: str, template: str, ext: str, *,
                    seq: int, seq_width: int, now: datetime) -> str:
     """
-    Build a single output filename: expanded prefix + base name + expanded
-    suffix + extension, sanitized for the filesystem.
+    Build a single output filename from a stem template (e.g. "{name}_ccr"),
+    expanding macros and sanitizing for the filesystem.
 
     Args:
         ext (str): Extension including the leading dot, e.g. ".tiff"
     """
-    stem = (
-        expand_macros(prefix, base_name=base_name, seq=seq, seq_width=seq_width, now=now)
-        + base_name
-        + expand_macros(suffix, base_name=base_name, seq=seq, seq_width=seq_width, now=now)
-    )
+    stem = expand_macros(template, base_name=base_name, seq=seq, seq_width=seq_width, now=now)
     stem = sanitize_filename(stem)
     if not stem:
         stem = base_name or "image"
@@ -72,7 +68,8 @@ def uniquify_in_batch(names: Sequence[str]) -> List[str]:
     Make a list of filenames unique within itself (case-insensitive). The
     first occurrence keeps its name; later duplicates get -1, -2, ... before
     the extension. Always applied regardless of conflict policy, since a
-    macro-only suffix (e.g. just {date}) would otherwise collide every file.
+    template without {name} or {seq} (e.g. just "{date}") would otherwise
+    collide every file.
     """
     seen = set()
     result = []
@@ -95,14 +92,15 @@ def uniquify_in_batch(names: Sequence[str]) -> List[str]:
     return result
 
 
-def build_export_names(base_names: Sequence[str], prefix: str, suffix: str, ext: str,
+def build_export_names(base_names: Sequence[str], template: str, ext: str,
                        now: Optional[datetime] = None) -> List[str]:
     """
-    Build the full list of output filenames for a batch, expanding macros and
-    guaranteeing in-batch uniqueness.
+    Build the full list of output filenames for a batch from a stem template,
+    expanding macros and guaranteeing in-batch uniqueness.
 
     Args:
         base_names: Original file base names (no extension), in export order
+        template: Stem template, e.g. "{name}_ccr"
         ext (str): Extension including the leading dot, e.g. ".jpg"
         now: Timestamp for {date}/{time}; defaults to datetime.now()
 
@@ -113,7 +111,7 @@ def build_export_names(base_names: Sequence[str], prefix: str, suffix: str, ext:
         now = datetime.now()
     seq_width = max(3, len(str(len(base_names))))
     names = [
-        build_filename(base, prefix, suffix, ext, seq=i + 1, seq_width=seq_width, now=now)
+        build_filename(base, template, ext, seq=i + 1, seq_width=seq_width, now=now)
         for i, base in enumerate(base_names)
     ]
     return uniquify_in_batch(names)

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -1,5 +1,5 @@
 """
-Export settings dialog: scope, destination, prefix/suffix naming with macros,
+Export settings dialog: scope, destination, filename template with macros,
 format + JPEG quality with live size estimate, resize-on-export, conflict
 policy and persisted preferences.
 """
@@ -95,20 +95,16 @@ class ExportSettingsDialog(QDialog):
         naming_group = QGroupBox("File naming")
         naming_layout = QVBoxLayout(naming_group)
         fields_layout = QHBoxLayout()
-        fields_layout.addWidget(QLabel("Prefix"))
-        self.prefix_edit = QLineEdit()
-        fields_layout.addWidget(self.prefix_edit, 1)
-        fields_layout.addWidget(QLabel("Suffix"))
-        self.suffix_edit = QLineEdit()
-        fields_layout.addWidget(self.suffix_edit, 1)
+        fields_layout.addWidget(QLabel("Filename"))
+        self.filename_edit = QLineEdit("{name}_ccr")
+        fields_layout.addWidget(self.filename_edit, 1)
         naming_layout.addLayout(fields_layout)
-        hint = QLabel("Macros: {date}  {time}  {seq}  {name}")
+        hint = QLabel("Macros: {name} = original filename, {date}, {time}, {seq}")
         hint.setStyleSheet("color: gray;")
         naming_layout.addWidget(hint)
         self.example_label = QLabel("")
         naming_layout.addWidget(self.example_label)
-        self.prefix_edit.textChanged.connect(self._update_example)
-        self.suffix_edit.textChanged.connect(self._update_example)
+        self.filename_edit.textChanged.connect(self._update_example)
         layout.addWidget(naming_group)
 
         # Format / quality / estimate / resize / conflicts
@@ -186,8 +182,7 @@ class ExportSettingsDialog(QDialog):
 
         if s.value("export/scope", "all", type=str) == "current" and self._current_converted:
             self.scope_current_radio.setChecked(True)
-        self.prefix_edit.setText(s.value("export/prefix", "", type=str))
-        self.suffix_edit.setText(s.value("export/suffix", "_ccr", type=str))
+        self.filename_edit.setText(s.value("export/filename_template", "{name}_ccr", type=str))
         fmt_index = self.format_combo.findData(s.value("export/format", "tiff", type=str))
         if fmt_index >= 0:
             self.format_combo.setCurrentIndex(fmt_index)
@@ -205,8 +200,7 @@ class ExportSettingsDialog(QDialog):
         s = self._settings
         s.setValue("export/destination", self.dest_edit.text().strip())
         s.setValue("export/scope", "current" if self.scope_current_radio.isChecked() else "all")
-        s.setValue("export/prefix", self.prefix_edit.text())
-        s.setValue("export/suffix", self.suffix_edit.text())
+        s.setValue("export/filename_template", self.filename_edit.text())
         s.setValue("export/format", self.format_combo.currentData())
         s.setValue("export/jpeg_quality", self.quality_slider.value())
         s.setValue("export/resize", self.resize_combo.currentData())
@@ -279,9 +273,8 @@ class ExportSettingsDialog(QDialog):
             return
         base = self._base_names(indices[:1])[0]
         seq_width = max(3, len(str(len(indices))))
-        name = build_filename(base, self.prefix_edit.text(), self.suffix_edit.text(),
-                              self._selected_ext(), seq=1, seq_width=seq_width,
-                              now=datetime.now())
+        name = build_filename(base, self.filename_edit.text(), self._selected_ext(),
+                              seq=1, seq_width=seq_width, now=datetime.now())
         self.example_label.setText(f"Example: {name}")
 
     # ---------- size estimate ----------
@@ -345,8 +338,8 @@ class ExportSettingsDialog(QDialog):
                                     "There are no converted images to export.")
             return
 
-        names = build_export_names(self._base_names(indices), self.prefix_edit.text(),
-                                   self.suffix_edit.text(), self._selected_ext())
+        names = build_export_names(self._base_names(indices), self.filename_edit.text(),
+                                   self._selected_ext())
         full_paths = [os.path.join(destination, name) for name in names]
         resolved = resolve_conflicts(full_paths, self.conflict_combo.currentData(),
                                      exists=os.path.exists)

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -1,0 +1,374 @@
+"""
+Export settings dialog: scope, destination, prefix/suffix naming with macros,
+format + JPEG quality with live size estimate, resize-on-export, conflict
+policy and persisted preferences.
+"""
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from PySide6.QtCore import Qt, QSettings, QTimer
+from PySide6.QtWidgets import (
+    QCheckBox, QComboBox, QDialog, QFileDialog, QFormLayout, QGroupBox,
+    QHBoxLayout, QLabel, QLineEdit, QMessageBox, QPushButton, QRadioButton,
+    QSlider, QVBoxLayout,
+)
+
+from core.ccr_backend import ccr_backend
+from core import export_estimator
+from utils.export_naming import build_export_names, build_filename, resolve_conflicts
+from utils.unicode_path_utils import normalize_unicode_path, validate_unicode_path
+
+
+@dataclass
+class ExportPlan:
+    """Everything the export worker needs, resolved by the dialog."""
+    items: List[Tuple[int, str]] = field(default_factory=list)  # (image idx, absolute output path)
+    jpg_output: bool = False
+    jpg_quality: int = 92
+    max_long_side: Optional[int] = None  # None = keep original size
+    open_folder: bool = False
+    destination: str = ""
+    skipped: int = 0  # files dropped by the "skip existing" policy
+
+
+class ExportSettingsDialog(QDialog):
+    """
+    Modal export configuration dialog. On accept, `self.plan` holds the
+    resolved ExportPlan; the caller runs the actual export worker.
+    """
+
+    def __init__(self, parent=None, current_idx=None):
+        super().__init__(parent)
+        self.setWindowTitle("Export")
+        self.setModal(True)
+        self.setMinimumWidth(440)
+
+        self.plan: Optional[ExportPlan] = None
+        self._current_idx = current_idx
+        self._converted_indices = [idx for idx, img in enumerate(ccr_backend.images) if img.converted]
+        self._current_converted = (
+            current_idx is not None
+            and 0 <= current_idx < len(ccr_backend.images)
+            and ccr_backend.images[current_idx].converted
+        )
+        self._bpp_cache = {}  # quality -> bytes per pixel sample
+
+        self._settings = QSettings("FreeCCR", "FreeCCR")
+        self._build_ui()
+        self._restore_settings()
+        self._update_example()
+        self._schedule_estimate()
+
+    # ---------- UI ----------
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+
+        # Scope
+        scope_group = QGroupBox("Export scope")
+        scope_layout = QHBoxLayout(scope_group)
+        self.scope_all_radio = QRadioButton(f"All converted images ({len(self._converted_indices)})")
+        self.scope_all_radio.setChecked(True)
+        self.scope_current_radio = QRadioButton("Current image only")
+        if not self._current_converted:
+            self.scope_current_radio.setEnabled(False)
+            self.scope_current_radio.setToolTip("The current image has not been converted yet.")
+        scope_layout.addWidget(self.scope_all_radio)
+        scope_layout.addWidget(self.scope_current_radio)
+        self.scope_all_radio.toggled.connect(self._on_scope_changed)
+        layout.addWidget(scope_group)
+
+        # Destination
+        dest_layout = QHBoxLayout()
+        dest_layout.addWidget(QLabel("Destination:"))
+        self.dest_edit = QLineEdit()
+        self.dest_edit.textChanged.connect(self._on_dest_changed)
+        dest_layout.addWidget(self.dest_edit, 1)
+        browse_btn = QPushButton("Browse…")
+        browse_btn.clicked.connect(self._on_browse)
+        dest_layout.addWidget(browse_btn)
+        layout.addLayout(dest_layout)
+
+        # Naming
+        naming_group = QGroupBox("File naming")
+        naming_layout = QVBoxLayout(naming_group)
+        fields_layout = QHBoxLayout()
+        fields_layout.addWidget(QLabel("Prefix"))
+        self.prefix_edit = QLineEdit()
+        fields_layout.addWidget(self.prefix_edit, 1)
+        fields_layout.addWidget(QLabel("Suffix"))
+        self.suffix_edit = QLineEdit()
+        fields_layout.addWidget(self.suffix_edit, 1)
+        naming_layout.addLayout(fields_layout)
+        hint = QLabel("Macros: {date}  {time}  {seq}  {name}")
+        hint.setStyleSheet("color: gray;")
+        naming_layout.addWidget(hint)
+        self.example_label = QLabel("")
+        naming_layout.addWidget(self.example_label)
+        self.prefix_edit.textChanged.connect(self._update_example)
+        self.suffix_edit.textChanged.connect(self._update_example)
+        layout.addWidget(naming_group)
+
+        # Format / quality / estimate / resize / conflicts
+        form = QFormLayout()
+        self.format_combo = QComboBox()
+        self.format_combo.addItem("TIFF 16-bit (lossless)", "tiff")
+        self.format_combo.addItem("JPEG", "jpeg")
+        self.format_combo.currentIndexChanged.connect(self._on_format_changed)
+        form.addRow("Format:", self.format_combo)
+
+        quality_layout = QHBoxLayout()
+        self.quality_slider = QSlider(Qt.Horizontal)
+        self.quality_slider.setRange(1, 100)
+        self.quality_slider.setValue(92)
+        self.quality_value_label = QLabel("92")
+        self.quality_value_label.setMinimumWidth(28)
+        quality_layout.addWidget(self.quality_slider, 1)
+        quality_layout.addWidget(self.quality_value_label)
+        self.quality_slider.valueChanged.connect(self._on_quality_changed)
+        self.quality_row_label = QLabel("Quality:")
+        form.addRow(self.quality_row_label, quality_layout)
+        self._quality_layout = quality_layout
+
+        self.estimate_label = QLabel("Estimated total size: …")
+        form.addRow("", self.estimate_label)
+
+        self.resize_combo = QComboBox()
+        self.resize_combo.addItem("Original size", 0)
+        self.resize_combo.addItem("4000 px long edge", 4000)
+        self.resize_combo.addItem("2000 px long edge", 2000)
+        self.resize_combo.addItem("1080 px long edge", 1080)
+        self.resize_combo.currentIndexChanged.connect(self._schedule_estimate)
+        form.addRow("Resize:", self.resize_combo)
+
+        self.conflict_combo = QComboBox()
+        self.conflict_combo.addItem("Auto-rename (-1, -2…)", "rename")
+        self.conflict_combo.addItem("Overwrite", "overwrite")
+        self.conflict_combo.addItem("Skip existing", "skip")
+        form.addRow("If file exists:", self.conflict_combo)
+        layout.addLayout(form)
+
+        self.open_folder_checkbox = QCheckBox("Open folder when done")
+        layout.addWidget(self.open_folder_checkbox)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        button_layout.addStretch(1)
+        self.export_button = QPushButton("Export")
+        self.export_button.setDefault(True)
+        self.export_button.clicked.connect(self._on_export_clicked)
+        cancel_button = QPushButton("Cancel")
+        cancel_button.clicked.connect(self.reject)
+        button_layout.addWidget(self.export_button)
+        button_layout.addWidget(cancel_button)
+        layout.addLayout(button_layout)
+
+        # Debounced size estimation
+        self._estimate_timer = QTimer(self)
+        self._estimate_timer.setSingleShot(True)
+        self._estimate_timer.setInterval(300)
+        self._estimate_timer.timeout.connect(self._update_estimate)
+
+        self._update_quality_visibility()
+
+    # ---------- settings ----------
+
+    def _restore_settings(self):
+        s = self._settings
+        destination = s.value("export/destination", "", type=str)
+        if not destination:
+            scoped = self._scope_indices()
+            if scoped:
+                destination = os.path.dirname(ccr_backend.images[scoped[0]].file_path)
+        self.dest_edit.setText(destination)
+
+        if s.value("export/scope", "all", type=str) == "current" and self._current_converted:
+            self.scope_current_radio.setChecked(True)
+        self.prefix_edit.setText(s.value("export/prefix", "", type=str))
+        self.suffix_edit.setText(s.value("export/suffix", "_ccr", type=str))
+        fmt_index = self.format_combo.findData(s.value("export/format", "tiff", type=str))
+        if fmt_index >= 0:
+            self.format_combo.setCurrentIndex(fmt_index)
+        self.quality_slider.setValue(s.value("export/jpeg_quality", 92, type=int))
+        resize_index = self.resize_combo.findData(s.value("export/resize", 0, type=int))
+        if resize_index >= 0:
+            self.resize_combo.setCurrentIndex(resize_index)
+        conflict_index = self.conflict_combo.findData(s.value("export/conflict", "rename", type=str))
+        if conflict_index >= 0:
+            self.conflict_combo.setCurrentIndex(conflict_index)
+        self.open_folder_checkbox.setChecked(s.value("export/open_folder", False, type=bool))
+        self._update_quality_visibility()
+
+    def _save_settings(self):
+        s = self._settings
+        s.setValue("export/destination", self.dest_edit.text().strip())
+        s.setValue("export/scope", "current" if self.scope_current_radio.isChecked() else "all")
+        s.setValue("export/prefix", self.prefix_edit.text())
+        s.setValue("export/suffix", self.suffix_edit.text())
+        s.setValue("export/format", self.format_combo.currentData())
+        s.setValue("export/jpeg_quality", self.quality_slider.value())
+        s.setValue("export/resize", self.resize_combo.currentData())
+        s.setValue("export/conflict", self.conflict_combo.currentData())
+        s.setValue("export/open_folder", self.open_folder_checkbox.isChecked())
+
+    # ---------- helpers ----------
+
+    def _scope_indices(self) -> List[int]:
+        if self.scope_current_radio.isChecked() and self._current_converted:
+            return [self._current_idx]
+        return list(self._converted_indices)
+
+    def _base_names(self, indices) -> List[str]:
+        return [os.path.splitext(os.path.basename(ccr_backend.images[i].file_path))[0]
+                for i in indices]
+
+    def _selected_ext(self) -> str:
+        return ".jpg" if self.format_combo.currentData() == "jpeg" else ".tiff"
+
+    def _selected_max_long_side(self) -> Optional[int]:
+        value = self.resize_combo.currentData()
+        return value if value else None
+
+    def _sample_image(self):
+        """Image whose converted preview seeds the JPEG bytes-per-pixel sample."""
+        indices = self._scope_indices()
+        if self._current_converted and self._current_idx in indices:
+            return ccr_backend.images[self._current_idx]
+        return ccr_backend.images[indices[0]] if indices else None
+
+    # ---------- slots ----------
+
+    def _on_browse(self):
+        folder = QFileDialog.getExistingDirectory(
+            self, "Select Export Folder", self.dest_edit.text(),
+            QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks
+        )
+        if folder:
+            self.dest_edit.setText(folder)
+
+    def _on_dest_changed(self):
+        self.export_button.setEnabled(bool(self.dest_edit.text().strip()))
+
+    def _on_scope_changed(self):
+        self._update_example()
+        self._schedule_estimate()
+
+    def _on_format_changed(self):
+        self._update_quality_visibility()
+        self._update_example()
+        self._schedule_estimate()
+
+    def _on_quality_changed(self, value):
+        self.quality_value_label.setText(str(value))
+        self._schedule_estimate()
+
+    def _update_quality_visibility(self):
+        is_jpeg = self.format_combo.currentData() == "jpeg"
+        self.quality_row_label.setVisible(is_jpeg)
+        for i in range(self._quality_layout.count()):
+            widget = self._quality_layout.itemAt(i).widget()
+            if widget is not None:
+                widget.setVisible(is_jpeg)
+
+    def _update_example(self):
+        indices = self._scope_indices()
+        if not indices:
+            self.example_label.setText("Example: —")
+            return
+        base = self._base_names(indices[:1])[0]
+        seq_width = max(3, len(str(len(indices))))
+        name = build_filename(base, self.prefix_edit.text(), self.suffix_edit.text(),
+                              self._selected_ext(), seq=1, seq_width=seq_width,
+                              now=datetime.now())
+        self.example_label.setText(f"Example: {name}")
+
+    # ---------- size estimate ----------
+
+    def _schedule_estimate(self, *args):
+        self._estimate_timer.start()
+
+    def _update_estimate(self):
+        indices = self._scope_indices()
+        if not indices:
+            self.estimate_label.setText("Estimated total size: —")
+            return
+        fmt = self.format_combo.currentData()
+        max_long_side = self._selected_max_long_side()
+        bpp = None
+        if fmt == "jpeg":
+            quality = self.quality_slider.value()
+            bpp = self._bpp_cache.get(quality)
+            if bpp is None:
+                sample = self._sample_image()
+                if sample is not None and sample.resized_raw is not None:
+                    bpp = export_estimator.jpeg_bytes_per_pixel(sample.resized_raw, quality)
+                    if bpp is not None:
+                        self._bpp_cache[quality] = bpp
+            if bpp is None:
+                self.estimate_label.setText("Estimated total size: —")
+                return
+        dims_list = [export_estimator.get_original_dims(ccr_backend.images[i]) for i in indices]
+        total = export_estimator.estimate_total_bytes(dims_list, fmt, bpp=bpp,
+                                                      max_long_side=max_long_side)
+        count = len(indices)
+        self.estimate_label.setText(
+            f"Estimated total size: {export_estimator.format_size(total)}"
+            f"  ({count} file{'s' if count != 1 else ''})"
+        )
+
+    # ---------- accept ----------
+
+    def _on_export_clicked(self):
+        destination = self.dest_edit.text().strip()
+        if not destination:
+            return
+        destination = normalize_unicode_path(destination)
+        try:
+            os.makedirs(destination, exist_ok=True)
+        except OSError as e:
+            QMessageBox.warning(self, "Export Folder Error",
+                                f"Cannot create the export folder:\n\n{destination}\n\n{e}")
+            return
+        if not validate_unicode_path(destination):
+            QMessageBox.warning(
+                self, "Unicode Path Warning",
+                f"The export folder path contains characters that may cause issues:\n\n"
+                f"{destination}\n\nPlease choose a simpler folder path."
+            )
+            return
+
+        indices = self._scope_indices()
+        if not indices:
+            QMessageBox.information(self, "Nothing to Export",
+                                    "There are no converted images to export.")
+            return
+
+        names = build_export_names(self._base_names(indices), self.prefix_edit.text(),
+                                   self.suffix_edit.text(), self._selected_ext())
+        full_paths = [os.path.join(destination, name) for name in names]
+        resolved = resolve_conflicts(full_paths, self.conflict_combo.currentData(),
+                                     exists=os.path.exists)
+
+        items = [(idx, path) for idx, path in zip(indices, resolved) if path is not None]
+        skipped = len(resolved) - len(items)
+        if not items:
+            QMessageBox.information(
+                self, "Nothing to Export",
+                "All files already exist and were skipped.\n"
+                "Change the conflict policy or the file naming to export them."
+            )
+            return
+
+        self.plan = ExportPlan(
+            items=items,
+            jpg_output=self.format_combo.currentData() == "jpeg",
+            jpg_quality=self.quality_slider.value(),
+            max_long_side=self._selected_max_long_side(),
+            open_folder=self.open_folder_checkbox.isChecked(),
+            destination=destination,
+            skipped=skipped,
+        )
+        self._save_settings()
+        self.accept()

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1,11 +1,12 @@
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QToolBar, QMessageBox, QSlider, QGraphicsView, QGraphicsScene,
-    QGraphicsPixmapItem, QGraphicsRectItem, QStyleOptionSlider, QFileDialog, QDialog,
-    QLabel, QPushButton, QStyle, QCheckBox, QSizePolicy  
+    QGraphicsPixmapItem, QGraphicsRectItem, QStyleOptionSlider, QDialog,
+    QLabel, QPushButton, QStyle, QSizePolicy
 )
-from PySide6.QtGui import QPixmap, QIcon, QTransform, QPen, QColor, QAction, QPainter, QCursor
-from PySide6.QtCore import Qt, QSize, Signal, QRectF, QPointF, QThread, QTimer
+from PySide6.QtGui import QPixmap, QIcon, QTransform, QPen, QColor, QAction, QPainter, QCursor, QDesktopServices
+from PySide6.QtCore import Qt, QSize, Signal, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
+from widgets.export_dialog import ExportSettingsDialog
 import sys
 import os
 
@@ -56,18 +57,6 @@ def resource_path(relative_path):
     # Not found, return as-is (QIcon will fail gracefully)
     return relative_path
 
-
-def normalize_unicode_path(path):
-    """Normalize Unicode path - fallback if utils not available"""
-    return os.path.normpath(os.path.abspath(path))
-
-
-def validate_unicode_path(path):
-    """Validate Unicode path - fallback if utils not available"""
-    try:
-        return os.path.exists(path)
-    except (UnicodeError, OSError):
-        return False
 
 class GraphicsImageView(QGraphicsView):
     def __init__(self, parent=None):
@@ -448,21 +437,9 @@ class ImagePreview(QWidget):
         self.toolbar.addAction(self.unconvert_action)
         add_spacer()
 
-        self.export_action = QAction("Export", self)  # <-- assign to self
-        self.export_action.triggered.connect(self.export_image)
+        self.export_action = QAction("Export…", self)
+        self.export_action.triggered.connect(self.open_export_dialog)
         self.toolbar.addAction(self.export_action)
-        add_spacer()
-
-        self.export_all_action = QAction("Export All", self)  # <-- assign to self
-        self.export_all_action.triggered.connect(self.export_all_images)
-        self.toolbar.addAction(self.export_all_action)
-        add_spacer()
-
-        # --- Add Export jpgs checkbox ---
-        self.export_jpgs_checkbox = QCheckBox("Export jpgs")
-        self.export_jpgs_checkbox.setChecked(False)
-        self.toolbar.addWidget(self.export_jpgs_checkbox)
-        # --- End checkbox addition ---
 
         self.layout.addWidget(self.toolbar)
 
@@ -710,7 +687,7 @@ class ImagePreview(QWidget):
     def _update_unconvert_action_state(self):
         self.current_converted = ccr_backend.get_converted_state_by_index(self.current_idx) if self.current_idx is not None else False
         self.unconvert_action.setEnabled(self.current_converted)
-        self.export_action.setEnabled(self.current_converted)
+        self.export_action.setEnabled(any(img.converted for img in ccr_backend.images))
         parent = self.parent()
         if hasattr(parent.parent(), "sliders_panel"):
             print("Setting sliders enabled based on current_converted:", self.current_converted)
@@ -754,89 +731,39 @@ class ImagePreview(QWidget):
         # Show completion hint
         self.parent().parent().sliders_panel.set_temporary_hint("Auto frame conversion completed!", duration=2000)
 
-    def export_image(self):
-        if self.current_idx is None:
-            QMessageBox.warning(self, "No Image Selected", "Please select an image to convert.")
+    def open_export_dialog(self):
+        if not any(img.converted for img in ccr_backend.images):
+            QMessageBox.information(self, "Nothing to Export",
+                                    "Convert at least one image before exporting.")
             return
 
-        ccr_img = ccr_backend.images[self.current_idx]
-        base_name = os.path.splitext(os.path.basename(ccr_img.file_path))[0]
-
-        export_jpg = self.export_jpgs_checkbox.isChecked()  # <-- Check the checkbox state
-
-        if export_jpg:
-            default_name = f"{base_name}_ccr.jpg"
-            file_filter = "JPEG Files (*.jpg *.jpeg)"
-        else:
-            default_name = f"{base_name}_ccr.tiff"
-            file_filter = "TIFF Files (*.tiff *.tif)"
-
-        file_path, _ = QFileDialog.getSaveFileName(
-            self,
-            "Export Normalized Image",
-            default_name,
-            file_filter
-        )
-        if not file_path:
+        settings_dialog = ExportSettingsDialog(self, current_idx=self.current_idx)
+        if settings_dialog.exec_() != QDialog.Accepted or settings_dialog.plan is None:
             return
-        
-        # Validate Unicode path
-        normalized_path = normalize_unicode_path(file_path)
-        if not validate_unicode_path(os.path.dirname(normalized_path)):
-            QMessageBox.warning(
-                self,
-                "Unicode Path Warning",
-                f"The export path contains characters that may cause issues:\n\n{file_path}\n\nPlease choose a simpler path name."
-            )
-            return
+        plan = settings_dialog.plan
 
-        # Ensure correct extension
-        if export_jpg:
-            if not (normalized_path.lower().endswith(".jpg") or normalized_path.lower().endswith(".jpeg")):
-                normalized_path += ".jpg"
-        else:
-            if not (normalized_path.lower().endswith(".tiff") or normalized_path.lower().endswith(".tif")):
-                normalized_path += ".tiff"
+        progress_dialog = ExportProgressDialog(self)
+        self._export_worker = ExportItemsWorker(plan)
+        progress_dialog.set_worker(self._export_worker)
+        self._export_worker.progress.connect(progress_dialog.set_progress)
+        self._export_worker.finished.connect(
+            lambda result: self._on_export_finished(progress_dialog, result, plan))
+        self._export_worker.start()
+        progress_dialog.exec_()
 
-        dialog = ExportDialog(self)
-        worker = ExportWorker(self.current_idx, normalized_path, export_jpg)  # <-- Pass flag to worker
-        worker.finished.connect(lambda path: self._on_export_all_finished(dialog, path))
-        worker.start()
-        dialog.exec_()
-
-    def export_all_images(self):
-        folder = QFileDialog.getExistingDirectory(
-            self,
-            "Select Folder to Export All Images",
-            "",
-            QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks
-        )
-        if not folder:
-            return
-        
-        # Validate Unicode path
-        normalized_folder = normalize_unicode_path(folder)
-        if not validate_unicode_path(normalized_folder):
-            QMessageBox.warning(
-                self,
-                "Unicode Path Warning",
-                f"The export folder path contains characters that may cause issues:\n\n{folder}\n\nPlease choose a simpler folder path."
-            )
-            return
-
-        export_jpg = self.export_jpgs_checkbox.isChecked()  # <-- Check the checkbox state
-
-        dialog = ExportDialog(self)
-        worker = ExportAllWorker(normalized_folder, export_jpg)  # <-- Pass flag to worker
-        dialog.set_worker(worker)
-        worker.progress.connect(dialog.set_progress)
-        worker.finished.connect(lambda path: self._on_export_all_finished(dialog, path))
-        worker.start()
-        dialog.exec_()
-
-    def _on_export_all_finished(self, dialog, path):
+    def _on_export_finished(self, dialog, result, plan):
         dialog.accept()
-        QMessageBox.information(self, "Export Complete", f"All images exported to:\n{path}")
+        lines = [f"Exported: {result.get('exported', 0)}"]
+        if plan.skipped:
+            lines.append(f"Skipped (already exist): {plan.skipped}")
+        if result.get("failed"):
+            lines.append(f"Failed: {result['failed']}")
+        if result.get("cancelled"):
+            lines.append("Export was stopped before completion.")
+        lines.append(f"\nFolder: {plan.destination}")
+        QMessageBox.information(self, "Export Complete", "\n".join(lines))
+        if plan.open_folder:
+            QDesktopServices.openUrl(QUrl.fromLocalFile(plan.destination))
 
 class AutoFrameWorker(QThread):
     finished = Signal()
@@ -930,53 +857,39 @@ class AutoFrameDialog(QDialog):
         else:
             super().keyPressEvent(event)
 
-class ExportWorker(QThread):
-    finished = Signal(str)
-
-    def __init__(self, idx, file_path, jpg_output=False):  # <-- Add jpg_output
-        super().__init__()
-        self.idx = idx
-        self.file_path = file_path
-        self.jpg_output = jpg_output  # <-- Store flag
-
-    def run(self):
-        ccr_backend.export_image_by_index(self.idx, self.file_path, jpg_output=self.jpg_output)  # <-- Pass flag
-        self.finished.emit(self.file_path)
-
-class ExportAllWorker(QThread):
-    finished = Signal(str)
+class ExportItemsWorker(QThread):
+    finished = Signal(dict)
     progress = Signal(int, int)  # current, total
 
-    def __init__(self, output_folder, jpg_output=False):  # <-- Add jpg_output
+    def __init__(self, plan):
         super().__init__()
-        self.output_folder = output_folder
-        self.jpg_output = jpg_output  # <-- Store flag
+        self.plan = plan
         self._stop_requested = False
 
     def run(self):
-        images = ccr_backend.images
-        total = sum(1 for img in images if img.converted)
-        if not os.path.exists(self.output_folder):
-            os.makedirs(self.output_folder)
-        self.progress.emit(0, total)
-        
-        # Define progress callback
         def progress_callback(current, total_count):
             if not self._stop_requested:
                 self.progress.emit(current, total_count)
-        
-        # Use the parallel export functionality from backend with progress
+
         try:
-            ccr_backend.export_all_images(self.output_folder, jpg_output=self.jpg_output, progress_callback=progress_callback)
+            result = ccr_backend.export_items(
+                self.plan.items,
+                jpg_output=self.plan.jpg_output,
+                jpg_quality=self.plan.jpg_quality,
+                max_long_side=self.plan.max_long_side,
+                progress_callback=progress_callback,
+                cancel_check=lambda: self._stop_requested,
+            )
         except Exception as e:
             print(f"Failed to export images: {e}")
-        
-        self.finished.emit(self.output_folder)
+            result = {"exported": 0, "failed": len(self.plan.items),
+                      "cancelled": False, "failures": []}
+        self.finished.emit(result)
 
     def stop(self):
         self._stop_requested = True
 
-class ExportDialog(QDialog):
+class ExportProgressDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Exporting...")

--- a/tests/test_export_naming.py
+++ b/tests/test_export_naming.py
@@ -58,19 +58,22 @@ class TestSanitizeFilename:
 
 class TestBuildFilename:
     def test_default_ccr_convention(self):
-        # Matches the legacy "{base}_ccr.tiff" naming
-        out = build_filename("photo", "", "_ccr", ".tiff", seq=1, seq_width=3, now=NOW)
+        # The default "{name}_ccr" template matches the legacy "{base}_ccr.tiff" naming
+        out = build_filename("photo", "{name}_ccr", ".tiff", seq=1, seq_width=3, now=NOW)
         assert out == "photo_ccr.tiff"
 
-    def test_prefix_and_suffix_with_macros(self):
-        out = build_filename("roll1", "{date}_", "_{seq}", ".jpg", seq=2, seq_width=3, now=NOW)
+    def test_template_with_macros(self):
+        out = build_filename("roll1", "{date}_{name}_{seq}", ".jpg", seq=2, seq_width=3, now=NOW)
         assert out == "2026-06-10_roll1_002.jpg"
 
-    def test_empty_prefix_suffix_keeps_base(self):
-        assert build_filename("scan", "", "", ".tiff", seq=1, seq_width=3, now=NOW) == "scan.tiff"
+    def test_template_without_name_macro(self):
+        assert build_filename("scan", "output", ".tiff", seq=1, seq_width=3, now=NOW) == "output.tiff"
+
+    def test_empty_template_falls_back_to_base(self):
+        assert build_filename("scan", "", ".tiff", seq=1, seq_width=3, now=NOW) == "scan.tiff"
 
     def test_sanitization_applied_to_whole_stem(self):
-        out = build_filename("a/b", "x:", "", ".jpg", seq=1, seq_width=3, now=NOW)
+        out = build_filename("a/b", "x:{name}", ".jpg", seq=1, seq_width=3, now=NOW)
         assert out == "x_a_b.jpg"
 
 
@@ -95,24 +98,28 @@ class TestUniquifyInBatch:
 
 class TestBuildExportNames:
     def test_seq_width_minimum_three(self):
-        out = build_export_names(["a"], "{seq}_", "", ".jpg", now=NOW)
+        out = build_export_names(["a"], "{seq}_{name}", ".jpg", now=NOW)
         assert out == ["001_a.jpg"]
 
     def test_seq_width_grows_with_count(self):
         bases = [f"img{i}" for i in range(1500)]
-        out = build_export_names(bases, "{seq}_", "", ".jpg", now=NOW)
+        out = build_export_names(bases, "{seq}_{name}", ".jpg", now=NOW)
         assert out[0] == "0001_img0.jpg"
         assert out[-1] == "1500_img1499.jpg"
 
-    def test_date_only_suffix_forces_in_batch_dedup(self):
+    def test_name_only_template_forces_in_batch_dedup(self):
         # Identical stems after macro expansion must still be unique
-        out = build_export_names(["a", "b"], "", "", ".jpg", now=NOW)
+        out = build_export_names(["a", "b"], "{name}", ".jpg", now=NOW)
         assert out == ["a.jpg", "b.jpg"]
-        out = build_export_names(["same", "same"], "", "_{date}", ".jpg", now=NOW)
+        out = build_export_names(["same", "same"], "{name}_{date}", ".jpg", now=NOW)
         assert out == ["same_2026-06-10.jpg", "same_2026-06-10-1.jpg"]
 
+    def test_template_without_name_dedups_whole_batch(self):
+        out = build_export_names(["x", "y", "z"], "{date}", ".jpg", now=NOW)
+        assert out == ["2026-06-10.jpg", "2026-06-10-1.jpg", "2026-06-10-2.jpg"]
+
     def test_legacy_convention_for_batch(self):
-        out = build_export_names(["p1", "p2"], "", "_ccr", ".tiff", now=NOW)
+        out = build_export_names(["p1", "p2"], "{name}_ccr", ".tiff", now=NOW)
         assert out == ["p1_ccr.tiff", "p2_ccr.tiff"]
 
 
@@ -146,7 +153,7 @@ class TestResolveConflicts:
 class TestCombinedScenario:
     def test_full_pipeline(self):
         bases = ["roll1_001", "roll1_001", "roll1_002"]
-        names = build_export_names(bases, "", "_{date}", ".jpg", now=NOW)
+        names = build_export_names(bases, "{name}_{date}", ".jpg", now=NOW)
         assert names == [
             "roll1_001_2026-06-10.jpg",
             "roll1_001_2026-06-10-1.jpg",

--- a/tests/test_export_naming.py
+++ b/tests/test_export_naming.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+pytest tests for the export filename-building logic (src/utils/export_naming.py).
+Run with: pytest tests/test_export_naming.py -v
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+# Add the src directory to the path so we can import the naming module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from utils.export_naming import (
+    build_export_names,
+    build_filename,
+    expand_macros,
+    resolve_conflicts,
+    sanitize_filename,
+    uniquify_in_batch,
+)
+
+NOW = datetime(2026, 6, 10, 14, 30, 5)
+
+
+class TestExpandMacros:
+    def test_date_time_seq_name(self):
+        out = expand_macros("{date}_{time}_{seq}_{name}", base_name="IMG_0042",
+                            seq=7, seq_width=3, now=NOW)
+        assert out == "2026-06-10_143005_007_IMG_0042"
+
+    def test_unknown_macro_left_literal(self):
+        out = expand_macros("{foo}_{date}{bar}", base_name="x", seq=1, seq_width=3, now=NOW)
+        assert out == "{foo}_2026-06-10{bar}"
+
+    def test_empty_template(self):
+        assert expand_macros("", base_name="x", seq=1, seq_width=3, now=NOW) == ""
+
+    def test_seq_padding_width(self):
+        assert expand_macros("{seq}", base_name="x", seq=12, seq_width=5, now=NOW) == "00012"
+
+
+class TestSanitizeFilename:
+    def test_reserved_chars_replaced(self):
+        assert sanitize_filename('a<b>c:d"e/f\\g|h?i*j') == "a_b_c_d_e_f_g_h_i_j"
+
+    def test_control_chars_replaced(self):
+        assert sanitize_filename("a\x00b\x1fc") == "a_b_c"
+
+    def test_trailing_dots_and_spaces_stripped(self):
+        assert sanitize_filename("name.. ") == "name"
+
+    def test_unicode_preserved(self):
+        assert sanitize_filename("照片_テスト") == "照片_テスト"
+
+
+class TestBuildFilename:
+    def test_default_ccr_convention(self):
+        # Matches the legacy "{base}_ccr.tiff" naming
+        out = build_filename("photo", "", "_ccr", ".tiff", seq=1, seq_width=3, now=NOW)
+        assert out == "photo_ccr.tiff"
+
+    def test_prefix_and_suffix_with_macros(self):
+        out = build_filename("roll1", "{date}_", "_{seq}", ".jpg", seq=2, seq_width=3, now=NOW)
+        assert out == "2026-06-10_roll1_002.jpg"
+
+    def test_empty_prefix_suffix_keeps_base(self):
+        assert build_filename("scan", "", "", ".tiff", seq=1, seq_width=3, now=NOW) == "scan.tiff"
+
+    def test_sanitization_applied_to_whole_stem(self):
+        out = build_filename("a/b", "x:", "", ".jpg", seq=1, seq_width=3, now=NOW)
+        assert out == "x_a_b.jpg"
+
+
+class TestUniquifyInBatch:
+    def test_no_duplicates_untouched(self):
+        names = ["a.jpg", "b.jpg"]
+        assert uniquify_in_batch(names) == names
+
+    def test_duplicates_get_numbered(self):
+        out = uniquify_in_batch(["x.jpg", "x.jpg", "x.jpg"])
+        assert out == ["x.jpg", "x-1.jpg", "x-2.jpg"]
+
+    def test_case_insensitive(self):
+        out = uniquify_in_batch(["Photo.jpg", "photo.jpg"])
+        assert out == ["Photo.jpg", "photo-1.jpg"]
+
+    def test_avoids_existing_batch_name(self):
+        # The -1 candidate is already taken by a real entry
+        out = uniquify_in_batch(["x.jpg", "x-1.jpg", "x.jpg"])
+        assert out == ["x.jpg", "x-1.jpg", "x-2.jpg"]
+
+
+class TestBuildExportNames:
+    def test_seq_width_minimum_three(self):
+        out = build_export_names(["a"], "{seq}_", "", ".jpg", now=NOW)
+        assert out == ["001_a.jpg"]
+
+    def test_seq_width_grows_with_count(self):
+        bases = [f"img{i}" for i in range(1500)]
+        out = build_export_names(bases, "{seq}_", "", ".jpg", now=NOW)
+        assert out[0] == "0001_img0.jpg"
+        assert out[-1] == "1500_img1499.jpg"
+
+    def test_date_only_suffix_forces_in_batch_dedup(self):
+        # Identical stems after macro expansion must still be unique
+        out = build_export_names(["a", "b"], "", "", ".jpg", now=NOW)
+        assert out == ["a.jpg", "b.jpg"]
+        out = build_export_names(["same", "same"], "", "_{date}", ".jpg", now=NOW)
+        assert out == ["same_2026-06-10.jpg", "same_2026-06-10-1.jpg"]
+
+    def test_legacy_convention_for_batch(self):
+        out = build_export_names(["p1", "p2"], "", "_ccr", ".tiff", now=NOW)
+        assert out == ["p1_ccr.tiff", "p2_ccr.tiff"]
+
+
+class TestResolveConflicts:
+    def test_overwrite_keeps_all(self):
+        names = ["a.jpg", "b.jpg"]
+        out = resolve_conflicts(names, "overwrite", exists=lambda n: True)
+        assert out == names
+
+    def test_skip_drops_existing(self):
+        on_disk = {"a.jpg"}
+        out = resolve_conflicts(["a.jpg", "b.jpg"], "skip", exists=lambda n: n in on_disk)
+        assert out == [None, "b.jpg"]
+
+    def test_rename_bumps_until_free(self):
+        on_disk = {"a.jpg", "a-1.jpg"}
+        out = resolve_conflicts(["a.jpg", "b.jpg"], "rename", exists=lambda n: n in on_disk)
+        assert out == ["a-2.jpg", "b.jpg"]
+
+    def test_rename_avoids_other_batch_names(self):
+        # a.jpg exists on disk; its -1 candidate collides with a batch member
+        on_disk = {"a.jpg"}
+        out = resolve_conflicts(["a.jpg", "a-1.jpg"], "rename", exists=lambda n: n in on_disk)
+        assert out == ["a-2.jpg", "a-1.jpg"]
+
+    def test_unknown_policy_raises(self):
+        with pytest.raises(ValueError):
+            resolve_conflicts(["a.jpg"], "bogus", exists=lambda n: False)
+
+
+class TestCombinedScenario:
+    def test_full_pipeline(self):
+        bases = ["roll1_001", "roll1_001", "roll1_002"]
+        names = build_export_names(bases, "", "_{date}", ".jpg", now=NOW)
+        assert names == [
+            "roll1_001_2026-06-10.jpg",
+            "roll1_001_2026-06-10-1.jpg",
+            "roll1_002_2026-06-10.jpg",
+        ]
+        on_disk = {"roll1_002_2026-06-10.jpg"}
+        final = resolve_conflicts(names, "rename", exists=lambda n: n in on_disk)
+        assert final == [
+            "roll1_001_2026-06-10.jpg",
+            "roll1_001_2026-06-10-1.jpg",
+            "roll1_002_2026-06-10-1.jpg",
+        ]


### PR DESCRIPTION
## Summary

Consolidates the three toolbar export controls (**Export**, **Export All**, **Export jpgs** checkbox) into a single **Export…** button that opens a full settings dialog, per the export-refinement plan.

### The dialog
- **Scope** — all converted images *(N)* or current image only (radio disabled with a tooltip when the current image isn''t converted)
- **Destination** folder with Browse
- **Filename template** (default `{name}_ccr`) with `{name}` `{date}` `{time}` `{seq}` macros and a live example-filename preview; duplicate names are auto-uniquified within a batch
- **Format** — TIFF 16-bit (lossless) or JPEG; JPEG shows a quality slider (1–100, default 92) plus a debounced **estimated total output size** sampled from the converted preview
- **Resize on export** — original / 4000 / 2000 / 1080 px long edge
- **If file exists** — auto-rename (`-1`, `-2`…), overwrite, or skip existing
- **Open folder when done**, and all settings persist across restarts via QSettings
- New **File ▸ Export… (Ctrl+E)** menu entry

### Under the hood
- `ccr_backend.export_items()` replaces `export_all_images()`: takes explicit `(idx, path)` pairs (naming now lives in the dialog layer), returns exported/failed/cancelled counts, and honors a cancel flag — **the Stop button now actually halts the batch** (previously it only stopped progress updates)
- JPEG quality and long-edge resize threaded through both normalization pipelines and `safe_cv2_imwrite`
- `CCRImage` captures original full-res dimensions at load (`raw.sizes` for RAW, image shape otherwise) for the size estimator
- New pure modules: `src/utils/export_naming.py` (macros, sanitization, collision handling) and `src/core/export_estimator.py` (dims probe + size math)
- Completion message now reports exported / skipped / failed / cancelled counts

## Testing
- New `tests/test_export_naming.py`: 28 headless tests covering macro expansion, sanitization, sequence padding, in-batch dedup, and all three conflict policies — all pass
- Full suite: 38 passed; the one failure (`test_days_remaining_calculation`) is a pre-existing time-of-day-dependent activation test that fails identically on `main`
- Headless end-to-end smoke run (offscreen Qt): synthetic 16-bit negative → convert → dialog-driven export verified JPEG quality affects file size, resize caps the long edge exactly, TIFF stays 16-bit full-res, settings persist, auto-rename produces `-1` names, and a cancelled export writes nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)