### PR TITLE
Add subtracted saturation, non-destructive crop, and Ctrl+Z undo

### DIFF
--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -255,29 +255,6 @@ class CCRBackend:
             return self.images[idx].adjustment_settings
         return None       
 
-    def sync_adjustment_to_all(self, adjustment: dict):
-        """
-        Apply the given adjustment settings to all images in the backend.
-        
-        Args:
-            adjustment (dict): Dictionary containing adjustment parameters like
-                             'temperature', 'tint', 'exposure', 'brightness', etc.
-        """
-        if not adjustment:
-            return
-            
-        print(f"Syncing adjustment to {len(self.images)} images: {adjustment}")
-        
-        for idx, image_obj in enumerate(self.images):
-            try:
-                # Set the adjustment settings for each image
-                image_obj.adjustment_settings = adjustment.copy()
-                # Update the thumbnail and preview to reflect the changes
-                image_obj.update_thumbnail_and_preview()
-                print(f"Applied adjustment to image {idx + 1}/{len(self.images)}")
-            except Exception as e:
-                print(f"Failed to apply adjustment to image at index {idx}: {e}")
-
     def apply_adjustment_by_index(self, idx: int):
         """
         Applies the adjustment settings to the image at the given index.

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -52,6 +52,11 @@ class CCRImage:
         self.horizontal_mirrored = horizontal_mirrored
         self.vertical_mirrored = vertical_mirrored
         self.converted = converted  # Indicates if the image has been converted to CCR format
+        # User crop as normalized (x1, y1, x2, y2) fractions of the un-rotated/
+        # un-flipped image; None = no crop. Display-level only — resized_raw is
+        # never modified, so clearing the crop needs no re-conversion.
+        self.crop_rect: Optional[tuple[float, float, float, float]] = None
+        self.undo_stack: list = []  # Snapshots for Ctrl+Z, most recent last
         self.contrast_base: int = 0      # Non-destructive base contrast added internally; slider shows 0
         self.temperature_base: int = 0   # Non-destructive base temperature offset; slider shows 0
         self.brightness_base: int = -8   # Non-destructive base brightness offset; slider shows 0
@@ -418,8 +423,48 @@ class CCRImage:
                      ch_g_blackpoint=s.get('ch_g_blackpoint', 0),
                      ch_b_shift=s.get('ch_b_shift', 0),
                      ch_b_gain=s.get('ch_b_gain', 0),
-                     ch_b_blackpoint=s.get('ch_b_blackpoint', 0))
+                     ch_b_blackpoint=s.get('ch_b_blackpoint', 0),
+                     sub_saturation=s.get('sub_saturation', 0))
         return adjusted
+
+    # --- Undo support (Ctrl+Z) ---------------------------------------------
+    UNDO_STACK_LIMIT = 50
+
+    def capture_undo_state(self) -> dict:
+        """Snapshot of every user-editable, non-destructive setting."""
+        return {
+            "adjustment_settings": dict(self.adjustment_settings),
+            "crop_rect": self.crop_rect,
+            "rotation_angle": self.rotation_angle,
+            "fine_rotation_angle": self.fine_rotation_angle,
+            "horizontal_mirrored": self.horizontal_mirrored,
+            "vertical_mirrored": self.vertical_mirrored,
+        }
+
+    def push_undo_state(self) -> None:
+        """Push the current state onto the undo stack. Call BEFORE mutating
+        settings. Consecutive identical snapshots are collapsed so every
+        Ctrl+Z press changes something."""
+        state = self.capture_undo_state()
+        if self.undo_stack and self.undo_stack[-1] == state:
+            return
+        self.undo_stack.append(state)
+        if len(self.undo_stack) > self.UNDO_STACK_LIMIT:
+            del self.undo_stack[0]
+
+    def pop_undo_state(self) -> bool:
+        """Restore the most recent snapshot. Returns False when there is
+        nothing to undo. Callers own refreshing previews/UI afterwards."""
+        if not self.undo_stack:
+            return False
+        state = self.undo_stack.pop()
+        self.adjustment_settings = state["adjustment_settings"]
+        self.crop_rect = state["crop_rect"]
+        self.rotation_angle = state["rotation_angle"]
+        self.fine_rotation_angle = state["fine_rotation_angle"]
+        self.horizontal_mirrored = state["horizontal_mirrored"]
+        self.vertical_mirrored = state["vertical_mirrored"]
+        return True
 
     def _auto_brightness_for_preview(self, image: np.ndarray) -> np.ndarray:
         """

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -55,7 +55,10 @@ class CCRImage:
         # User crop as normalized (x1, y1, x2, y2) fractions of the un-rotated/
         # un-flipped image; None = no crop. Display-level only — resized_raw is
         # never modified, so clearing the crop needs no re-conversion.
+        # crop_angle rotates the box about its center (degrees, positive =
+        # clockwise on screen, Qt convention).
         self.crop_rect: Optional[tuple[float, float, float, float]] = None
+        self.crop_angle: float = 0.0
         self.undo_stack: list = []  # Snapshots for Ctrl+Z, most recent last
         self.contrast_base: int = 0      # Non-destructive base contrast added internally; slider shows 0
         self.temperature_base: int = 0   # Non-destructive base temperature offset; slider shows 0
@@ -435,6 +438,7 @@ class CCRImage:
         return {
             "adjustment_settings": dict(self.adjustment_settings),
             "crop_rect": self.crop_rect,
+            "crop_angle": self.crop_angle,
             "rotation_angle": self.rotation_angle,
             "fine_rotation_angle": self.fine_rotation_angle,
             "horizontal_mirrored": self.horizontal_mirrored,
@@ -460,6 +464,7 @@ class CCRImage:
         state = self.undo_stack.pop()
         self.adjustment_settings = state["adjustment_settings"]
         self.crop_rect = state["crop_rect"]
+        self.crop_angle = state.get("crop_angle", 0.0)
         self.rotation_angle = state["rotation_angle"]
         self.fine_rotation_angle = state["fine_rotation_angle"]
         self.horizontal_mirrored = state["horizontal_mirrored"]

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -91,6 +91,7 @@ def _initialize_opencl():
             float ch_b_shift      = params[20];
             float ch_b_gain       = params[21];
             float ch_b_blackpoint = params[22];
+            float sub_saturation  = params[23];
 
             int idx = gid * 3;
             float r = img[idx];
@@ -349,6 +350,26 @@ def _initialize_opencl():
                 r = img_norm_r * 65535.0f;
                 g = img_norm_g * 65535.0f;
                 b = img_norm_b * 65535.0f;
+            }
+
+            // Subtractive (film-density) saturation: scale each pixel's
+            // chromaticity ratios by a power while pinning the dominant
+            // channel, so saturation is gained by absorbing light in the
+            // other channels (darker, denser colors) instead of adding it.
+            if (sub_saturation != 0.0f) {
+                float sr = clamp(r / 65535.0f, 0.0f, 1.0f);
+                float sg = clamp(g / 65535.0f, 0.0f, 1.0f);
+                float sb = clamp(b / 65535.0f, 0.0f, 1.0f);
+                float mx = fmax(sr, fmax(sg, sb));
+                if (mx > 1e-6f) {
+                    float gamma_s = pow(2.0f, sub_saturation / 100.0f);
+                    sr = mx * pow(sr / mx, gamma_s);
+                    sg = mx * pow(sg / mx, gamma_s);
+                    sb = mx * pow(sb / mx, gamma_s);
+                }
+                r = sr * 65535.0f;
+                g = sg * 65535.0f;
+                b = sb * 65535.0f;
             }
 
             // Per-channel levels controls (linear domain, post-conversion data).
@@ -716,6 +737,10 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
     # --- End of user adjustments ---
 
     if output_path is not None:  # this is for output
+        # User crop (normalized rect in un-rotated/un-flipped space) — applied
+        # before flips/rotation so it matches the cropped preview orientation.
+        rgb_brightness_normalized = apply_crop_to_image(
+            rgb_brightness_normalized, getattr(ccr_image, 'crop_rect', None))
         step_start = time.time()
         # Apply flips and rotation to rgb_brightness_normalized before export
         if h_flip and v_flip:
@@ -969,6 +994,9 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
 
     # --- Export path: flips, rotation, watermark, file write ---
     if output_path is not None:
+        # User crop (normalized rect in un-rotated/un-flipped space) — applied
+        # before flips/rotation so it matches the cropped preview orientation.
+        rgb_result = apply_crop_to_image(rgb_result, getattr(ccr_image, 'crop_rect', None))
         # Flips
         if h_flip and v_flip:
             rgb_result = cv2.flip(rgb_result, -1)
@@ -1046,6 +1074,26 @@ def to_8bit(img16: np.ndarray) -> np.ndarray:
     img16 = np.clip(img16, 0, 65535)
     img8 = (img16 / 257).astype(np.uint8)
     return img8
+
+
+def apply_crop_to_image(img: np.ndarray, crop_rect_norm) -> np.ndarray:
+    """
+    Crop an image using a rect of normalized (x1, y1, x2, y2) fractions
+    defined in un-rotated/un-flipped image space (the same space as
+    resized_raw). Returns the input unchanged when the rect is missing or
+    degenerate, so callers can pass it unconditionally.
+    """
+    if crop_rect_norm is None:
+        return img
+    h, w = img.shape[:2]
+    fx1, fy1, fx2, fy2 = crop_rect_norm
+    x1 = max(0, min(w - 1, int(round(fx1 * w))))
+    y1 = max(0, min(h - 1, int(round(fy1 * h))))
+    x2 = max(x1 + 1, min(w, int(round(fx2 * w))))
+    y2 = max(y1 + 1, min(h, int(round(fy2 * h))))
+    if (x2 - x1) < 2 or (y2 - y1) < 2:
+        return img
+    return img[y1:y2, x1:x2]
 
 def auto_fine_angle(img16: np.ndarray, debug: bool = False) -> float:
     """
@@ -1476,6 +1524,7 @@ def adjust_image(
     ch_b_shift: float = 0.0,
     ch_b_gain: float = 0.0,
     ch_b_blackpoint: float = 0.0,
+    sub_saturation: float = 0.0,
 ) -> np.ndarray:
     """
     Apply temperature, tint, exposure, brightness, blackpoint, whitepoint, highlights, shadows,
