### PR TITLE
Add Color Profile (Color / Black & White) dropdown

### DIFF
--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -108,6 +108,7 @@ def serialize_image(img) -> dict:
         "converted": bool(img.converted),
         "conversion_inputs": _ci_to_json(img.conversion_inputs),
         "adjustment_settings": dict(img.adjustment_settings),
+        "color_profile": getattr(img, "color_profile", "color"),
         "crop_rect": list(img.crop_rect) if img.crop_rect else None,
         "crop_angle": float(img.crop_angle or 0.0),
         "rotation_angle": int(img.rotation_angle),
@@ -125,7 +126,9 @@ def serialize_image(img) -> dict:
 def _is_pristine(state: dict) -> bool:
     """True when a serialized state carries no user edits worth saving."""
     return (not state["converted"] and not state["source_ops"]
-            and not state["adjustment_settings"] and state["crop_rect"] is None
+            and not state["adjustment_settings"]
+            and state.get("color_profile", "color") == "color"
+            and state["crop_rect"] is None
             and state["rotation_angle"] == 0 and state["fine_rotation_angle"] == 0
             and not state["horizontal_mirrored"] and not state["vertical_mirrored"]
             and state["reference_frame"] is None)
@@ -316,6 +319,7 @@ def _restore_image(file_path: str, state: dict):
                       if state.get("slice_parent") else None),
     )
     img.is_duplicate = bool(state.get("is_duplicate", False))
+    img.color_profile = state.get("color_profile", "color")
     ref = state.get("reference_frame")
     img.reference_frame = tuple(ref) if ref else None
     crop = state.get("crop_rect")

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -653,6 +653,7 @@ class CCRBackend:
                 preloaded_img=img.resized_raw.copy(),
                 preloaded_full_size=img.original_full_size,
                 display_name=f"{stem}_copy{n}{ext}",
+                color_profile=img.color_profile,
             )
             dup.reference_frame = img.reference_frame
             dup.conversion_inputs = (dict(img.conversion_inputs)
@@ -824,6 +825,7 @@ class CCRBackend:
                     display_name=f"{stem}_s{index}{ext}",
                     slice_group=slice_group,
                     slice_parent=dict(slice_parent),
+                    color_profile=img_obj.color_profile,
                 )
                 child.conversion_inputs = child_ci
                 # Slices descend from the parent's loaded content — carry its
@@ -967,6 +969,7 @@ class CCRBackend:
                 slice_group=parent_group,
                 slice_parent=(dict(parent_slice_parent)
                               if parent_slice_parent else None),
+                color_profile=template.color_profile,
             )
         except Exception as e:
             print(f"Reset slice failed: could not re-decode "

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -46,6 +46,7 @@ class CCRImage:
         display_name: Optional[str] = None,
         slice_group: Optional[str] = None,
         slice_parent: Optional[Dict[str, Any]] = None,
+        color_profile: str = "color",
         ):
         # Normalize file path to handle Unicode characters properly
         self.file_path = os.path.normpath(file_path)
@@ -78,6 +79,10 @@ class CCRImage:
         self.reference_frame = reference_frame
         self.resized_preview = None  # Placeholder for resized preview, if needed later
         self.adjustment_settings = adjustment_settings if adjustment_settings is not None else {}
+        # Color profile: "color" = full RGB (the original behaviour), "bw" =
+        # map the adjusted result to a single luminance channel. Affects both
+        # the preview/thumbnail and the exported file.
+        self.color_profile = color_profile if color_profile in ("color", "bw") else "color"
         self.rotation_angle = rotation_angle
         self.fine_rotation_angle = fine_rotation_angle
         self.horizontal_mirrored = horizontal_mirrored
@@ -499,8 +504,18 @@ class CCRImage:
         )
         return qimage
 
