### PR TITLE
Add spatial feathering (softness) for color-band selections

### DIFF
--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -2164,7 +2164,7 @@ def adjust_image(
         # as the OpenCL kernel, so CPU and GPU renders stay aligned.
         bin_deltas = _band_bin_lut(band_settings)
         if bin_deltas is not None:
-            feather = float(band_settings.get('band_feather', 0) or 0)
+            feather = float(band_settings.get('band_feather', _BAND_FEATHER_DEFAULT) or 0)
             img_norm = np.clip(img / 65535.0, 0.0, 1.0).astype(np.float32)
             img = _apply_color_bands_float(img_norm, bin_deltas, feather) * 65535.0
 
@@ -2268,7 +2268,7 @@ def apply_color_band_adjustments(img16: np.ndarray, settings: dict) -> np.ndarra
     bin_deltas = _band_bin_lut(settings)
     if bin_deltas is None:
         return img16
-    feather = float(settings.get('band_feather', 0) or 0)
+    feather = float(settings.get('band_feather', _BAND_FEATHER_DEFAULT) or 0)
     rgb = np.clip(img16.astype(np.float32) / 65535.0, 0.0, 1.0)
     rgb = _apply_color_bands_float(rgb, bin_deltas, feather)
     return np.clip(rgb * 65535.0, 0.0, 65535.0).astype(np.uint16)
@@ -2279,6 +2279,11 @@ def apply_color_band_adjustments(img16: np.ndarray, settings: dict) -> np.ndarra
 # keeps the softness visually consistent between the 1080px preview and the
 # full-resolution export.
 _BAND_FEATHER_MAX_FRAC = 0.012
+
+# Default feather amount when a settings dict carries no explicit band_feather
+# (new edits and pre-feathering catalogs): a gentle edge-softening baseline.
+# Mirrors SlidersPanel.SLIDER_DEFAULTS["band_feather"] so UI and render agree.
+_BAND_FEATHER_DEFAULT = 10.0
 
 
 def _feather_band_effect(orig: np.ndarray, adjusted: np.ndarray,
@@ -2436,7 +2441,7 @@ def adjust_image_opencl(
     # band + feather staging identical). This is also the normal fallback when
     # OpenCL is unavailable.
     feather_active = bool(band_settings) and \
-        (float(band_settings.get('band_feather', 0) or 0) > 0) and \
+        (float(band_settings.get('band_feather', _BAND_FEATHER_DEFAULT) or 0) > 0) and \
         any(band_settings.get(k, 0) for k in BAND_ADJUSTMENT_KEYS)
     if feather_active or not _initialize_opencl():
         return adjust_image(img16, kelvin_shift, tint_shift, exposure, brightness,

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -2164,8 +2164,9 @@ def adjust_image(
         # as the OpenCL kernel, so CPU and GPU renders stay aligned.
         bin_deltas = _band_bin_lut(band_settings)
         if bin_deltas is not None:
+            feather = float(band_settings.get('band_feather', 0) or 0)
             img_norm = np.clip(img / 65535.0, 0.0, 1.0).astype(np.float32)
-            img = _apply_color_bands_float(img_norm, bin_deltas) * 65535.0
+            img = _apply_color_bands_float(img_norm, bin_deltas, feather) * 65535.0
 
     img = np.clip(img, 0, 65535)
     return img.astype(np.uint16)
@@ -2267,12 +2268,47 @@ def apply_color_band_adjustments(img16: np.ndarray, settings: dict) -> np.ndarra
     bin_deltas = _band_bin_lut(settings)
     if bin_deltas is None:
         return img16
+    feather = float(settings.get('band_feather', 0) or 0)
     rgb = np.clip(img16.astype(np.float32) / 65535.0, 0.0, 1.0)
-    rgb = _apply_color_bands_float(rgb, bin_deltas)
+    rgb = _apply_color_bands_float(rgb, bin_deltas, feather)
     return np.clip(rgb * 65535.0, 0.0, 65535.0).astype(np.uint16)
 
 
-def _apply_color_bands_float(rgb: np.ndarray, bin_deltas: np.ndarray) -> np.ndarray:
+# Spatial feathering: at feather=100 the band correction is low-passed with a
+# Gaussian of this fraction of the image's long edge. Scaling by image size
+# keeps the softness visually consistent between the 1080px preview and the
+# full-resolution export.
+_BAND_FEATHER_MAX_FRAC = 0.012
+
+
+def _feather_band_effect(orig: np.ndarray, adjusted: np.ndarray,
+                         feather: float) -> np.ndarray:
+    """Soften the band effect's hard spatial edges (the DaVinci-qualifier
+    "blur radius" idea): the bands key per pixel from hue/sat, so the effect
+    can jump abruptly across a colour boundary. Rather than blur the image
+    (which would lose detail), low-pass only the *correction* the bands
+    introduced and re-add it to the untouched original — detail is preserved,
+    only the effect's transition is feathered.
+
+    orig / adjusted: float32 RGB in [0, 1]. feather in 0..100 (0 = off).
+    Like any matte blur this can bleed the correction slightly across
+    high-contrast colour edges (a faint halo), so keep the amount modest.
+    """
+    if feather <= 0:
+        return adjusted
+    h, w = orig.shape[:2]
+    sigma = (min(feather, 100.0) / 100.0) * _BAND_FEATHER_MAX_FRAC * max(h, w)
+    if sigma < 0.5:
+        return adjusted
+    delta = adjusted - orig
+    cv2.GaussianBlur(delta, (0, 0), sigmaX=sigma, sigmaY=sigma, dst=delta)
+    out = orig + delta
+    np.clip(out, 0.0, 1.0, out=out)
+    return out
+
+
+def _apply_color_bands_float(rgb: np.ndarray, bin_deltas: np.ndarray,
+                             feather: float = 0.0) -> np.ndarray:
     """Per-color-band core on a float32 RGB image in [0, 1].
 
     Band selection happens on the ORIGINAL hue, so a band's own hue
@@ -2287,8 +2323,10 @@ def _apply_color_bands_float(rgb: np.ndarray, bin_deltas: np.ndarray) -> np.ndar
     one int index + one take per active parameter instead of full-
     resolution interpolation math. 0.5° bins are far below visible
     precision for curves this smooth. May modify rgb in place; use the
-    return value.
+    return value. When feather > 0 the band correction is spatially
+    low-passed (see _feather_band_effect) before being returned.
     """
+    orig = rgb.copy() if feather > 0 else None
     param_active = [bool(bin_deltas[:, p].any())
                     for p in range(len(BAND_PARAMS))]
 
@@ -2354,6 +2392,8 @@ def _apply_color_bands_float(rgb: np.ndarray, bin_deltas: np.ndarray) -> np.ndar
                                     mx * np.exp(np.log(ratio) * gamma), sub)
             rgb = flat.reshape(rgb.shape)
 
+    if orig is not None:
+        rgb = _feather_band_effect(orig, rgb, feather)
     return rgb
 
 
@@ -2391,9 +2431,14 @@ def adjust_image_opencl(
     """
     global _opencl_cache
 
-    # Initialize OpenCL if not already done
-    if not _initialize_opencl():
-        # Fallback to CPU version
+    # Spatial band feathering is a CPU post-blur the per-pixel kernel can't
+    # do, so run the whole adjustment on the CPU when it is active (keeps the
+    # band + feather staging identical). This is also the normal fallback when
+    # OpenCL is unavailable.
+    feather_active = bool(band_settings) and \
+        (float(band_settings.get('band_feather', 0) or 0) > 0) and \
+        any(band_settings.get(k, 0) for k in BAND_ADJUSTMENT_KEYS)
+    if feather_active or not _initialize_opencl():
         return adjust_image(img16, kelvin_shift, tint_shift, exposure, brightness,
                           blackpoint, whitepoint, contrast, saturation, tint_balance_factor,
                           highlights, shadows,

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -23,7 +23,8 @@ SYNC_GROUPS = [
         "ch_r_shift", "ch_r_gain", "ch_r_blackpoint",
         "ch_g_shift", "ch_g_gain", "ch_g_blackpoint",
         "ch_b_shift", "ch_b_gain", "ch_b_blackpoint")),
-    ("bands", "Subtractive Saturations (per color)", BAND_ADJUSTMENT_KEYS),
+    ("bands", "Subtractive Saturations (per color)",
+     tuple(BAND_ADJUSTMENT_KEYS) + ("band_feather",)),
 ]
 
 
@@ -186,7 +187,11 @@ class SlidersPanel(QWidget):
         "ch_b_shift", "ch_b_gain", "ch_b_blackpoint",
         # Per-color-band sliders (Subtractive Saturations section, created
         # last): band_<color>_<param> for the color bands × 4 params
-    ] + list(BAND_ADJUSTMENT_KEYS)
+    ] + list(BAND_ADJUSTMENT_KEYS) + [
+        # Global spatial-feather amount for the band effect (created after the
+        # per-band sliders, so it stays last in the positional zip).
+        "band_feather",
+    ]
 
     # Color Profile combo: row index -> CCRImage.color_profile value.
     COLOR_PROFILES = ("color", "bw")
@@ -458,6 +463,13 @@ class SlidersPanel(QWidget):
             page.setVisible(False)
             self.band_section.add_widget(page)
             self._band_pages[color] = page
+
+        # Global feather (softness): spatially low-passes the band correction
+        # to soften hard colour-selection edges. 0 = off. Applies to all
+        # bands, so it lives below the per-band pages. Created LAST so it maps
+        # to the trailing "band_feather" key in ADJUSTMENT_KEYS.
+        self.band_section.add_layout(
+            self.create_slider("Feather", min_value=0, max_value=100))
         self._show_band_page("red")
 
         # --- Signal connections ---
@@ -511,10 +523,10 @@ class SlidersPanel(QWidget):
             self.histogram_label.clear()
             self.histogram_label.setText("")
 
-    def create_slider(self, label_text):
+    def create_slider(self, label_text, min_value=-100, max_value=100):
         slider = ResettableSlider(Qt.Horizontal)
-        slider.setMinimum(-100)
-        slider.setMaximum(100)
+        slider.setMinimum(min_value)
+        slider.setMaximum(max_value)
         slider.setValue(0)
         slider.setOrientation(Qt.Horizontal)
         slider.setTickInterval(10)

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -193,6 +193,16 @@ class SlidersPanel(QWidget):
         "band_feather",
     ]
 
+    # Non-zero default values for specific adjustment keys. Keys not listed
+    # default to 0. band_feather defaults to 10 so band edits get a gentle
+    # edge-softening out of the box (matches _BAND_FEATHER_DEFAULT in
+    # ccr_processor). Used everywhere a slider is populated from a (possibly
+    # partial) adjustment dict, so UI and render agree on the default.
+    SLIDER_DEFAULTS = {"band_feather": 10}
+
+    def _default_for(self, key):
+        return self.SLIDER_DEFAULTS.get(key, 0)
+
     # Color Profile combo: row index -> CCRImage.color_profile value.
     COLOR_PROFILES = ("color", "bw")
 
@@ -469,7 +479,8 @@ class SlidersPanel(QWidget):
         # bands, so it lives below the per-band pages. Created LAST so it maps
         # to the trailing "band_feather" key in ADJUSTMENT_KEYS.
         self.band_section.add_layout(
-            self.create_slider("Feather", min_value=0, max_value=100))
+            self.create_slider("Feather", min_value=0, max_value=100,
+                               default_value=self._default_for("band_feather")))
         self._show_band_page("red")
 
         # --- Signal connections ---
@@ -523,11 +534,12 @@ class SlidersPanel(QWidget):
             self.histogram_label.clear()
             self.histogram_label.setText("")
 
-    def create_slider(self, label_text, min_value=-100, max_value=100):
+    def create_slider(self, label_text, min_value=-100, max_value=100,
+                      default_value=0):
         slider = ResettableSlider(Qt.Horizontal)
         slider.setMinimum(min_value)
         slider.setMaximum(max_value)
-        slider.setValue(0)
+        slider.setValue(default_value)
         slider.setOrientation(Qt.Horizontal)
         slider.setTickInterval(10)
         slider.setFixedHeight(30)
@@ -656,19 +668,22 @@ class SlidersPanel(QWidget):
         adjustment = ccr_backend.get_adjustment_by_index(idx)
         print(f"Setting current index: {idx}, adjustment: {adjustment}")
         if adjustment is None or not adjustment:
-            # Set all sliders and labels to 0 if no adjustment
+            # No adjustment yet: show each slider's default (0 for most,
+            # 10 for band_feather).
             for i, slider in enumerate(self.sliders):
+                key = self.adjustment_keys[i] if i < len(self.adjustment_keys) else None
+                default = self._default_for(key)
                 slider.blockSignals(True)
-                slider.setValue(0)
+                slider.setValue(default)
                 slider.blockSignals(False)
-                self.slider_value_labels[i].setText("0")
+                self.slider_value_labels[i].setText(str(default))
             return
 
-        # Missing keys count as 0 so a partial dict can never leave a slider
-        # showing the previously selected image's value.
+        # Missing keys fall back to the slider default so a partial dict can
+        # never leave a slider showing the previously selected image's value.
         for i, key in enumerate(self.adjustment_keys):
             if i < len(self.sliders):
-                val = adjustment.get(key, 0)
+                val = adjustment.get(key, self._default_for(key))
                 self.sliders[i].blockSignals(True)
                 self.sliders[i].setValue(val)
                 self.sliders[i].blockSignals(False)
@@ -754,12 +769,14 @@ class SlidersPanel(QWidget):
         img = ccr_backend.get_image_by_index(self.current_idx) if self.current_idx is not None else None
         if img is not None:
             img.push_undo_state()
-        # Set all sliders to 0 and update preview
+        # Reset every slider to its default (0 for most, 10 for band_feather).
         for i, slider in enumerate(self.sliders):
+            key = self.adjustment_keys[i] if i < len(self.adjustment_keys) else None
+            default = self._default_for(key)
             slider.blockSignals(True)
-            slider.setValue(0)
+            slider.setValue(default)
             slider.blockSignals(False)
-            self.slider_value_labels[i].setText("0")
+            self.slider_value_labels[i].setText(str(default))
         # Save adjustment to backend and update preview
         if self.current_idx is not None:
             adjustment = {key: 0 for key in self.adjustment_keys}
@@ -785,7 +802,7 @@ class SlidersPanel(QWidget):
         if self.current_idx is not None and hasattr(self, "_original_adjustment"):
             adjustment = self._original_adjustment or {}
             for i, key in enumerate(self.adjustment_keys):
-                val = adjustment.get(key, 0)
+                val = adjustment.get(key, self._default_for(key))
                 self.sliders[i].blockSignals(True)
                 self.sliders[i].setValue(val)
                 self.sliders[i].blockSignals(False)
@@ -832,7 +849,8 @@ class SlidersPanel(QWidget):
         print(f"Syncing groups {sorted(g for g, on in selection.items() if on)} to all images")
 
         for img in ccr_backend.images:
-            adj_changes = any(img.adjustment_settings.get(k, 0) != current_adjustment.get(k, 0)
+            adj_changes = any(img.adjustment_settings.get(k, self._default_for(k))
+                              != current_adjustment.get(k, self._default_for(k))
                               for k in keys)
             crop_changes = sync_crop and (img.crop_rect != crop_rect
                                           or getattr(img, "crop_angle", 0.0) != crop_angle)
@@ -845,9 +863,10 @@ class SlidersPanel(QWidget):
                 # rest of the app keeps its invariant that a non-empty
                 # adjustment dict carries every key — set_current_idx and
                 # friends rely on it.
-                merged = {k: img.adjustment_settings.get(k, 0) for k in self.adjustment_keys}
+                merged = {k: img.adjustment_settings.get(k, self._default_for(k))
+                          for k in self.adjustment_keys}
                 for k in keys:
-                    merged[k] = current_adjustment.get(k, 0)
+                    merged[k] = current_adjustment.get(k, self._default_for(k))
                 img.adjustment_settings = merged
             if sync_crop:
                 img.crop_rect = crop_rect

--- a/tests/test_color_bands.py
+++ b/tests/test_color_bands.py
@@ -262,8 +262,11 @@ class TestUIWiring:
 
     def test_adjustment_keys_include_bands_in_order(self):
         from widgets.sliders_panel import SlidersPanel
-        assert SlidersPanel.ADJUSTMENT_KEYS[-len(BAND_ADJUSTMENT_KEYS):] == \
-               list(BAND_ADJUSTMENT_KEYS)
+        keys = SlidersPanel.ADJUSTMENT_KEYS
+        # The global band feather amount is the trailing key; the per-band
+        # keys appear in order immediately before it.
+        assert keys[-1] == "band_feather"
+        assert keys[-1 - len(BAND_ADJUSTMENT_KEYS):-1] == list(BAND_ADJUSTMENT_KEYS)
         assert len(BAND_ADJUSTMENT_KEYS) == len(COLOR_BANDS) * len(BAND_PARAMS)
 
     def test_panel_slider_count_matches_keys(self):


### PR DESCRIPTION
## What

Adds a global **Feather** control to the per-color-band "Subtractive Saturations" so strong band adjustments no longer leave hard edges / artefacts at colour boundaries.

## Why

The bands key each pixel from its hue/saturation, with smooth falloff *in colour space* (hue blend + sat gate) but **no spatial component**. So across a colour boundary the effect can jump abruptly, producing visible hard edges — exactly what you'd get from a DaVinci Resolve qualifier with no blur on the key.

Research confirms the standard fix: qualifier/secondary tools (Resolve **Blur Radius**, Capture One Color Editor **smoothness**) spatially soften the *matte*, not the image. Global HSL panels (Lightroom) don't — which is why hard moves there look crunchy too.

## How

`_feather_band_effect()` low-passes only the **correction** the bands introduce — `out = original + GaussianBlur(adjusted − original)` — so all original detail is preserved and only the effect's spatial transition is feathered. Gaussian sigma scales with the image's long edge so the 1080px preview and full-res export match. `0 = off`.

- Threaded through `_apply_color_bands_float` / `apply_color_band_adjustments` / `adjust_image` via a new `band_feather` setting (deliberately **not** in `BAND_ADJUSTMENT_KEYS`, so feather alone never triggers a no-op band pass).
- The OpenCL kernel has no spatial pass, so when feather is active the render routes through the CPU path — keeps band+feather staging identical.
- UI: a **Feather** slider (0..100) in the Subtractive Saturations section; `create_slider()` gains optional min/max; `band_feather` joins the bands sync group.

## Caveat

Like any matte blur, large amounts can bleed the correction slightly across high-contrast colour edges (a faint halo) — same tradeoff Resolve warns about. Keep it modest; an edge-aware (guided-filter) upgrade is a possible follow-up.

## Testing

- `feather=0` is byte-identical to previous output (regression-safe).
- Verified a hard red/green boundary becomes a ~24px soft transition while flat interior is untouched; slider↔key alignment 52/52.
- 27 band + 22 zoom/catalog tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