@@ -1705,6 +1754,20 @@ def adjust_image(
         img_norm = np.clip(img_norm, 0, 1)
         img = img_norm * 65535.0
 
+    # Subtractive (film-density) saturation: scale each pixel's chromaticity
+    # ratios by a power while pinning the dominant channel, so saturation is
+    # gained by absorbing light in the other channels (darker, denser colors)
+    # instead of adding it. Mirrors the OpenCL kernel block exactly.
+    if sub_saturation != 0.0:
+        img_norm = np.clip(img / 65535.0, 0.0, 1.0)
+        mx = np.max(img_norm, axis=-1, keepdims=True)
+        gamma_s = 2.0 ** (sub_saturation / 100.0)
+        safe_mx = np.maximum(mx, 1e-6)
+        img_norm = np.where(mx > 1e-6,
+                            mx * (img_norm / safe_mx) ** gamma_s,
+                            img_norm)
+        img = img_norm * 65535.0
+
     # Per-channel levels controls (linear domain, post-conversion data).
     # Runs only when at least one slider is non-zero; otherwise a no-op.
     #
@@ -1778,6 +1841,7 @@ def adjust_image_opencl(
     ch_b_shift: float = 0.0,
     ch_b_gain: float = 0.0,
     ch_b_blackpoint: float = 0.0,
+    sub_saturation: float = 0.0,
 ) -> np.ndarray:
     """
     GPU-accelerated (OpenCL) version of adjust_image.
@@ -1794,7 +1858,8 @@ def adjust_image_opencl(
                           ch_input_gain, ch_master_shift, ch_master_gain,
                           ch_r_shift, ch_r_gain, ch_r_blackpoint,
                           ch_g_shift, ch_g_gain, ch_g_blackpoint,
-                          ch_b_shift, ch_b_gain, ch_b_blackpoint)
+                          ch_b_shift, ch_b_gain, ch_b_blackpoint,
+                          sub_saturation=sub_saturation)
 
     try:
         # Use cached OpenCL objects
@@ -1810,7 +1875,8 @@ def adjust_image_opencl(
         img_flat = img.reshape(-1, 3)
         img_buf = cl_array.to_device(queue, img_flat)
 
-        # Prepare parameters as numpy array (params[0..10] existing, params[11..22] channel levels)
+        # Prepare parameters as numpy array (params[0..10] existing,
+        # params[11..22] channel levels, params[23] subtractive saturation)
         params = np.array([
             kelvin_shift, tint_shift, exposure, brightness,
             blackpoint, whitepoint, contrast, saturation, balance_factor,
@@ -1819,6 +1885,7 @@ def adjust_image_opencl(
             ch_r_shift, ch_r_gain, ch_r_blackpoint,
             ch_g_shift, ch_g_gain, ch_g_blackpoint,
             ch_b_shift, ch_b_gain, ch_b_blackpoint,
+            sub_saturation,
         ], dtype=np.float32)
 
         params_buf = cl_array.to_device(queue, params)
@@ -1840,7 +1907,8 @@ def adjust_image_opencl(
                           ch_input_gain, ch_master_shift, ch_master_gain,
                           ch_r_shift, ch_r_gain, ch_r_blackpoint,
                           ch_g_shift, ch_g_gain, ch_g_blackpoint,
-                          ch_b_shift, ch_b_gain, ch_b_blackpoint)
+                          ch_b_shift, ch_b_gain, ch_b_blackpoint,
+                          sub_saturation=sub_saturation)
 
 
 

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -772,6 +772,11 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
             )
         x1, y1, x2, y2 = final_mapped_rect
         del final_mapped_rect  # Clean up as it's no longer needed
+        if getattr(ccr_image, 'crop_rect', None) is not None:
+            # A crop invalidates the reference-rect scaling above — anchor
+            # the watermark to the output's bottom-right corner instead
+            # (same as the bwpoint pipeline).
+            y2, x2 = rgb_brightness_normalized.shape[:2]
         step_start = time.time()
         if water_mark:
             # Ensure the array is contiguous for OpenCV

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -740,7 +740,8 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
         # User crop (normalized rect in un-rotated/un-flipped space) — applied
         # before flips/rotation so it matches the cropped preview orientation.
         rgb_brightness_normalized = apply_crop_to_image(
-            rgb_brightness_normalized, getattr(ccr_image, 'crop_rect', None))
+            rgb_brightness_normalized, getattr(ccr_image, 'crop_rect', None),
+            getattr(ccr_image, 'crop_angle', 0.0))
         step_start = time.time()
         # Apply flips and rotation to rgb_brightness_normalized before export
         if h_flip and v_flip:
@@ -1001,7 +1002,8 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
     if output_path is not None:
         # User crop (normalized rect in un-rotated/un-flipped space) — applied
         # before flips/rotation so it matches the cropped preview orientation.
-        rgb_result = apply_crop_to_image(rgb_result, getattr(ccr_image, 'crop_rect', None))
+        rgb_result = apply_crop_to_image(rgb_result, getattr(ccr_image, 'crop_rect', None),
+                                         getattr(ccr_image, 'crop_angle', 0.0))
         # Flips
         if h_flip and v_flip:
             rgb_result = cv2.flip(rgb_result, -1)
@@ -1081,17 +1083,40 @@ def to_8bit(img16: np.ndarray) -> np.ndarray:
     return img8
 
 
-def apply_crop_to_image(img: np.ndarray, crop_rect_norm) -> np.ndarray:
+def apply_crop_to_image(img: np.ndarray, crop_rect_norm, crop_angle: float = 0.0) -> np.ndarray:
     """
-    Crop an image using a rect of normalized (x1, y1, x2, y2) fractions
+    Crop an image using a box of normalized (x1, y1, x2, y2) fractions
     defined in un-rotated/un-flipped image space (the same space as
-    resized_raw). Returns the input unchanged when the rect is missing or
-    degenerate, so callers can pass it unconditionally.
+    resized_raw), optionally rotated by crop_angle degrees about the box
+    center (positive = clockwise on screen, matching Qt's rotate()).
+    Returns the input unchanged when the rect is missing or degenerate,
+    so callers can pass it unconditionally.
     """
     if crop_rect_norm is None:
         return img
     h, w = img.shape[:2]
     fx1, fy1, fx2, fy2 = crop_rect_norm
+    if crop_angle:
+        # Rotated crop box: output pixel (u, v) samples the source at
+        # C + R(angle) . (u - bw/2, v - bh/2). R matches Qt's
+        # clockwise-positive rotate() in y-down coords, so the exported
+        # content equals the on-screen selection. Areas outside the source
+        # are filled black. The box rect is not clamped to the image here —
+        # a rotated box may legitimately overhang the image bounds.
+        bw = int(round((fx2 - fx1) * w))
+        bh = int(round((fy2 - fy1) * h))
+        if bw < 2 or bh < 2:
+            return img
+        cx = (fx1 + fx2) / 2.0 * w
+        cy = (fy1 + fy2) / 2.0 * h
+        theta = np.deg2rad(crop_angle)
+        cos_t, sin_t = np.cos(theta), np.sin(theta)
+        rot = np.array([[cos_t, -sin_t], [sin_t, cos_t]], dtype=np.float64)
+        offset = np.array([cx, cy]) - rot @ np.array([bw / 2.0, bh / 2.0])
+        affine = np.hstack([rot, offset[:, None]]).astype(np.float32)
+        return cv2.warpAffine(img, affine, (bw, bh),
+                              flags=cv2.INTER_LINEAR | cv2.WARP_INVERSE_MAP,
+                              borderMode=cv2.BORDER_CONSTANT, borderValue=0)
     x1 = max(0, min(w - 1, int(round(fx1 * w))))
     y1 = max(0, min(h - 1, int(round(fy1 * h))))
     x2 = max(x1 + 1, min(w, int(round(fx2 * w))))

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import QMainWindow, QHBoxLayout, QWidget, QFileDialog, QMessageBox, QDialog, QVBoxLayout, QTextEdit, QPushButton, QLabel, QLineEdit
-from PySide6.QtGui import QIcon
+from PySide6.QtGui import QIcon, QShortcut, QKeySequence
 from PySide6.QtCore import Qt, QEvent, QThread, Signal, QObject
 from widgets.thumbnail_list import ThumbnailList
 from widgets.image_preview import ImagePreview
@@ -68,6 +68,11 @@ class MainWindow(QMainWindow):
         self.installEventFilter(self)
         self.create_menu()
 
+        # Ctrl+Z (Cmd+Z on macOS): undo the last action on the current image;
+        # repeated presses walk further back through the undo stack.
+        self.undo_shortcut = QShortcut(QKeySequence.Undo, self)
+        self.undo_shortcut.activated.connect(self.undo_last_action)
+
         # Activation and verification checks are intentionally bypassed.
         ccr_backend.software_activated = True
         _, license_type = validate_software()
@@ -89,6 +94,24 @@ class MainWindow(QMainWindow):
 
     def on_image_selected(self, file_path):
         pass
+
+    def undo_last_action(self):
+        """Restore the current image's previous state (adjustments, crop,
+        rotation, flips). Each Ctrl+Z press pops one more snapshot."""
+        idx = self.image_preview.current_idx
+        img = ccr_backend.get_image_by_index(idx) if idx is not None else None
+        if img is None:
+            return
+        if not img.pop_undo_state():
+            self.sliders_panel.set_temporary_hint("Nothing to undo.", duration=2000)
+            return
+        img.update_thumbnail_and_preview()
+        self.thumbnail_list.update_thumbnail(idx)
+        self.image_preview.update_preview(idx)
+        remaining = len(img.undo_stack)
+        self.sliders_panel.set_temporary_hint(
+            f"Undo applied ({remaining} more available)." if remaining else "Undo applied.",
+            duration=2500)
 
     def create_menu(self):
         menu_bar = self.menuBar()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -98,6 +98,10 @@ class MainWindow(QMainWindow):
     def undo_last_action(self):
         """Restore the current image's previous state (adjustments, crop,
         rotation, flips). Each Ctrl+Z press pops one more snapshot."""
+        # While Compare is held, the backend holds a temporary zeroed state
+        # that the button release will overwrite — undoing now would be lost.
+        if hasattr(self.sliders_panel, "_original_adjustment"):
+            return
         idx = self.image_preview.current_idx
         img = ccr_backend.get_image_by_index(idx) if idx is not None else None
         if img is None:
@@ -105,6 +109,10 @@ class MainWindow(QMainWindow):
         if not img.pop_undo_state():
             self.sliders_panel.set_temporary_hint("Nothing to undo.", duration=2000)
             return
+        # End the coalescing bursts so the next edit pushes a fresh snapshot
+        # of the just-restored state instead of merging into a stale burst.
+        self.sliders_panel.end_undo_burst()
+        self.image_preview.end_undo_bursts()
         img.update_thumbnail_and_preview()
         self.thumbnail_list.update_thumbnail(idx)
         self.image_preview.update_preview(idx)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1,13 +1,15 @@
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QToolBar, QMessageBox, QSlider, QGraphicsView, QGraphicsScene,
-    QGraphicsPixmapItem, QGraphicsRectItem, QGraphicsPathItem, QStyleOptionSlider, QDialog,
+    QGraphicsPixmapItem, QGraphicsRectItem, QGraphicsPathItem, QGraphicsEllipseItem,
+    QGraphicsLineItem, QStyleOptionSlider, QDialog,
     QLabel, QPushButton, QStyle, QSizePolicy
 )
 from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QPainter,
-                           QCursor, QDesktopServices, QPainterPath, QBrush)
+                           QCursor, QDesktopServices, QPainterPath, QBrush, QPolygonF)
 from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
 from widgets.export_dialog import ExportSettingsDialog
+import math
 import sys
 import os
 
@@ -77,8 +79,6 @@ class GraphicsImageView(QGraphicsView):
 
         self.wb_pick_mode = False  # eyedropper: click a neutral point for auto temp/tint
 
-        self._crop_drag_start = None  # scene pos where a crop-mode drag began
-
         # Disable scrollbars
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
@@ -86,7 +86,7 @@ class GraphicsImageView(QGraphicsView):
     def mousePressEvent(self, event):
         if self.parent_widget.crop_mode and self.parent_widget.pixmap_item is not None:
             if event.button() == Qt.LeftButton:
-                self._crop_drag_start = self.mapToScene(event.pos())
+                self.parent_widget.begin_crop_drag(self.mapToScene(event.pos()))
             elif event.button() == Qt.RightButton:
                 self.parent_widget.clear_crop()
             return
@@ -127,9 +127,7 @@ class GraphicsImageView(QGraphicsView):
 
     def mouseMoveEvent(self, event):
         if self.parent_widget.crop_mode:
-            if self._crop_drag_start is not None:
-                self.parent_widget.update_crop_selection(
-                    self._crop_drag_start, self.mapToScene(event.pos()))
+            self.parent_widget.update_crop_drag(self.mapToScene(event.pos()))
             return
         if self.bwpoint_mode and self._bw_drag_start is not None:
             self._bw_drag_end = self.mapToScene(event.pos())
@@ -192,8 +190,8 @@ class GraphicsImageView(QGraphicsView):
         local = base_transform.inverted()[0].map(scene_pos)
         # Displayed pixmap may be a crop of the full image — map back to
         # full-image coordinates before indexing resized_raw.
-        dx, dy = pw.displayed_crop_offset()
-        x, y = int(local.x()) + dx, int(local.y()) + dy
+        fx, fy = pw.map_displayed_to_full(local.x(), local.y())
+        x, y = int(fx), int(fy)
 
         img_obj = ccr_backend.get_image_by_index(pw.current_idx)
         if img_obj is None or img_obj.resized_raw is None:
@@ -219,10 +217,8 @@ class GraphicsImageView(QGraphicsView):
 
     def mouseReleaseEvent(self, event):
         if self.parent_widget.crop_mode:
-            if event.button() == Qt.LeftButton and self._crop_drag_start is not None:
-                self.parent_widget.update_crop_selection(
-                    self._crop_drag_start, self.mapToScene(event.pos()))
-                self._crop_drag_start = None
+            if event.button() == Qt.LeftButton:
+                self.parent_widget.end_crop_drag(self.mapToScene(event.pos()))
             return
         if self.bwpoint_mode and event.button() == Qt.LeftButton and self._bw_drag_start is not None:
             drag_start_scene = self._bw_drag_start
@@ -251,12 +247,14 @@ class GraphicsImageView(QGraphicsView):
                 inv = base_transform.inverted()[0]
                 s = inv.map(drag_start_scene)
                 e = inv.map(drag_end_scene)
-                # Map from displayed (possibly cropped) coords to full-image coords
-                dx, dy = pw.displayed_crop_offset()
-                x1 = int(min(s.x(), e.x())) + dx
-                y1 = int(min(s.y(), e.y())) + dy
-                x2 = int(max(s.x(), e.x())) + dx
-                y2 = int(max(s.y(), e.y())) + dy
+                # Map from displayed (possibly cropped/rotated) coords to
+                # full-image coords; use the AABB of the mapped corners.
+                sx, sy = pw.map_displayed_to_full(s.x(), s.y())
+                ex, ey = pw.map_displayed_to_full(e.x(), e.y())
+                x1 = int(min(sx, ex))
+                y1 = int(min(sy, ey))
+                x2 = int(max(sx, ex))
+                y2 = int(max(sy, ey))
 
                 img_obj = ccr_backend.get_image_by_index(pw.current_idx)
                 if img_obj is not None:
@@ -318,11 +316,14 @@ class GraphicsImageView(QGraphicsView):
             x2, y2 = max(x1, x2), max(y1, y2)
             w, h = x2 - x, y2 - y
             if w > 20 and h > 20:
-                # Map from displayed (possibly cropped) coords to full-image coords
-                dx, dy = self.parent_widget.displayed_crop_offset()
+                # Map from displayed (possibly cropped/rotated) coords to
+                # full-image coords; store the AABB of the mapped corners.
+                ax, ay = self.parent_widget.map_displayed_to_full(x, y)
+                bx, by = self.parent_widget.map_displayed_to_full(x2, y2)
                 ccr_backend.set_reference_frame_by_index(
                     self.parent_widget.current_idx,
-                    (int(x) + dx, int(y) + dy, int(x2) + dx, int(y2) + dy)
+                    (int(min(ax, bx)), int(min(ay, by)),
+                     int(max(ax, bx)), int(max(ay, by)))
                 )
                 self.parent_widget.parent().parent().sliders_panel.set_temporary_hint(
                     "<b>Hint:</b><br>Reference frame set! Click the Convert button to view the updates.",
@@ -510,9 +511,15 @@ class ImagePreview(QWidget):
         # pixmap only (display-level — no reprocessing/re-conversion).
         self.crop_mode = False
         self._crop_rerender = False          # guards update_preview while entering crop mode
-        self._pending_crop_local = None      # QRectF selection in full-pixmap coords
+        self._pending_crop_local = None      # QRectF box (un-rotated) in full-pixmap coords
+        self._pending_crop_angle = 0.0       # box rotation, degrees (Qt clockwise-positive)
+        self._crop_drag = None               # in-progress handle/new-rect drag state
         self._crop_overlay_item = None
-        self._crop_display_offset = (0, 0)   # px offset of displayed crop within full image
+        self._crop_handle_items = []
+        # Maps displayed-pixmap coords -> full-image coords while a confirmed
+        # crop is displayed (None = identity / no crop shown)
+        self._crop_display_transform = None
+        self._crop_display_angle = 0.0
 
         # Coalesce a fine-rotation drag into a single undo step
         self._fine_rot_burst_active = False
@@ -571,15 +578,25 @@ class ImagePreview(QWidget):
         # mode where the full image is shown so the user can adjust/regret.
         # Skipped for un-converted images: the crop tool is disabled there,
         # and the full negative (incl. film base) is needed to draw frames.
-        self._crop_display_offset = (0, 0)
+        self._crop_display_transform = None
+        self._crop_display_angle = 0.0
         crop = getattr(ccr_backend.images[idx], "crop_rect", None)
+        crop_angle = getattr(ccr_backend.images[idx], "crop_angle", 0.0) or 0.0
         if (preview_img is not None and not preview_img.isNull()
                 and crop is not None and not self.crop_mode
                 and ccr_backend.images[idx].converted):
-            px_rect = self._crop_rect_to_pixels(crop, preview_img)
-            if px_rect is not None:
-                preview_img = preview_img.copy(px_rect)
-                self._crop_display_offset = (px_rect.x(), px_rect.y())
+            if crop_angle:
+                extracted = self._extract_rotated_crop(preview_img, crop, crop_angle)
+                if extracted is not None:
+                    preview_img, self._crop_display_transform = extracted
+                    self._crop_display_angle = crop_angle
+            else:
+                px_rect = self._crop_rect_to_pixels(crop, preview_img)
+                if px_rect is not None:
+                    t = QTransform()
+                    t.translate(px_rect.x(), px_rect.y())
+                    self._crop_display_transform = t
+                    preview_img = preview_img.copy(px_rect)
 
         self.current_pixmap = preview_img
         self.current_fine_rotation = ccr_backend.get_image_fine_rotation_by_index(idx)
@@ -593,6 +610,7 @@ class ImagePreview(QWidget):
         self.reference_rect_item = None
         self.view._bw_rect_item = None
         self._crop_overlay_item = None
+        self._crop_handle_items = []
 
         self.parent().parent().sliders_panel.set_current_idx(idx)
 
@@ -604,20 +622,22 @@ class ImagePreview(QWidget):
             ref = getattr(ccr_backend.images[idx], "reference_frame", None)
             print("Loaded reference_frame from backend:", ref)
             if ref:
-                x1, y1, x2, y2 = ref
-                # Backend rect is in full-image coords; shift into the
-                # displayed (possibly cropped) pixmap's coordinate space and
-                # clip to it so no dashed lines float beside the image.
-                dx, dy = self._crop_display_offset
-                rect = QRectF(x1 - dx, y1 - dy, x2 - x1, y2 - y1)
-                if self._crop_display_offset != (0, 0):
-                    rect = rect.intersected(
-                        QRectF(0, 0, preview_img.width(), preview_img.height()))
-                if not rect.isEmpty():
-                    self.reference_rect_item = QGraphicsRectItem(rect)
-                    pen = QPen(QColor(255, 0, 0, 180), 2, Qt.DashLine)
-                    self.reference_rect_item.setPen(pen)
-                    self.scene.addItem(self.reference_rect_item)
+                # Backend rect is in full-image coords; map into the displayed
+                # (possibly cropped) pixmap's coordinate space and clip to it.
+                # With a rotated crop displayed the frame would not be
+                # axis-aligned in display space, so it is not drawn at all.
+                if self._crop_display_angle == 0.0:
+                    x1, y1, x2, y2 = ref
+                    rect = QRectF(x1, y1, x2 - x1, y2 - y1)
+                    if self._crop_display_transform is not None:
+                        inv = self._crop_display_transform.inverted()[0]
+                        rect = inv.mapRect(rect).intersected(
+                            QRectF(0, 0, preview_img.width(), preview_img.height()))
+                    if not rect.isEmpty():
+                        self.reference_rect_item = QGraphicsRectItem(rect)
+                        pen = QPen(QColor(255, 0, 0, 180), 2, Qt.DashLine)
+                        self.reference_rect_item.setPen(pen)
+                        self.scene.addItem(self.reference_rect_item)
 
             else:
                 # Show hint when no reference frame exists
@@ -717,16 +737,14 @@ class ImagePreview(QWidget):
         if self.reference_rect_item:
             self.reference_rect_item.setTransform(base_transform)
 
-        # Crop overlay follows the same coarse transform, so toolbar
-        # rotates/flips during crop mode keep it aligned with the image
-        if self._crop_overlay_item is not None:
-            try:
-                self._crop_overlay_item.setTransform(base_transform)
-            except RuntimeError:
-                self._crop_overlay_item = None
-
         # Always fit the view to the content consistently
         self._fit_view_to_content()
+
+        # Rebuild the crop overlay after fitting: toolbar rotates/flips during
+        # crop mode change both the base transform and the view scale (which
+        # sizes the handles), so a full redraw keeps everything aligned.
+        if self.crop_mode and self._crop_overlay_item is not None:
+            self._draw_crop_overlay()
 
     def _end_fine_rot_burst(self):
         self._fine_rot_burst_active = False
@@ -840,10 +858,42 @@ class ImagePreview(QWidget):
 
     # --- Crop mode -----------------------------------------------------
 
-    def displayed_crop_offset(self):
-        """Pixel offset of the displayed pixmap within the full preview image.
-        (0, 0) unless a confirmed crop is currently being displayed."""
-        return self._crop_display_offset
+    def map_displayed_to_full(self, x, y):
+        """Map a point from displayed-pixmap coords to full-image coords.
+        Identity unless a confirmed crop is currently being displayed."""
+        if self._crop_display_transform is None:
+            return x, y
+        p = self._crop_display_transform.map(QPointF(x, y))
+        return p.x(), p.y()
+
+    @staticmethod
+    def _extract_rotated_crop(pixmap, crop, angle):
+        """Render the content under a rotated crop box into an upright pixmap.
+        Returns (pixmap, displayed->full QTransform), or None when degenerate.
+        Display twin of apply_crop_to_image's rotated branch: displayed pixel
+        (u, v) shows the source at C + R(angle) . (u - bw/2, v - bh/2)."""
+        w, h = pixmap.width(), pixmap.height()
+        bw = int(round((crop[2] - crop[0]) * w))
+        bh = int(round((crop[3] - crop[1]) * h))
+        if bw < 2 or bh < 2 or w <= 0 or h <= 0:
+            return None
+        cx = (crop[0] + crop[2]) / 2.0 * w
+        cy = (crop[1] + crop[3]) / 2.0 * h
+        to_full = QTransform()
+        to_full.translate(cx, cy)
+        to_full.rotate(angle)
+        to_full.translate(-bw / 2.0, -bh / 2.0)
+        inverted, ok = to_full.inverted()
+        if not ok:
+            return None
+        out = QPixmap(bw, bh)
+        out.fill(QColor(0, 0, 0))
+        painter = QPainter(out)
+        painter.setRenderHint(QPainter.SmoothPixmapTransform)
+        painter.setTransform(inverted)
+        painter.drawPixmap(0, 0, pixmap)
+        painter.end()
+        return out, to_full
 
     @staticmethod
     def _crop_rect_to_pixels(crop, pixmap) -> "QRect | None":
@@ -891,6 +941,8 @@ class ImagePreview(QWidget):
         self.view.wb_pick_mode = False
         self.crop_mode = True
         self._pending_crop_local = None
+        self._pending_crop_angle = 0.0
+        self._crop_drag = None
         self._crop_rerender = True
         try:
             self.update_preview(self.current_idx)  # re-render un-cropped
@@ -902,56 +954,267 @@ class ImagePreview(QWidget):
             self._pending_crop_local = QRectF(
                 crop[0] * w, crop[1] * h,
                 (crop[2] - crop[0]) * w, (crop[3] - crop[1]) * h)
+            self._pending_crop_angle = getattr(img_obj, "crop_angle", 0.0) or 0.0
         self._draw_crop_overlay()
         self.view.setCursor(Qt.CrossCursor)
         return True
 
-    def update_crop_selection(self, start_scene, end_scene):
-        """Update the pending crop selection from a drag (scene coords)."""
+    # ---- Crop drag interaction: new rect + 10 control handles -----------
+    # 4 corners (resize), 4 edge midpoints (move that edge), a rotate knob
+    # above the top edge, and a center handle (move the whole box).
+
+    HANDLE_VIEW_PX = 14.0          # hit tolerance, in view pixels
+    HANDLE_DRAW_PX = 9.0           # handle glyph size, in view pixels
+    ROTATE_HANDLE_VIEW_PX = 28.0   # rotate-knob stem length, in view pixels
+    _CORNER_SIGNS = {"tl": (-1, -1), "tr": (1, -1), "bl": (-1, 1), "br": (1, 1)}
+
+    def _view_scale(self):
+        m = self.view.transform().m11()
+        return abs(m) if m else 1.0
+
+    def _box_transform(self, sel):
+        """Rotation of the crop box about its own center (image coords)."""
+        c = sel.center()
+        t = QTransform()
+        t.translate(c.x(), c.y())
+        t.rotate(self._pending_crop_angle)
+        t.translate(-c.x(), -c.y())
+        return t
+
+    def _crop_handle_at(self, p):
+        """Return the handle name under local image point p, or None."""
+        sel = self._pending_crop_local
+        if sel is None or sel.width() < 2 or sel.height() < 2:
+            return None
+        c = sel.center()
+        unrot = QTransform()
+        unrot.rotate(-self._pending_crop_angle)
+        q = unrot.map(QPointF(p.x() - c.x(), p.y() - c.y()))
+        hw, hh = sel.width() / 2.0, sel.height() / 2.0
+        tol = self.HANDLE_VIEW_PX / self._view_scale()
+        rot_off = self.ROTATE_HANDLE_VIEW_PX / self._view_scale()
+        # Corners first (most specific), then the rotate knob, edges, center.
+        handles = [
+            ("corner-tl", -hw, -hh), ("corner-tr", hw, -hh),
+            ("corner-bl", -hw, hh), ("corner-br", hw, hh),
+            ("rotate", 0.0, -hh - rot_off),
+            ("edge-t", 0.0, -hh), ("edge-b", 0.0, hh),
+            ("edge-l", -hw, 0.0), ("edge-r", hw, 0.0),
+            ("move", 0.0, 0.0),
+        ]
+        for name, hx, hy in handles:
+            if abs(q.x() - hx) <= tol and abs(q.y() - hy) <= tol:
+                return name
+        return None
+
+    def begin_crop_drag(self, scene_pos):
         base = self._base_transform()
         if base is None or self.current_pixmap is None:
             return
-        inv = base.inverted()[0]
-        s = inv.map(start_scene)
-        e = inv.map(end_scene)
-        w, h = self.current_pixmap.width(), self.current_pixmap.height()
-        x1 = max(0.0, min(float(w), min(s.x(), e.x())))
-        y1 = max(0.0, min(float(h), min(s.y(), e.y())))
-        x2 = max(0.0, min(float(w), max(s.x(), e.x())))
-        y2 = max(0.0, min(float(h), max(s.y(), e.y())))
-        if (x2 - x1) < 3 and (y2 - y1) < 3:
-            # Stray click, not a drag — keep the current selection so the
-            # display keeps matching what Enter will confirm.
+        p = base.inverted()[0].map(scene_pos)
+        mode = self._crop_handle_at(p) or "new"
+        sel = self._pending_crop_local
+        self._crop_drag = {
+            "mode": mode,
+            "start": QPointF(p),
+            "box0": QRectF(sel) if sel is not None else None,
+            "angle0": self._pending_crop_angle,
+        }
+        self.update_crop_drag(scene_pos)
+
+    def update_crop_drag(self, scene_pos):
+        drag = self._crop_drag
+        if drag is None or self.current_pixmap is None:
             return
-        self._pending_crop_local = QRectF(x1, y1, x2 - x1, y2 - y1)
+        base = self._base_transform()
+        if base is None:
+            return
+        p = base.inverted()[0].map(scene_pos)
+        mode = drag["mode"]
+        if mode == "new":
+            self._update_new_selection(drag["start"], p)
+        elif mode == "move":
+            self._drag_move_box(drag, p)
+        elif mode == "rotate":
+            self._drag_rotate_box(drag, p)
+        elif mode.startswith("corner-"):
+            self._drag_corner(drag, p, mode[len("corner-"):])
+        elif mode.startswith("edge-"):
+            self._drag_edge(drag, p, mode[len("edge-"):])
         self._draw_crop_overlay()
 
-    def _draw_crop_overlay(self):
-        """Dim everything outside the pending crop selection so both the
-        entire image and the crop target stay visible."""
+    def end_crop_drag(self, scene_pos):
+        if self._crop_drag is None:
+            return
+        self.update_crop_drag(scene_pos)
+        self._crop_drag = None
+
+    def _update_new_selection(self, p0, p1):
+        w, h = self.current_pixmap.width(), self.current_pixmap.height()
+        x1 = max(0.0, min(float(w), min(p0.x(), p1.x())))
+        y1 = max(0.0, min(float(h), min(p0.y(), p1.y())))
+        x2 = max(0.0, min(float(w), max(p0.x(), p1.x())))
+        y2 = max(0.0, min(float(h), max(p0.y(), p1.y())))
+        if (x2 - x1) < 3 and (y2 - y1) < 3:
+            # Stray click, not a drag — keep the current selection (and its
+            # angle) so the display keeps matching what Enter will confirm.
+            return
+        # A freshly drawn box starts axis-aligned
+        self._pending_crop_local = QRectF(x1, y1, x2 - x1, y2 - y1)
+        self._pending_crop_angle = 0.0
+
+    def _drag_move_box(self, drag, p):
+        box0 = drag["box0"]
+        if box0 is None:
+            return
+        w, h = self.current_pixmap.width(), self.current_pixmap.height()
+        c = box0.center() + (p - drag["start"])
+        box = QRectF(box0)
+        box.moveCenter(QPointF(min(max(c.x(), 0.0), float(w)),
+                               min(max(c.y(), 0.0), float(h))))
+        self._pending_crop_local = box
+
+    def _drag_rotate_box(self, drag, p):
+        box0 = drag["box0"]
+        if box0 is None:
+            return
+        c = box0.center()
+        v0 = drag["start"] - c
+        v1 = p - c
+        if (abs(v1.x()) + abs(v1.y())) < 1e-6:
+            return
+        a0 = math.degrees(math.atan2(v0.y(), v0.x()))
+        a1 = math.degrees(math.atan2(v1.y(), v1.x()))
+        angle = drag["angle0"] + (a1 - a0)
+        angle = (angle + 180.0) % 360.0 - 180.0
+        if abs(angle) < 0.75:
+            angle = 0.0  # snap to straight
+        self._pending_crop_angle = angle
+        self._pending_crop_local = QRectF(box0)
+
+    def _drag_corner(self, drag, p, which):
+        box0 = drag["box0"]
+        if box0 is None:
+            return
+        sx, sy = self._CORNER_SIGNS[which]
+        angle = drag["angle0"]
+        fwd = QTransform()
+        fwd.rotate(angle)
+        unrot = QTransform()
+        unrot.rotate(-angle)
+        hw0, hh0 = box0.width() / 2.0, box0.height() / 2.0
+        # The opposite corner stays fixed in image space
+        anchor = box0.center() + fwd.map(QPointF(-sx * hw0, -sy * hh0))
+        d = unrot.map(p - anchor)  # dragged corner in box frame, rel. anchor
+        min_sz = 10.0
+        dx = sx * max(sx * d.x(), min_sz)
+        dy = sy * max(sy * d.y(), min_sz)
+        c = anchor + fwd.map(QPointF(dx / 2.0, dy / 2.0))
+        bw, bh = abs(dx), abs(dy)
+        self._pending_crop_local = QRectF(c.x() - bw / 2.0, c.y() - bh / 2.0, bw, bh)
+
+    def _drag_edge(self, drag, p, which):
+        box0 = drag["box0"]
+        if box0 is None:
+            return
+        angle = drag["angle0"]
+        fwd = QTransform()
+        fwd.rotate(angle)
+        unrot = QTransform()
+        unrot.rotate(-angle)
+        c0 = box0.center()
+        hw0, hh0 = box0.width() / 2.0, box0.height() / 2.0
+        d = unrot.map(p - c0)  # mouse in box frame, rel. the old center
+        min_sz = 10.0
+        left, right, top, bottom = -hw0, hw0, -hh0, hh0
+        if which == "r":
+            right = max(d.x(), left + min_sz)
+        elif which == "l":
+            left = min(d.x(), right - min_sz)
+        elif which == "b":
+            bottom = max(d.y(), top + min_sz)
+        elif which == "t":
+            top = min(d.y(), bottom - min_sz)
+        c = c0 + fwd.map(QPointF((left + right) / 2.0, (top + bottom) / 2.0))
+        bw, bh = right - left, bottom - top
+        self._pending_crop_local = QRectF(c.x() - bw / 2.0, c.y() - bh / 2.0, bw, bh)
+
+    def _remove_crop_overlay_items(self):
+        for item in self._crop_handle_items:
+            try:
+                self.scene.removeItem(item)
+            except RuntimeError:
+                pass
+        self._crop_handle_items = []
         if self._crop_overlay_item is not None:
             try:
                 self.scene.removeItem(self._crop_overlay_item)
             except RuntimeError:
                 pass
             self._crop_overlay_item = None
+
+    def _draw_crop_overlay(self):
+        """Dim everything outside the pending crop box (so both the entire
+        image and the crop target stay visible) and draw its 10 control
+        handles: 4 corners, 4 edge midpoints, a rotate knob sticking out on
+        top, and a center move handle."""
+        self._remove_crop_overlay_items()
         if not self.crop_mode or self.current_pixmap is None:
             return
         sel = self._pending_crop_local
         if sel is None or sel.width() < 2 or sel.height() < 2:
             return
+        base = self._base_transform()
+        if base is None:
+            return
+        box_t = self._box_transform(sel)
+        combined = box_t * base  # box rotation first, then coarse flips/rotation
+
         path = QPainterPath()
         path.setFillRule(Qt.OddEvenFill)
         path.addRect(QRectF(0, 0, self.current_pixmap.width(), self.current_pixmap.height()))
-        path.addRect(sel)
-        item = QGraphicsPathItem(path)
-        item.setBrush(QBrush(QColor(0, 0, 0, 110)))
-        item.setPen(QPen(QColor(255, 255, 255, 220), 2, Qt.DashLine))
-        base = self._base_transform()
-        if base is not None:
-            item.setTransform(base)
-        self.scene.addItem(item)
-        self._crop_overlay_item = item
+        path.addPolygon(box_t.map(QPolygonF(sel)))
+        overlay = QGraphicsPathItem(path)
+        overlay.setBrush(QBrush(QColor(0, 0, 0, 110)))
+        overlay.setPen(QPen(QColor(255, 255, 255, 220), 2, Qt.DashLine))
+        overlay.setTransform(base)
+        self.scene.addItem(overlay)
+        self._crop_overlay_item = overlay
+
+        # Handles are laid out in un-rotated box coords and carry the
+        # combined transform, so they ride along with the box rotation.
+        scale = self._view_scale()
+        hs = self.HANDLE_DRAW_PX / scale
+        rot_off = self.ROTATE_HANDLE_VIEW_PX / scale
+        hw, hh = sel.width() / 2.0, sel.height() / 2.0
+        c = sel.center()
+        handle_pen = QPen(QColor(30, 30, 30, 230), max(1.0 / scale, 0.5))
+        handle_brush = QBrush(QColor(255, 255, 255, 235))
+
+        def add_handle(item):
+            item.setPen(handle_pen)
+            item.setBrush(handle_brush)
+            item.setTransform(combined)
+            self.scene.addItem(item)
+            self._crop_handle_items.append(item)
+
+        # 4 corners + 4 edge midpoints (squares)
+        for hx, hy in ((-hw, -hh), (hw, -hh), (-hw, hh), (hw, hh),
+                       (0.0, -hh), (0.0, hh), (-hw, 0.0), (hw, 0.0)):
+            x, y = c.x() + hx, c.y() + hy
+            add_handle(QGraphicsRectItem(QRectF(x - hs / 2, y - hs / 2, hs, hs)))
+
+        # Rotate knob: stem + circle sticking out above the top edge
+        stem = QGraphicsLineItem(c.x(), c.y() - hh, c.x(), c.y() - hh - rot_off)
+        stem.setPen(QPen(QColor(255, 255, 255, 220), max(1.5 / scale, 0.5)))
+        stem.setTransform(combined)
+        self.scene.addItem(stem)
+        self._crop_handle_items.append(stem)
+        add_handle(QGraphicsEllipseItem(
+            QRectF(c.x() - hs / 2, c.y() - hh - rot_off - hs / 2, hs, hs)))
+
+        # Center (move) handle (circle)
+        add_handle(QGraphicsEllipseItem(QRectF(c.x() - hs / 2, c.y() - hs / 2, hs, hs)))
 
     @staticmethod
     def _crops_equal(a, b, w, h):
@@ -977,16 +1240,26 @@ class ImagePreview(QWidget):
         too_small = False
         if img_obj is not None and sel is not None and self.current_pixmap is not None:
             w, h = self.current_pixmap.width(), self.current_pixmap.height()
+            angle = self._pending_crop_angle
+            if abs(angle) < 0.05:
+                angle = 0.0
+                # Without rotation, anything outside the image is empty —
+                # commit only the visible part of the box.
+                sel = sel.intersected(QRectF(0, 0, w, h))
             if sel.width() >= 10 and sel.height() >= 10:
-                new_crop = (max(0.0, sel.left() / w), max(0.0, sel.top() / h),
-                            min(1.0, sel.right() / w), min(1.0, sel.bottom() / h))
-                # Selecting (almost) the whole image clears the crop
-                if (new_crop[0] <= 0.001 and new_crop[1] <= 0.001
+                new_crop = (sel.left() / w, sel.top() / h,
+                            sel.right() / w, sel.bottom() / h)
+                # An un-rotated selection of (almost) the whole image clears the crop
+                if (angle == 0.0
+                        and new_crop[0] <= 0.001 and new_crop[1] <= 0.001
                         and new_crop[2] >= 0.999 and new_crop[3] >= 0.999):
                     new_crop = None
-                if not self._crops_equal(new_crop, img_obj.crop_rect, w, h):
+                old_angle = getattr(img_obj, "crop_angle", 0.0) or 0.0
+                if (not self._crops_equal(new_crop, img_obj.crop_rect, w, h)
+                        or abs(angle - old_angle) >= 0.05):
                     img_obj.push_undo_state()
                     img_obj.crop_rect = new_crop
+                    img_obj.crop_angle = 0.0 if new_crop is None else angle
                     applied = True
                     cleared = new_crop is None
             else:
@@ -1016,22 +1289,20 @@ class ImagePreview(QWidget):
     def clear_crop(self):
         """Right-click in crop mode: remove the crop entirely."""
         img_obj = ccr_backend.get_image_by_index(self.current_idx)
-        if img_obj is not None and img_obj.crop_rect is not None:
+        if img_obj is not None and (img_obj.crop_rect is not None
+                                    or getattr(img_obj, "crop_angle", 0.0)):
             img_obj.push_undo_state()
             img_obj.crop_rect = None
+            img_obj.crop_angle = 0.0
         self._exit_crop_mode()
         self.update_preview(self.current_idx)
 
     def _exit_crop_mode(self):
         self.crop_mode = False
         self._pending_crop_local = None
-        self.view._crop_drag_start = None
-        if self._crop_overlay_item is not None:
-            try:
-                self.scene.removeItem(self._crop_overlay_item)
-            except RuntimeError:
-                pass
-            self._crop_overlay_item = None
+        self._pending_crop_angle = 0.0
+        self._crop_drag = None
+        self._remove_crop_overlay_items()
         self.view.setCursor(Qt.ArrowCursor)
 
     def resizeEvent(self, event):

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -248,13 +248,16 @@ class GraphicsImageView(QGraphicsView):
                 s = inv.map(drag_start_scene)
                 e = inv.map(drag_end_scene)
                 # Map from displayed (possibly cropped/rotated) coords to
-                # full-image coords; use the AABB of the mapped corners.
-                sx, sy = pw.map_displayed_to_full(s.x(), s.y())
-                ex, ey = pw.map_displayed_to_full(e.x(), e.y())
-                x1 = int(min(sx, ex))
-                y1 = int(min(sy, ey))
-                x2 = int(max(sx, ex))
-                y2 = int(max(sy, ey))
+                # full-image coords. All FOUR rect corners must be mapped —
+                # under a rotated crop, the AABB of just the two diagonal
+                # corners degenerates (zero width at 45 degrees).
+                pts = [pw.map_displayed_to_full(px, py)
+                       for px, py in ((s.x(), s.y()), (e.x(), s.y()),
+                                      (s.x(), e.y()), (e.x(), e.y()))]
+                x1 = int(min(p[0] for p in pts))
+                y1 = int(min(p[1] for p in pts))
+                x2 = int(max(p[0] for p in pts))
+                y2 = int(max(p[1] for p in pts))
 
                 img_obj = ccr_backend.get_image_by_index(pw.current_idx)
                 if img_obj is not None:
@@ -317,19 +320,24 @@ class GraphicsImageView(QGraphicsView):
             w, h = x2 - x, y2 - y
             if w > 20 and h > 20:
                 # Map from displayed (possibly cropped/rotated) coords to
-                # full-image coords; store the AABB of the mapped corners.
-                ax, ay = self.parent_widget.map_displayed_to_full(x, y)
-                bx, by = self.parent_widget.map_displayed_to_full(x2, y2)
-                ccr_backend.set_reference_frame_by_index(
-                    self.parent_widget.current_idx,
-                    (int(min(ax, bx)), int(min(ay, by)),
-                     int(max(ax, bx)), int(max(ay, by)))
-                )
-                self.parent_widget.parent().parent().sliders_panel.set_temporary_hint(
-                    "<b>Hint:</b><br>Reference frame set! Click the Convert button to view the updates.",
-                    duration=5000
-                )
-                print("Set reference frame:", (int(x), int(y), int(x2), int(y2)))
+                # full-image coords. All FOUR corners must be mapped — under
+                # a rotated crop the two-diagonal AABB degenerates — and the
+                # minimum size re-checked in full-image space.
+                pw = self.parent_widget
+                pts = [pw.map_displayed_to_full(px, py)
+                       for px, py in ((x, y), (x2, y), (x, y2), (x2, y2))]
+                fx1 = int(min(p[0] for p in pts))
+                fy1 = int(min(p[1] for p in pts))
+                fx2 = int(max(p[0] for p in pts))
+                fy2 = int(max(p[1] for p in pts))
+                if (fx2 - fx1) > 20 and (fy2 - fy1) > 20:
+                    ccr_backend.set_reference_frame_by_index(
+                        pw.current_idx, (fx1, fy1, fx2, fy2))
+                    pw.parent().parent().sliders_panel.set_temporary_hint(
+                        "<b>Hint:</b><br>Reference frame set! Click the Convert button to view the updates.",
+                        duration=5000
+                    )
+                    print("Set reference frame:", (fx1, fy1, fx2, fy2))
         self.parent_widget.update_preview(self.parent_widget.current_idx)
 
     def resizeEvent(self, event):
@@ -700,6 +708,11 @@ class ImagePreview(QWidget):
         elif self.scene.sceneRect() and not self.scene.sceneRect().isNull():
             # Fallback to scene rect if no pixmap item
             self.view.fitInView(self.scene.sceneRect(), Qt.KeepAspectRatio)
+        # Crop handle glyph sizes are baked at draw time from the view scale,
+        # which fitInView just changed (window resize, rotate, ...) — rebuild
+        # so the drawn handles keep matching their hit-test zones.
+        if self.crop_mode and self._crop_overlay_item is not None:
+            self._draw_crop_overlay()
 
     def apply_transformations(self):
         if not self.pixmap_item:
@@ -737,14 +750,10 @@ class ImagePreview(QWidget):
         if self.reference_rect_item:
             self.reference_rect_item.setTransform(base_transform)
 
-        # Always fit the view to the content consistently
+        # Always fit the view to the content consistently. (This also
+        # rebuilds the crop overlay when crop mode is active, keeping the
+        # dim region and handles aligned after rotates/flips.)
         self._fit_view_to_content()
-
-        # Rebuild the crop overlay after fitting: toolbar rotates/flips during
-        # crop mode change both the base transform and the view scale (which
-        # sizes the handles), so a full redraw keeps everything aligned.
-        if self.crop_mode and self._crop_overlay_item is not None:
-            self._draw_crop_overlay()
 
     def _end_fine_rot_burst(self):
         self._fine_rot_burst_active = False
@@ -783,18 +792,21 @@ class ImagePreview(QWidget):
 
     def rotate_left(self):
         self._push_undo_for_current()
+        self._crop_drag = None  # base transform change invalidates an active crop drag
         self.current_rotation = (self.current_rotation - 90) % 360
         ccr_backend.set_image_rotation_by_index(self.current_idx, self.current_rotation)
         self.apply_transformations()
 
     def rotate_right(self):
         self._push_undo_for_current()
+        self._crop_drag = None  # base transform change invalidates an active crop drag
         self.current_rotation = (self.current_rotation + 90) % 360
         ccr_backend.set_image_rotation_by_index(self.current_idx, self.current_rotation)
         self.apply_transformations()
 
     def mirror_vertical(self):
         self._push_undo_for_current()
+        self._crop_drag = None  # base transform change invalidates an active crop drag
         flip = ccr_backend.get_image_vertical_flip_by_index(self.current_idx)
         ccr_backend.set_image_vertical_flip_by_index(self.current_idx, not flip)
         self.current_vertical_flip = not flip
@@ -802,6 +814,7 @@ class ImagePreview(QWidget):
 
     def mirror_horizontal(self):
         self._push_undo_for_current()
+        self._crop_drag = None  # base transform change invalidates an active crop drag
         flip = ccr_backend.get_image_horizontal_flip_by_index(self.current_idx)
         ccr_backend.set_image_horizontal_flip_by_index(self.current_idx, not flip)
         self.current_horizontal_flip = not flip
@@ -1002,10 +1015,18 @@ class ImagePreview(QWidget):
             ("edge-l", -hw, 0.0), ("edge-r", hw, 0.0),
             ("move", 0.0, 0.0),
         ]
+        # Pick the NEAREST handle among all within tolerance — on small boxes
+        # the zones overlap, and first-match priority would shadow the center
+        # move handle behind corners/edges.
+        best = None
+        best_d2 = None
         for name, hx, hy in handles:
-            if abs(q.x() - hx) <= tol and abs(q.y() - hy) <= tol:
-                return name
-        return None
+            dx, dy = q.x() - hx, q.y() - hy
+            if abs(dx) <= tol and abs(dy) <= tol:
+                d2 = dx * dx + dy * dy
+                if best_d2 is None or d2 < best_d2:
+                    best, best_d2 = name, d2
+        return best
 
     def begin_crop_drag(self, scene_pos):
         base = self._base_transform()
@@ -1067,8 +1088,15 @@ class ImagePreview(QWidget):
         box0 = drag["box0"]
         if box0 is None:
             return
+        delta = p - drag["start"]
+        if abs(delta.x()) < 1e-9 and abs(delta.y()) < 1e-9:
+            # A plain click must be a no-op: if the box center sits outside
+            # the image (possible after a big corner drag), the clamp below
+            # would otherwise yank the box inward without any mouse motion.
+            self._pending_crop_local = QRectF(box0)
+            return
         w, h = self.current_pixmap.width(), self.current_pixmap.height()
-        c = box0.center() + (p - drag["start"])
+        c = box0.center() + delta
         box = QRectF(box0)
         box.moveCenter(QPointF(min(max(c.x(), 0.0), float(w)),
                                min(max(c.y(), 0.0), float(h))))

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -558,16 +558,24 @@ class ImagePreview(QWidget):
         # (image switch, slider change, conversion, ...).
         if self.crop_mode and not self._crop_rerender:
             self._exit_crop_mode()
+        # The fine-rotation burst belongs to the previous image; a switch
+        # must end it so the next image's first drag gets its own snapshot.
+        if idx != self.current_idx:
+            self._end_fine_rot_burst()
+            self._fine_rot_burst_timer.stop()
 
         preview_img = ccr_backend.get_preview_by_index(idx)
         self.current_idx = idx
 
         # Display-level crop: show only the cropped region, except in crop
         # mode where the full image is shown so the user can adjust/regret.
+        # Skipped for un-converted images: the crop tool is disabled there,
+        # and the full negative (incl. film base) is needed to draw frames.
         self._crop_display_offset = (0, 0)
         crop = getattr(ccr_backend.images[idx], "crop_rect", None)
         if (preview_img is not None and not preview_img.isNull()
-                and crop is not None and not self.crop_mode):
+                and crop is not None and not self.crop_mode
+                and ccr_backend.images[idx].converted):
             px_rect = self._crop_rect_to_pixels(crop, preview_img)
             if px_rect is not None:
                 preview_img = preview_img.copy(px_rect)
@@ -598,13 +606,18 @@ class ImagePreview(QWidget):
             if ref:
                 x1, y1, x2, y2 = ref
                 # Backend rect is in full-image coords; shift into the
-                # displayed (possibly cropped) pixmap's coordinate space.
+                # displayed (possibly cropped) pixmap's coordinate space and
+                # clip to it so no dashed lines float beside the image.
                 dx, dy = self._crop_display_offset
                 rect = QRectF(x1 - dx, y1 - dy, x2 - x1, y2 - y1)
-                self.reference_rect_item = QGraphicsRectItem(rect)
-                pen = QPen(QColor(255, 0, 0, 180), 2, Qt.DashLine)
-                self.reference_rect_item.setPen(pen)
-                self.scene.addItem(self.reference_rect_item)
+                if self._crop_display_offset != (0, 0):
+                    rect = rect.intersected(
+                        QRectF(0, 0, preview_img.width(), preview_img.height()))
+                if not rect.isEmpty():
+                    self.reference_rect_item = QGraphicsRectItem(rect)
+                    pen = QPen(QColor(255, 0, 0, 180), 2, Qt.DashLine)
+                    self.reference_rect_item.setPen(pen)
+                    self.scene.addItem(self.reference_rect_item)
 
             else:
                 # Show hint when no reference frame exists
@@ -688,9 +701,12 @@ class ImagePreview(QWidget):
             base_transform.rotate(self.current_rotation)
         base_transform.translate(-cx, -cy)
 
-        # Fine rotation (only for image)
+        # Fine rotation (only for image). Suppressed while in crop mode so
+        # the displayed image, the dim overlay, and the drag-to-rect mapping
+        # (all base-transform-only) share the same coordinate space — the
+        # selection then bounds exactly the pixels the crop keeps.
         img_transform = QTransform(base_transform)
-        if self.current_fine_rotation:
+        if self.current_fine_rotation and not self.crop_mode:
             img_transform.translate(cx, cy)
             img_transform.rotate(self.current_fine_rotation / 100.0)
             img_transform.translate(-cx, -cy)
@@ -701,11 +717,25 @@ class ImagePreview(QWidget):
         if self.reference_rect_item:
             self.reference_rect_item.setTransform(base_transform)
 
+        # Crop overlay follows the same coarse transform, so toolbar
+        # rotates/flips during crop mode keep it aligned with the image
+        if self._crop_overlay_item is not None:
+            try:
+                self._crop_overlay_item.setTransform(base_transform)
+            except RuntimeError:
+                self._crop_overlay_item = None
+
         # Always fit the view to the content consistently
         self._fit_view_to_content()
 
     def _end_fine_rot_burst(self):
         self._fine_rot_burst_active = False
+
+    def end_undo_bursts(self):
+        """End any in-progress fine-rotation undo burst, e.g. after an undo,
+        so the next change gets its own snapshot."""
+        self._end_fine_rot_burst()
+        self._fine_rot_burst_timer.stop()
 
     def _on_slider_rotate(self, value):
         # Snapshot once per burst, and only for real user changes (the slider
@@ -792,6 +822,9 @@ class ImagePreview(QWidget):
 
     def set_bwpoint_mode(self, mode):
         """mode: 'black' | 'white' | None"""
+        if mode and self.crop_mode:
+            # Pick modes and crop mode are mutually exclusive in both directions
+            self.cancel_crop_mode()
         self.view.bwpoint_mode = mode
         self.view.wb_pick_mode = False
         self.view.setCursor(Qt.CrossCursor if mode else Qt.ArrowCursor)
@@ -799,6 +832,8 @@ class ImagePreview(QWidget):
     def set_wb_pick_mode(self, enabled):
         """Eyedropper mode: next click on the image picks a neutral point
         for automatic temperature/tint adjustment."""
+        if enabled and self.crop_mode:
+            self.cancel_crop_mode()
         self.view.wb_pick_mode = enabled
         self.view.bwpoint_mode = None
         self.view.setCursor(_eyedropper_cursor() if enabled else Qt.ArrowCursor)
@@ -884,6 +919,10 @@ class ImagePreview(QWidget):
         y1 = max(0.0, min(float(h), min(s.y(), e.y())))
         x2 = max(0.0, min(float(w), max(s.x(), e.x())))
         y2 = max(0.0, min(float(h), max(s.y(), e.y())))
+        if (x2 - x1) < 3 and (y2 - y1) < 3:
+            # Stray click, not a drag — keep the current selection so the
+            # display keeps matching what Enter will confirm.
+            return
         self._pending_crop_local = QRectF(x1, y1, x2 - x1, y2 - y1)
         self._draw_crop_overlay()
 
@@ -914,6 +953,18 @@ class ImagePreview(QWidget):
         self.scene.addItem(item)
         self._crop_overlay_item = item
 
+    @staticmethod
+    def _crops_equal(a, b, w, h):
+        """Sub-pixel-tolerant comparison of normalized crop rects, so an
+        unchanged selection round-tripped through pixel coords does not
+        register as a change (and push a junk undo snapshot)."""
+        if a is None or b is None:
+            return a is b
+        tol_x = 0.5 / max(w, 1)
+        tol_y = 0.5 / max(h, 1)
+        return (abs(a[0] - b[0]) < tol_x and abs(a[2] - b[2]) < tol_x
+                and abs(a[1] - b[1]) < tol_y and abs(a[3] - b[3]) < tol_y)
+
     def confirm_crop(self):
         """Enter pressed in crop mode: store the selection as the new crop.
         Display-level only — the conversion result is untouched."""
@@ -921,23 +972,37 @@ class ImagePreview(QWidget):
             return
         img_obj = ccr_backend.get_image_by_index(self.current_idx)
         sel = self._pending_crop_local
-        if (img_obj is not None and sel is not None and self.current_pixmap is not None
-                and sel.width() >= 10 and sel.height() >= 10):
+        applied = False
+        cleared = False
+        too_small = False
+        if img_obj is not None and sel is not None and self.current_pixmap is not None:
             w, h = self.current_pixmap.width(), self.current_pixmap.height()
-            new_crop = (max(0.0, sel.left() / w), max(0.0, sel.top() / h),
-                        min(1.0, sel.right() / w), min(1.0, sel.bottom() / h))
-            # Selecting (almost) the whole image clears the crop
-            if (new_crop[0] <= 0.001 and new_crop[1] <= 0.001
-                    and new_crop[2] >= 0.999 and new_crop[3] >= 0.999):
-                new_crop = None
-            if new_crop != img_obj.crop_rect:
-                img_obj.push_undo_state()
-                img_obj.crop_rect = new_crop
+            if sel.width() >= 10 and sel.height() >= 10:
+                new_crop = (max(0.0, sel.left() / w), max(0.0, sel.top() / h),
+                            min(1.0, sel.right() / w), min(1.0, sel.bottom() / h))
+                # Selecting (almost) the whole image clears the crop
+                if (new_crop[0] <= 0.001 and new_crop[1] <= 0.001
+                        and new_crop[2] >= 0.999 and new_crop[3] >= 0.999):
+                    new_crop = None
+                if not self._crops_equal(new_crop, img_obj.crop_rect, w, h):
+                    img_obj.push_undo_state()
+                    img_obj.crop_rect = new_crop
+                    applied = True
+                    cleared = new_crop is None
+            else:
+                too_small = True
         self._exit_crop_mode()
         self.update_preview(self.current_idx)
+        if cleared:
+            hint = "Crop cleared. Ctrl+Z to undo."
+        elif applied:
+            hint = "Crop applied. Ctrl+Z to undo, or press Crop again to adjust."
+        elif too_small:
+            hint = "Selection too small — crop unchanged."
+        else:
+            hint = "Crop unchanged."
         try:
-            self.parent().parent().sliders_panel.set_temporary_hint(
-                "Crop applied. Ctrl+Z to undo, or press Crop again to adjust.", duration=4000)
+            self.parent().parent().sliders_panel.set_temporary_hint(hint, duration=4000)
         except AttributeError:
             pass
 

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1,10 +1,11 @@
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QToolBar, QMessageBox, QSlider, QGraphicsView, QGraphicsScene,
-    QGraphicsPixmapItem, QGraphicsRectItem, QStyleOptionSlider, QDialog,
+    QGraphicsPixmapItem, QGraphicsRectItem, QGraphicsPathItem, QStyleOptionSlider, QDialog,
     QLabel, QPushButton, QStyle, QSizePolicy
 )
-from PySide6.QtGui import QPixmap, QIcon, QTransform, QPen, QColor, QAction, QPainter, QCursor, QDesktopServices
-from PySide6.QtCore import Qt, QSize, Signal, QRectF, QPointF, QThread, QTimer, QUrl
+from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QPainter,
+                           QCursor, QDesktopServices, QPainterPath, QBrush)
+from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
 from widgets.export_dialog import ExportSettingsDialog
 import sys
@@ -76,11 +77,19 @@ class GraphicsImageView(QGraphicsView):
 
         self.wb_pick_mode = False  # eyedropper: click a neutral point for auto temp/tint
 
+        self._crop_drag_start = None  # scene pos where a crop-mode drag began
+
         # Disable scrollbars
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
     def mousePressEvent(self, event):
+        if self.parent_widget.crop_mode and self.parent_widget.pixmap_item is not None:
+            if event.button() == Qt.LeftButton:
+                self._crop_drag_start = self.mapToScene(event.pos())
+            elif event.button() == Qt.RightButton:
+                self.parent_widget.clear_crop()
+            return
         if event.button() == Qt.LeftButton and self.wb_pick_mode and self.parent_widget.pixmap_item is not None:
             scene_pos = self.mapToScene(event.pos())
             self.wb_pick_mode = False
@@ -117,6 +126,11 @@ class GraphicsImageView(QGraphicsView):
             super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
+        if self.parent_widget.crop_mode:
+            if self._crop_drag_start is not None:
+                self.parent_widget.update_crop_selection(
+                    self._crop_drag_start, self.mapToScene(event.pos()))
+            return
         if self.bwpoint_mode and self._bw_drag_start is not None:
             self._bw_drag_end = self.mapToScene(event.pos())
             self._update_bw_rect(self._bw_drag_start, self._bw_drag_end)
@@ -176,7 +190,10 @@ class GraphicsImageView(QGraphicsView):
         if not base_transform.isInvertible():
             return
         local = base_transform.inverted()[0].map(scene_pos)
-        x, y = int(local.x()), int(local.y())
+        # Displayed pixmap may be a crop of the full image — map back to
+        # full-image coordinates before indexing resized_raw.
+        dx, dy = pw.displayed_crop_offset()
+        x, y = int(local.x()) + dx, int(local.y()) + dy
 
         img_obj = ccr_backend.get_image_by_index(pw.current_idx)
         if img_obj is None or img_obj.resized_raw is None:
@@ -201,6 +218,12 @@ class GraphicsImageView(QGraphicsView):
             pass
 
     def mouseReleaseEvent(self, event):
+        if self.parent_widget.crop_mode:
+            if event.button() == Qt.LeftButton and self._crop_drag_start is not None:
+                self.parent_widget.update_crop_selection(
+                    self._crop_drag_start, self.mapToScene(event.pos()))
+                self._crop_drag_start = None
+            return
         if self.bwpoint_mode and event.button() == Qt.LeftButton and self._bw_drag_start is not None:
             drag_start_scene = self._bw_drag_start
             drag_end_scene = self.mapToScene(event.pos())
@@ -228,10 +251,12 @@ class GraphicsImageView(QGraphicsView):
                 inv = base_transform.inverted()[0]
                 s = inv.map(drag_start_scene)
                 e = inv.map(drag_end_scene)
-                x1 = int(min(s.x(), e.x()))
-                y1 = int(min(s.y(), e.y()))
-                x2 = int(max(s.x(), e.x()))
-                y2 = int(max(s.y(), e.y()))
+                # Map from displayed (possibly cropped) coords to full-image coords
+                dx, dy = pw.displayed_crop_offset()
+                x1 = int(min(s.x(), e.x())) + dx
+                y1 = int(min(s.y(), e.y())) + dy
+                x2 = int(max(s.x(), e.x())) + dx
+                y2 = int(max(s.y(), e.y())) + dy
 
                 img_obj = ccr_backend.get_image_by_index(pw.current_idx)
                 if img_obj is not None:
@@ -293,9 +318,11 @@ class GraphicsImageView(QGraphicsView):
             x2, y2 = max(x1, x2), max(y1, y2)
             w, h = x2 - x, y2 - y
             if w > 20 and h > 20:
+                # Map from displayed (possibly cropped) coords to full-image coords
+                dx, dy = self.parent_widget.displayed_crop_offset()
                 ccr_backend.set_reference_frame_by_index(
                     self.parent_widget.current_idx,
-                    (int(x), int(y), int(x2), int(y2))
+                    (int(x) + dx, int(y) + dy, int(x2) + dx, int(y2) + dy)
                 )
                 self.parent_widget.parent().parent().sliders_panel.set_temporary_hint(
                     "<b>Hint:</b><br>Reference frame set! Click the Convert button to view the updates.",
@@ -478,6 +505,21 @@ class ImagePreview(QWidget):
         self.reference_rect_item = None
         self.group_item = None
 
+        # Crop state. crop_mode shows the full image with a selection overlay;
+        # outside crop mode the confirmed crop is applied to the displayed
+        # pixmap only (display-level — no reprocessing/re-conversion).
+        self.crop_mode = False
+        self._crop_rerender = False          # guards update_preview while entering crop mode
+        self._pending_crop_local = None      # QRectF selection in full-pixmap coords
+        self._crop_overlay_item = None
+        self._crop_display_offset = (0, 0)   # px offset of displayed crop within full image
+
+        # Coalesce a fine-rotation drag into a single undo step
+        self._fine_rot_burst_active = False
+        self._fine_rot_burst_timer = QTimer(self)
+        self._fine_rot_burst_timer.setSingleShot(True)
+        self._fine_rot_burst_timer.timeout.connect(self._end_fine_rot_burst)
+
         self._update_unconvert_action_state()
 
         # --- Add hotkey support ---
@@ -490,17 +532,47 @@ class ImagePreview(QWidget):
         QShortcut(QKeySequence("["), self, self.rotate_left)
         # Right bracket: rotate right
         QShortcut(QKeySequence("]"), self, self.rotate_right)
-        # Enter: convert image
-        QShortcut(QKeySequence(Qt.Key_Return), self, self.convert_ccr)
-        QShortcut(QKeySequence(Qt.Key_Enter), self, self.convert_ccr)
+        # Enter: confirm crop while in crop mode, otherwise convert image
+        QShortcut(QKeySequence(Qt.Key_Return), self, self._on_enter_key)
+        QShortcut(QKeySequence(Qt.Key_Enter), self, self._on_enter_key)
+        # Esc: leave crop mode without changing the crop
+        QShortcut(QKeySequence(Qt.Key_Escape), self, self._on_escape_key)
+
+    def _on_enter_key(self):
+        if self.crop_mode:
+            # Confirming a crop is display-level only — never re-converts.
+            self.confirm_crop()
+        else:
+            self.convert_ccr()
+
+    def _on_escape_key(self):
+        if self.crop_mode:
+            self.cancel_crop_mode()
 
     def update_preview(self, idx):
         ''' Update the UI image based on the backend, using the index from the thumbnail list. '''
         if idx is None or not (0 <= idx < len(ccr_backend.images)):
             print("Invalid index for update_preview:", idx)
             return
+        # Any external refresh while picking a crop abandons crop mode
+        # (image switch, slider change, conversion, ...).
+        if self.crop_mode and not self._crop_rerender:
+            self._exit_crop_mode()
+
         preview_img = ccr_backend.get_preview_by_index(idx)
         self.current_idx = idx
+
+        # Display-level crop: show only the cropped region, except in crop
+        # mode where the full image is shown so the user can adjust/regret.
+        self._crop_display_offset = (0, 0)
+        crop = getattr(ccr_backend.images[idx], "crop_rect", None)
+        if (preview_img is not None and not preview_img.isNull()
+                and crop is not None and not self.crop_mode):
+            px_rect = self._crop_rect_to_pixels(crop, preview_img)
+            if px_rect is not None:
+                preview_img = preview_img.copy(px_rect)
+                self._crop_display_offset = (px_rect.x(), px_rect.y())
+
         self.current_pixmap = preview_img
         self.current_fine_rotation = ccr_backend.get_image_fine_rotation_by_index(idx)
         self.rotation_slider.setValue(self.current_fine_rotation)
@@ -512,6 +584,7 @@ class ImagePreview(QWidget):
         self.pixmap_item = None
         self.reference_rect_item = None
         self.view._bw_rect_item = None
+        self._crop_overlay_item = None
 
         self.parent().parent().sliders_panel.set_current_idx(idx)
 
@@ -524,7 +597,10 @@ class ImagePreview(QWidget):
             print("Loaded reference_frame from backend:", ref)
             if ref:
                 x1, y1, x2, y2 = ref
-                rect = QRectF(x1, y1, x2 - x1, y2 - y1)
+                # Backend rect is in full-image coords; shift into the
+                # displayed (possibly cropped) pixmap's coordinate space.
+                dx, dy = self._crop_display_offset
+                rect = QRectF(x1 - dx, y1 - dy, x2 - x1, y2 - y1)
                 self.reference_rect_item = QGraphicsRectItem(rect)
                 pen = QPen(QColor(255, 0, 0, 180), 2, Qt.DashLine)
                 self.reference_rect_item.setPen(pen)
@@ -628,7 +704,18 @@ class ImagePreview(QWidget):
         # Always fit the view to the content consistently
         self._fit_view_to_content()
 
+    def _end_fine_rot_burst(self):
+        self._fine_rot_burst_active = False
+
     def _on_slider_rotate(self, value):
+        # Snapshot once per burst, and only for real user changes (the slider
+        # is also set programmatically to the backend value on image switch).
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is not None and img.fine_rotation_angle != value:
+            if not self._fine_rot_burst_active:
+                img.push_undo_state()
+                self._fine_rot_burst_active = True
+            self._fine_rot_burst_timer.start(800)
         self.current_fine_rotation = value
         ccr_backend.set_image_fine_rotation_by_index(self.current_idx, value)
         self.apply_transformations()
@@ -641,23 +728,32 @@ class ImagePreview(QWidget):
         self.show_grid = False
         self.view.viewport().update()
 
+    def _push_undo_for_current(self):
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is not None:
+            img.push_undo_state()
+
     def rotate_left(self):
+        self._push_undo_for_current()
         self.current_rotation = (self.current_rotation - 90) % 360
         ccr_backend.set_image_rotation_by_index(self.current_idx, self.current_rotation)
         self.apply_transformations()
 
     def rotate_right(self):
+        self._push_undo_for_current()
         self.current_rotation = (self.current_rotation + 90) % 360
         ccr_backend.set_image_rotation_by_index(self.current_idx, self.current_rotation)
         self.apply_transformations()
 
     def mirror_vertical(self):
+        self._push_undo_for_current()
         flip = ccr_backend.get_image_vertical_flip_by_index(self.current_idx)
         ccr_backend.set_image_vertical_flip_by_index(self.current_idx, not flip)
         self.current_vertical_flip = not flip
         self.apply_transformations()
 
     def mirror_horizontal(self):
+        self._push_undo_for_current()
         flip = ccr_backend.get_image_horizontal_flip_by_index(self.current_idx)
         ccr_backend.set_image_horizontal_flip_by_index(self.current_idx, not flip)
         self.current_horizontal_flip = not flip
@@ -706,6 +802,172 @@ class ImagePreview(QWidget):
         self.view.wb_pick_mode = enabled
         self.view.bwpoint_mode = None
         self.view.setCursor(_eyedropper_cursor() if enabled else Qt.ArrowCursor)
+
+    # --- Crop mode -----------------------------------------------------
+
+    def displayed_crop_offset(self):
+        """Pixel offset of the displayed pixmap within the full preview image.
+        (0, 0) unless a confirmed crop is currently being displayed."""
+        return self._crop_display_offset
+
+    @staticmethod
+    def _crop_rect_to_pixels(crop, pixmap) -> "QRect | None":
+        """Convert a normalized (x1, y1, x2, y2) crop to a QRect in pixmap
+        pixels, or None when the rect is degenerate."""
+        w, h = pixmap.width(), pixmap.height()
+        if w <= 0 or h <= 0:
+            return None
+        x1 = max(0, min(w - 1, int(round(crop[0] * w))))
+        y1 = max(0, min(h - 1, int(round(crop[1] * h))))
+        x2 = max(x1 + 1, min(w, int(round(crop[2] * w))))
+        y2 = max(y1 + 1, min(h, int(round(crop[3] * h))))
+        if (x2 - x1) < 2 or (y2 - y1) < 2:
+            return None
+        return QRect(x1, y1, x2 - x1, y2 - y1)
+
+    def _base_transform(self):
+        """Coarse flip/rotation transform around the displayed pixmap center
+        (same construction the reference-frame and B/W tools use)."""
+        if self.current_pixmap is None:
+            return None
+        cx = self.current_pixmap.width() / 2
+        cy = self.current_pixmap.height() / 2
+        t = QTransform()
+        t.translate(cx, cy)
+        if self.current_vertical_flip:
+            t.scale(1, -1)
+        if self.current_horizontal_flip:
+            t.scale(-1, 1)
+        if self.current_rotation:
+            t.rotate(self.current_rotation)
+        t.translate(-cx, -cy)
+        return t if t.isInvertible() else None
+
+    def enter_crop_mode(self) -> bool:
+        """Show the full image with the current crop (if any) as the starting
+        selection, so the user can adjust or undo a previous crop."""
+        if self.current_idx is None:
+            return False
+        img_obj = ccr_backend.get_image_by_index(self.current_idx)
+        if img_obj is None or self.current_pixmap is None or self.current_pixmap.isNull():
+            return False
+        # Crop mode replaces any other interactive pick mode
+        self.view.bwpoint_mode = None
+        self.view.wb_pick_mode = False
+        self.crop_mode = True
+        self._pending_crop_local = None
+        self._crop_rerender = True
+        try:
+            self.update_preview(self.current_idx)  # re-render un-cropped
+        finally:
+            self._crop_rerender = False
+        crop = getattr(img_obj, "crop_rect", None)
+        if crop is not None and self.current_pixmap is not None:
+            w, h = self.current_pixmap.width(), self.current_pixmap.height()
+            self._pending_crop_local = QRectF(
+                crop[0] * w, crop[1] * h,
+                (crop[2] - crop[0]) * w, (crop[3] - crop[1]) * h)
+        self._draw_crop_overlay()
+        self.view.setCursor(Qt.CrossCursor)
+        return True
+
+    def update_crop_selection(self, start_scene, end_scene):
+        """Update the pending crop selection from a drag (scene coords)."""
+        base = self._base_transform()
+        if base is None or self.current_pixmap is None:
+            return
+        inv = base.inverted()[0]
+        s = inv.map(start_scene)
+        e = inv.map(end_scene)
+        w, h = self.current_pixmap.width(), self.current_pixmap.height()
+        x1 = max(0.0, min(float(w), min(s.x(), e.x())))
+        y1 = max(0.0, min(float(h), min(s.y(), e.y())))
+        x2 = max(0.0, min(float(w), max(s.x(), e.x())))
+        y2 = max(0.0, min(float(h), max(s.y(), e.y())))
+        self._pending_crop_local = QRectF(x1, y1, x2 - x1, y2 - y1)
+        self._draw_crop_overlay()
+
+    def _draw_crop_overlay(self):
+        """Dim everything outside the pending crop selection so both the
+        entire image and the crop target stay visible."""
+        if self._crop_overlay_item is not None:
+            try:
+                self.scene.removeItem(self._crop_overlay_item)
+            except RuntimeError:
+                pass
+            self._crop_overlay_item = None
+        if not self.crop_mode or self.current_pixmap is None:
+            return
+        sel = self._pending_crop_local
+        if sel is None or sel.width() < 2 or sel.height() < 2:
+            return
+        path = QPainterPath()
+        path.setFillRule(Qt.OddEvenFill)
+        path.addRect(QRectF(0, 0, self.current_pixmap.width(), self.current_pixmap.height()))
+        path.addRect(sel)
+        item = QGraphicsPathItem(path)
+        item.setBrush(QBrush(QColor(0, 0, 0, 110)))
+        item.setPen(QPen(QColor(255, 255, 255, 220), 2, Qt.DashLine))
+        base = self._base_transform()
+        if base is not None:
+            item.setTransform(base)
+        self.scene.addItem(item)
+        self._crop_overlay_item = item
+
+    def confirm_crop(self):
+        """Enter pressed in crop mode: store the selection as the new crop.
+        Display-level only — the conversion result is untouched."""
+        if not self.crop_mode:
+            return
+        img_obj = ccr_backend.get_image_by_index(self.current_idx)
+        sel = self._pending_crop_local
+        if (img_obj is not None and sel is not None and self.current_pixmap is not None
+                and sel.width() >= 10 and sel.height() >= 10):
+            w, h = self.current_pixmap.width(), self.current_pixmap.height()
+            new_crop = (max(0.0, sel.left() / w), max(0.0, sel.top() / h),
+                        min(1.0, sel.right() / w), min(1.0, sel.bottom() / h))
+            # Selecting (almost) the whole image clears the crop
+            if (new_crop[0] <= 0.001 and new_crop[1] <= 0.001
+                    and new_crop[2] >= 0.999 and new_crop[3] >= 0.999):
+                new_crop = None
+            if new_crop != img_obj.crop_rect:
+                img_obj.push_undo_state()
+                img_obj.crop_rect = new_crop
+        self._exit_crop_mode()
+        self.update_preview(self.current_idx)
+        try:
+            self.parent().parent().sliders_panel.set_temporary_hint(
+                "Crop applied. Ctrl+Z to undo, or press Crop again to adjust.", duration=4000)
+        except AttributeError:
+            pass
+
+    def cancel_crop_mode(self):
+        """Esc pressed in crop mode: leave without changing the crop."""
+        if not self.crop_mode:
+            return
+        self._exit_crop_mode()
+        self.update_preview(self.current_idx)
+
+    def clear_crop(self):
+        """Right-click in crop mode: remove the crop entirely."""
+        img_obj = ccr_backend.get_image_by_index(self.current_idx)
+        if img_obj is not None and img_obj.crop_rect is not None:
+            img_obj.push_undo_state()
+            img_obj.crop_rect = None
+        self._exit_crop_mode()
+        self.update_preview(self.current_idx)
+
+    def _exit_crop_mode(self):
+        self.crop_mode = False
+        self._pending_crop_local = None
+        self.view._crop_drag_start = None
+        if self._crop_overlay_item is not None:
+            try:
+                self.scene.removeItem(self._crop_overlay_item)
+            except RuntimeError:
+                pass
+            self._crop_overlay_item = None
+        self.view.setCursor(Qt.ArrowCursor)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -504,12 +504,15 @@ class SlidersPanel(QWidget):
                 self.slider_value_labels[i].setText("0")
             return
 
+        # Missing keys count as 0 so a partial dict can never leave a slider
+        # showing the previously selected image's value.
         for i, key in enumerate(self.adjustment_keys):
-            if key in adjustment and i < len(self.sliders):
+            if i < len(self.sliders):
+                val = adjustment.get(key, 0)
                 self.sliders[i].blockSignals(True)
-                self.sliders[i].setValue(adjustment[key])
+                self.sliders[i].setValue(val)
                 self.sliders[i].blockSignals(False)
-                self.slider_value_labels[i].setText(str(adjustment[key]))
+                self.slider_value_labels[i].setText(str(val))
         if idx is not None:
             ccr_backend.apply_adjustment_by_index(idx)
 
@@ -674,17 +677,25 @@ class SlidersPanel(QWidget):
             if not adj_changes and not crop_changes:
                 continue  # nothing to change — and no dead undo snapshot
             img.push_undo_state()
-            merged = dict(img.adjustment_settings)
-            for k in keys:
-                merged[k] = current_adjustment.get(k, 0)
-            img.adjustment_settings = merged
+            if adj_changes:
+                # Build a COMPLETE dict (missing keys filled with 0) so the
+                # rest of the app keeps its invariant that a non-empty
+                # adjustment dict carries every key — set_current_idx and
+                # friends rely on it.
+                merged = {k: img.adjustment_settings.get(k, 0) for k in self.adjustment_keys}
+                for k in keys:
+                    merged[k] = current_adjustment.get(k, 0)
+                img.adjustment_settings = merged
             if sync_crop:
                 img.crop_rect = crop_rect
                 img.crop_angle = crop_angle
-            try:
-                img.update_thumbnail_and_preview()
-            except Exception as e:
-                print(f"Failed to sync settings to {img.file_path}: {e}")
+            if adj_changes:
+                # Crop is display/export-level only — no reprocessing needed
+                # when nothing but the crop changed.
+                try:
+                    img.update_thumbnail_and_preview()
+                except Exception as e:
+                    print(f"Failed to sync settings to {img.file_path}: {e}")
 
         mw = self.parent().parent()
         try:

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -513,8 +513,15 @@ class SlidersPanel(QWidget):
     def _end_undo_burst(self):
         self._undo_burst_active = False
 
+    def end_undo_burst(self):
+        """End any in-progress slider undo burst (after an undo or an action
+        that pushes its own snapshot) so the next change gets a fresh one."""
+        self._end_undo_burst()
+        self._undo_burst_timer.stop()
+
     def on_reset_clicked(self):
         # Reset is a single undoable action
+        self.end_undo_burst()
         img = ccr_backend.get_image_by_index(self.current_idx) if self.current_idx is not None else None
         if img is not None:
             img.push_undo_state()
@@ -571,12 +578,15 @@ class SlidersPanel(QWidget):
     
     def _perform_sync_to_all(self):
         """Perform the actual sync operation after UI update."""
-        # Each image gets its own undo snapshot so Ctrl+Z can revert the sync
-        # on whichever image is selected.
-        for img in ccr_backend.images:
-            img.push_undo_state()
+        self.end_undo_burst()
         # Get the current adjustment settings
         current_adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
+        # Each image whose settings will actually change gets its own undo
+        # snapshot, so Ctrl+Z can revert the sync on whichever image is
+        # selected — without dead no-op entries on already-matching images.
+        for img in ccr_backend.images:
+            if img.adjustment_settings != current_adjustment:
+                img.push_undo_state()
         print(f"Syncing adjustment to all images: {current_adjustment}")
         
         # Apply to all images in the backend
@@ -603,6 +613,8 @@ class SlidersPanel(QWidget):
 
     def on_wb_sampled(self, temp_value, tint_value):
         """Apply the auto-computed temperature/tint from the WB eyedropper."""
+        # The WB pick is its own undo step — don't merge it into a slider burst
+        self.end_undo_burst()
         temp_idx = self.adjustment_keys.index("temperature")
         tint_idx = self.adjustment_keys.index("tint")
         for idx, val in ((temp_idx, temp_value), (tint_idx, tint_value)):
@@ -711,6 +723,7 @@ class SlidersPanel(QWidget):
         """
         if self.current_idx is not None and self.copied_adjustment is not None:
             print(f"Pasting adjustment settings: {self.copied_adjustment}")
