### PR TITLE
Add cyan color band to fill the green->blue gap

### DIFF
--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -2171,22 +2171,24 @@ def adjust_image(
     return img.astype(np.uint16)
 
 
-# --- Per-color-band "Subtractive Saturations" (Resolve-style six vector) ---
+# --- Per-color-band "Subtractive Saturations" (Resolve-style color vectors) ---
 # Each band is a hue sector with four sliders in [-100, 100]:
 #   subsat — film-density saturation (same model as the global slider),
 #   sat    — additive saturation,  bright — luminance gain,
 #   hue    — rotation toward the neighboring sectors (±30° at full scale).
-COLOR_BANDS = ("red", "skin", "yellow", "green", "blue", "purple")
+COLOR_BANDS = ("red", "skin", "yellow", "green", "cyan", "blue", "purple")
 BAND_PARAMS = ("subsat", "sat", "bright", "hue")
 BAND_ADJUSTMENT_KEYS = tuple(f"band_{color}_{param}"
                              for color in COLOR_BANDS for param in BAND_PARAMS)
 
 # Sector centers in degrees on the HSV wheel (red=0, green=120, blue=240),
 # in wheel order. "skin" sits in the orange range between red and yellow,
-# like Resolve's dedicated skin-tone vector.
+# like Resolve's dedicated skin-tone vector. "cyan" centers the wide
+# green->blue span (true cyan = 180), splitting it into two even sectors.
+# MUST stay sorted ascending by center — _band_param_deltas searchsorts it.
 BAND_HUE_CENTERS = (
     ("red", 0.0), ("skin", 28.0), ("yellow", 58.0),
-    ("green", 120.0), ("blue", 240.0), ("purple", 300.0),
+    ("green", 120.0), ("cyan", 180.0), ("blue", 240.0), ("purple", 300.0),
 )
 
 # Near-neutral pixels carry hue noise, not color: fade every band effect in

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -185,7 +185,7 @@ class SlidersPanel(QWidget):
         "ch_g_shift", "ch_g_gain", "ch_g_blackpoint",
         "ch_b_shift", "ch_b_gain", "ch_b_blackpoint",
         # Per-color-band sliders (Subtractive Saturations section, created
-        # last): band_<color>_<param> for the 6 bands × 4 params
+        # last): band_<color>_<param> for the color bands × 4 params
     ] + list(BAND_ADJUSTMENT_KEYS)
 
     # Color Profile combo: row index -> CCRImage.color_profile value.
@@ -419,7 +419,8 @@ class SlidersPanel(QWidget):
         # all 24 sliders exist (and feed adjustment_settings) regardless.
         band_swatch_colors = {
             "red": "#c0392b", "skin": "#d8956b", "yellow": "#c8b900",
-            "green": "#27ae60", "blue": "#2f6fd0", "purple": "#8e44ad",
+            "green": "#27ae60", "cyan": "#17a8b4", "blue": "#2f6fd0",
+            "purple": "#8e44ad",
         }
         self._band_buttons = {}
         self._band_pages = {}


### PR DESCRIPTION
## What

Adds a **cyan** band to the per-color-band "Subtractive Saturations" controls, centered at 180° on the hue wheel.

## Why

The band centers were:

```
red 0°   skin 28°   yellow 58°   green 120°   blue 240°   purple 300°
```

Every neighbor pair sat ~30–60° apart **except green→blue, a 120° span** — a full third of the wheel with no center. Since the blend only ever mixes the two bracketing bands, teal/cyan/aqua subjects could only be reached as a green/blue average and couldn't be targeted on their own. Cyan at 180° splits that span into two even 60° sectors. (This restores the cyan vector from Resolve's canonical R/Y/G/Cyan/B/M six-vector, which this app had previously dropped.)

## Changes

- `ccr_processor.py` — add `cyan` to `COLOR_BANDS` and `("cyan", 180.0)` to `BAND_HUE_CENTERS`
- `sliders_panel.py` — cyan swatch color (the only band-specific hardcode; the rest of the UI iterates `COLOR_BANDS`)

`BAND_ADJUSTMENT_KEYS`, the hue-binned OpenCL LUT (band count doesn't affect it), and saved settings all derive from these constants.

## Testing

- `tests/test_color_bands.py` — 27 pass; the data-driven tests now cover 7 bands (weight = 1.0 at the cyan center, all-band weights still sum to 1.0).
- Verified cyan-weight is 1.0 at 180° and 0.0 at the green (120°) and blue (240°) centers — the new sector is cleanly isolated from its neighbors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
