### PR TITLE
Fix density slice/replay color mismatch (thread level-stretch through params)

### DIFF
--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -70,7 +70,7 @@ def _ci_to_json(ci):
         out["ref"] = list(out["ref"])
     if out.get("bw") is not None:
         out["bw"] = [list(out["bw"][0]), list(out["bw"][1])]
-    for key in ("base_density", "gamma_ch"):
+    for key in ("base_density", "gamma_ch", "levels"):
         if out.get(key) is not None:
             out[key] = list(out[key])
     return out
@@ -84,7 +84,7 @@ def _ci_from_json(ci):
         out["ref"] = tuple(out["ref"])
     if out.get("bw") is not None:
         out["bw"] = (tuple(out["bw"][0]), tuple(out["bw"][1]))
-    for key in ("base_density", "gamma_ch"):
+    for key in ("base_density", "gamma_ch", "levels"):
         if out.get(key) is not None:
             out[key] = tuple(out[key])
     return out
@@ -368,7 +368,7 @@ def _replay_conversion(img, ci) -> None:
             print("Skipping legacy ref_params replay (re-slice to reconvert).")
             return
         img.resized_raw = apply_reference_normalization(
-            img.resized_raw, ci["base_density"], ci["gamma_ch"])
+            img.resized_raw, ci["base_density"], ci["gamma_ch"], ci.get("levels"))
     elif mode == "bw":
         saved_fine = img.fine_rotation_angle
         img.fine_rotation_angle = ci.get("fine_rot", 0)

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -454,6 +454,7 @@ class CCRBackend:
                     # Sliced child of a reference-converted parent: replay the
                     # stored conversion constants at full resolution.
                     ccr_normalize_with_refparams(image_obj, ci["base_density"], ci["gamma_ch"],
+                                                 ci.get("levels"),
                                                  output_path=output_path,
                                                  water_mark=not self.software_activated,
                                                  jpg_out=jpg_output, jpg_quality=jpg_quality,
@@ -746,12 +747,14 @@ class CCRBackend:
         if parent_ci is not None and parent_ci.get("mode") == "ref":
             from core.ccr_processor import compute_reference_norm_params
             ref_small = img_obj.resize_image_to_max_pixel(full, 1080)
-            base_density, gamma_ch = compute_reference_norm_params(
+            base_density, gamma_ch, levels = compute_reference_norm_params(
                 ref_small, parent_ci["ref"], parent_ci["fine_rot"])
             norm_params = (tuple(float(v) for v in base_density),
-                           tuple(float(v) for v in gamma_ch))
+                           tuple(float(v) for v in gamma_ch),
+                           tuple(float(v) for v in levels))
         elif parent_ci is not None and parent_ci.get("mode") == "ref_params":
-            norm_params = (parent_ci["base_density"], parent_ci["gamma_ch"])
+            norm_params = (parent_ci["base_density"], parent_ci["gamma_ch"],
+                           parent_ci.get("levels"))
 
         # Bake the parent's current fine rotation: the cuts were placed on
         # the rotated display, so the slices are cut from the rotated frame.
@@ -803,7 +806,7 @@ class CCRBackend:
                     from core.ccr_processor import apply_reference_normalization
                     crop = apply_reference_normalization(crop, *norm_params)
                     child_ci = {"mode": "ref_params", "base_density": norm_params[0],
-                                "gamma_ch": norm_params[1]}
+                                "gamma_ch": norm_params[1], "levels": norm_params[2]}
                 elif parent_ci is not None and parent_ci.get("mode") == "bw":
                     from core.ccr_processor import apply_bwpoint_normalization
                     black_point, white_point = parent_ci["bw"]
@@ -941,12 +944,13 @@ class CCRBackend:
             child_full = template.read_image(template.file_path, preview=True)
             if child_full is not None:
                 small = template.resize_image_to_max_pixel(child_full, 1080)