+            self.end_undo_burst()
             img = ccr_backend.get_image_by_index(self.current_idx)
             if img is not None:
                 img.push_undo_state()

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -115,11 +115,13 @@ class SlidersPanel(QWidget):
         self.slider_labels = []
         self.image_slider_map = {}
         self.current_image_id = None
+        # Order must match the create_slider() call order exactly — the two
+        # lists are zipped positionally.
         self.adjustment_keys = [
             "temperature", "tint", "exposure", "brightness", "highlights",
             "white_point", "shadows", "black_point", "contrast", "saturation",
-            # Per-channel levels controls — appended so existing positional
-            # zip(adjustment_keys, sliders) indices are unchanged.
+            "sub_saturation",
+            # Per-channel levels controls (collapsible section, created last)
             "ch_input_gain", "ch_master_shift", "ch_master_gain",
             "ch_r_shift", "ch_r_gain", "ch_r_blackpoint",
             "ch_g_shift", "ch_g_gain", "ch_g_blackpoint",
@@ -133,7 +135,13 @@ class SlidersPanel(QWidget):
         self._processing = False
         self._pending_adjustment = None
         self._pending_idx = None
-        
+
+        # Coalesce rapid slider changes (one drag) into a single undo step.
+        self._undo_burst_active = False
+        self._undo_burst_timer = QTimer(self)
+        self._undo_burst_timer.setSingleShot(True)
+        self._undo_burst_timer.timeout.connect(self._end_undo_burst)
+
         self.initUI()
         self.setup_shortcuts()
         self._debounce_timer = QTimer(self)
@@ -174,7 +182,8 @@ class SlidersPanel(QWidget):
 
         self.slider_labels = [
             "Temperature", "Tint", "Exposure", "Brightness",
-            "Highlights", "White Point", "Shadows", "Black Point", "Contrast", "Saturation"
+            "Highlights", "White Point", "Shadows", "Black Point", "Contrast", "Saturation",
+            "Subtracted Sat"
         ]
 
         self.current_idx = None
@@ -211,7 +220,16 @@ class SlidersPanel(QWidget):
         self.wb_picker_btn.setToolTip(
             "Click, then pick a neutral gray/white point on the image "
             "to auto-set Temperature and Tint.")
-        scroll_layout.addWidget(self.wb_picker_btn, alignment=Qt.AlignLeft)
+        # Crop: non-destructive crop of the preview/export (same gating).
+        self.crop_btn = QPushButton("Crop")
+        self.crop_btn.setToolTip(
+            "Crop the image. Drag to set the area, Enter to confirm, "
+            "Esc to cancel, right-click to clear the crop.")
+        wb_crop_row = QHBoxLayout()
+        wb_crop_row.addWidget(self.wb_picker_btn)
+        wb_crop_row.addWidget(self.crop_btn)
+        wb_crop_row.addStretch()
+        scroll_layout.addLayout(wb_crop_row)
 
         self.temperature_slider_layout = self.create_slider("Temperature")
         self.tint_slider_layout = self.create_slider("Tint")
@@ -223,6 +241,7 @@ class SlidersPanel(QWidget):
         self.black_point_slider_layout = self.create_slider("Black Point")
         self.contrast_slider_layout = self.create_slider("Contrast")
         self.saturation_slider_layout = self.create_slider("Saturation")
+        self.sub_saturation_slider_layout = self.create_slider("Subtracted Sat")
 
         scroll_layout.addLayout(self.temperature_slider_layout)
         scroll_layout.addLayout(self.tint_slider_layout)
@@ -234,6 +253,7 @@ class SlidersPanel(QWidget):
         scroll_layout.addLayout(self.black_point_slider_layout)
         scroll_layout.addLayout(self.contrast_slider_layout)
         scroll_layout.addLayout(self.saturation_slider_layout)
+        scroll_layout.addLayout(self.sub_saturation_slider_layout)
 
         # --- Reset / Compare / Sync buttons ---
         buttons_layout = QHBoxLayout()
@@ -301,6 +321,7 @@ class SlidersPanel(QWidget):
         self.compare_button.setCheckable(False)
         self.sync_to_all_button.clicked.connect(self.on_sync_to_all_clicked)
         self.wb_picker_btn.clicked.connect(self._on_pick_neutral_point)
+        self.crop_btn.clicked.connect(self._on_crop_clicked)
         self.white_point_btn.clicked.connect(self._on_set_white_point)
         self.black_point_btn.clicked.connect(self._on_set_black_point)
         self.convert_current_bwp_btn.clicked.connect(self._on_convert_current_bwpoint)
@@ -382,6 +403,7 @@ class SlidersPanel(QWidget):
     def set_sliders_enabled(self, enabled: bool):
         print(f"Setting sliders enabled: {enabled}")
         self.wb_picker_btn.setEnabled(enabled)
+        self.crop_btn.setEnabled(enabled)
         for slider in self.sliders:
             slider.setEnabled(enabled)
             if not enabled:
@@ -398,7 +420,12 @@ class SlidersPanel(QWidget):
         self._pending_adjustment = None
         self._pending_idx = None
         self._debounce_timer.stop()
-        
+        # End the undo burst only on a real image switch — this method is
+        # also re-entered on same-image refreshes during a slider drag.
+        if idx != self.current_idx:
+            self._end_undo_burst()
+            self._undo_burst_timer.stop()
+
         self.current_idx = idx
         adjustment = ccr_backend.get_adjustment_by_index(idx)
         print(f"Setting current index: {idx}, adjustment: {adjustment}")
@@ -428,9 +455,12 @@ class SlidersPanel(QWidget):
         """
         if self.current_idx is not None:
             adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
-            
+
             # Immediate lightweight feedback - just store the adjustment settings
             if 0 <= self.current_idx < len(ccr_backend.images):
+                # Snapshot the pre-change state once per burst so a whole
+                # slider drag undoes as a single Ctrl+Z step.
+                self._begin_undo_burst(ccr_backend.images[self.current_idx])
                 ccr_backend.images[self.current_idx].adjustment_settings = adjustment
             
             # Immediate preview update for visual feedback
@@ -472,7 +502,22 @@ class SlidersPanel(QWidget):
     def get_slider_values(self):
         return {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
 
+    def _begin_undo_burst(self, img):
+        """Push one undo snapshot at the start of a burst of rapid slider
+        changes; the burst ends after a short idle period."""
+        if not self._undo_burst_active:
+            img.push_undo_state()
+            self._undo_burst_active = True
+        self._undo_burst_timer.start(800)
+
+    def _end_undo_burst(self):
+        self._undo_burst_active = False
+
     def on_reset_clicked(self):
+        # Reset is a single undoable action
+        img = ccr_backend.get_image_by_index(self.current_idx) if self.current_idx is not None else None
+        if img is not None:
+            img.push_undo_state()
         # Set all sliders to 0 and update preview
         for i, slider in enumerate(self.sliders):
             slider.blockSignals(True)
@@ -526,6 +571,10 @@ class SlidersPanel(QWidget):
     
     def _perform_sync_to_all(self):
         """Perform the actual sync operation after UI update."""
+        # Each image gets its own undo snapshot so Ctrl+Z can revert the sync
+        # on whichever image is selected.
+        for img in ccr_backend.images:
+            img.push_undo_state()
         # Get the current adjustment settings
         current_adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
         print(f"Syncing adjustment to all images: {current_adjustment}")
@@ -544,6 +593,13 @@ class SlidersPanel(QWidget):
             self.image_preview.set_wb_pick_mode(True)
             self.set_temporary_hint(
                 "<b>Auto WB:</b> Click a neutral gray or white point on the image.", duration=8000)
+
+    def _on_crop_clicked(self):
+        if hasattr(self, 'image_preview') and self.image_preview:
+            if self.image_preview.enter_crop_mode():
+                self.set_temporary_hint(
+                    "<b>Crop:</b> Drag to set the crop area. <b>Enter</b> = confirm, "
+                    "<b>Esc</b> = cancel, right-click = clear crop.", duration=12000)
 
     def on_wb_sampled(self, temp_value, tint_value):
         """Apply the auto-computed temperature/tint from the WB eyedropper."""
@@ -655,7 +711,10 @@ class SlidersPanel(QWidget):
         """
         if self.current_idx is not None and self.copied_adjustment is not None:
             print(f"Pasting adjustment settings: {self.copied_adjustment}")
-            
+            img = ccr_backend.get_image_by_index(self.current_idx)
+            if img is not None:
+                img.push_undo_state()
+
             # Apply the copied settings to the current sliders
             for i, key in enumerate(self.adjustment_keys):
                 if key in self.copied_adjustment and i < len(self.sliders):

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -1,9 +1,71 @@
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QSlider, QLabel, QHBoxLayout,
                                 QSizePolicy, QStyleOptionSlider, QFrame, QStyle,
-                                QPushButton, QDialog, QMessageBox, QScrollArea)
+                                QPushButton, QDialog, QMessageBox, QScrollArea,
+                                QCheckBox)
 from PySide6.QtCore import Qt, QTimer, QThread, Signal
 from PySide6.QtGui import QPixmap, QKeySequence, QShortcut
 from core.ccr_backend import ccr_backend
