### PR TITLE
Make density-space inversion permanent; remove the linear method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ src/utils/unicode_path_utils.py → Cross-platform Unicode filename handling
 
 **Image processing pipeline**: RAW files decoded via rawpy → 16-bit numpy arrays → resized to 1080px max side → `ccr_processor.adjust_image()` applies color corrections. OpenCL GPU acceleration is optional and conditionally compiled. Thumbnails (8-bit) are generated separately from full previews.
 
-**Negative conversion paths**: The **B/W-point tool** (`ccr_normalize_with_bwpoint`, user samples a clear-film point + a dense point) is the primary conversion path. The auto reference-frame path (`ccr_normalize_with_reference`) is **legacy**. An experimental density-space (Cineon/negadoctor-style) inversion can be toggled with `FREECCR_DENSITY_INVERT=1` / `FREECCR_DENSITY_GAMMA`. See `docs/conversion-pipeline.md`.
+**Negative conversion**: Inversion is done in optical-density (log) space (Cineon/negadoctor-style) — the only method; the old linear `65535 - v` inversion was removed. The **B/W-point tool** (`ccr_normalize_with_bwpoint`, user samples a clear-film point + a dense point) is the primary path; the auto reference-frame path (`ccr_normalize_with_reference`) also runs density. `FREECCR_DENSITY_GAMMA` (default 0.55) tunes film contrast. See `docs/conversion-pipeline.md`.
 
 **Unicode path handling**: Windows non-ASCII filenames require `normalize_unicode_path()` and `validate_unicode_path()` from `src/utils/unicode_path_utils.py`. Always validate paths before passing to image loaders.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ src/utils/unicode_path_utils.py → Cross-platform Unicode filename handling
 
 **Image processing pipeline**: RAW files decoded via rawpy → 16-bit numpy arrays → resized to 1080px max side → `ccr_processor.adjust_image()` applies color corrections. OpenCL GPU acceleration is optional and conditionally compiled. Thumbnails (8-bit) are generated separately from full previews.
 
+**Negative conversion paths**: The **B/W-point tool** (`ccr_normalize_with_bwpoint`, user samples a clear-film point + a dense point) is the primary conversion path. The auto reference-frame path (`ccr_normalize_with_reference`) is **legacy**. An experimental density-space (Cineon/negadoctor-style) inversion can be toggled with `FREECCR_DENSITY_INVERT=1` / `FREECCR_DENSITY_GAMMA`. See `docs/conversion-pipeline.md`.
+
 **Unicode path handling**: Windows non-ASCII filenames require `normalize_unicode_path()` and `validate_unicode_path()` from `src/utils/unicode_path_utils.py`. Always validate paths before passing to image loaders.
 
 **Resource resolution**: `resource_path()` in `image_preview.py` handles both dev and Nuitka-bundled contexts. Nuitka embeds `src/icons/` and `LICENSES/` directories at build time.

--- a/docs/conversion-pipeline.md
+++ b/docs/conversion-pipeline.md
@@ -1,7 +1,6 @@
 # Negative conversion pipeline
 
-This documents how FreeCCR turns a scanned/photographed film negative into a
-positive, and the experimental **density-space** inversion on this branch.
+How FreeCCR turns a scanned/photographed film negative into a positive.
 
 ## Decode (shared by every path)
 