-                base_density, gamma_ch = compute_reference_norm_params(
+                base_density, gamma_ch, levels = compute_reference_norm_params(
                     small, ci["ref"], ci.get("fine_rot", 0))
                 norm_params = (tuple(float(v) for v in base_density),
-                               tuple(float(v) for v in gamma_ch))
+                               tuple(float(v) for v in gamma_ch),
+                               tuple(float(v) for v in levels))
         elif ci is not None and ci.get("mode") == "ref_params":
-            norm_params = (ci["base_density"], ci["gamma_ch"])
+            norm_params = (ci["base_density"], ci["gamma_ch"], ci.get("levels"))
         elif ci is not None and ci.get("mode") == "bw":
             bw_points = ci["bw"]
 
@@ -980,7 +984,7 @@ class CCRBackend:
             parent.converted = True
             parent.conversion_inputs = {
                 "mode": "ref_params", "base_density": norm_params[0],
-                "gamma_ch": norm_params[1]}
+                "gamma_ch": norm_params[1], "levels": norm_params[2]}
         elif bw_points is not None:
             parent.resized_raw = apply_bwpoint_normalization(
                 parent.resized_raw, *bw_points)

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -595,14 +595,14 @@ class CCRImage:
         t0 = time.time()
         if ci.get("mode") == "ref":
             ref_small = self.resize_image_to_max_pixel(img, 1080)