+
+# Setting groups offered by the "Sync to All" dialog. The adjustment-key
+# groups partition SlidersPanel.ADJUSTMENT_KEYS exactly; "crop" syncs the
+# image's crop box (rect + angle) instead of adjustment keys.
+SYNC_GROUPS = [
+    ("wb", "White Balance / Tint", ("temperature", "tint")),
+    ("tone", "Tone (exposure, brightness, contrast, ...)",
+     ("exposure", "brightness", "highlights", "white_point",
+      "shadows", "black_point", "contrast")),
+    ("sat", "Saturation", ("saturation", "sub_saturation")),
+    ("crop", "Crop", ()),
+    ("channels", "Channel Levels", (
+        "ch_input_gain", "ch_master_shift", "ch_master_gain",
+        "ch_r_shift", "ch_r_gain", "ch_r_blackpoint",
+        "ch_g_shift", "ch_g_gain", "ch_g_blackpoint",
+        "ch_b_shift", "ch_b_gain", "ch_b_blackpoint")),
+]
+
+
+class SyncSettingsDialog(QDialog):
+    """Pick which setting groups 'Sync to All' copies to every image."""
+
+    def __init__(self, parent=None, selection=None):
+        super().__init__(parent)
+        self.setWindowTitle("Sync to All")
+        self.setMinimumWidth(280)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Sync these settings to all images:"))
+
+        self._checkboxes = {}
+        for gid, label, _keys in SYNC_GROUPS:
+            checkbox = QCheckBox(label)
+            checkbox.setChecked(True if selection is None else selection.get(gid, True))
+            layout.addWidget(checkbox)
+            self._checkboxes[gid] = checkbox
+
+        select_row = QHBoxLayout()
+        select_all_btn = QPushButton("Select All")
+        deselect_all_btn = QPushButton("Deselect All")
+        select_all_btn.clicked.connect(lambda: self._set_all(True))
+        deselect_all_btn.clicked.connect(lambda: self._set_all(False))
+        select_row.addWidget(select_all_btn)
+        select_row.addWidget(deselect_all_btn)
+        layout.addLayout(select_row)
+
+        button_row = QHBoxLayout()
+        sync_btn = QPushButton("Sync")
+        sync_btn.setDefault(True)
+        cancel_btn = QPushButton("Cancel")
+        sync_btn.clicked.connect(self.accept)
+        cancel_btn.clicked.connect(self.reject)
+        button_row.addWidget(sync_btn)
+        button_row.addWidget(cancel_btn)
+        layout.addLayout(button_row)
+
+    def _set_all(self, checked: bool):
+        for checkbox in self._checkboxes.values():
+            checkbox.setChecked(checked)
+
+    def selection(self) -> dict:
+        return {gid: checkbox.isChecked() for gid, checkbox in self._checkboxes.items()}
 
 class CollapsibleSection(QWidget):
     """A toggle-button header that shows/hides its content widget. Default: collapsed."""