+    @staticmethod
+    def _to_grayscale(image: np.ndarray) -> np.ndarray:
+        """Map an RGB image to a single luminance channel (Rec.601 weights:
+        0.299R + 0.587G + 0.114B) replicated across all three channels, so it
+        renders/exports as black & white while keeping the RGB shape and dtype
+        every downstream stage expects. Returns a new array."""
+        gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        return cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
+
     def apply_adjustments(self, image: np.ndarray, settings=None, contrast_base=None,
-                          temperature_base=None, brightness_base=None) -> np.ndarray:
+                          temperature_base=None, brightness_base=None,
+                          color_profile=None) -> np.ndarray:
         """Apply the slider adjustments. The optional overrides let the zoom
         hi-res worker render from a snapshot taken at request time instead of
         live state the GUI thread may be mutating concurrently."""
@@ -508,8 +523,11 @@ class CCRImage:
         cb = self.contrast_base if contrast_base is None else contrast_base
         tb = self.temperature_base if temperature_base is None else temperature_base
         bb = self.brightness_base if brightness_base is None else brightness_base
+        profile = self.color_profile if color_profile is None else color_profile
         if not s and cb == 0 and tb == 0 and bb == 0:
-            return image
+            # No slider/base adjustments — but Black & White still has to map
+            # the image to a single luminance channel.
+            return self._to_grayscale(image) if profile == "bw" else image
         adjusted = adjust_image_opencl(image,
                      s.get('temperature', 0) + tb,
                      s.get('tint', 0),
@@ -543,6 +561,8 @@ class CCRImage:
                      band_settings=(s if any(s.get(k, 0)
                                              for k in BAND_ADJUSTMENT_KEYS)
                                     else None))
+        if profile == "bw":
+            adjusted = self._to_grayscale(adjusted)
         return adjusted
 
     def render_hires_base(self, max_long_side: Optional[int] = None,
@@ -607,6 +627,7 @@ class CCRImage:
         """Snapshot of every user-editable, non-destructive setting."""
         return {
             "adjustment_settings": dict(self.adjustment_settings),
+            "color_profile": self.color_profile,
             "crop_rect": self.crop_rect,
             "crop_angle": self.crop_angle,
             "rotation_angle": self.rotation_angle,
@@ -633,6 +654,7 @@ class CCRImage:
             return False
         state = self.undo_stack.pop()
         self.adjustment_settings = state["adjustment_settings"]
+        self.color_profile = state.get("color_profile", "color")
         self.crop_rect = state["crop_rect"]
         self.crop_angle = state.get("crop_angle", 0.0)
         self.rotation_angle = state["rotation_angle"]

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -217,6 +217,8 @@ class MainWindow(QMainWindow):
         # displayed content — a preserved zoom would strand the viewport.
         self.image_preview._reset_zoom()
         img.update_thumbnail_and_preview()
+        # Keep the Color Profile dropdown in step with the restored state.
+        self.sliders_panel._sync_color_profile_combo(idx)
         self.thumbnail_list.update_thumbnail(idx)
         self.image_preview.update_preview(idx)
         remaining = len(img.undo_stack)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1390,7 +1390,8 @@ class ImagePreview(QWidget):
         if img is None:
             return None
         return (tuple(sorted(img.adjustment_settings.items())),
-                img.contrast_base, img.temperature_base, img.brightness_base)
+                img.contrast_base, img.temperature_base, img.brightness_base,
+                getattr(img, "color_profile", "color"))
 
     HIRES_MAX_LONG_SIDE = 4500   # bounds non-RAW decodes (RAW half-size passes through)
 

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QSlider, QLabel, QHBoxLayout,
                                 QSizePolicy, QStyleOptionSlider, QFrame, QStyle,
                                 QPushButton, QDialog, QMessageBox, QScrollArea,
-                                QCheckBox)
+                                QCheckBox, QComboBox)
 from PySide6.QtCore import Qt, QTimer, QThread, Signal
 from PySide6.QtGui import QPixmap, QKeySequence, QShortcut
 from core.ccr_backend import ccr_backend