@@ -11,77 +10,41 @@ space (`ccr_image.read_image` → rawpy `gamma=(1,1)`, `use_camera_wb=False`,
 proportional to the negative's **transmittance** — the correct physical
 starting point for an inversion.
 
-## Two conversion entry points
+## Inversion — optical-density (log) space
 
-| Path | Function | Status |
-|------|----------|--------|
-| **B/W-point tool** (user samples a clear-film point and a dense point) | `ccr_normalize_with_bwpoint` / `apply_bwpoint_normalization` | **Active — primary tool** |
-| Auto reference frame (percentile + OD mean-equalisation) | `ccr_normalize_with_reference` / `apply_reference_normalization` | **Legacy** |
+FreeCCR inverts in **optical density**, because film records density as a
+roughly linear function of *log* exposure (the Hurter–Driffield characteristic
+curve). The earlier linear `out = 65535 - v` method (and its saturation/shadow
+"look") has been **removed** — density is the only inversion the app uses.
 
-> The auto reference path is **legacy**. New work targets the B/W-point tool,
-> where the user explicitly samples the film base (clear film) and the densest
-> area — exactly the anchors a physically-based inversion needs.
+Per channel:
 
-## Inversion algorithm (selectable)
+1. `D = -log10(transmittance)` — optical density.
+2. Subtract the **film base `Dmin`** (the orange mask) as a log **offset**.
+3. Divide by a per-channel **gamma** (`FREECCR_DENSITY_GAMMA`, default 0.55 —
+   the C-41 taking gamma — times a per-channel balance term).
+4. `H = 10^((D - Dmin)/gamma)` recovers scene-linear exposure; a luminance
+   level-stretch sets black/white, then sRGB encode → display-referred
+   positive. No saturation boost or shadow tint (pure faithful).
 
-Selected at runtime by the module flag `USE_DENSITY_INVERSION`
-(`core.ccr_processor`), settable via environment variable:
+Shared core: `_density_params_from_ref` (compute per-channel params) +
+`_density_apply` (apply them). `FREECCR_DENSITY_GAMMA` tunes contrast
+(≈0.45 punchier, ≈0.75 flatter).
 
-```
-FREECCR_DENSITY_INVERT=1     # use the density-space inversion (default: off)
-FREECCR_DENSITY_GAMMA=0.55   # film contrast used by the density path
-```
+## Two entry points
 
-### `standard` (default) — linear inversion
+| Path | Functions | Dmin / gamma source |
+|------|-----------|---------------------|
+| **B/W-point tool** (primary) | `ccr_normalize_with_bwpoint` / `apply_bwpoint_normalization` / `_density_invert_points` | clear-film point = Dmin; dense point fixes per-channel gamma (both endpoints neutralised) |
+| Auto reference frame | `ccr_normalize_with_reference` / `compute_reference_norm_params` + `apply_reference_normalization` | Dmin from the clear-film percentile; gamma from gray-world mean of the reference frame |
 
-Per-channel black/white-point normalisation in linear light, an optical-density
-mean-equalisation for cast balance, then a **linear `out = 65535 - v`**
-inversion, followed by a saturation boost + shadow-warmth "look".
+Both use the same density core, so preview, hi-res zoom, and export match.
+`compute_reference_norm_params` returns `(base_density, gamma_ch)`, which
+sliced children persist (conversion_inputs `mode: "ref_params"`).
 
-This is pleasing but not colorimetrically faithful: film density is ~linear in
-*log* exposure (the Hurter–Driffield characteristic curve), so a linear
-inversion bends the tonal transfer into a non-film curve, and the orange mask is
-removed by density *scaling* rather than a base *offset*.
-
-### `density` (experimental) — Cineon / negadoctor-style
-
-Inverts in optical-density (log) space, the way the film curve encodes the
-scene:
-
-1. `D = -log10(transmittance)` — per-channel optical density.
-2. Subtract the per-channel **film base `Dmin`** (the orange mask) as a log
-   **offset**. In the B/W-point tool this comes directly from the sampled
-   clear-film point; in the legacy auto path it is estimated from a high
-   percentile of the reference frame.
-3. Divide by a per-channel **gamma** (`FREECCR_DENSITY_GAMMA` × a per-channel
-   balance term). In the B/W-point tool the balance comes from the sampled
-   dense point, so the clear point lands on neutral black and the dense point on
-   neutral white — the mask is cancelled across the whole tonal range with no
-   gray-world guess.
-4. `H = 10^((D - Dmin)/gamma)` recovers scene-linear exposure; the result is
-   sRGB-encoded for display.
-
-On this branch the density path is **pure faithful**: the saturation boost and
-shadow-warmth styling are **not** applied (they would re-introduce a colour
-cast). Tune contrast with `FREECCR_DENSITY_GAMMA` (≈0.45 punchier, ≈0.75
-flatter).
-
-#### Known limitation
-
-The B/W-point tool is exact in density mode at every resolution (preview, zoom,
-export all go through `_density_invert_points`). The **legacy auto path's**
-hi-res replay (`apply_reference_normalization`) still uses the linear inversion
-in density mode — only its styling is dropped — so auto + density is approximate
-on zoom/export. This is intentional: the auto path is legacy.
-
-## Trying it
+## Offline check
 
 ```bash
-# Live in the app (your normal workflow, B/W-point tool):
-FREECCR_DENSITY_INVERT=1 python src/main.py        # PowerShell: $env:FREECCR_DENSITY_INVERT=1
-
-# Offline A/B on a single file:
 python experiments/density_compare.py NEG.tif --black 60000,42000,30000 --white 3500,2600,1900
-python experiments/density_compare.py NEG.tif --ref 120,90,300,260     # legacy auto path
-python experiments/density_compare.py --synthetic                       # no file needed
+python experiments/density_compare.py --synthetic
 ```

--- a/docs/conversion-pipeline.md
+++ b/docs/conversion-pipeline.md
@@ -1,0 +1,87 @@
+# Negative conversion pipeline
+
+This documents how FreeCCR turns a scanned/photographed film negative into a
+positive, and the experimental **density-space** inversion on this branch.
+
+## Decode (shared by every path)
+
+RAW frames are decoded **linear**, with no white balance and in the raw colour
+space (`ccr_image.read_image` → rawpy `gamma=(1,1)`, `use_camera_wb=False`,
+`output_color=raw`, `no_auto_bright=True`). The decoded value is therefore
+proportional to the negative's **transmittance** — the correct physical
+starting point for an inversion.
+
+## Two conversion entry points
+
+| Path | Function | Status |
+|------|----------|--------|
+| **B/W-point tool** (user samples a clear-film point and a dense point) | `ccr_normalize_with_bwpoint` / `apply_bwpoint_normalization` | **Active — primary tool** |
+| Auto reference frame (percentile + OD mean-equalisation) | `ccr_normalize_with_reference` / `apply_reference_normalization` | **Legacy** |
+
+> The auto reference path is **legacy**. New work targets the B/W-point tool,
+> where the user explicitly samples the film base (clear film) and the densest
+> area — exactly the anchors a physically-based inversion needs.
+
+## Inversion algorithm (selectable)
+
+Selected at runtime by the module flag `USE_DENSITY_INVERSION`
+(`core.ccr_processor`), settable via environment variable:
+
+```
+FREECCR_DENSITY_INVERT=1     # use the density-space inversion (default: off)
+FREECCR_DENSITY_GAMMA=0.55   # film contrast used by the density path
+```
+
+### `standard` (default) — linear inversion
+
+Per-channel black/white-point normalisation in linear light, an optical-density
+mean-equalisation for cast balance, then a **linear `out = 65535 - v`**
+inversion, followed by a saturation boost + shadow-warmth "look".
+
+This is pleasing but not colorimetrically faithful: film density is ~linear in
+*log* exposure (the Hurter–Driffield characteristic curve), so a linear
+inversion bends the tonal transfer into a non-film curve, and the orange mask is
+removed by density *scaling* rather than a base *offset*.
+
+### `density` (experimental) — Cineon / negadoctor-style
+
+Inverts in optical-density (log) space, the way the film curve encodes the
+scene:
+
+1. `D = -log10(transmittance)` — per-channel optical density.
+2. Subtract the per-channel **film base `Dmin`** (the orange mask) as a log
+   **offset**. In the B/W-point tool this comes directly from the sampled
+   clear-film point; in the legacy auto path it is estimated from a high
+   percentile of the reference frame.
+3. Divide by a per-channel **gamma** (`FREECCR_DENSITY_GAMMA` × a per-channel
+   balance term). In the B/W-point tool the balance comes from the sampled
+   dense point, so the clear point lands on neutral black and the dense point on
+   neutral white — the mask is cancelled across the whole tonal range with no
+   gray-world guess.
+4. `H = 10^((D - Dmin)/gamma)` recovers scene-linear exposure; the result is
+   sRGB-encoded for display.
+
+On this branch the density path is **pure faithful**: the saturation boost and
+shadow-warmth styling are **not** applied (they would re-introduce a colour
+cast). Tune contrast with `FREECCR_DENSITY_GAMMA` (≈0.45 punchier, ≈0.75
+flatter).
+
+#### Known limitation
+
+The B/W-point tool is exact in density mode at every resolution (preview, zoom,
+export all go through `_density_invert_points`). The **legacy auto path's**
+hi-res replay (`apply_reference_normalization`) still uses the linear inversion
+in density mode — only its styling is dropped — so auto + density is approximate
+on zoom/export. This is intentional: the auto path is legacy.
+
+## Trying it
+
+```bash
+# Live in the app (your normal workflow, B/W-point tool):
+FREECCR_DENSITY_INVERT=1 python src/main.py        # PowerShell: $env:FREECCR_DENSITY_INVERT=1
+
+# Offline A/B on a single file:
+python experiments/density_compare.py NEG.tif --black 60000,42000,30000 --white 3500,2600,1900
+python experiments/density_compare.py NEG.tif --ref 120,90,300,260     # legacy auto path
+python experiments/density_compare.py --synthetic                       # no file needed
+```

--- a/experiments/.gitignore
+++ b/experiments/.gitignore
@@ -1,0 +1,5 @@
+# Generated comparison images
+*.png
+*.jpg
+*.tif
+*.tiff

--- a/experiments/density_compare.py
+++ b/experiments/density_compare.py
@@ -107,18 +107,35 @@ def convert(rgb, ref, density):
     return P.ccr_normalize_with_reference(FakeImage(rgb.copy(), ref))
 
 
+def convert_bw(rgb, black, white, density):
+    P.USE_DENSITY_INVERSION = density
+    return P.ccr_normalize_with_bwpoint(FakeImage(rgb.copy(), None), black, white)
+
+
+def _triple(s):
+    vals = [float(v) for v in s.split(",")]
+    if len(vals) != 3:
+        raise SystemExit("expected three comma-separated values B,G,R")
+    return vals
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("image", nargs="?", help="negative file (RAW/TIFF/PNG/JPG)")
     ap.add_argument("--synthetic", action="store_true",
                     help="run on a simulated negative instead of a file")
     ap.add_argument("--ref", default=None, help="x1,y1,x2,y2 in resized px")
+    ap.add_argument("--black", default=None,
+                    help="B/W-point tool: clear-film sample as B,G,R sensor values")
+    ap.add_argument("--white", default=None,
+                    help="B/W-point tool: dense-area sample as B,G,R sensor values")
     ap.add_argument("--gamma", type=float, default=None, help="density film gamma")
     ap.add_argument("--out", default=None)
     a = ap.parse_args()
 
     if a.gamma is not None:
         P.DENSITY_FILM_GAMMA = a.gamma
+    bw = a.black is not None and a.white is not None
 
     extras = []
     if a.synthetic:
@@ -138,10 +155,16 @@ def main():
     else:
         x1, y1, x2, y2 = int(w * 0.2), int(h * 0.2), int(w * 0.8), int(h * 0.8)
     ref = (x1, y1, x2, y2)
-    print(f"image {w}x{h}, reference frame {ref}, film_gamma={P.DENSITY_FILM_GAMMA}")
+    mode = "B/W-point" if bw else "reference"
+    print(f"image {w}x{h}, {mode} mode, film_gamma={P.DENSITY_FILM_GAMMA}")
 
-    std8 = to_bgr8(convert(rgb, ref, density=False))
-    den8 = to_bgr8(convert(rgb, ref, density=True))
+    if bw:
+        black, white = _triple(a.black), _triple(a.white)
+        std8 = to_bgr8(convert_bw(rgb, black, white, density=False))
+        den8 = to_bgr8(convert_bw(rgb, black, white, density=True))
+    else:
+        std8 = to_bgr8(convert(rgb, ref, density=False))
+        den8 = to_bgr8(convert(rgb, ref, density=True))
 
     os.makedirs(outdir, exist_ok=True)
     cv2.imwrite(os.path.join(outdir, f"{base}_standard.png"), std8)

--- a/experiments/density_compare.py
+++ b/experiments/density_compare.py
@@ -1,0 +1,167 @@
+"""A/B compare the standard vs density-space negative inversion.
+
+The standard pipeline inverts the scan in linear space (out = 65535 - v); the
+density pipeline inverts in optical-density (log) space the way the film curve
+actually encodes the scene (see _invert_negative_density in ccr_processor).
+
+Usage:
+    # On one of your own negatives (RAW or TIFF/PNG/JPG):
+    python experiments/density_compare.py PATH [--ref x1,y1,x2,y2] [--gamma 0.55] [--out DIR]
+
+    # Self-contained sanity check on a simulated negative (no file needed):
+    python experiments/density_compare.py --synthetic
+
+Writes <name>_standard.png, <name>_density.png and a side-by-side
+<name>_compare.png next to the input (or in --out). The reference frame
+defaults to the centre 60% box; pass --ref to match what you'd pick in the app.
+"""
+import os
+import sys
+import argparse
+import numpy as np
+import cv2
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+import core.ccr_processor as P  # noqa: E402
+
+RAW_EXTS = {".nef", ".cr2", ".cr3", ".arw", ".dng", ".raf",
+            ".rw2", ".orf", ".pef", ".srw", ".nrw", ".raw"}
+
+
+def decode_linear(path, max_side=1080):
+    """Decode to a linear 16-bit RGB array, mirroring FreeCCR's rawpy params
+    (linear gamma, no white balance, raw colour space)."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext in RAW_EXTS:
+        import rawpy
+        with rawpy.imread(path) as raw:
+            rgb = raw.postprocess(
+                output_bps=16, no_auto_bright=True, gamma=(1, 1),
+                use_camera_wb=False,
+                output_color=rawpy.ColorSpace.raw,
+                demosaic_algorithm=rawpy.DemosaicAlgorithm.AHD,
+                half_size=False)
+    else:
+        img = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+        if img is None:
+            raise SystemExit(f"Could not read {path}")
+        if img.ndim == 2:
+            img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+        else:
+            img = cv2.cvtColor(img[..., :3], cv2.COLOR_BGR2RGB)
+        rgb = (img.astype(np.uint16) << 8) if img.dtype == np.uint8 \
+            else img.astype(np.uint16)
+    h, w = rgb.shape[:2]
+    s = max_side / max(h, w)
+    if s < 1.0:
+        rgb = cv2.resize(rgb, (int(round(w * s)), int(round(h * s))),
+                         interpolation=cv2.INTER_AREA)
+    return rgb
+
+
+def simulate_negative(size=512):
+    """Build a synthetic scene (positive) and the C-41 negative a camera would
+    record from it: v = base * H**(-gamma) per channel, with an orange mask
+    (per-channel film base). Returns (negative_linear_u16, scene_positive_u8)."""
+    h = w = size
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    # Scene exposure H in (0,1]: horizontal luminance ramp x vertical tint ramp.
+    lum = np.clip(0.04 + 0.95 * (xx / w), 1e-3, 1.0)
+    scene = np.empty((h, w, 3), np.float32)
+    scene[..., 0] = lum * (0.6 + 0.4 * (yy / h))      # R varies top->bottom
+    scene[..., 1] = lum
+    scene[..., 2] = lum * (1.0 - 0.4 * (yy / h))      # B opposite
+    # colour patches so casts are obvious
+    scene[40:140, 40:140] = (0.75, 0.15, 0.15)        # red
+    scene[40:140, 200:300] = (0.15, 0.55, 0.20)       # green
+    scene[40:140, 360:460] = (0.15, 0.25, 0.75)       # blue
+    scene = np.clip(scene, 1e-3, 1.0)
+
+    gamma = np.array([0.62, 0.58, 0.55], np.float32)  # per-layer film contrast
+    mask_base = np.array([0.95, 0.55, 0.30], np.float32)  # orange mask (R>G>B)
+    neg = mask_base[None, None, :] * np.power(scene, -gamma[None, None, :])
+    neg = neg / neg.max()                              # fit into [0,1]
+    neg_u16 = np.clip(neg * 65535.0, 0, 65535).astype(np.uint16)
+    scene_u8 = (np.clip(scene, 0, 1) ** (1 / 2.2) * 255).astype(np.uint8)
+    return neg_u16, scene_u8
+
+
+class FakeImage:
+    """Minimal stand-in for CCRImage in preview mode (output_path=None)."""
+    def __init__(self, resized_raw, reference_frame):
+        self.resized_raw = resized_raw
+        self.reference_frame = reference_frame
+        self.fine_rotation_angle = 0
+        self.horizontal_mirrored = False
+        self.vertical_mirrored = False
+        self.color_profile = "color"
+
+
+def to_bgr8(rgb16):
+    b8 = (rgb16.astype(np.uint32) >> 8).astype(np.uint8)
+    return cv2.cvtColor(b8, cv2.COLOR_RGB2BGR)
+
+
+def convert(rgb, ref, density):
+    P.USE_DENSITY_INVERSION = density
+    return P.ccr_normalize_with_reference(FakeImage(rgb.copy(), ref))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("image", nargs="?", help="negative file (RAW/TIFF/PNG/JPG)")
+    ap.add_argument("--synthetic", action="store_true",
+                    help="run on a simulated negative instead of a file")
+    ap.add_argument("--ref", default=None, help="x1,y1,x2,y2 in resized px")
+    ap.add_argument("--gamma", type=float, default=None, help="density film gamma")
+    ap.add_argument("--out", default=None)
+    a = ap.parse_args()
+
+    if a.gamma is not None:
+        P.DENSITY_FILM_GAMMA = a.gamma
+
+    extras = []
+    if a.synthetic:
+        rgb, scene_u8 = simulate_negative()
+        base, outdir = "synthetic", a.out or os.path.dirname(os.path.abspath(__file__))
+        extras = [("scene_truth", cv2.cvtColor(scene_u8, cv2.COLOR_RGB2BGR))]
+    elif a.image:
+        rgb = decode_linear(a.image)
+        base = os.path.splitext(os.path.basename(a.image))[0]
+        outdir = a.out or os.path.dirname(os.path.abspath(a.image))
+    else:
+        ap.error("provide an image path or --synthetic")
+
+    h, w = rgb.shape[:2]
+    if a.ref:
+        x1, y1, x2, y2 = (int(v) for v in a.ref.split(","))
+    else:
+        x1, y1, x2, y2 = int(w * 0.2), int(h * 0.2), int(w * 0.8), int(h * 0.8)
+    ref = (x1, y1, x2, y2)
+    print(f"image {w}x{h}, reference frame {ref}, film_gamma={P.DENSITY_FILM_GAMMA}")
+
+    std8 = to_bgr8(convert(rgb, ref, density=False))
+    den8 = to_bgr8(convert(rgb, ref, density=True))
+
+    os.makedirs(outdir, exist_ok=True)
+    cv2.imwrite(os.path.join(outdir, f"{base}_standard.png"), std8)
+    cv2.imwrite(os.path.join(outdir, f"{base}_density.png"), den8)
+
+    panels = [("STANDARD", std8), ("DENSITY", den8)] + \
+             [(n.upper(), im) for n, im in extras]
+    gap = np.full((std8.shape[0], 12, 3), 32, np.uint8)
+    tiles = []
+    for i, (label, im) in enumerate(panels):
+        if i:
+            tiles.append(gap)
+        lab = im.copy()
+        cv2.putText(lab, label, (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.9,
+                    (255, 255, 255), 2, cv2.LINE_AA)
+        tiles.append(lab)
+    combo_path = os.path.join(outdir, f"{base}_compare.png")
+    cv2.imwrite(combo_path, np.hstack(tiles))
+    print("wrote:", combo_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -70,7 +70,7 @@ def _ci_to_json(ci):
         out["ref"] = list(out["ref"])
     if out.get("bw") is not None:
         out["bw"] = [list(out["bw"][0]), list(out["bw"][1])]
-    for key in ("p_lo", "p_hi", "od"):
+    for key in ("base_density", "gamma_ch"):
         if out.get(key) is not None:
             out[key] = list(out[key])
     return out
@@ -84,7 +84,7 @@ def _ci_from_json(ci):
         out["ref"] = tuple(out["ref"])
     if out.get("bw") is not None:
         out["bw"] = (tuple(out["bw"][0]), tuple(out["bw"][1]))
-    for key in ("p_lo", "p_hi", "od"):
+    for key in ("base_density", "gamma_ch"):
         if out.get(key) is not None:
             out[key] = tuple(out[key])
     return out
@@ -361,8 +361,14 @@ def _replay_conversion(img, ci) -> None:
             img.reference_frame = saved_ref
         img.resized_raw = processed
     elif mode == "ref_params":
+        if ci.get("base_density") is None:
+            # Pre-density catalog (old linear ref_params child): the legacy
+            # params can't be migrated to density, so leave the decoded frame
+            # as-is rather than crash. Re-slice to reconvert.
+            print("Skipping legacy ref_params replay (re-slice to reconvert).")
+            return
         img.resized_raw = apply_reference_normalization(
-            img.resized_raw, ci["p_lo"], ci["p_hi"], ci["od"])
+            img.resized_raw, ci["base_density"], ci["gamma_ch"])
     elif mode == "bw":
         saved_fine = img.fine_rotation_angle
         img.fine_rotation_angle = ci.get("fine_rot", 0)

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -453,7 +453,7 @@ class CCRBackend:
                 if ci is not None and ci.get("mode") == "ref_params":
                     # Sliced child of a reference-converted parent: replay the
                     # stored conversion constants at full resolution.
-                    ccr_normalize_with_refparams(image_obj, ci["p_lo"], ci["p_hi"], ci["od"],
+                    ccr_normalize_with_refparams(image_obj, ci["base_density"], ci["gamma_ch"],
                                                  output_path=output_path,
                                                  water_mark=not self.software_activated,
                                                  jpg_out=jpg_output, jpg_quality=jpg_quality,
@@ -746,13 +746,12 @@ class CCRBackend:
         if parent_ci is not None and parent_ci.get("mode") == "ref":
             from core.ccr_processor import compute_reference_norm_params
             ref_small = img_obj.resize_image_to_max_pixel(full, 1080)
-            p_lo, p_hi, od = compute_reference_norm_params(
+            base_density, gamma_ch = compute_reference_norm_params(
                 ref_small, parent_ci["ref"], parent_ci["fine_rot"])
-            norm_params = (tuple(float(v) for v in p_lo),
-                           tuple(float(v) for v in p_hi),
-                           tuple(float(v) for v in od))
+            norm_params = (tuple(float(v) for v in base_density),
+                           tuple(float(v) for v in gamma_ch))
         elif parent_ci is not None and parent_ci.get("mode") == "ref_params":
-            norm_params = (parent_ci["p_lo"], parent_ci["p_hi"], parent_ci["od"])
+            norm_params = (parent_ci["base_density"], parent_ci["gamma_ch"])
 
         # Bake the parent's current fine rotation: the cuts were placed on
         # the rotated display, so the slices are cut from the rotated frame.
@@ -803,8 +802,8 @@ class CCRBackend:
                 if norm_params is not None:
                     from core.ccr_processor import apply_reference_normalization
                     crop = apply_reference_normalization(crop, *norm_params)
-                    child_ci = {"mode": "ref_params", "p_lo": norm_params[0],
-                                "p_hi": norm_params[1], "od": norm_params[2]}
+                    child_ci = {"mode": "ref_params", "base_density": norm_params[0],
+                                "gamma_ch": norm_params[1]}
                 elif parent_ci is not None and parent_ci.get("mode") == "bw":
                     from core.ccr_processor import apply_bwpoint_normalization
                     black_point, white_point = parent_ci["bw"]
@@ -942,13 +941,12 @@ class CCRBackend:
             child_full = template.read_image(template.file_path, preview=True)
             if child_full is not None:
                 small = template.resize_image_to_max_pixel(child_full, 1080)
-                p_lo, p_hi, od = compute_reference_norm_params(
+                base_density, gamma_ch = compute_reference_norm_params(
                     small, ci["ref"], ci.get("fine_rot", 0))
-                norm_params = (tuple(float(v) for v in p_lo),
-                               tuple(float(v) for v in p_hi),
-                               tuple(float(v) for v in od))
+                norm_params = (tuple(float(v) for v in base_density),
+                               tuple(float(v) for v in gamma_ch))
         elif ci is not None and ci.get("mode") == "ref_params":
-            norm_params = (ci["p_lo"], ci["p_hi"], ci["od"])
+            norm_params = (ci["base_density"], ci["gamma_ch"])
         elif ci is not None and ci.get("mode") == "bw":
             bw_points = ci["bw"]
 
@@ -981,8 +979,8 @@ class CCRBackend:
                 parent.resized_raw, *norm_params)
             parent.converted = True
             parent.conversion_inputs = {
-                "mode": "ref_params", "p_lo": norm_params[0],
-                "p_hi": norm_params[1], "od": norm_params[2]}
+                "mode": "ref_params", "base_density": norm_params[0],
+                "gamma_ch": norm_params[1]}
         elif bw_points is not None:
             parent.resized_raw = apply_bwpoint_normalization(
                 parent.resized_raw, *bw_points)

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -595,14 +595,14 @@ class CCRImage:
         t0 = time.time()
         if ci.get("mode") == "ref":
             ref_small = self.resize_image_to_max_pixel(img, 1080)
-            p_lo, p_hi, od_factors = compute_reference_norm_params(
+            base_density, gamma_ch = compute_reference_norm_params(
                 ref_small, ci["ref"], ci["fine_rot"])
-            out = apply_reference_normalization(img, p_lo, p_hi, od_factors)
+            out = apply_reference_normalization(img, base_density, gamma_ch)
         elif ci.get("mode") == "ref_params":
             # Sliced children of a reference-converted parent carry the
             # parent's precomputed conversion constants directly (the
             # parent's frame coordinates would be meaningless here).
-            out = apply_reference_normalization(img, ci["p_lo"], ci["p_hi"], ci["od"])
+            out = apply_reference_normalization(img, ci["base_density"], ci["gamma_ch"])
         elif ci.get("mode") == "bw":
             # The bwpoint pipeline bakes the fine rotation into the preview
             # pixels BEFORE normalization — replicate that here so the

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -17,6 +17,25 @@ except ImportError:
     cl = None
     cl_array = None
 
+# --- Experimental negative-inversion algorithm selection -------------------
+# The original pipeline inverts the scanned negative in LINEAR space
+# (out = 65535 - v) after a per-channel optical-density mean-equalisation that
+# is used only for cast balance. Film records density as a roughly linear
+# function of *log* exposure (the Hurter-Driffield characteristic curve), so
+# the physically faithful inversion happens in optical-density (log) space:
+# subtract the per-channel film base (Dmin / orange mask) as an offset, divide
+# by a per-channel gamma, then encode for display. See _invert_negative_density.
+#
+# Toggle at runtime by setting the module global, or via env var:
+#   FREECCR_DENSITY_INVERT=1   -> use the density-space inversion
+#   FREECCR_DENSITY_GAMMA=0.55 -> film contrast (gamma) used by that path
+def _env_flag(name, default=False):
+    return os.environ.get(name, "1" if default else "0").strip().lower() \
+        not in ("0", "", "false", "no", "off")
+
+USE_DENSITY_INVERSION = _env_flag("FREECCR_DENSITY_INVERT", False)
+DENSITY_FILM_GAMMA = float(os.environ.get("FREECCR_DENSITY_GAMMA", "0.55"))
+
 # The hi-res zoom worker can call adjust_image_opencl concurrently with the
 # GUI thread; pyopencl command queues are not safe for concurrent submission.
 _opencl_lock = threading.Lock()
@@ -594,6 +613,134 @@ def safe_tifffile_imwrite(output_path: str, image: np.ndarray, **kwargs) -> bool
 
 
 
+def _invert_negative_standard(img, img_ref, ref_crop, x1, y1, x2, y2):
+    """Original FreeCCR inversion (the default).
+
+    Per-channel linear black/white-point normalisation against the reference
+    crop's 1st/99th percentiles, then an optical-density mean-equalisation
+    (per-channel density *scaling*) for cast balance, then a LINEAR
+    ``65535 - v`` inversion. Returns the inverted positive as uint16.
+    """
+    step_start = time.time()
+    norm = np.empty_like(img, dtype=np.float32)
+    norm_ref = np.empty_like(img_ref, dtype=np.float32)
+    for c in range(3):
+        ch_crop = ref_crop[..., c]
+        p10 = np.percentile(ch_crop, 1)     # 1st percentile
+        p90 = np.percentile(ch_crop, 99)    # 99th percentile
+
+        ch_full = img[..., c]
+        ch_full_ref = img_ref[..., c]
+
+        # Linear mapping: p10 -> 8192, p90 -> 65535
+        np.subtract(ch_full, p10, out=norm[..., c])
+        np.divide(norm[..., c], (p90 - p10), out=norm[..., c])
+        np.multiply(norm[..., c], (65535 - 8192), out=norm[..., c])
+        np.add(norm[..., c], 8192, out=norm[..., c])
+        np.clip(norm[..., c], 0, 65535, out=norm[..., c])
+
+        np.subtract(ch_full_ref, p10, out=norm_ref[..., c])
+        np.divide(norm_ref[..., c], (p90 - p10), out=norm_ref[..., c])
+        np.multiply(norm_ref[..., c], (65535 - 8192), out=norm_ref[..., c])
+        np.add(norm_ref[..., c], 8192, out=norm_ref[..., c])
+        np.clip(norm_ref[..., c], 0, 65535, out=norm_ref[..., c])
+    print(f"BWPN: {time.time() - step_start:.3f}s")
+
+    # Optical density alignment (per-channel mean-density equalisation)
+    step_start = time.time()
+    ref_norm_crop = norm_ref[y1:y2, x1:x2]
+    np.add(ref_norm_crop, 1e-6, out=ref_norm_crop)
+    od_crop = -np.log10(ref_norm_crop / 65535.0)
+    mean_od_crop = np.mean(od_crop, axis=(0, 1))
+    target_mean_od = np.mean(mean_od_crop)
+    scaling_factors = target_mean_od / (mean_od_crop + 1e-12)
+
+    norm_full = norm
+    np.add(norm_full, 1e-6, out=norm_full)
+    od_full = -np.log10(norm_full / 65535.0)
+    od_aligned_full = od_full * scaling_factors
+    del ref_norm_crop, od_crop, mean_od_crop, scaling_factors, od_full
+
+    np.power(10, -od_aligned_full, out=od_aligned_full)
+    od_aligned_full *= 65535.0
+    np.clip(od_aligned_full, 0, 65535, out=od_aligned_full)
+    rgb_aligned_full = od_aligned_full.astype(np.uint16, copy=False)
+
+    rgb_inverted_full = 65535 - rgb_aligned_full
+    del od_aligned_full, rgb_aligned_full, norm, norm_ref
+    print(f"ODAI: {time.time() - step_start:.3f}s")
+    return rgb_inverted_full
+
+
+def _srgb_encode(x):
+    """Linear [0,1] -> sRGB display values [0,1] (the standard OETF)."""
+    x = np.clip(x, 0.0, 1.0)
+    return np.where(x <= 0.0031308, x * 12.92,
+                    1.055 * np.power(x, 1.0 / 2.4) - 0.055)
+
+
+def _invert_negative_density(img, ref_crop, film_gamma=None):
+    """Density-space (Cineon / darktable-negadoctor-style) inversion.
+
+    Works in optical density rather than linear light, because film density is
+    ~linear in *log* exposure (the H&D characteristic curve):
+
+      1. D = -log10(v / white)                  per-channel optical density
+      2. Dmin[c] from the clear-film percentile  (film base / orange mask)
+      3. d = D - Dmin[c]                          relative density (>= 0)
+      4. gamma[c] = film_gamma * mean_d[c]/mean   per-channel gray-world balance
+                                                  x film contrast
+      5. H[c] = 10^(d / gamma[c])                 recovered scene-linear exposure
+      6. luminance level-stretch + sRGB encode    -> display-referred positive
+
+    Unlike the standard path this removes the orange mask as a per-channel
+    density OFFSET (step 2-3) and performs the inversion in log space, so the
+    tonal transfer follows the film curve rather than a linear 65535 - v.
+    Returns the inverted positive as uint16.
+    """
+    if film_gamma is None:
+        film_gamma = DENSITY_FILM_GAMMA
+    white = 65535.0
+    t0 = time.time()
+
+    base_density = np.zeros(3, dtype=np.float64)
+    mean_rel = np.zeros(3, dtype=np.float64)
+    for c in range(3):
+        ch_ref = ref_crop[..., c].astype(np.float32)
+        # Clear film (orange-mask base) is the brightest = least-dense end.
+        v_base = max(float(np.percentile(ch_ref, 99.0)), 1.0)
+        d_base = -np.log10(v_base / white)
+        base_density[c] = d_base
+        d_ref = -np.log10(np.clip(ch_ref, 1.0, white) / white) - d_base
+        np.clip(d_ref, 0.0, None, out=d_ref)
+        mean_rel[c] = max(float(d_ref.mean()), 1e-6)
+
+    # Gray-world: the per-channel ratio of mean densities sets the balance;
+    # film_gamma sets the absolute contrast (typical C-41 taking gamma ~0.55).
+    target = float(np.mean(mean_rel))
+    gamma_ch = film_gamma * (mean_rel / target)
+
+    pos = np.empty_like(img, dtype=np.float32)
+    for c in range(3):
+        d = -np.log10(np.clip(img[..., c], 1.0, white) / white) - base_density[c]
+        np.clip(d, 0.0, None, out=d)
+        pos[..., c] = np.power(10.0, d / gamma_ch[c])
+
+    # White/black anchored by a single luminance level-stretch (scalar offset
+    # + scale applied to all channels) so neutrals stay neutral.
+    lum = 0.299 * pos[..., 0] + 0.587 * pos[..., 1] + 0.114 * pos[..., 2]
+    black = float(np.percentile(lum, 0.5))
+    whitep = float(np.percentile(lum, 99.5))
+    denom = max(whitep - black, 1e-6)
+    pos -= black
+    pos /= denom
+
+    out = _srgb_encode(pos)
+    out = np.clip(out * white, 0, 65535).astype(np.uint16)
+    print(f"Density inversion (gamma={film_gamma:.2f}): {time.time() - t0:.3f}s")
+    return out
+
+
 def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_out=False,jpg_quality=95,max_long_side=None) -> np.ndarray:
     """
     Normalize and align the image using the CCR algorithm, using a reference rectangle
@@ -674,64 +821,17 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
     # plt.axis('off')
     # plt.show()
 
-    # Black/white point normalization per channel with three-segment linear compression
-    step_start = time.time()
-    norm = np.empty_like(img, dtype=np.float32)
-    norm_ref = np.empty_like(img_ref, dtype=np.float32)
-    for c in range(3):
-        ch_crop = ref_crop[..., c]
-        # Get percentiles for linear mapping with compressed extremes
-        p10 = np.percentile(ch_crop, 1)    # 1st percentile
-        p90 = np.percentile(ch_crop, 99)    # 99th percentile  
-        
-        ch_full = img[..., c]
-        ch_full_ref = img_ref[..., c]
-        
-        # Linear mapping: p10->6086, p90->43882:
-        # Formula: output = (input - p10) / (p90 - p10) * (43882 - 6086) + 6086
-        np.subtract(ch_full, p10, out=norm[..., c])
-        np.divide(norm[..., c], (p90 - p10), out=norm[..., c])
-        np.multiply(norm[..., c], (65535 - 8192), out=norm[..., c])
-        np.add(norm[..., c], 8192, out=norm[..., c])
-        np.clip(norm[..., c], 0, 65535, out=norm[..., c])
-
-        np.subtract(ch_full_ref, p10, out=norm_ref[..., c])
-        np.divide(norm_ref[..., c], (p90 - p10), out=norm_ref[..., c])
-        np.multiply(norm_ref[..., c], (65535 - 8192), out=norm_ref[..., c])
-        np.add(norm_ref[..., c], 8192, out=norm_ref[..., c])
-        np.clip(norm_ref[..., c], 0, 65535, out=norm_ref[..., c])
-    
-    # Clean up intermediate arrays
+    # --- Negative inversion -------------------------------------------------
+    # standard: per-channel linear normalisation + OD cast-balance + linear
+    #           65535 - v inversion (the original FreeCCR algorithm).
+    # density : Cineon/negadoctor-style inversion in optical-density space.
+    # Selected by USE_DENSITY_INVERSION (env FREECCR_DENSITY_INVERT).
+    if USE_DENSITY_INVERSION:
+        rgb_inverted_full = _invert_negative_density(img, ref_crop)
+    else:
+        rgb_inverted_full = _invert_negative_standard(
+            img, img_ref, ref_crop, x1, y1, x2, y2)
     del ref_crop
-    print(f"BWPN: {time.time() - step_start:.3f}s")
-      # Optical density alignment (conservative optimization)
-    step_start = time.time()
-    ref_norm_crop = norm_ref[y1:y2, x1:x2]
-    np.add(ref_norm_crop, 1e-6, out=ref_norm_crop)
-    od_crop = -np.log10(ref_norm_crop / 65535.0)
-    mean_od_crop = np.mean(od_crop, axis=(0, 1))
-    target_mean_od = np.mean(mean_od_crop)
-    scaling_factors = target_mean_od / (mean_od_crop + 1e-12)  # Only add division by zero protection
-
-    # Apply scaling to full image (keep original approach)
-    norm_full = norm
-    np.add(norm_full, 1e-6, out=norm_full)
-    od_full = -np.log10(norm_full / 65535.0)
-    od_aligned_full = od_full * scaling_factors
-      # Clean up intermediate arrays
-    del ref_norm_crop, od_crop, mean_od_crop, scaling_factors, od_full
-    
-    np.power(10, -od_aligned_full, out=od_aligned_full)
-    od_aligned_full *= 65535.0
-    np.clip(od_aligned_full, 0, 65535, out=od_aligned_full)
-    rgb_aligned_full = od_aligned_full.astype(np.uint16, copy=False)
-
-    # Invert
-    rgb_inverted_full = 65535 - rgb_aligned_full
-    
-    # Clean up more intermediate arrays
-    del od_aligned_full, rgb_aligned_full, norm, norm_ref
-    print(f"ODAI: {time.time() - step_start:.3f}s")
 
     # # --- Brightness normalization using grayscale ---
     # # Convert to grayscale using standard luminance weights

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -741,6 +741,54 @@ def _invert_negative_density(img, ref_crop, film_gamma=None):
     return out
 
 
+def _density_invert_points(img, black_point_bgr, white_point_bgr, film_gamma=None):
+    """Density-space inversion for the explicit B/W-point workflow.
+
+    The two sampled points pin the optical-density mapping directly, which is
+    exactly what the density model needs:
+      * black_point = clear/transparent film  -> the per-channel film base Dmin
+        (the orange mask), subtracted as a log-space OFFSET.
+      * white_point = densest exposed area     -> the per-channel Dmax, which
+        fixes the density range, hence the per-channel gamma.
+
+    Per channel: gamma is set so the dense point lands on a common neutral
+    white, and Dmin subtraction puts the clear point at neutral black, so both
+    endpoints are colour-balanced without any gray-world guess. Recovers
+    scene-linear exposure H = 10^((D - Dmin)/gamma), maps [base, dense] -> [0,1]
+    and sRGB-encodes. Returns a display-referred positive (uint16), pure
+    faithful (no saturation/shadow styling). Clear film -> black, dense ->
+    white, matching the linear B/W-point path's polarity.
+    """
+    if film_gamma is None:
+        film_gamma = DENSITY_FILM_GAMMA
+    white = 65535.0
+    img_f = img.astype(np.float32)
+
+    base_density = np.zeros(3, dtype=np.float64)
+    d_dense = np.zeros(3, dtype=np.float64)
+    for c in range(3):
+        b = max(float(black_point_bgr[c]), 1.0)    # clear film (high value) -> Dmin
+        w_ = max(float(white_point_bgr[c]), 1.0)   # dense film (low value)  -> Dmax
+        base_density[c] = -np.log10(b / white)
+        d_dense[c] = max(-np.log10(w_ / white) - base_density[c], 1e-6)
+
+    mean_dd = max(float(np.mean(d_dense)), 1e-6)
+    gamma_ch = film_gamma * (d_dense / mean_dd)        # per-channel; neutralises white
+    white_anchor = 10.0 ** (mean_dd / film_gamma)      # equal across channels at dense
+    denom = max(white_anchor - 1.0, 1e-6)
+
+    pos = np.empty_like(img_f)
+    for c in range(3):
+        d = -np.log10(np.clip(img_f[..., c], 1.0, white) / white) - base_density[c]
+        np.clip(d, 0.0, None, out=d)
+        h = np.power(10.0, d / gamma_ch[c])
+        pos[..., c] = (h - 1.0) / denom                # base -> 0, dense -> 1
+    np.clip(pos, 0.0, 1.0, out=pos)
+
+    out = _srgb_encode(pos)
+    return np.clip(out * white, 0, 65535).astype(np.uint16)
+
+
 def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_out=False,jpg_quality=95,max_long_side=None) -> np.ndarray:
     """
     Normalize and align the image using the CCR algorithm, using a reference rectangle
@@ -856,68 +904,15 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
     # else:
     #     stretch_scale = 1.0    # rgb_brightness_normalized = np.clip(rgb_scaled * stretch_scale, 0, 65535).astype(np.uint16)    # Apply inverted gamma correction for inverted linear data
     # Since we have inverted linear data, apply inverted gamma 1.5
-    rgb_norm = rgb_inverted_full.astype(np.float32) / 65535.0
-      # Apply inverted gamma 2.2 (use gamma = 2.2 for inverted image)
-    gamma_corrected = np.power(np.clip(rgb_norm, 0.0, 1.0), 1.0)
-    del rgb_norm
-
-    # Convert to LAB-like processing for saturation
-    # Calculate luminance using standard weights
-    luminance = np.dot(gamma_corrected[..., :3], [0.299, 0.587, 0.114])
-    luminance_expanded = np.expand_dims(luminance, axis=-1)
-    
-    # Create saturation curve that has minimal effect in shadows and stronger effect in midtones/highlights
-    # Using power curve: luminance^0.8 gives gentle increase from shadows to highlights
-    saturation_curve = np.power(luminance, 0.8)  # Smooth curve from 0 to 1
-    del luminance  # Clean up luminance as it's no longer needed
-    base_saturation = 1.15  # 15% maximum saturation increase
-
-    # Calculate dynamic saturation factor: minimal in shadows (1.02), full in highlights (1.12)
-    min_saturation = 1.00  # 2% minimum saturation in pure shadows
-    saturation_range = base_saturation - min_saturation  # 0.10 range
-    dynamic_saturation = min_saturation + saturation_range * saturation_curve
-    del saturation_curve
-    dynamic_saturation = np.expand_dims(dynamic_saturation, axis=-1)
-    
-    # Apply luminance-aware saturation by blending between grayscale and color
-    gamma_corrected = luminance_expanded + dynamic_saturation * (gamma_corrected - luminance_expanded)
-    del luminance_expanded, dynamic_saturation
-    gamma_corrected = np.clip(gamma_corrected, 0.0, 1.0)
-    
-    # Convert back to 16-bit and assign to rgb_brightness_normalized
-    # rgb_brightness_normalized = np.clip(gamma_corrected * 65535.0, 0, 65535).astype(np.uint16)
-
-        # Shadow-specific color correction: add warmth and green to dark shadows only
-    # Convert back to normalized for shadow correction
-    shadow_corrected = gamma_corrected
-    # Calculate luminance for curve-based shadow correction
-    shadow_luminance = np.dot(shadow_corrected[..., :3], [0.299, 0.587, 0.114])
-    
-    # Create smooth exponential curves that naturally target shadows
-    # These curves provide maximum effect in deep shadows and fade smoothly to highlights
-    
-    # Warmth curve: exponential decay from shadows (stronger effect in darker areas)
-    warmth_curve = np.exp(-shadow_luminance * 4.0)  # Exponential decay, strong in shadows
-    warmth_strength = 0.35 * warmth_curve  # 30% max correction in pure black
-    del warmth_curve  # Clean up as it's no longer needed
-    # Green tint curve: similar but with different decay rate for natural look
-    green_curve = np.exp(-shadow_luminance * 3.5)  # Slightly different curve shape
-    del shadow_luminance  # Clean up as it's no longer needed
-    green_strength = 0.15 * green_curve  # 12% max correction in pure black
-    del green_curve  # Clean up as it's no longer needed
-
-    # Apply corrections using smooth curves (no masks or conditionals)
-    shadow_corrected[..., 0] *= (1.0 + warmth_strength * 0.8)  # Red: moderate warmth boost
-    shadow_corrected[..., 1] *= (1.0 + green_strength)  # Green: boost to counter magenta
-    shadow_corrected[..., 2] *= (1.0 - warmth_strength)  # Blue: reduce to counter blue cast
-    del warmth_strength, green_strength  # Clean up as they're no longer needed
-    
-    # Convert back to 16-bit
-    rgb_brightness_normalized = np.clip(shadow_corrected * 65535.0, 0, 65535).astype(np.uint16)
-
-    del shadow_corrected, gamma_corrected  # Clean up as they're no longer needed
-
-    # Clean up rgb_inverted_full as it's no longer needed
+    # --- Post-invert styling -----------------------------------------------
+    # density: pure faithful — the density inversion already produced a
+    #          display-referred positive, so NO saturation boost or shadow
+    #          warmth is applied (it would re-introduce a colour cast).
+    # standard: the legacy saturation-boost + shadow-warmth look.
+    if USE_DENSITY_INVERSION:
+        rgb_brightness_normalized = rgb_inverted_full
+    else:
+        rgb_brightness_normalized = apply_postinvert_look(rgb_inverted_full)
     del rgb_inverted_full
     gc.collect()
     # --- End of brightness normalization ---
@@ -1096,8 +1091,14 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
     white_point_bgr: (B,G,R) scan values of dense/exposed film area (LOW values).
                      Dense areas → output white (65535) after inversion.
 
-    Pipeline: BWPN (user B/W points) → inversion → saturation boost → shadow correction
-    ODAI is skipped because per-channel B/W point mapping already normalises channels.
+    Inversion algorithm selected by USE_DENSITY_INVERSION (env
+    FREECCR_DENSITY_INVERT):
+      * density  — optical-density (log) space inversion, pure faithful, no
+                   styling. See _density_invert_points.
+      * standard — legacy per-channel linear stretch + 65535 - v inversion +
+                   saturation/shadow look.
+    ODAI is skipped because per-channel B/W point mapping already normalises
+    channels.
     """
     total_start_time = time.time()
 