@@ -108,6 +170,19 @@ class ResettableSlider(QSlider):
         event.accept()
 
 class SlidersPanel(QWidget):
+    # Order must match the create_slider() call order exactly — the two
+    # lists are zipped positionally.
+    ADJUSTMENT_KEYS = [
+        "temperature", "tint", "exposure", "brightness", "highlights",
+        "white_point", "shadows", "black_point", "contrast", "saturation",
+        "sub_saturation",
+        # Per-channel levels controls (collapsible section, created last)
+        "ch_input_gain", "ch_master_shift", "ch_master_gain",
+        "ch_r_shift", "ch_r_gain", "ch_r_blackpoint",
+        "ch_g_shift", "ch_g_gain", "ch_g_blackpoint",
+        "ch_b_shift", "ch_b_gain", "ch_b_blackpoint",
+    ]
+
     def __init__(self, parent=None):
         super().__init__()
         self.sliders = []
@@ -115,18 +190,8 @@ class SlidersPanel(QWidget):
         self.slider_labels = []
         self.image_slider_map = {}
         self.current_image_id = None
-        # Order must match the create_slider() call order exactly — the two
-        # lists are zipped positionally.
-        self.adjustment_keys = [
-            "temperature", "tint", "exposure", "brightness", "highlights",
-            "white_point", "shadows", "black_point", "contrast", "saturation",
-            "sub_saturation",
-            # Per-channel levels controls (collapsible section, created last)
-            "ch_input_gain", "ch_master_shift", "ch_master_gain",
-            "ch_r_shift", "ch_r_gain", "ch_r_blackpoint",
-            "ch_g_shift", "ch_g_gain", "ch_g_blackpoint",
-            "ch_b_shift", "ch_b_gain", "ch_b_blackpoint",
-        ]
+        self.adjustment_keys = list(self.ADJUSTMENT_KEYS)
+        self._sync_group_selection = None  # remembered while the app is open
         self.copied_adjustment = None  # Store copied adjustment settings
         self._hint_timer = QTimer(self)  # Timer for temporary hints
         self._hint_timer.setSingleShot(True)