@@ -11,6 +11,7 @@ from core.ccr_processor import COLOR_BANDS, BAND_PARAMS, BAND_ADJUSTMENT_KEYS
 # groups partition SlidersPanel.ADJUSTMENT_KEYS exactly; "crop" syncs the
 # image's crop box (rect + angle) instead of adjustment keys.
 SYNC_GROUPS = [
+    ("profile", "Color Profile (Color / B&W)", ()),
     ("wb", "White Balance / Tint", ("temperature", "tint")),
     ("tone", "Tone (exposure, brightness, contrast, ...)",
      ("exposure", "brightness", "highlights", "white_point",
@@ -187,6 +188,9 @@ class SlidersPanel(QWidget):
         # last): band_<color>_<param> for the 6 bands × 4 params
     ] + list(BAND_ADJUSTMENT_KEYS)
 
+    # Color Profile combo: row index -> CCRImage.color_profile value.
+    COLOR_PROFILES = ("color", "bw")
+
     def __init__(self, parent=None):
         super().__init__()
         self.sliders = []
@@ -312,6 +316,11 @@ class SlidersPanel(QWidget):
         wb_crop_row.addStretch()
         scroll_layout.addLayout(wb_crop_row)
 
+        # Color Profile dropdown — sits right above Temperature. "Color" keeps
+        # the full-RGB pipeline; "Black & White" maps the result to a single
+        # luminance channel (preview and export). Per-image, like the sliders.
+        self.color_profile_row = self._create_color_profile_row()
+
         self.temperature_slider_layout = self.create_slider("Temperature")
         self.tint_slider_layout = self.create_slider("Tint")
         self.exposure_slider_layout = self.create_slider("Exposure")
@@ -324,6 +333,7 @@ class SlidersPanel(QWidget):
         self.saturation_slider_layout = self.create_slider("Saturation")
         self.sub_saturation_slider_layout = self.create_slider("Subtracted Sat")
 
+        scroll_layout.addLayout(self.color_profile_row)
         scroll_layout.addLayout(self.temperature_slider_layout)
         scroll_layout.addLayout(self.tint_slider_layout)
         scroll_layout.addLayout(self.exposure_slider_layout)
@@ -536,6 +546,62 @@ class SlidersPanel(QWidget):
 
         return slider_layout
 
+    def _create_color_profile_row(self):
+        """Build the 'Color Profile' label + dropdown row (Color / Black &
+        White). Laid out like a slider row so it lines up with Temperature."""
+        label = QLabel("Color Profile")
+        label.setMinimumWidth(70)
+        label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        label.setFixedHeight(30)
+        label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+
+        self.color_profile_combo = QComboBox()
+        self.color_profile_combo.addItems(["Color", "Black & White"])
+        self.color_profile_combo.setFixedHeight(28)
+        self.color_profile_combo.currentIndexChanged.connect(self.on_color_profile_changed)
+
+        row = QHBoxLayout()
+        row.addWidget(label, alignment=Qt.AlignVCenter)
+        row.addWidget(self.color_profile_combo, alignment=Qt.AlignVCenter)
+        return row
+
+    def _sync_color_profile_combo(self, idx):
+        """Reflect the image's stored color profile in the dropdown without
+        firing the change handler."""
+        img = ccr_backend.get_image_by_index(idx) if idx is not None else None
+        profile = getattr(img, "color_profile", "color") if img is not None else "color"
+        try:
+            row = self.COLOR_PROFILES.index(profile)
+        except ValueError:
+            row = 0
+        self.color_profile_combo.blockSignals(True)
+        self.color_profile_combo.setCurrentIndex(row)
+        self.color_profile_combo.blockSignals(False)
+
+    def on_color_profile_changed(self, index):
+        """Switch the current image between Color and Black & White. A single
+        undoable action; reprocesses the preview/thumbnail (and invalidates
+        the hi-res zoom cache via the adjustment signature)."""
+        if self.current_idx is None:
+            return
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None:
+            return
+        profile = self.COLOR_PROFILES[index] if 0 <= index < len(self.COLOR_PROFILES) else "color"
+        if img.color_profile == profile:
+            return
+        # Discrete action — don't merge into an in-progress slider undo burst.
+        self.end_undo_burst()
+        img.push_undo_state()
+        img.color_profile = profile
+        img.update_thumbnail_and_preview()
+        mw = self.parent().parent()
+        try:
+            mw.thumbnail_list.update_thumbnail(self.current_idx)
+        except AttributeError:
+            pass
+        mw.image_preview.update_preview(self.current_idx)
+
     def _show_band_page(self, color: str):
         """Show one color band's slider page in the Subtractive Saturations
         section; the others stay hidden (but keep their values)."""
@@ -547,6 +613,7 @@ class SlidersPanel(QWidget):
         print(f"Setting sliders enabled: {enabled}")
         self.wb_picker_btn.setEnabled(enabled)
         self.crop_btn.setEnabled(enabled)
+        self.color_profile_combo.setEnabled(enabled)
         for slider in self.sliders:
             slider.setEnabled(enabled)
             if not enabled:
@@ -570,6 +637,9 @@ class SlidersPanel(QWidget):
             self._undo_burst_timer.stop()
 
         self.current_idx = idx
+        # Reflect this image's color profile (independent of the slider dict,
+        # so it must be synced on both the empty and populated paths below).
+        self._sync_color_profile_combo(idx)
         adjustment = ccr_backend.get_adjustment_by_index(idx)
         print(f"Setting current index: {idx}, adjustment: {adjustment}")
         if adjustment is None or not adjustment:
@@ -740,10 +810,12 @@ class SlidersPanel(QWidget):
         keys = [k for gid, _label, group_keys in SYNC_GROUPS
                 if selection.get(gid) for k in group_keys]
         sync_crop = bool(selection.get("crop"))
+        sync_profile = bool(selection.get("profile"))
         current_adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
         src = ccr_backend.get_image_by_index(self.current_idx)
         crop_rect = src.crop_rect if src is not None else None
         crop_angle = getattr(src, "crop_angle", 0.0) if src is not None else 0.0
+        src_profile = getattr(src, "color_profile", "color") if src is not None else "color"
         print(f"Syncing groups {sorted(g for g, on in selection.items() if on)} to all images")
 
         for img in ccr_backend.images:
@@ -751,7 +823,8 @@ class SlidersPanel(QWidget):
                               for k in keys)
             crop_changes = sync_crop and (img.crop_rect != crop_rect
                                           or getattr(img, "crop_angle", 0.0) != crop_angle)
-            if not adj_changes and not crop_changes:
+            profile_changes = sync_profile and getattr(img, "color_profile", "color") != src_profile
+            if not adj_changes and not crop_changes and not profile_changes:
                 continue  # nothing to change — and no dead undo snapshot
             img.push_undo_state()
             if adj_changes:
@@ -766,9 +839,12 @@ class SlidersPanel(QWidget):
             if sync_crop:
                 img.crop_rect = crop_rect
                 img.crop_angle = crop_angle
-            if adj_changes:
+            if profile_changes:
+                img.color_profile = src_profile
+            if adj_changes or profile_changes:
                 # Crop is display/export-level only — no reprocessing needed
-                # when nothing but the crop changed.
+                # when nothing but the crop changed. Adjustments and the color
+                # profile both change pixels, so they do.
                 try:
                     img.update_thumbnail_and_preview()
                 except Exception as e:

--- a/tests/test_color_bands.py
+++ b/tests/test_color_bands.py
@@ -232,6 +232,7 @@ class TestPipelineIntegration:
         from core.ccr_image import CCRImage
         img_obj = CCRImage.__new__(CCRImage)
         img_obj.adjustment_settings = {"band_red_sat": -100}
+        img_obj.color_profile = "color"
         img_obj.contrast_base = 0
         img_obj.temperature_base = 0
         img_obj.brightness_base = 0
@@ -243,6 +244,7 @@ class TestPipelineIntegration:
         from core.ccr_image import CCRImage
         img_obj = CCRImage.__new__(CCRImage)
         img_obj.adjustment_settings = {"saturation": 0}
+        img_obj.color_profile = "color"
         img_obj.contrast_base = 0
         img_obj.temperature_base = 0
         img_obj.brightness_base = 0

--- a/tests/test_color_profile.py
+++ b/tests/test_color_profile.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Tests for the Color Profile feature (Color / Black & White).
+
+Black & White maps the adjusted RGB result to a single luminance channel
+(Rec.601 weights) replicated across R/G/B, so it renders and exports as a
+neutral grayscale image while keeping the 3-channel shape downstream expects.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.ccr_image import CCRImage  # noqa: E402
+
+
+def _stub_image(color_profile="color", adjustment_settings=None):
+    """CCRImage without the heavy file-loading __init__."""
+    img = CCRImage.__new__(CCRImage)
+    img.adjustment_settings = adjustment_settings or {}
+    img.color_profile = color_profile
+    img.contrast_base = 0
+    img.temperature_base = 0
+    img.brightness_base = 0
+    img.tint_balance_factor = 1.0
+    return img
+
+
+def _color_image():
+    img = np.zeros((2, 3, 3), dtype=np.uint16)
+    img[0, 0] = (60000, 30000, 10000)   # saturated orange
+    img[0, 1] = (10000, 50000, 20000)   # saturated green
+    img[0, 2] = (30000, 30000, 30000)   # neutral gray
+    img[1, 0] = (0, 0, 0)               # black
+    img[1, 1] = (65535, 65535, 65535)   # white
+    img[1, 2] = (200, 100, 50)          # dark saturated
+    return img
+
+
+def _is_neutral(img):
+    """True when every pixel has R == G == B (i.e. truly grayscale)."""
+    return np.array_equal(img[..., 0], img[..., 1]) and np.array_equal(img[..., 1], img[..., 2])
+
+
+class TestColorProfile:
+    def test_color_profile_is_identity_no_adjustments(self):
+        img = _color_image()
+        out = _stub_image("color").apply_adjustments(img)
+        # No adjustments + Color profile = unchanged input (same object).
+        assert out is img
+
+    def test_bw_no_adjustments_produces_grayscale(self):
+        img = _color_image()
+        out = _stub_image("bw").apply_adjustments(img)
+        assert out.shape == img.shape
+        assert out.dtype == img.dtype
+        assert _is_neutral(out)
+
+    def test_bw_does_not_mutate_input(self):
+        img = _color_image()
+        before = img.copy()
+        _stub_image("bw").apply_adjustments(img)
+        np.testing.assert_array_equal(img, before)
+
+    def test_bw_luminance_matches_rec601_weights(self):
+        img = _color_image()
+        out = _stub_image("bw").apply_adjustments(img)
+        expected = (img[..., 0] * 0.299 + img[..., 1] * 0.587
+                    + img[..., 2] * 0.114)
+        # cv2's RGB2GRAY rounds; allow a 1-LSB tolerance.
+        np.testing.assert_allclose(out[..., 0].astype(np.int64),
+                                   expected, atol=1)
+
+    def test_bw_preserves_neutral_extremes(self):
+        img = _color_image()
+        out = _stub_image("bw").apply_adjustments(img)
+        np.testing.assert_array_equal(out[1, 0], (0, 0, 0))            # black
+        np.testing.assert_array_equal(out[1, 1], (65535, 65535, 65535))  # white
+
+    def test_bw_with_adjustments_is_grayscale(self):
+        img = _color_image()
+        out = _stub_image("bw", {"saturation": 50, "contrast": 20}).apply_adjustments(img)
+        assert out.shape == img.shape
+        assert out.dtype == np.uint16
+        assert _is_neutral(out)
+
+    def test_color_with_adjustments_keeps_color(self):
+        img = _color_image()
+        out = _stub_image("color", {"saturation": 50}).apply_adjustments(img)
+        # A saturated image boosted in Color mode must NOT collapse to gray.
+        assert not _is_neutral(out)
+
+
+class TestColorProfilePersistence:
+    def test_undo_round_trips_color_profile(self):
+        img = _stub_image("color")
+        img.crop_rect = None
+        img.crop_angle = 0.0
+        img.rotation_angle = 0
+        img.fine_rotation_angle = 0
+        img.horizontal_mirrored = False
+        img.vertical_mirrored = False
+        img.undo_stack = []
+
+        img.push_undo_state()
+        img.color_profile = "bw"
+        assert img.pop_undo_state() is True
+        assert img.color_profile == "color"
+
+    def test_catalog_serialize_round_trip(self):
+        from core.catalog import serialize_image
+        img = _stub_image("bw")
+        img.display_name = None
+        img.is_duplicate = False
+        img.slice_group = None
+        img.slice_parent = None
+        img.source_ops = []
+        img.converted = False
+        img.conversion_inputs = None
+        img.crop_rect = None
+        img.crop_angle = 0.0
+        img.rotation_angle = 0
+        img.fine_rotation_angle = 0
+        img.horizontal_mirrored = False
+        img.vertical_mirrored = False
+        img.reference_frame = None
+        state = serialize_image(img)
+        assert state["color_profile"] == "bw"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_sub_saturation_crop_undo.py
+++ b/tests/test_sub_saturation_crop_undo.py
@@ -164,13 +164,14 @@ class TestSyncGroups:
     def test_expected_group_ids(self):
         from widgets.sliders_panel import SYNC_GROUPS
         assert [gid for gid, _l, _k in SYNC_GROUPS] == [
-            "wb", "tone", "sat", "crop", "channels", "bands"]
+            "profile", "wb", "tone", "sat", "crop", "channels", "bands"]
 
 
 def _stub_image():
     """CCRImage without the heavy file-loading __init__."""
     img = CCRImage.__new__(CCRImage)
     img.adjustment_settings = {}