@@ -1121,67 +1122,35 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
                               borderMode=cv2.BORDER_CONSTANT, borderValue=0)
         del rot_mat
 
-    # --- BWPN: B/W point values are absolute anchors, constant across the whole roll ---
-    #
-    # With no_auto_bright=True in rawpy, film base and dense-area values are identical in every
-    # frame. The sampled B/W points are applied directly as fixed per-channel anchors.
-    img_f = img.astype(np.float32)
-    norm = np.empty_like(img_f)
-    for c in range(3):
-        p_hi = max(float(black_point_bgr[c]), 1.0)   # transparent film (film base) → maps to black
-        p_lo = max(float(white_point_bgr[c]), 1.0)   # dense film (exposed area) → maps to white
-
-        denom = p_hi - p_lo
-        if abs(denom) < 1.0:
-            norm[..., c] = 0.0
-            continue
-        np.subtract(img_f[..., c], p_lo, out=norm[..., c])
-        np.divide(norm[..., c], denom, out=norm[..., c])
-        np.multiply(norm[..., c], 65535.0, out=norm[..., c])
-        np.clip(norm[..., c], 0, 65535, out=norm[..., c])
-    del img_f
-    print(f"BWPN (user points): {time.time() - total_start_time:.3f}s")
-
-    # --- Inversion (ODAI skipped: per-channel B/W points already equalise channels) ---
-    rgb_inverted = (65535.0 - norm).clip(0, 65535).astype(np.uint16)
-    del norm
-    gc.collect()
-
-    # --- Saturation boost (identical to main pipeline) ---
-    rgb_norm = rgb_inverted.astype(np.float32) / 65535.0
-    gamma_corrected = np.power(np.clip(rgb_norm, 0.0, 1.0), 1.0)
-    del rgb_norm
-
-    luminance = np.dot(gamma_corrected[..., :3], [0.299, 0.587, 0.114])
-    luminance_expanded = np.expand_dims(luminance, axis=-1)
-    saturation_curve = np.power(luminance, 0.8)
-    del luminance
-    base_saturation = 1.15
-    min_saturation = 1.00
-    dynamic_saturation = min_saturation + (base_saturation - min_saturation) * saturation_curve
-    del saturation_curve
-    dynamic_saturation = np.expand_dims(dynamic_saturation, axis=-1)
-    gamma_corrected = luminance_expanded + dynamic_saturation * (gamma_corrected - luminance_expanded)
-    del luminance_expanded, dynamic_saturation
-    gamma_corrected = np.clip(gamma_corrected, 0.0, 1.0)
-
-    # --- Shadow warmth correction (identical to main pipeline) ---
-    shadow_corrected = gamma_corrected
-    shadow_luminance = np.dot(shadow_corrected[..., :3], [0.299, 0.587, 0.114])
-    warmth_curve = np.exp(-shadow_luminance * 4.0)
-    warmth_strength = 0.35 * warmth_curve
-    del warmth_curve
-    green_curve = np.exp(-shadow_luminance * 3.5)
-    del shadow_luminance
-    green_strength = 0.15 * green_curve
-    del green_curve
-    shadow_corrected[..., 0] *= (1.0 + warmth_strength * 0.8)
-    shadow_corrected[..., 1] *= (1.0 + green_strength)
-    shadow_corrected[..., 2] *= (1.0 - warmth_strength)
-    del warmth_strength, green_strength
-
-    rgb_result = np.clip(shadow_corrected * 65535.0, 0, 65535).astype(np.uint16)
-    del shadow_corrected, gamma_corrected, rgb_inverted
+    # --- Inversion: density (pure faithful) or legacy linear ----------------
+    # The sampled points are absolute per-channel anchors, constant across the
+    # roll (no_auto_bright=True keeps film-base/dense values identical between
+    # frames). The clear-film point is the per-channel Dmin (orange mask).
+    if USE_DENSITY_INVERSION:
+        # Density-space inversion in optical density; no styling applied.
+        rgb_result = _density_invert_points(img, black_point_bgr, white_point_bgr)
+        print(f"Density inversion (B/W points): {time.time() - total_start_time:.3f}s")
+    else:
+        # Legacy: per-channel linear stretch + 65535 - v inversion + look.
+        img_f = img.astype(np.float32)
+        norm = np.empty_like(img_f)
+        for c in range(3):
+            p_hi = max(float(black_point_bgr[c]), 1.0)   # transparent film → black
+            p_lo = max(float(white_point_bgr[c]), 1.0)   # dense film → white
+            denom = p_hi - p_lo
+            if abs(denom) < 1.0:
+                norm[..., c] = 0.0
+                continue
+            np.subtract(img_f[..., c], p_lo, out=norm[..., c])
+            np.divide(norm[..., c], denom, out=norm[..., c])
+            np.multiply(norm[..., c], 65535.0, out=norm[..., c])
+            np.clip(norm[..., c], 0, 65535, out=norm[..., c])
+        del img_f
+        rgb_inverted = (65535.0 - norm).clip(0, 65535).astype(np.uint16)
+        del norm
+        rgb_result = apply_postinvert_look(rgb_inverted)
+        del rgb_inverted
+        print(f"BWPN (user points): {time.time() - total_start_time:.3f}s")
     gc.collect()
 
     # Non-destructive base offsets applied through the adjustment pipeline (UI shows 0).