@@ -223,8 +288,9 @@ class SlidersPanel(QWidget):
         # Crop: non-destructive crop of the preview/export (same gating).
         self.crop_btn = QPushButton("Crop")
         self.crop_btn.setToolTip(
-            "Crop the image. Drag to set the area, Enter to confirm, "
-            "Esc to cancel, right-click to clear the crop.")
+            "Crop the image. Drag to draw a box; drag the handles to resize, "
+            "the top knob to rotate, the center to move. Enter confirms, "
+            "Esc cancels, right-click clears the crop.")
         wb_crop_row = QHBoxLayout()
         wb_crop_row.addWidget(self.wb_picker_btn)
         wb_crop_row.addWidget(self.crop_btn)
@@ -567,36 +633,68 @@ class SlidersPanel(QWidget):
 
     def on_sync_to_all_clicked(self):
         """
-        Apply the current image's adjustment settings to all images.
+        Apply the current image's settings to all images. A dialog picks
+        which setting groups to sync; the choice is remembered while the
+        app is open.
         """
-        if self.current_idx is not None:
-            # Show syncing hint
-            self.set_hint("Syncing adjustments to all images...")
-            
-            # Use QTimer to allow UI to update before starting the operation
-            QTimer.singleShot(100, self._perform_sync_to_all)
-    
+        if self.current_idx is None:
+            return
+        dialog = SyncSettingsDialog(self, self._sync_group_selection)
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        self._sync_group_selection = dialog.selection()
+        if not any(self._sync_group_selection.values()):
+            self.set_temporary_hint("Nothing selected to sync.", duration=3000)
+            return
+        # Show syncing hint
+        self.set_hint("Syncing settings to all images...")
+
+        # Use QTimer to allow UI to update before starting the operation
+        QTimer.singleShot(100, self._perform_sync_to_all)
+
     def _perform_sync_to_all(self):