+    img.color_profile = "color"
     img.crop_rect = None
     img.crop_angle = 0.0
     img.rotation_angle = 0


### PR DESCRIPTION
## Summary

Adds a per-image **Color Profile** dropdown directly above the Temperature slider with two options:

- **Color** — the existing full-RGB pipeline (unchanged behaviour)
- **Black & White** — maps the adjusted result to a single luminance channel (Rec.601 weights `0.299R + 0.587G + 0.114B`) replicated across R/G/B, so both the **preview** and the **exported file** render as neutral grayscale.

The conversion happens at the end of `CCRImage.apply_adjustments`, so it automatically flows through every consumer of that method: preview/thumbnail, full-res export (reference-frame and B/W-point pipelines), and the hi-res zoom detail worker. All the color sliders still apply first and shape the luminance mix; the result is then desaturated.

## Where the profile is carried

It is stored per image (`CCRImage.color_profile`, default `"color"`) and persisted/inherited through:

- **Catalog** save/restore — reopening a file restores the chosen profile
- **Undo** (Ctrl+Z)
- **Duplicate**, **Slice**, and **Reset Slice** — children inherit the parent's profile
- **Sync to All** — new "Color Profile" group in the sync dialog
- **Hi-res zoom** — the adjustment signature now includes the profile, so toggling it while zoomed re-renders the detail layer

The dropdown is gated with the sliders (enabled once an image is converted) and stays in sync when switching images and after undo.

## Tests

- New `tests/test_color_profile.py` — grayscale mapping, Rec.601 weights, input immutability, neutral-extreme preservation, undo and catalog round-trips
- Updated existing undo/color-band stubs and the sync-group-id assertion for the new attribute/group
- Full suite: **205 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
