### PR TITLE
Add Reset option to thumbnail right-click menu

### DIFF
--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -363,7 +363,10 @@ class CCRBackend:
     def reset_images_by_indices(self, indices) -> bool:
         """Reset each image in indices to its freshly-loaded state.
         Returns True if at least one image was reset."""
-        return any(self.reset_image_by_index(i) for i in sorted(set(indices)))
+        # Materialize the results first: any() over a generator short-circuits
+        # on the first True and would leave the rest of the selection un-reset.
+        results = [self.reset_image_by_index(i) for i in sorted(set(indices))]
+        return any(results)
 
     def convert_negative_by_index(self, idx: int):
         """

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -331,6 +331,40 @@ class CCRBackend:
             else:
                 print(f"Image at index {idx} is not converted.")
 
+    def reset_image_by_index(self, idx: int) -> bool:
+        """Reset the image at idx to its freshly-loaded state: undo the
+        conversion and clear every non-destructive edit (adjustments,
+        reference frame, crop, orientation, colour profile) so it matches a
+        just-imported image. Slicing (source_ops/lineage) is preserved — a
+        slice resets to its un-edited region, not back to the whole file
+        (use "Reset Slice" for that). Returns False if idx is out of range."""
+        if idx is None or not (0 <= idx < len(self.images)):
+            return False
+        image_obj = self.images[idx]
+        # Clear edit state BEFORE reloading so the rebuilt preview reflects
+        # the pristine settings. reload_image() re-decodes resized_raw and
+        # resets the base offsets + conversion_inputs.
+        image_obj.converted = False
+        image_obj.adjustment_settings = {}
+        image_obj.reference_frame = None
+        image_obj.crop_rect = None
+        image_obj.crop_angle = 0.0
+        image_obj.rotation_angle = 0
+        image_obj.fine_rotation_angle = 0
+        image_obj.horizontal_mirrored = False
+        image_obj.vertical_mirrored = False
+        image_obj.color_profile = "color"
+        # The conversion is gone, so the undo history (which never captured
+        # the conversion anyway) would be inconsistent — drop it.
+        image_obj.undo_stack = []
+        image_obj.reload_image()
+        return True
+
+    def reset_images_by_indices(self, indices) -> bool:
+        """Reset each image in indices to its freshly-loaded state.
+        Returns True if at least one image was reset."""
+        return any(self.reset_image_by_index(i) for i in sorted(set(indices)))
+
     def convert_negative_by_index(self, idx: int):
         """
         Converts the negative image at the given index using CCR normalization with reference.

--- a/src/widgets/thumbnail_list.py
+++ b/src/widgets/thumbnail_list.py
@@ -243,6 +243,7 @@ class ThumbnailList(QWidget):
         remove_action = menu.addAction(f"Remove from list{suffix}")
         menu.addSeparator()
         export_action = menu.addAction("Export…")
+        reset_action = menu.addAction(f"Reset{suffix}")
         # Offered only when the selection contains slices: restores the
         # un-sliced parent image(s) in place of all their slices.
         reset_slice_action = None
@@ -261,6 +262,8 @@ class ThumbnailList(QWidget):
         elif action == export_action:
             # Open the export dialog pre-scoped to the right-clicked selection.
             self._main_window().image_preview.open_export_dialog(default_scope="selected")
+        elif action == reset_action:
+            self.reset_images(indices)
         elif reset_slice_action is not None and action == reset_slice_action:
             self.reset_slices(indices)
 
@@ -295,6 +298,29 @@ class ThumbnailList(QWidget):
     def remove_image(self, idx):
         """Single-image removal (kept for compatibility)."""
         self.remove_images([idx])
+
+    def reset_images(self, indices):
+        # Reset re-decodes the source file(s) synchronously; show a busy
+        # cursor so the brief GUI-thread freeze reads as work, not a hang.
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            changed = ccr_backend.reset_images_by_indices(indices)
+        finally:
+            QApplication.restoreOverrideCursor()
+        if not changed:
+            return
+        for idx in indices:
+            self.update_thumbnail(idx)
+        # Refresh the preview, sliders, and convert/unconvert state for the
+        # currently selected image (the list itself is unchanged).
+        current = self.thumbnail_list.currentItem()
+        if current is not None:
+            cur_idx = current.data(Qt.UserRole)
+            main_window = self._main_window()
+            main_window.image_preview.update_preview(cur_idx)
+            main_window.sliders_panel.set_current_idx(cur_idx)
+            main_window.image_preview._update_unconvert_action_state()
+        ccr_backend.save_catalog()
 
     def reset_slices(self, indices):
         # Reset re-decodes the source file(s) synchronously; show a busy


### PR DESCRIPTION
## Summary

Adds a **Reset** option to the thumbnail right-click menu. Resetting returns the selected image(s) to their freshly-loaded state — both the negative conversion and all adjustments are undone.

## What gets reset

- Conversion (`converted` → False, re-decodes the original scan)
- Slider adjustments (`adjustment_settings` → empty)
- Reference frame, crop rect/angle
- Orientation (rotation, fine rotation, mirroring)
- Colour profile (back to `color`)
- Base offsets + `conversion_inputs` (via `reload_image()`)
- Undo history (the conversion was never captured there, so it's dropped to stay consistent)

Slicing lineage (`source_ops` / slice group) is **preserved** — a slice resets to its un-edited region, not back to the whole file. "Reset Slice" remains the way to collapse slices.

## Implementation

- `ccr_backend.reset_image_by_index` / `reset_images_by_indices` — clear edit state then `reload_image()`.
- `thumbnail_list.reset_images` — menu handler with a busy cursor; refreshes the thumbnails, preview, sliders, and convert/unconvert action state, then saves the catalog.
- Menu entry supports multi-selection (`Reset (N)`), matching the other actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