-            base_density, gamma_ch = compute_reference_norm_params(
+            base_density, gamma_ch, levels = compute_reference_norm_params(
                 ref_small, ci["ref"], ci["fine_rot"])
-            out = apply_reference_normalization(img, base_density, gamma_ch)
+            out = apply_reference_normalization(img, base_density, gamma_ch, levels)
         elif ci.get("mode") == "ref_params":
             # Sliced children of a reference-converted parent carry the
             # parent's precomputed conversion constants directly (the
             # parent's frame coordinates would be meaningless here).
-            out = apply_reference_normalization(img, ci["base_density"], ci["gamma_ch"])
+            out = apply_reference_normalization(img, ci["base_density"], ci["gamma_ch"], ci.get("levels"))
         elif ci.get("mode") == "bw":
             # The bwpoint pipeline bakes the fine rotation into the preview
             # pixels BEFORE normalization — replicate that here so the

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -635,30 +635,46 @@ def _density_params_from_ref(ref_crop, film_gamma=None):
     return base_density, gamma_ch
 
 
-def _density_apply(img, base_density, gamma_ch):
-    """Apply density-space inversion with precomputed per-channel params.
-
-    H[c] = 10^((D[c] - Dmin[c]) / gamma[c]) recovers scene-linear exposure;
-    a single luminance level-stretch sets the black/white points, then sRGB
-    encode -> display-referred positive (uint16). Pure faithful: no saturation
-    boost or shadow-warmth styling.
-    """
+def _density_scene_linear(img, base_density, gamma_ch):
+    """Per-channel density inversion to scene-linear exposure (pre
+    level-stretch): H[c] = 10^((D[c] - Dmin[c]) / gamma[c])."""
     white = 65535.0
     pos = np.empty(img.shape, dtype=np.float32)
     for c in range(3):
         d = -np.log10(np.clip(img[..., c], 1.0, white) / white) - base_density[c]
         np.clip(d, 0.0, None, out=d)
         pos[..., c] = np.power(10.0, d / gamma_ch[c])
-    # White/black anchored by a single luminance level-stretch (scalar offset
-    # + scale applied to all channels) so neutrals stay neutral.
+    return pos
+
+
+def _density_levels(pos):
+    """The (black, denom) luminance level-stretch for a scene-linear positive
+    `pos`. Precomputed once from the full frame so crops/replays reuse the same
+    anchors and match exactly (a per-crop stretch would diverge)."""
     lum = 0.299 * pos[..., 0] + 0.587 * pos[..., 1] + 0.114 * pos[..., 2]
     black = float(np.percentile(lum, 0.5))
     whitep = float(np.percentile(lum, 99.5))
-    denom = max(whitep - black, 1e-6)
+    return black, max(whitep - black, 1e-6)
+
+
+def _density_apply(img, base_density, gamma_ch, levels=None):
+    """Apply density-space inversion with precomputed per-channel params.
+
+    Recovers scene-linear exposure, applies a single luminance level-stretch
+    for black/white, then sRGB-encodes -> display-referred positive (uint16).
+    Pure faithful: no saturation boost or shadow-warmth styling.
+
+    levels: optional (black, denom) from _density_levels. When None it is
+    derived from this image; pass the full-frame levels so a crop or hi-res
+    replay reproduces the full conversion exactly.
+    """
+    pos = _density_scene_linear(img, base_density, gamma_ch)
+    black, denom = _density_levels(pos) if levels is None else \
+        (float(levels[0]), max(float(levels[1]), 1e-6))
     pos -= black
     pos /= denom
     out = _srgb_encode(pos)
-    return np.clip(out * white, 0, 65535).astype(np.uint16)
+    return np.clip(out * 65535.0, 0, 65535).astype(np.uint16)
 
 
 def _srgb_encode(x):
@@ -1146,7 +1162,7 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
     return rgb_result
 
 
-def ccr_normalize_with_refparams(ccr_image, base_density, gamma_ch,
+def ccr_normalize_with_refparams(ccr_image, base_density, gamma_ch, levels=None,
                                  output_path=None, water_mark=True, jpg_out=False,
                                  jpg_quality=95, max_long_side=None):
     """
@@ -1165,7 +1181,7 @@ def ccr_normalize_with_refparams(ccr_image, base_density, gamma_ch,
     if img is None:
         raise ValueError("CCRImage: could not load image data for ref-params conversion")
 
-    rgb_result = apply_reference_normalization(img, base_density, gamma_ch)
+    rgb_result = apply_reference_normalization(img, base_density, gamma_ch, levels)
 
     if output_path is None:
         print(f"TOTAL ref-params normalization time: {time.time() - total_start_time:.3f}s")
@@ -1304,8 +1320,10 @@ def compute_reference_norm_params(ref_img: np.ndarray, reference_rect,
                                   fine_rotation_angle: int):
     """Derive the per-channel density parameters that
     ccr_normalize_with_reference computes from the reference frame of ref_img
-    (the 1080px scan), so the conversion can be replayed at any resolution.
-    Returns (base_density[3], gamma_ch[3]) — see _density_params_from_ref."""
+    (the 1080px scan), so the conversion can be replayed (or cropped) at any
+    resolution and match exactly. Returns (base_density[3], gamma_ch[3],
+    levels) where levels = (black, denom) is the full-frame luminance
+    level-stretch — see _density_params_from_ref / _density_levels."""
     img_ref = ref_img
     fine_angle = fine_rotation_angle / 100.0
     if fine_angle != 0:
@@ -1315,14 +1333,21 @@ def compute_reference_norm_params(ref_img: np.ndarray, reference_rect,
                                  borderMode=cv2.BORDER_CONSTANT, borderValue=0)
     x1, y1, x2, y2 = map_rect_to_original(ref_img.shape, img_ref.shape, reference_rect)
     ref_crop = img_ref[y1:y2, x1:x2].astype(np.float32)
-    return _density_params_from_ref(ref_crop)
+    base_density, gamma_ch = _density_params_from_ref(ref_crop)
+    # Level-stretch from the UNROTATED full frame — the pipeline computes it
+    # from the unrotated working image, so children/replays must too.
+    levels = _density_levels(
+        _density_scene_linear(ref_img.astype(np.float32), base_density, gamma_ch))
+    return base_density, gamma_ch, levels
 
 
-def apply_reference_normalization(img: np.ndarray, base_density, gamma_ch) -> np.ndarray:
+def apply_reference_normalization(img: np.ndarray, base_density, gamma_ch,
+                                  levels=None) -> np.ndarray:
     """Apply the reference-frame density inversion to an image of any
-    resolution, using params precomputed by compute_reference_norm_params.
-    Matches ccr_normalize_with_reference (both go through _density_apply)."""
-    return _density_apply(img, base_density, gamma_ch)
+    resolution (or a crop of it), using params precomputed by
+    compute_reference_norm_params. Passing the full-frame `levels` makes the
+    result match ccr_normalize_with_reference exactly."""
+    return _density_apply(img, base_density, gamma_ch, levels)
 
 
 def apply_bwpoint_normalization(img: np.ndarray, black_point_bgr, white_point_bgr) -> np.ndarray:

--- a/tests/test_zoom_hires.py
+++ b/tests/test_zoom_hires.py
@@ -58,8 +58,8 @@ class TestHiResColorMatch:
         img = _scan_like_image()
         ref = (20, 20, 280, 180)
         expected = ccr_normalize_with_reference(_conversion_stub(img.copy(), ref))
-        base_density, gamma_ch = compute_reference_norm_params(img, ref, 0)
-        got = apply_reference_normalization(img, base_density, gamma_ch)
+        base_density, gamma_ch, levels = compute_reference_norm_params(img, ref, 0)
+        got = apply_reference_normalization(img, base_density, gamma_ch, levels)
         np.testing.assert_allclose(got.astype(np.int64),
                                    expected.astype(np.int64), atol=2)
 
@@ -68,8 +68,8 @@ class TestHiResColorMatch:
         ref = (40, 30, 260, 170)
         fine_rot = 250  # 2.5 degrees
         expected = ccr_normalize_with_reference(_conversion_stub(img.copy(), ref, fine_rot))
-        base_density, gamma_ch = compute_reference_norm_params(img, ref, fine_rot)
-        got = apply_reference_normalization(img, base_density, gamma_ch)
+        base_density, gamma_ch, levels = compute_reference_norm_params(img, ref, fine_rot)
+        got = apply_reference_normalization(img, base_density, gamma_ch, levels)
         np.testing.assert_allclose(got.astype(np.int64),
                                    expected.astype(np.int64), atol=2)
 
@@ -90,9 +90,9 @@ class TestHiResColorMatch:
         img2x = _scan_like_image(h=400, w=600, seed=11)
         img1x = cv2.resize(img2x, (300, 200), interpolation=cv2.INTER_AREA)
         ref = (20, 20, 280, 180)
-        base_density, gamma_ch = compute_reference_norm_params(img1x, ref, 0)
-        out1x = apply_reference_normalization(img1x, base_density, gamma_ch)
-        out2x = apply_reference_normalization(img2x, base_density, gamma_ch)
+        base_density, gamma_ch, levels = compute_reference_norm_params(img1x, ref, 0)
+        out1x = apply_reference_normalization(img1x, base_density, gamma_ch, levels)
+        out2x = apply_reference_normalization(img2x, base_density, gamma_ch, levels)
         out2x_down = cv2.resize(out2x, (300, 200), interpolation=cv2.INTER_AREA)
         # Interpolation through the nonlinear look costs a little accuracy;
         # the images must still be visually identical (small mean error).


### PR DESCRIPTION
## Problem

After merging the density-inversion and feathering PRs, `test_slice.py::TestEditInheritance::test_conversion_and_adjustments_inherited` failed (~99% of pixels mismatched). The density inversion's luminance **level-stretch** (black/white anchors) was computed per-image, so a sliced child (a crop of the parent) got *different* anchors than the parent's full-frame conversion and its colours diverged. The old linear replay was crop-independent; the density one wasn't.

## Fix

Make the level-stretch part of the precomputed params instead of per-image:

- `_density_levels` derives `(black, denom)` once from the **full** frame.
- `compute_reference_norm_params` now returns `(base_density, gamma_ch, levels)`.
- `apply_reference_normalization` / `ccr_normalize_with_refparams` accept `levels`, so crops and hi-res replays reuse the parent's anchors and match exactly.
- Levels are taken from the **unrotated** full frame, matching what `ccr_normalize_with_reference` uses for its own stretch.
- Threaded through `ccr_backend` (slice / reset-slice / export), `ccr_image` (zoom replay), and `catalog` (`conversion_inputs` `ref_params` persists `base_density` / `gamma_ch` / `levels`).

## Testing

Full suite: **204 passed** (was 1 failed). The hi-res color-match and scale-consistency guarantees hold, and slice children now match the parent's conversion within tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