@@ -1514,13 +1483,22 @@ def apply_reference_normalization(img: np.ndarray, p_lo, p_hi, od_factors) -> np
     norm *= np.float32(65535.0)
     np.clip(norm, 0, 65535, out=norm)
     inverted = 65535 - norm.astype(np.uint16)
+    # The reference (auto) path is legacy; in density mode we only drop the
+    # styling here. Its hi-res replay still uses the linear inversion, so the
+    # density auto path is exact only in the B/W-point tool (the focus). See
+    # docs/conversion-pipeline.md.
+    if USE_DENSITY_INVERSION:
+        return inverted
     return apply_postinvert_look(inverted)
 
 
 def apply_bwpoint_normalization(img: np.ndarray, black_point_bgr, white_point_bgr) -> np.ndarray:
     """B/W-point conversion at any resolution: absolute per-channel anchors +
-    inversion + standard look — mirrors ccr_normalize_with_bwpoint's preview
-    path (the anchors are global constants, so no rescaling is needed)."""
+    inversion — mirrors ccr_normalize_with_bwpoint's preview path (the anchors
+    are global constants, so no rescaling is needed). Honours
+    USE_DENSITY_INVERSION so hi-res zoom/export match the preview exactly."""
+    if USE_DENSITY_INVERSION:
+        return _density_invert_points(img, black_point_bgr, white_point_bgr)
     img_f = img.astype(np.float32)
     norm = np.empty_like(img_f)
     for c in range(3):

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -17,23 +17,15 @@ except ImportError:
     cl = None
     cl_array = None
 
-# --- Experimental negative-inversion algorithm selection -------------------
-# The original pipeline inverts the scanned negative in LINEAR space
-# (out = 65535 - v) after a per-channel optical-density mean-equalisation that
-# is used only for cast balance. Film records density as a roughly linear
-# function of *log* exposure (the Hurter-Driffield characteristic curve), so
-# the physically faithful inversion happens in optical-density (log) space:
-# subtract the per-channel film base (Dmin / orange mask) as an offset, divide
-# by a per-channel gamma, then encode for display. See _invert_negative_density.
+# --- Negative-inversion in optical-density (log) space ---------------------
+# Film records density as a roughly linear function of *log* exposure (the
+# Hurter-Driffield characteristic curve), so the faithful inversion happens in
+# optical-density space: take D = -log10(transmittance), subtract the
+# per-channel film base (Dmin / orange mask) as an OFFSET, divide by a
+# per-channel gamma, then encode for display. This is the only inversion the
+# app uses; the earlier linear "65535 - v" method has been removed.
 #
-# Toggle at runtime by setting the module global, or via env var:
-#   FREECCR_DENSITY_INVERT=1   -> use the density-space inversion
-#   FREECCR_DENSITY_GAMMA=0.55 -> film contrast (gamma) used by that path
-def _env_flag(name, default=False):
-    return os.environ.get(name, "1" if default else "0").strip().lower() \
-        not in ("0", "", "false", "no", "off")
-
-USE_DENSITY_INVERSION = _env_flag("FREECCR_DENSITY_INVERT", False)
+# FREECCR_DENSITY_GAMMA tunes the film contrast (the C-41 taking gamma).
 DENSITY_FILM_GAMMA = float(os.environ.get("FREECCR_DENSITY_GAMMA", "0.55"))
 
 # The hi-res zoom worker can call adjust_image_opencl concurrently with the
@@ -613,63 +605,60 @@ def safe_tifffile_imwrite(output_path: str, image: np.ndarray, **kwargs) -> bool
 
 
 
-def _invert_negative_standard(img, img_ref, ref_crop, x1, y1, x2, y2):
-    """Original FreeCCR inversion (the default).
+def _density_params_from_ref(ref_crop, film_gamma=None):
+    """Per-channel density parameters from the reference crop.
 
-    Per-channel linear black/white-point normalisation against the reference
-    crop's 1st/99th percentiles, then an optical-density mean-equalisation
-    (per-channel density *scaling*) for cast balance, then a LINEAR
-    ``65535 - v`` inversion. Returns the inverted positive as uint16.
+    Returns (base_density[3], gamma_ch[3]):
+      base_density[c] = Dmin from the clear-film (99th) percentile — the
+                        orange-mask offset, subtracted in log space.
+      gamma_ch[c]     = film_gamma * mean_rel[c]/mean — gray-world balance x
+                        film contrast.
+    Shared by the full conversion (_invert_negative_density) and the hi-res
+    replay (apply_reference_normalization) so they produce matching results.
     """