-        """Perform the actual sync operation after UI update."""
+        """Sync the selected setting groups from the current image to all
+        images, leaving each image's un-synced groups untouched."""
         self.end_undo_burst()
-        # Get the current adjustment settings
+        selection = self._sync_group_selection or {gid: True for gid, _l, _k in SYNC_GROUPS}
+        keys = [k for gid, _label, group_keys in SYNC_GROUPS
+                if selection.get(gid) for k in group_keys]
+        sync_crop = bool(selection.get("crop"))
         current_adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
-        # Each image whose settings will actually change gets its own undo
-        # snapshot, so Ctrl+Z can revert the sync on whichever image is
-        # selected — without dead no-op entries on already-matching images.
+        src = ccr_backend.get_image_by_index(self.current_idx)
+        crop_rect = src.crop_rect if src is not None else None
+        crop_angle = getattr(src, "crop_angle", 0.0) if src is not None else 0.0
+        print(f"Syncing groups {sorted(g for g, on in selection.items() if on)} to all images")
+
         for img in ccr_backend.images:
-            if img.adjustment_settings != current_adjustment:
-                img.push_undo_state()
-        print(f"Syncing adjustment to all images: {current_adjustment}")
-        
-        # Apply to all images in the backend
-        ccr_backend.sync_adjustment_to_all(current_adjustment)
-        
-        # Update the preview for the current image to reflect any changes
-        self.parent().parent().image_preview.update_preview(self.current_idx)
-        
+            adj_changes = any(img.adjustment_settings.get(k, 0) != current_adjustment.get(k, 0)
+                              for k in keys)
+            crop_changes = sync_crop and (img.crop_rect != crop_rect
+                                          or getattr(img, "crop_angle", 0.0) != crop_angle)
+            if not adj_changes and not crop_changes:
+                continue  # nothing to change — and no dead undo snapshot
+            img.push_undo_state()
+            merged = dict(img.adjustment_settings)
+            for k in keys:
+                merged[k] = current_adjustment.get(k, 0)
+            img.adjustment_settings = merged
+            if sync_crop:
+                img.crop_rect = crop_rect
+                img.crop_angle = crop_angle
+            try:
+                img.update_thumbnail_and_preview()
+            except Exception as e:
+                print(f"Failed to sync settings to {img.file_path}: {e}")
+
+        mw = self.parent().parent()
+        try:
+            mw.thumbnail_list.update_all_thumbnails()
+        except AttributeError:
+            pass
+        mw.image_preview.update_preview(self.current_idx)
+
         # Show completion hint