-    step_start = time.time()
-    norm = np.empty_like(img, dtype=np.float32)
-    norm_ref = np.empty_like(img_ref, dtype=np.float32)
+    if film_gamma is None:
+        film_gamma = DENSITY_FILM_GAMMA
+    white = 65535.0
+    base_density = np.zeros(3, dtype=np.float64)
+    mean_rel = np.zeros(3, dtype=np.float64)
     for c in range(3):
-        ch_crop = ref_crop[..., c]
-        p10 = np.percentile(ch_crop, 1)     # 1st percentile
-        p90 = np.percentile(ch_crop, 99)    # 99th percentile
+        ch_ref = ref_crop[..., c].astype(np.float32)
+        # Clear film (orange-mask base) is the brightest = least-dense end.
+        v_base = max(float(np.percentile(ch_ref, 99.0)), 1.0)
+        d_base = -np.log10(v_base / white)
+        base_density[c] = d_base
+        d_ref = -np.log10(np.clip(ch_ref, 1.0, white) / white) - d_base
+        np.clip(d_ref, 0.0, None, out=d_ref)
+        mean_rel[c] = max(float(d_ref.mean()), 1e-6)
+    target = float(np.mean(mean_rel))
+    gamma_ch = film_gamma * (mean_rel / target)
+    return base_density, gamma_ch
 
-        ch_full = img[..., c]
-        ch_full_ref = img_ref[..., c]
 
-        # Linear mapping: p10 -> 8192, p90 -> 65535
-        np.subtract(ch_full, p10, out=norm[..., c])
-        np.divide(norm[..., c], (p90 - p10), out=norm[..., c])
-        np.multiply(norm[..., c], (65535 - 8192), out=norm[..., c])
-        np.add(norm[..., c], 8192, out=norm[..., c])
-        np.clip(norm[..., c], 0, 65535, out=norm[..., c])
+def _density_apply(img, base_density, gamma_ch):
+    """Apply density-space inversion with precomputed per-channel params.
 
-        np.subtract(ch_full_ref, p10, out=norm_ref[..., c])
-        np.divide(norm_ref[..., c], (p90 - p10), out=norm_ref[..., c])
-        np.multiply(norm_ref[..., c], (65535 - 8192), out=norm_ref[..., c])
-        np.add(norm_ref[..., c], 8192, out=norm_ref[..., c])
-        np.clip(norm_ref[..., c], 0, 65535, out=norm_ref[..., c])
-    print(f"BWPN: {time.time() - step_start:.3f}s")
-
-    # Optical density alignment (per-channel mean-density equalisation)
-    step_start = time.time()
-    ref_norm_crop = norm_ref[y1:y2, x1:x2]
-    np.add(ref_norm_crop, 1e-6, out=ref_norm_crop)
-    od_crop = -np.log10(ref_norm_crop / 65535.0)
-    mean_od_crop = np.mean(od_crop, axis=(0, 1))
-    target_mean_od = np.mean(mean_od_crop)
-    scaling_factors = target_mean_od / (mean_od_crop + 1e-12)
-
-    norm_full = norm
-    np.add(norm_full, 1e-6, out=norm_full)
-    od_full = -np.log10(norm_full / 65535.0)
-    od_aligned_full = od_full * scaling_factors
-    del ref_norm_crop, od_crop, mean_od_crop, scaling_factors, od_full
-
-    np.power(10, -od_aligned_full, out=od_aligned_full)
-    od_aligned_full *= 65535.0
-    np.clip(od_aligned_full, 0, 65535, out=od_aligned_full)
-    rgb_aligned_full = od_aligned_full.astype(np.uint16, copy=False)
-
-    rgb_inverted_full = 65535 - rgb_aligned_full
-    del od_aligned_full, rgb_aligned_full, norm, norm_ref
-    print(f"ODAI: {time.time() - step_start:.3f}s")
-    return rgb_inverted_full
+    H[c] = 10^((D[c] - Dmin[c]) / gamma[c]) recovers scene-linear exposure;
+    a single luminance level-stretch sets the black/white points, then sRGB
+    encode -> display-referred positive (uint16). Pure faithful: no saturation
+    boost or shadow-warmth styling.
+    """
+    white = 65535.0
+    pos = np.empty(img.shape, dtype=np.float32)
+    for c in range(3):
+        d = -np.log10(np.clip(img[..., c], 1.0, white) / white) - base_density[c]
+        np.clip(d, 0.0, None, out=d)
+        pos[..., c] = np.power(10.0, d / gamma_ch[c])
+    # White/black anchored by a single luminance level-stretch (scalar offset
+    # + scale applied to all channels) so neutrals stay neutral.
+    lum = 0.299 * pos[..., 0] + 0.587 * pos[..., 1] + 0.114 * pos[..., 2]
+    black = float(np.percentile(lum, 0.5))
+    whitep = float(np.percentile(lum, 99.5))
+    denom = max(whitep - black, 1e-6)
+    pos -= black
+    pos /= denom
+    out = _srgb_encode(pos)
+    return np.clip(out * white, 0, 65535).astype(np.uint16)
 
 
 def _srgb_encode(x):