-        self.set_temporary_hint("Synced all adjustments!", duration=4000)
+        self.set_temporary_hint("Synced selected settings to all images!", duration=4000)
 
     def _on_pick_neutral_point(self):
         if hasattr(self, 'image_preview') and self.image_preview:
@@ -608,7 +706,8 @@ class SlidersPanel(QWidget):
         if hasattr(self, 'image_preview') and self.image_preview:
             if self.image_preview.enter_crop_mode():
                 self.set_temporary_hint(
-                    "<b>Crop:</b> Drag to set the crop area. <b>Enter</b> = confirm, "
+                    "<b>Crop:</b> Drag to draw a box; drag handles to resize, "
+                    "top knob to rotate, center to move. <b>Enter</b> = confirm, "
                     "<b>Esc</b> = cancel, right-click = clear crop.", duration=12000)
 
     def on_wb_sampled(self, temp_value, tint_value):

--- a/tests/test_sub_saturation_crop_undo.py
+++ b/tests/test_sub_saturation_crop_undo.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Tests for the subtracted (film-density) saturation slider, the non-destructive
+crop helper, and the per-image undo stack.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.ccr_processor import adjust_image, adjust_image_opencl, apply_crop_to_image  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+
+
+def _test_image():
+    """Small image with neutral, saturated, black, and white pixels."""
+    img = np.zeros((2, 3, 3), dtype=np.uint16)
+    img[0, 0] = (30000, 30000, 30000)   # neutral gray
+    img[0, 1] = (60000, 30000, 10000)   # saturated orange
+    img[0, 2] = (10000, 50000, 20000)   # saturated green
+    img[1, 0] = (0, 0, 0)               # black
+    img[1, 1] = (65535, 65535, 65535)   # white
+    img[1, 2] = (200, 100, 50)          # dark saturated
+    return img
+
+
+class TestSubtractedSaturation:
+    def test_zero_is_identity(self):
+        img = _test_image()
+        out = adjust_image(img, sub_saturation=0)
+        assert np.array_equal(out, img)
+
+    def test_neutral_pixels_unchanged(self):
+        img = _test_image()
+        for amount in (-100, -50, 25, 100):
+            out = adjust_image(img, sub_saturation=amount)
+            # gray, black, and white pixels must stay neutral and unmoved
+            for pos in ((0, 0), (1, 0), (1, 1)):
+                np.testing.assert_allclose(
+                    out[pos].astype(np.int64), img[pos].astype(np.int64), atol=2)
+
+    def test_positive_darkens_non_dominant_channels(self):
+        img = _test_image()
+        out = adjust_image(img, sub_saturation=50).astype(np.int64)
+        src = img.astype(np.int64)
+        # Dominant channel is pinned; the others are darkened (denser color)
+        assert abs(out[0, 1, 0] - src[0, 1, 0]) <= 2          # R (max) pinned
+        assert out[0, 1, 1] < src[0, 1, 1] - 100              # G darkened
+        assert out[0, 1, 2] < src[0, 1, 2] - 100              # B darkened
+        assert abs(out[0, 2, 1] - src[0, 2, 1]) <= 2          # G (max) pinned
+        assert out[0, 2, 0] < src[0, 2, 0] - 100
+        assert out[0, 2, 2] < src[0, 2, 2] - 100
+        # Total light is reduced: saturation comes from absorption
+        assert out[0, 1].sum() < src[0, 1].sum()
+
+    def test_negative_desaturates_toward_dominant(self):
+        img = _test_image()
+        out = adjust_image(img, sub_saturation=-50).astype(np.int64)
+        src = img.astype(np.int64)
+        assert abs(out[0, 1, 0] - src[0, 1, 0]) <= 2          # R (max) pinned
+        assert out[0, 1, 1] > src[0, 1, 1] + 100              # G lifted toward R
+        assert out[0, 1, 2] > src[0, 1, 2] + 100              # B lifted toward R
+
+    def test_opencl_matches_cpu(self):
+        img = _test_image()
+        cpu = adjust_image(img, sub_saturation=40)
+        gpu = adjust_image_opencl(img, sub_saturation=40)
+        np.testing.assert_allclose(cpu.astype(np.int64), gpu.astype(np.int64), atol=2)
+
+    def test_combines_with_regular_saturation(self):
+        img = _test_image()
+        out = adjust_image(img, saturation=30, sub_saturation=30)
+        assert out.shape == img.shape
+        assert out.dtype == np.uint16
+
+
+class TestApplyCrop:
+    def test_none_returns_input(self):
+        img = _test_image()
+        assert apply_crop_to_image(img, None) is img
+
+    def test_basic_crop_dimensions(self):
+        img = np.zeros((100, 200, 3), dtype=np.uint16)
+        out = apply_crop_to_image(img, (0.25, 0.10, 0.75, 0.90))
+        assert out.shape == (80, 100, 3)
+
+    def test_full_rect_is_identity_shape(self):
+        img = np.zeros((50, 60, 3), dtype=np.uint16)
+        out = apply_crop_to_image(img, (0.0, 0.0, 1.0, 1.0))
+        assert out.shape == img.shape
+
+    def test_degenerate_rect_returns_input(self):
+        img = np.zeros((50, 60, 3), dtype=np.uint16)
+        out = apply_crop_to_image(img, (0.5, 0.5, 0.5, 0.5))
+        assert out.shape == img.shape
+
+    def test_out_of_range_rect_is_clamped(self):
+        img = np.zeros((50, 60, 3), dtype=np.uint16)
+        out = apply_crop_to_image(img, (-0.5, -0.5, 1.5, 1.5))
+        assert out.shape == img.shape
+
+    def test_crop_selects_expected_region(self):
+        img = np.arange(10 * 10 * 3, dtype=np.uint16).reshape(10, 10, 3)
+        out = apply_crop_to_image(img, (0.2, 0.3, 0.7, 0.8))
+        np.testing.assert_array_equal(out, img[3:8, 2:7])
+
+
+def _stub_image():
+    """CCRImage without the heavy file-loading __init__."""
+    img = CCRImage.__new__(CCRImage)
+    img.adjustment_settings = {}
+    img.crop_rect = None
+    img.rotation_angle = 0
+    img.fine_rotation_angle = 0
+    img.horizontal_mirrored = False
+    img.vertical_mirrored = False
+    img.undo_stack = []
+    return img
+
+
+class TestUndoStack:
+    def test_pop_empty_returns_false(self):
+        img = _stub_image()
+        assert img.pop_undo_state() is False
+
+    def test_push_then_pop_restores_state(self):
+        img = _stub_image()
+        img.adjustment_settings = {"temperature": 10}
+        img.push_undo_state()
+        img.adjustment_settings = {"temperature": 50}
+        img.crop_rect = (0.1, 0.1, 0.9, 0.9)
+        img.rotation_angle = 90
+        assert img.pop_undo_state() is True
+        assert img.adjustment_settings == {"temperature": 10}
+        assert img.crop_rect is None
+        assert img.rotation_angle == 0
+
+    def test_multiple_undo_steps(self):
+        img = _stub_image()
+        for temp in (10, 20, 30):
+            img.push_undo_state()
+            img.adjustment_settings = {"temperature": temp}
+        assert img.pop_undo_state()
+        assert img.adjustment_settings == {"temperature": 20}
+        assert img.pop_undo_state()
+        assert img.adjustment_settings == {"temperature": 10}
+        assert img.pop_undo_state()
+        assert img.adjustment_settings == {}
+        assert img.pop_undo_state() is False
+
+    def test_consecutive_identical_snapshots_collapse(self):
+        img = _stub_image()
+        img.push_undo_state()
+        img.push_undo_state()
+        img.push_undo_state()
+        assert len(img.undo_stack) == 1
+
+    def test_stack_is_capped(self):
+        img = _stub_image()
+        for i in range(CCRImage.UNDO_STACK_LIMIT + 25):
+            img.adjustment_settings = {"temperature": i}
+            img.push_undo_state()
+        assert len(img.undo_stack) == CCRImage.UNDO_STACK_LIMIT
+
+    def test_snapshot_is_isolated_from_later_mutation(self):
+        img = _stub_image()
+        img.adjustment_settings = {"temperature": 5}
+        img.push_undo_state()
+        # Mutating the live dict must not corrupt the stored snapshot
+        img.adjustment_settings["temperature"] = 99
+        assert img.pop_undo_state()
+        assert img.adjustment_settings == {"temperature": 5}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_sub_saturation_crop_undo.py
+++ b/tests/test_sub_saturation_crop_undo.py
@@ -110,11 +110,69 @@ class TestApplyCrop:
         np.testing.assert_array_equal(out, img[3:8, 2:7])
 
 
+def _coordinate_image(h=200, w=200):
+    """Image whose channel 0 encodes x*100 and channel 1 encodes y*100."""
+    img = np.zeros((h, w, 3), dtype=np.uint16)
+    img[..., 0] = (np.arange(w, dtype=np.uint16) * 100)[None, :]
+    img[..., 1] = (np.arange(h, dtype=np.uint16) * 100)[:, None]
+    return img
+
+
+class TestRotatedCrop:
+    # Box: center (100, 100), 40 wide x 60 tall, on a 200x200 image
+    CROP = (80 / 200, 70 / 200, 120 / 200, 130 / 200)
+
+    def test_angle_zero_uses_plain_slice(self):
+        img = _coordinate_image()
+        out = apply_crop_to_image(img, self.CROP, 0.0)
+        np.testing.assert_array_equal(out, img[70:130, 80:120])
+
+    def test_rotated_90_orientation(self):
+        # Output (u, v) samples source at C + R(angle).(u - bw/2, v - bh/2);
+        # R is Qt's clockwise-positive rotation, so at 90 deg:
+        # src = (cx - (v - bh/2), cy + (u - bw/2)).
+        img = _coordinate_image()
+        out = apply_crop_to_image(img, self.CROP, 90.0)
+        assert out.shape == (60, 40, 3)
+        assert out[30, 20, 0] == 100 * 100 and out[30, 20, 1] == 100 * 100  # center
+        assert out[10, 10, 0] == 120 * 100  # src x = 100 - (10 - 30) = 120
+        assert out[10, 10, 1] == 90 * 100   # src y = 100 + (10 - 20) = 90
+
+    def test_small_angle_center_is_invariant(self):
+        img = _coordinate_image()
+        out = apply_crop_to_image(img, self.CROP, 7.0)
+        assert out.shape == (60, 40, 3)
+        np.testing.assert_allclose(
+            out[30, 20, :2].astype(np.int64), (100 * 100, 100 * 100), atol=200)
+
+    def test_overhanging_rotated_box_fills_black(self):
+        img = np.full((100, 100, 3), 30000, dtype=np.uint16)
+        # Box centered near the corner, rotated — parts fall outside the image
+        out = apply_crop_to_image(img, (-0.2, -0.2, 0.3, 0.3), 30.0)
+        assert out.shape == (50, 50, 3)
+        assert (out == 0).any()        # black fill outside the source
+        assert (out == 30000).any()    # and real content inside
+
+
+class TestSyncGroups:
+    def test_groups_partition_adjustment_keys(self):
+        from widgets.sliders_panel import SYNC_GROUPS, SlidersPanel
+        keys = [k for _gid, _label, group_keys in SYNC_GROUPS for k in group_keys]
+        assert sorted(keys) == sorted(SlidersPanel.ADJUSTMENT_KEYS)
+        assert len(keys) == len(set(keys))
+
+    def test_expected_group_ids(self):
+        from widgets.sliders_panel import SYNC_GROUPS
+        assert [gid for gid, _l, _k in SYNC_GROUPS] == [
+            "wb", "tone", "sat", "crop", "channels"]
+
+
 def _stub_image():
     """CCRImage without the heavy file-loading __init__."""
     img = CCRImage.__new__(CCRImage)
     img.adjustment_settings = {}
     img.crop_rect = None
+    img.crop_angle = 0.0
     img.rotation_angle = 0
     img.fine_rotation_angle = 0
     img.horizontal_mirrored = False
@@ -134,10 +192,12 @@ class TestUndoStack:
         img.push_undo_state()
         img.adjustment_settings = {"temperature": 50}
         img.crop_rect = (0.1, 0.1, 0.9, 0.9)
+        img.crop_angle = 12.5
         img.rotation_angle = 90
         assert img.pop_undo_state() is True
         assert img.adjustment_settings == {"temperature": 10}
         assert img.crop_rect is None
+        assert img.crop_angle == 0.0
         assert img.rotation_angle == 0
 
     def test_multiple_undo_steps(self):


### PR DESCRIPTION
## Summary

Three features requested together:

### 1. Subtracted saturation slider (below Saturation)
Film-density-style saturation, modeled after subtractive color tools (DaVinci ColorSlice density, [Thatcher Freeman''s utility DCTLs](https://github.com/thatcherfreeman/utility-dctls)): the pixel''s dominant channel is pinned and the chromaticity ratios are raised to a power (`gamma = 2^(slider/100)`), so increasing saturation **darkens** the non-dominant channels — like increasing dye density in film — instead of inflating chroma. Negative values desaturate by lifting toward the dominant channel.
- Implemented identically in the CPU `adjust_image` and the OpenCL kernel (`params[23]`); CPU/GPU parity covered by tests (verified on real OpenCL).
- Neutral pixels (gray/black/white) are exactly unchanged.

### 2. Crop (button to the right of Auto WB Picker)
- Crop mode shows the **entire image** with the current crop outlined and the outside dimmed, so a previous crop is easy to adjust or regret.
- Drag to set the area, **Enter confirms** (display-level only — never triggers a re-convert), **Esc** cancels, **right-click** clears. Selecting the whole image also clears.
- Crop is stored as normalized fractions on `CCRImage`, shown in the preview, and applied at export in both pipelines (before flips/rotation, matching the preview orientation).
- Fine rotation is suppressed during crop mode so the selection bounds exactly the pixels the crop keeps (WYSIWYG).
- WB eyedropper / B/W point sampling / reference-frame drawing stay correct while a cropped preview is displayed (coordinates mapped back through the crop offset).

### 3. Ctrl+Z undo (multi-level)
- Per-image snapshot stack (capped at 50) covering adjustments, crop, 90-degree rotation, flips, and fine rotation; repeated presses walk further back.
- A slider drag coalesces into a single undo step (800 ms burst window); bursts are correctly ended by undo itself, image switches, and snapshot-pushing actions.
- Sync-to-All snapshots every image it actually changes, so the sync is undoable per image.

## Review
The branch went through a 21-agent adversarial review (4 dimensions, every finding independently verified against the code); all 11 confirmed issues were fixed in the second commit — including a crop/fine-rotation WYSIWYG mismatch, pick-mode/crop-mode interference, and undo-burst leak edge cases.

## Tests
- `tests/test_sub_saturation_crop_undo.py`: 18 new tests (saturation math + CPU/OpenCL parity, crop helper geometry, undo stack semantics).
- Full suite: 56 passed; the only failure is the pre-existing time-of-day-flaky `test_days_remaining_calculation`, which also fails on `main`.

## Notes
- Thumbnails intentionally remain un-cropped; the crop shows in the main preview and the export.
- After Un-convert, the full negative (including film base) is shown even if a crop exists, so reference frames can still be drawn; the crop reapplies after re-converting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)