@@ -693,52 +682,13 @@ def _invert_negative_density(img, ref_crop, film_gamma=None):
       5. H[c] = 10^(d / gamma[c])                 recovered scene-linear exposure
       6. luminance level-stretch + sRGB encode    -> display-referred positive
 
-    Unlike the standard path this removes the orange mask as a per-channel
-    density OFFSET (step 2-3) and performs the inversion in log space, so the
-    tonal transfer follows the film curve rather than a linear 65535 - v.
-    Returns the inverted positive as uint16.
+    The orange mask is removed as a per-channel density OFFSET and the
+    inversion happens in log space, so the tonal transfer follows the film
+    curve rather than a linear 65535 - v. Returns the inverted positive as
+    uint16.
     """
-    if film_gamma is None:
-        film_gamma = DENSITY_FILM_GAMMA
-    white = 65535.0
-    t0 = time.time()
-
-    base_density = np.zeros(3, dtype=np.float64)
-    mean_rel = np.zeros(3, dtype=np.float64)
-    for c in range(3):
-        ch_ref = ref_crop[..., c].astype(np.float32)
-        # Clear film (orange-mask base) is the brightest = least-dense end.
-        v_base = max(float(np.percentile(ch_ref, 99.0)), 1.0)
-        d_base = -np.log10(v_base / white)
-        base_density[c] = d_base
-        d_ref = -np.log10(np.clip(ch_ref, 1.0, white) / white) - d_base
-        np.clip(d_ref, 0.0, None, out=d_ref)
-        mean_rel[c] = max(float(d_ref.mean()), 1e-6)
-
-    # Gray-world: the per-channel ratio of mean densities sets the balance;
-    # film_gamma sets the absolute contrast (typical C-41 taking gamma ~0.55).
-    target = float(np.mean(mean_rel))
-    gamma_ch = film_gamma * (mean_rel / target)
-
-    pos = np.empty_like(img, dtype=np.float32)
-    for c in range(3):
-        d = -np.log10(np.clip(img[..., c], 1.0, white) / white) - base_density[c]
-        np.clip(d, 0.0, None, out=d)
-        pos[..., c] = np.power(10.0, d / gamma_ch[c])
-
-    # White/black anchored by a single luminance level-stretch (scalar offset
-    # + scale applied to all channels) so neutrals stay neutral.
-    lum = 0.299 * pos[..., 0] + 0.587 * pos[..., 1] + 0.114 * pos[..., 2]
-    black = float(np.percentile(lum, 0.5))
-    whitep = float(np.percentile(lum, 99.5))
-    denom = max(whitep - black, 1e-6)
-    pos -= black
-    pos /= denom
-
-    out = _srgb_encode(pos)
-    out = np.clip(out * white, 0, 65535).astype(np.uint16)
-    print(f"Density inversion (gamma={film_gamma:.2f}): {time.time() - t0:.3f}s")
-    return out
+    base_density, gamma_ch = _density_params_from_ref(ref_crop, film_gamma)
+    return _density_apply(img, base_density, gamma_ch)
 
 
 def _density_invert_points(img, black_point_bgr, white_point_bgr, film_gamma=None):
@@ -869,16 +819,8 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
     # plt.axis('off')
     # plt.show()
 
-    # --- Negative inversion -------------------------------------------------
-    # standard: per-channel linear normalisation + OD cast-balance + linear
-    #           65535 - v inversion (the original FreeCCR algorithm).
-    # density : Cineon/negadoctor-style inversion in optical-density space.
-    # Selected by USE_DENSITY_INVERSION (env FREECCR_DENSITY_INVERT).
-    if USE_DENSITY_INVERSION:
-        rgb_inverted_full = _invert_negative_density(img, ref_crop)
-    else:
-        rgb_inverted_full = _invert_negative_standard(
-            img, img_ref, ref_crop, x1, y1, x2, y2)
+    # --- Negative inversion (optical-density / Cineon-style) ----------------
+    rgb_inverted_full = _invert_negative_density(img, ref_crop)
     del ref_crop
 
     # # --- Brightness normalization using grayscale ---
@@ -903,16 +845,9 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
     #     stretch_scale = 65535.0 / max_scaled
     # else:
     #     stretch_scale = 1.0    # rgb_brightness_normalized = np.clip(rgb_scaled * stretch_scale, 0, 65535).astype(np.uint16)    # Apply inverted gamma correction for inverted linear data
-    # Since we have inverted linear data, apply inverted gamma 1.5
-    # --- Post-invert styling -----------------------------------------------
-    # density: pure faithful — the density inversion already produced a
-    #          display-referred positive, so NO saturation boost or shadow
-    #          warmth is applied (it would re-introduce a colour cast).
-    # standard: the legacy saturation-boost + shadow-warmth look.
-    if USE_DENSITY_INVERSION:
-        rgb_brightness_normalized = rgb_inverted_full
-    else:
-        rgb_brightness_normalized = apply_postinvert_look(rgb_inverted_full)
+    # The density inversion already produced a display-referred, faithful
+    # positive — no saturation boost or shadow-warmth styling (pure faithful).
+    rgb_brightness_normalized = rgb_inverted_full
     del rgb_inverted_full
     gc.collect()
     # --- End of brightness normalization ---
@@ -1091,14 +1026,8 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
     white_point_bgr: (B,G,R) scan values of dense/exposed film area (LOW values).
                      Dense areas → output white (65535) after inversion.
 
-    Inversion algorithm selected by USE_DENSITY_INVERSION (env
-    FREECCR_DENSITY_INVERT):
-      * density  — optical-density (log) space inversion, pure faithful, no
-                   styling. See _density_invert_points.
-      * standard — legacy per-channel linear stretch + 65535 - v inversion +
-                   saturation/shadow look.
-    ODAI is skipped because per-channel B/W point mapping already normalises
-    channels.
+    Inversion is optical-density (log) space, pure faithful, no styling.
+    See _density_invert_points.
     """
     total_start_time = time.time()
 
@@ -1122,35 +1051,13 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
                               borderMode=cv2.BORDER_CONSTANT, borderValue=0)
         del rot_mat
 
-    # --- Inversion: density (pure faithful) or legacy linear ----------------
+    # --- Inversion (optical-density / Cineon-style, pure faithful) ----------
     # The sampled points are absolute per-channel anchors, constant across the
     # roll (no_auto_bright=True keeps film-base/dense values identical between
-    # frames). The clear-film point is the per-channel Dmin (orange mask).
-    if USE_DENSITY_INVERSION:
-        # Density-space inversion in optical density; no styling applied.
-        rgb_result = _density_invert_points(img, black_point_bgr, white_point_bgr)
-        print(f"Density inversion (B/W points): {time.time() - total_start_time:.3f}s")
-    else:
-        # Legacy: per-channel linear stretch + 65535 - v inversion + look.
-        img_f = img.astype(np.float32)
-        norm = np.empty_like(img_f)
-        for c in range(3):
-            p_hi = max(float(black_point_bgr[c]), 1.0)   # transparent film → black
-            p_lo = max(float(white_point_bgr[c]), 1.0)   # dense film → white
-            denom = p_hi - p_lo
-            if abs(denom) < 1.0:
-                norm[..., c] = 0.0
-                continue
-            np.subtract(img_f[..., c], p_lo, out=norm[..., c])
-            np.divide(norm[..., c], denom, out=norm[..., c])
-            np.multiply(norm[..., c], 65535.0, out=norm[..., c])
-            np.clip(norm[..., c], 0, 65535, out=norm[..., c])
-        del img_f
-        rgb_inverted = (65535.0 - norm).clip(0, 65535).astype(np.uint16)
-        del norm
-        rgb_result = apply_postinvert_look(rgb_inverted)
-        del rgb_inverted
-        print(f"BWPN (user points): {time.time() - total_start_time:.3f}s")
+    # frames). The clear-film point is the per-channel Dmin (orange mask); the
+    # dense point fixes the per-channel gamma. No styling applied.
+    rgb_result = _density_invert_points(img, black_point_bgr, white_point_bgr)
+    print(f"Density inversion (B/W points): {time.time() - total_start_time:.3f}s")
     gc.collect()
 
     # Non-destructive base offsets applied through the adjustment pipeline (UI shows 0).
@@ -1239,7 +1146,7 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
     return rgb_result
 
 
-def ccr_normalize_with_refparams(ccr_image, p_lo, p_hi, od_factors,
+def ccr_normalize_with_refparams(ccr_image, base_density, gamma_ch,
                                  output_path=None, water_mark=True, jpg_out=False,
                                  jpg_quality=95, max_long_side=None):
     """
@@ -1258,7 +1165,7 @@ def ccr_normalize_with_refparams(ccr_image, p_lo, p_hi, od_factors,
     if img is None:
         raise ValueError("CCRImage: could not load image data for ref-params conversion")
 
-    rgb_result = apply_reference_normalization(img, p_lo, p_hi, od_factors)
+    rgb_result = apply_reference_normalization(img, base_density, gamma_ch)
 
     if output_path is None:
         print(f"TOTAL ref-params normalization time: {time.time() - total_start_time:.3f}s")
@@ -1392,47 +1299,13 @@ def apply_crop_to_image(img: np.ndarray, crop_rect_norm, crop_angle: float = 0.0
 # conversion can be re-applied to a higher-resolution decode and come out
 # color-matched to the 1080px preview.
 
-_LUM_WEIGHTS = np.array([[0.299, 0.587, 0.114]], dtype=np.float32)
-
-
-def apply_postinvert_look(rgb_inverted: np.ndarray) -> np.ndarray:
-    """Shared saturation-boost + shadow-warmth styling applied after
-    inversion — identical math to both conversion pipelines, computed with
-    cv2 SIMD primitives (5-10x faster than numpy at hi-res sizes) and
-    in-place float32 ops."""
-    x = rgb_inverted.astype(np.float32)
-    x *= np.float32(1.0 / 65535.0)
-    np.clip(x, 0.0, 1.0, out=x)
-
-    luminance = cv2.transform(x, _LUM_WEIGHTS)          # (h, w) float32
-    sat_curve = cv2.pow(luminance, 0.8)
-    dynamic = np.float32(0.15) * sat_curve
-    dynamic += np.float32(1.0)                          # 1.0 + 0.15 * lum^0.8
-    lum3 = luminance[..., None]
-    x -= lum3
-    x *= dynamic[..., None]
-    x += lum3
-    np.clip(x, 0.0, 1.0, out=x)
-
-    shadow_lum = cv2.transform(x, _LUM_WEIGHTS)
-    warmth = cv2.exp(shadow_lum * np.float32(-4.0))
-    warmth *= np.float32(0.35)
-    green = cv2.exp(shadow_lum * np.float32(-3.5))
-    green *= np.float32(0.15)
-    x[..., 0] *= (np.float32(1.0) + warmth * np.float32(0.8))
-    x[..., 1] *= (np.float32(1.0) + green)
-    x[..., 2] *= (np.float32(1.0) - warmth)
-    x *= np.float32(65535.0)
-    np.clip(x, 0, 65535, out=x)
-    return x.astype(np.uint16)
-
 
 def compute_reference_norm_params(ref_img: np.ndarray, reference_rect,
                                   fine_rotation_angle: int):
-    """Derive the per-channel percentile anchors and OD alignment factors
-    that ccr_normalize_with_reference computes from the reference frame of
-    ref_img (the 1080px scan), so the conversion can be replayed at any
-    resolution. Returns (p_lo[3], p_hi[3], od_factors[3])."""
+    """Derive the per-channel density parameters that
+    ccr_normalize_with_reference computes from the reference frame of ref_img
+    (the 1080px scan), so the conversion can be replayed at any resolution.
+    Returns (base_density[3], gamma_ch[3]) — see _density_params_from_ref."""
     img_ref = ref_img
     fine_angle = fine_rotation_angle / 100.0
     if fine_angle != 0:
@@ -1442,78 +1315,21 @@ def compute_reference_norm_params(ref_img: np.ndarray, reference_rect,
                                  borderMode=cv2.BORDER_CONSTANT, borderValue=0)
     x1, y1, x2, y2 = map_rect_to_original(ref_img.shape, img_ref.shape, reference_rect)
     ref_crop = img_ref[y1:y2, x1:x2].astype(np.float32)
-
-    p_lo = np.empty(3, dtype=np.float64)
-    p_hi = np.empty(3, dtype=np.float64)
-    norm_crop = np.empty_like(ref_crop)
-    for c in range(3):
-        p_lo[c] = np.percentile(ref_crop[..., c], 1)
-        p_hi[c] = np.percentile(ref_crop[..., c], 99)
-        norm_crop[..., c] = np.clip(
-            (ref_crop[..., c] - p_lo[c]) / (p_hi[c] - p_lo[c])
-            * (65535 - 8192) + 8192, 0, 65535)
-    od_crop = -np.log10((norm_crop + 1e-6) / 65535.0)
-    mean_od = np.mean(od_crop, axis=(0, 1))
-    target = np.mean(mean_od)
-    od_factors = target / (mean_od + 1e-12)
-    return p_lo, p_hi, od_factors
+    return _density_params_from_ref(ref_crop)
 
 
-def apply_reference_normalization(img: np.ndarray, p_lo, p_hi, od_factors) -> np.ndarray:
-    """Apply the reference-frame normalization + inversion + standard look to
-    an image of any resolution, using precomputed constants.
-
-    The pipeline's OD alignment (od = -log10(v); od *= f; out = 10^-od) is
-    algebraically just out = v^f — computed that way here, which halves the
-    transcendental work on large hi-res frames. The per-channel linear map
-    is folded into a single cv2.transform and the power uses cv2.pow (SIMD)."""
-    # v*s + (8192 - p_lo*s), pre-divided by 65535 into the unit domain
-    affine = np.zeros((3, 4), dtype=np.float64)
-    for c in range(3):
-        s = (65535.0 - 8192.0) / (p_hi[c] - p_lo[c])
-        affine[c, c] = s / 65535.0
-        affine[c, 3] = (8192.0 - p_lo[c] * s) / 65535.0
-    norm = cv2.transform(img.astype(np.float32), affine)
-    np.clip(norm, 0.0, 1.0, out=norm)
-    norm += np.float32(1e-6 / 65535.0)
-    channels = list(cv2.split(norm))
-    for c in range(3):
-        cv2.pow(channels[c], float(od_factors[c]), channels[c])
-    norm = cv2.merge(channels)
-    norm *= np.float32(65535.0)
-    np.clip(norm, 0, 65535, out=norm)
-    inverted = 65535 - norm.astype(np.uint16)
-    # The reference (auto) path is legacy; in density mode we only drop the
-    # styling here. Its hi-res replay still uses the linear inversion, so the
-    # density auto path is exact only in the B/W-point tool (the focus). See
-    # docs/conversion-pipeline.md.
-    if USE_DENSITY_INVERSION:
-        return inverted
-    return apply_postinvert_look(inverted)
+def apply_reference_normalization(img: np.ndarray, base_density, gamma_ch) -> np.ndarray:
+    """Apply the reference-frame density inversion to an image of any
+    resolution, using params precomputed by compute_reference_norm_params.
+    Matches ccr_normalize_with_reference (both go through _density_apply)."""
+    return _density_apply(img, base_density, gamma_ch)
 
 
 def apply_bwpoint_normalization(img: np.ndarray, black_point_bgr, white_point_bgr) -> np.ndarray:
-    """B/W-point conversion at any resolution: absolute per-channel anchors +
-    inversion — mirrors ccr_normalize_with_bwpoint's preview path (the anchors
-    are global constants, so no rescaling is needed). Honours
-    USE_DENSITY_INVERSION so hi-res zoom/export match the preview exactly."""
-    if USE_DENSITY_INVERSION:
-        return _density_invert_points(img, black_point_bgr, white_point_bgr)
-    img_f = img.astype(np.float32)
-    norm = np.empty_like(img_f)
-    for c in range(3):
-        p_hi = max(float(black_point_bgr[c]), 1.0)
-        p_lo = max(float(white_point_bgr[c]), 1.0)
-        denom = p_hi - p_lo
-        if abs(denom) < 1.0:
-            norm[..., c] = 0.0
-            continue
-        np.subtract(img_f[..., c], p_lo, out=norm[..., c])
-        np.divide(norm[..., c], denom, out=norm[..., c])
-        np.multiply(norm[..., c], 65535.0, out=norm[..., c])
-        np.clip(norm[..., c], 0, 65535, out=norm[..., c])
-    inverted = (65535.0 - norm).clip(0, 65535).astype(np.uint16)
-    return apply_postinvert_look(inverted)
+    """B/W-point density inversion at any resolution: absolute per-channel
+    anchors (clear-film = Dmin, dense = gamma), so no rescaling is needed.
+    Mirrors ccr_normalize_with_bwpoint's preview path exactly."""
+    return _density_invert_points(img, black_point_bgr, white_point_bgr)
 
 
 def auto_fine_angle(img16: np.ndarray, debug: bool = False) -> float:

--- a/tests/test_zoom_hires.py
+++ b/tests/test_zoom_hires.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 from core.ccr_processor import (  # noqa: E402
     ccr_normalize_with_reference, ccr_normalize_with_bwpoint,
     compute_reference_norm_params, apply_reference_normalization,
-    apply_bwpoint_normalization, apply_postinvert_look,
+    apply_bwpoint_normalization,
 )
 from core.ccr_image import CCRImage  # noqa: E402
 
@@ -58,8 +58,8 @@ class TestHiResColorMatch:
         img = _scan_like_image()
         ref = (20, 20, 280, 180)
         expected = ccr_normalize_with_reference(_conversion_stub(img.copy(), ref))
-        p_lo, p_hi, od = compute_reference_norm_params(img, ref, 0)
-        got = apply_reference_normalization(img, p_lo, p_hi, od)
+        base_density, gamma_ch = compute_reference_norm_params(img, ref, 0)
+        got = apply_reference_normalization(img, base_density, gamma_ch)
         np.testing.assert_allclose(got.astype(np.int64),
                                    expected.astype(np.int64), atol=2)
 
@@ -68,8 +68,8 @@ class TestHiResColorMatch:
         ref = (40, 30, 260, 170)
         fine_rot = 250  # 2.5 degrees
         expected = ccr_normalize_with_reference(_conversion_stub(img.copy(), ref, fine_rot))
-        p_lo, p_hi, od = compute_reference_norm_params(img, ref, fine_rot)
-        got = apply_reference_normalization(img, p_lo, p_hi, od)
+        base_density, gamma_ch = compute_reference_norm_params(img, ref, fine_rot)
+        got = apply_reference_normalization(img, base_density, gamma_ch)
         np.testing.assert_allclose(got.astype(np.int64),
                                    expected.astype(np.int64), atol=2)
 
@@ -90,20 +90,14 @@ class TestHiResColorMatch:
         img2x = _scan_like_image(h=400, w=600, seed=11)
         img1x = cv2.resize(img2x, (300, 200), interpolation=cv2.INTER_AREA)
         ref = (20, 20, 280, 180)
-        p_lo, p_hi, od = compute_reference_norm_params(img1x, ref, 0)
-        out1x = apply_reference_normalization(img1x, p_lo, p_hi, od)
-        out2x = apply_reference_normalization(img2x, p_lo, p_hi, od)
+        base_density, gamma_ch = compute_reference_norm_params(img1x, ref, 0)
+        out1x = apply_reference_normalization(img1x, base_density, gamma_ch)
+        out2x = apply_reference_normalization(img2x, base_density, gamma_ch)
         out2x_down = cv2.resize(out2x, (300, 200), interpolation=cv2.INTER_AREA)
         # Interpolation through the nonlinear look costs a little accuracy;
         # the images must still be visually identical (small mean error).
         diff = np.abs(out2x_down.astype(np.int64) - out1x.astype(np.int64))
         assert diff.mean() < 600   # < ~1% of full scale on average
-
-    def test_postinvert_look_output_range(self):
-        img = _scan_like_image()
-        out = apply_postinvert_look(img)
-        assert out.dtype == np.uint16
-        assert out.shape == img.shape
 
 
 class TestRenderHiresBaseRouting:


### PR DESCRIPTION
## What

Makes the **optical-density (log-space) inversion the only** negative-conversion algorithm and removes the legacy linear `65535 - v` method.

## Why

Film records density as a roughly linear function of *log* exposure (the Hurter–Driffield characteristic curve), so a faithful inversion must happen in optical-density space: `D = -log10(transmittance)`, subtract the per-channel film base `Dmin` (orange mask) as a log **offset**, divide by a per-channel gamma, then sRGB-encode. The old linear inversion bent the tonal transfer into a non-film curve and removed the orange mask by scaling rather than offsetting. The density method has been tested on real negatives via the B/W-point tool.

## Changes

- Density is permanent: removed the `USE_DENSITY_INVERSION` / `FREECCR_DENSITY_INVERT` toggle, the linear `_invert_negative_standard`, and the saturation-boost + shadow-warmth styling (`apply_postinvert_look`). Output is **pure faithful**.
- Density core split into `_density_params_from_ref` (per-channel `Dmin` + gamma) and `_density_apply`, shared by the full conversion and the hi-res replay so **preview, zoom, and export match**.
- Both entry points are density-only: the **B/W-point tool** (clear-film point = `Dmin`, dense point fixes per-channel gamma — both endpoints neutralised) and the auto reference frame (gray-world balance).
- `compute_reference_norm_params` now returns `(base_density, gamma_ch)`; sliced-child `conversion_inputs` (`mode: "ref_params"`) persist those keys. Old catalogs with legacy `ref_params` children are skipped on load (re-slice to reconvert) rather than crashing; `"ref"`/`"bw"` children re-run the conversion and get density for free.
- `FREECCR_DENSITY_GAMMA` (default 0.55) still tunes film contrast.

## Testing

57 tests pass, including the hi-res color-match guarantee (replay == pipeline, both density now) and catalog round-trips.

Builds on the cyan band (already in `main`). See `docs/conversion-pipeline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
