### PR TITLE
Add Photoshop-style tone Curves control

### DIFF
--- a/spec/curves-tone-control.md
+++ b/spec/curves-tone-control.md
@@ -1,0 +1,320 @@
+# Spec: Curves (Tone Curve Control)
+
+Status: REFINED v2
+Owner: FreeCCR
+Feature branch: `feature/curves`
+
+## 1. Summary
+
+Add a Photoshop-style tone **Curves** control to the right adjustment panel. The
+control lets the user reshape image tonality by dragging an arbitrary number of
+control points on a curve, per composite channel (RGB/"All") and per individual
+channel (R, G, B). It lives in a new collapsible section (default collapsed),
+consistent with the existing "Channel Levels" and "Subtractive Saturations"
+sections in `SlidersPanel`.
+
+## 2. Goals / Non-goals
+
+### Goals
+- A collapsible "Curves" section in the right panel, **collapsed by default**.
+- An interactive Photoshop-style curve editor widget.
+- 2 fixed, non-removable endpoint control points: bottom-left `(0,0)` and
+  top-right `(255,255)`.
+- Left-click on the curve area adds a draggable control point.
+- Drag a control point to reshape the curve.
+- Right-click on a control point removes it (endpoints excepted).
+- Channel selector: **All / R / G / B**. Each channel keeps its own independent
+  set of control points.
+- A "Reset Curve" button that resets **only** the curve control points (all
+  channels back to identity), nothing else.
+- The curve affects the preview, the hi-res zoom detail, and the exported file,
+  at every resolution (resolution independent).
+- Curves persist in the catalog, participate in Undo/Redo, Copy/Paste of
+  adjustments, and "Sync to All".
+
+### Non-goals
+- No on-curve histogram overlay (may be a later enhancement).
+- No numeric input/output readout fields (later enhancement).
+- No per-point smoothing/corner toggles (always smooth interpolation).
+- No GPU/OpenCL path for curves; a CPU numpy LUT is fast enough (it is a single
+  vectorized lookup over the already-downscaled preview / export array).
+
+## 3. UX / Interaction
+
+### 3.1 Section placement
+A new `CollapsibleSection("Curves")` added to the scrollable area of
+`SlidersPanel`, after the "Subtractive Saturations" section (i.e. at the bottom),
+preceded by a horizontal separator, matching the existing pattern.
+
+### 3.2 Editor widget layout (top → bottom)
+1. Channel selector row: four small checkable buttons `All | R | G | B`
+   (`All` selected by default; mutually exclusive, like the band swatch buttons).
+2. The curve canvas — a square-ish drawing area (target ~220×220 px) with:
+   - A 1px border, a faint 4×4 grid, and the diagonal identity reference.
+   - The active channel's curve drawn as a smooth line.
+   - Control points drawn as small filled circles (~5 px radius); the active/
+     hovered point highlighted.
+3. A "Reset Curve" button.
+
+### 3.3 Coordinate system
+- The curve domain is **input** tone on X (left=0 shadow … right=255 highlight)
+  and **output** tone on Y (bottom=0 … top=255). Y is drawn inverted (screen
+  origin top-left); the editor maps between widget pixels and curve coordinates.
+- Control points are stored as `[x, y]` floats in `[0, 255]`.
+
+### 3.4 Mouse behaviour
+- **Hit area**: each control point has a square hit/"button" area of
+  `POINT_HIT = 11 px` (radius ~5–6 px) around its center.
+- **Left-press on empty canvas** (not within any point's hit area): create a new
+  control point at the clicked position and immediately begin dragging it.
+- **Left-press on an existing point's hit area**: grab that point and drag it
+  (no new point is created — this is the "button area won't create a new point"
+  rule).
+- **Drag**: moves the grabbed point.
+  - Endpoints (`x==0` and `x==255`): X is locked; Y is draggable `[0,255]`.
+  - Interior points: X clamped to stay strictly between the two neighbour points
+    (with a 1-unit min gap); Y clamped to `[0,255]`.
+  - Release ends the drag.
+- **Right-press on an existing interior point's hit area**: remove that point.
+  Endpoints cannot be removed (right-click on them is ignored).
+- **Right-press on empty canvas**: ignored (does nothing).
+- Points are always kept sorted by X internally.
+
+### 3.5 Reset Curve button
+Resets every channel (All/R/G/B) to its 2-point identity
+`[[0,0],[255,255]]`, redraws, and triggers a single undoable preview update.
+It does **not** touch sliders, crop, profile, etc.
+
+### 3.6 Relationship to the main "Reset" button
+The existing panel "Reset" button resets the whole image (all sliders) and, for
+consistency, **also clears curves**. The dedicated "Reset Curve" button is the
+curve-only reset.
+
+## 4. Data model
+
+### 4.1 Storage
+Curve state is stored inside the image's existing `adjustment_settings` dict
+under a single key `"curves"`:
+
+```python
+adjustment_settings["curves"] = {
+    "rgb": [[0, 0], [255, 255]],   # composite / "All"
+    "r":   [[0, 0], [255, 255]],
+    "g":   [[0, 0], [255, 255]],
+    "b":   [[0, 0], [255, 255]],
+}
+```
+
+Rationale: `adjustment_settings` already round-trips through the catalog
+(`json.dump`/`json.load` — lists of `[float,float]` serialize cleanly), through
+Undo snapshots (`capture_undo_state` copies `adjustment_settings`), and through
+the zoom worker (`HiResWorker._settings = dict(img.adjustment_settings)`). Reusing
+it means curves "just work" across all those paths with no new plumbing.
+
+Identity (all 4 channels = `[[0,0],[255,255]]`) is omitted / treated as "no
+curve" so untouched images store nothing extra.
+
+### 4.2 Invariant hazard & mitigation
+`SlidersPanel` rebuilds `adjustment_settings` from the slider list on every
+slider change:
+```python
+adjustment = {key: slider.value() for key, slider in zip(adjustment_keys, sliders)}
+```
+This would **drop** the `"curves"` key. Mitigation: every place that rebuilds the
+dict from sliders must re-attach the live curve state from the editor (see §6).
+The curve editor is the source of truth for the live curve while an image is
+selected; `set_current_idx` loads the stored curves into the editor on image
+switch.
+
+Shallow copies (`dict(adjustment_settings)`) are safe because edits always
+**replace** the `"curves"` value with a freshly-built dict — nested lists are
+never mutated in place — so Undo snapshots and the zoom snapshot never alias a
+mutating structure.
+
+## 5. Processing / math
+
+### 5.1 Where it applies
+In `CCRImage.apply_adjustments`, **after** `adjust_image_opencl(...)` returns and
+**before** the optional `_to_grayscale` step:
+
+```python
+adjusted = adjust_image_opencl(...)
+curves = s.get("curves")
+if curves:
+    adjusted = apply_curves(adjusted, curves)   # new ccr_processor function
+if profile == "bw":
+    adjusted = self._to_grayscale(adjusted)
+return adjusted
+```
+
+Applying before grayscale keeps curves operating in RGB (Photoshop-like) and
+means B&W images still respect the composite/per-channel curve before luminance
+collapse.
+
+### 5.2 LUT construction (`ccr_processor`)
+- `build_channel_lut(points) -> np.ndarray` (dtype `float32`, length 256):
+  - `points`: list of `[x,y]` sorted by x, spanning x=0..255.
+  - Interpolate y across integer x `0..255` using **monotone cubic** (Fritsch–
+    Carlson) interpolation so the curve passes through all points without
+    overshoot. With exactly 2 points this reduces to a straight line.
+  - Clamp output to `[0,255]`.
+- `apply_curves(img16, curves) -> np.ndarray (uint16)`:
+  - Build the 256-point curve for each of rgb/r/g/b.
+  - Compose: for each channel C in {r,g,b}, the effective 256-LUT is
+    `lut_C[x] = channel_C( rgb( x ) )` (composite applied first, then the
+    per-channel curve) — matching Photoshop.
+  - Expand each 256-entry LUT to a 65536-entry uint16 LUT via `np.interp`
+    (input domain `0..65535`), then index the image:
+    `out[...,c] = lut16_c[img16[...,c]]`.
+  - If all four channels are identity, return the input unchanged (fast path).
+  - Helper `_is_identity_curves(curves)` short-circuits the whole step.
+
+### 5.3 Performance
+One `np.interp` build (65536 samples) per channel plus three fancy-index lookups
+over a ≤1080px preview (or the export array). Negligible vs. the existing
+pipeline. No caching needed initially; can memoize per-signature later if shown
+necessary.
+
+## 6. Integration points in `SlidersPanel`
+
+| Location | Change |
+|---|---|
+| `initUI` | Build `CollapsibleSection("Curves")` with `CurveEditor`; wire `curveChanged`/`editFinished` signals. |
+| `on_slider_changed` | Re-attach `curves` from editor into the rebuilt adjustment dict (non-identity only). |
+| `set_current_idx` | Load `adjustment.get("curves")` into the editor (or identity if absent / no image). Disable editor when no image. |
+| `on_reset_clicked` | Also reset the editor to identity (curves dropped from the rebuilt dict). |
+| new `_on_curve_changed` | Build dict (sliders + curves), store on image, push undo burst, update preview (mirrors `on_slider_changed`). |
+| new `_on_curve_edit_finished` | End the undo burst. |
+| `on_reset_curve_clicked` | Editor reset only; single undo step + preview update. |
+| `set_sliders_enabled` | Enable/disable the editor. |
+| `copy_adjustment_settings` | Include `curves` in the copied dict. |
+| `paste_adjustment_settings` | Apply pasted `curves` to the editor + image. |
+| `on_compare_pressed/released` | Compare zeroes sliders and drops curves for the held preview, restores from `_original_adjustment` (which carries curves) on release. |
+| `SYNC_GROUPS` / `_perform_sync_to_all` | Add a `("curves", "Curves", ())` group; sync the source curves to targets when selected (handled like crop/profile, not via `adjustment_keys`). |
+
+`CurveEditor` API:
+- `get_curves() -> dict | None` (None when all identity).
+- `set_curves(curves: dict | None)` (None / missing → identity).
+- `reset()` → identity, emits change.
+- signals: `curveChanged` (live, per drag step), `editFinished` (drag/edit end).
+
+## 7. Files touched / added
+
+- **add** `src/widgets/curve_editor.py` — `CurveEditor` widget + curve math UI.
+- **edit** `src/widgets/sliders_panel.py` — section, wiring, persistence hooks.
+- **edit** `src/core/ccr_processor.py` — `build_channel_lut`, `apply_curves`,
+  `_is_identity_curves`.
+- **edit** `src/core/ccr_image.py` — call `apply_curves` in `apply_adjustments`.
+- **add** `tests/test_curves.py` — LUT identity, monotone interp, apply round-trip,
+  persistence merge invariant.
+
+## 8. Test plan
+
+Unit (`tests/test_curves.py`):
+- Identity curves leave a 16-bit image unchanged.
+- A 2-point endpoint move (e.g. lift black point to (0,64)) raises shadows as
+  expected; monotonic and clamped to `[0,65535]`.
+- Composite + per-channel compose in the right order.
+- `apply_curves` with `None`/missing returns input unchanged.
+- Adjustment-dict merge: a slider change preserves an existing `curves` entry
+  (regression for the §4.2 hazard) — exercised via a `SlidersPanel`-level helper
+  or a focused unit on the merge logic.
+
+Manual:
+- Collapsed by default; expands.
+- Add/drag/remove points; endpoints non-removable; right-click empty = no-op.
+- Channel switch keeps per-channel curves.
+- Reset Curve resets only curves.
+- Curve survives image switch, app restart (catalog), Undo/Redo, Copy/Paste,
+  Sync to All, and is visible in zoom + export.
+
+## 9. Refinement (v2) — resolved decisions & added detail
+
+### 9.1 Resolved open questions
+1. **Endpoint draggability**: endpoints keep X locked (`0` and `255`) but Y is
+   freely draggable in `[0,255]`. This gives black-/white-point lift the same way
+   Photoshop does and keeps the curve a total function over the full input range.
+2. **Main "Reset" clears curves**: YES. The rebuilt all-zero adjustment dict
+   simply omits `"curves"`, and `on_reset_clicked` also calls
+   `curve_editor.set_curves(None)` to sync the widget. The dedicated "Reset
+   Curve" button is the curve-only path.
+3. **Interpolation**: **monotone cubic (Fritsch–Carlson)**. Chosen over natural
+   cubic to prevent overshoot/ringing (a non-monotone tone curve would invert
+   local contrast and clip oddly). Degenerates to linear for 2 points, which is
+   exactly the identity we want for the default endpoints.
+
+### 9.2 apply_adjustments early-return guard (correctness)
+The existing fast path is:
+```python
+if not s and cb == 0 and tb == 0 and bb == 0:
+    return self._to_grayscale(image) if profile == "bw" else image
+```
+With a `"curves"` entry, `s` is truthy even when every other setting is neutral,
+so the full GPU pass would run for a curves-only edit (still correct, just not
+maximally cheap). Acceptable. `apply_curves` additionally guards with
+`_is_identity_curves`, so a stored-but-identity curve costs only the cheap
+identity check. No change to the guard is required for correctness; we will NOT
+special-case it in v1 to avoid touching the hot path.
+
+### 9.3 Curve dict normalization (defensive)
+`apply_curves` and the editor must tolerate partial/legacy dicts:
+- Missing channel key → identity for that channel.
+- Points not sorted / out of range → sorted and clamped before LUT build.
+- A channel with `< 2` points or a malformed entry → treated as identity.
+This keeps a hand-edited or older catalog from raising.
+
+### 9.4 Exact merge points for the §4.2 invariant
+The single helper used everywhere the dict is rebuilt from sliders:
+```python
+def _attach_curves(self, adjustment: dict) -> dict:
+    curves = self.curve_editor.get_curves()   # None when identity
+    if curves:
+        adjustment["curves"] = curves
+    return adjustment
+```
+Called in: `on_slider_changed`, `get_slider_values` (used by copy + sync source),
+`copy_adjustment_settings`. NOT called in `on_reset_clicked` / `on_compare_pressed`
+(those intentionally drop curves). `paste_adjustment_settings` and
+`set_current_idx` go the other direction: they push `adjustment.get("curves")`
+into the editor via `curve_editor.set_curves(...)`.
+
+### 9.5 Sync-to-All for curves
+- Add group `("curves", "Curves", ())` to `SYNC_GROUPS`.
+- In `_perform_sync_to_all`: capture `src_curves = curve_editor.get_curves()`.
+  For each target image, when the curves group is selected and the target's
+  stored `curves` differ from `src_curves`, push an undo state and set
+  `img.adjustment_settings["curves"] = deep-copied src_curves` (or delete the key
+  when `src_curves is None`), then reprocess (curves change pixels, like
+  adjustments/profile). Deep-copy the nested lists so synced targets don't alias
+  the source's structure.
+- The merged-dict rebuild in `_perform_sync_to_all` keys off `adjustment_keys`
+  (which excludes `"curves"`); preserve each target's own `"curves"` across that
+  rebuild unless the curves group is being synced.
+
+### 9.6 Editor ↔ panel signal contract
+- `curveChanged`: emitted on every mouse-move during a drag and on add/remove.
+  → `_on_curve_changed`: rebuild dict (sliders + curves), store on image, start
+  undo burst, `image_preview.update_preview(idx)` for live feedback, and queue
+  the debounced heavy reprocess (reuse the panel's existing
+  `_pending_adjustment`/`_debounce_timer` machinery so thumbnail/preview heavy
+  work is coalesced exactly like slider drags).
+- `editFinished`: emitted on mouse-release / after add/remove settles.
+  → `_on_curve_edit_finished`: `end_undo_burst()` so the next discrete edit
+  starts a fresh undo step (mirrors slider burst handling).
+
+### 9.7 Widget sizing / theme
+- Canvas: `setMinimumSize(200,200)`, `setFixedHeight(220)`; expands horizontally
+  with the panel. Dark theme to match (`#2b2b2b` canvas, `#555` grid, `#888`
+  identity diagonal, channel-tinted curve line: white for All, `#c66`/`#6a6`/
+  `#66c` for R/G/B mirroring the Channel-Levels labels).
+- Channel buttons reuse the small checkable style used by the band swatches.
+
+### 9.8 Catalog note
+`catalog.py:129` skips persisting some state when `adjustment_settings` is empty.
+A curves-only image now has a non-empty `adjustment_settings`, so it persists —
+which is the desired behaviour. Verify no inverse assumption (e.g. "empty ⇒
+identity") elsewhere breaks; none found in the slider/preview paths.
+
+### 9.9 Out-of-scope confirmations
+Histogram overlay, numeric I/O fields, per-point corner toggles, and a GPU curve
+path remain non-goals for this change.

--- a/spec/curves-tone-control.md
+++ b/spec/curves-tone-control.md
@@ -65,11 +65,18 @@ preceded by a horizontal separator, matching the existing pattern.
 ### 3.4 Mouse behaviour
 - **Hit area**: each control point has a square hit/"button" area of
   `POINT_HIT = 11 px` (radius ~5–6 px) around its center.
-- **Left-press on empty canvas** (not within any point's hit area): create a new
-  control point at the clicked position and immediately begin dragging it.
 - **Left-press on an existing point's hit area**: grab that point and drag it
   (no new point is created — this is the "button area won't create a new point"
   rule).
+- **Left-press on the curve line** (within `CURVE_HIT = 8 px` of the drawn
+  curve, vertically) but not on an existing point: create a new control point
+  **on the curve** at that input x and immediately begin dragging it.
+- **Left-press on empty canvas** away from both the curve and any point: does
+  nothing (no point is created). New points only come from clicking the line.
+- **Mouse grab**: on starting a drag (create or grab) the canvas calls
+  `grabMouse()` and releases it on mouse-release. This is required because the
+  curve canvas lives inside the panel's `QScrollArea`, which otherwise steals
+  the move events mid-drag (the point would not follow the cursor).
 - **Drag**: moves the grabbed point.
   - Endpoints (`x==0` and `x==255`): X is locked; Y is draggable `[0,255]`.
   - Interior points: X clamped to stay strictly between the two neighbour points
@@ -307,6 +314,11 @@ into the editor via `curve_editor.set_curves(...)`.
   with the panel. Dark theme to match (`#2b2b2b` canvas, `#555` grid, `#888`
   identity diagonal, channel-tinted curve line: white for All, `#c66`/`#6a6`/
   `#66c` for R/G/B mirroring the Channel-Levels labels).
+- **Plot inset / scrollbar clearance**: the interactive plot rect is inset from
+  the canvas edges (left/top/bottom 10 px, **right 22 px**). The larger right
+  inset keeps the `x=255` endpoint and the whole right edge of the curve clear
+  of the panel's vertical scrollbar, which overlays the canvas's rightmost
+  pixels — otherwise the top-right control point is unclickable.
 - Channel buttons reuse the small checkable style used by the band swatches.
 
 ### 9.8 Catalog note

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -9,7 +9,7 @@ import time
 from PySide6.QtGui import QImage, QPixmap  # or from PySide6.QtGui import QImage, QPixmap if you use PySide
 #import lensfunpy  # Make sure lensfunpy is installed
 from core.ccr_processor import (adjust_image, adjust_image_opencl,
-                                BAND_ADJUSTMENT_KEYS)
+                                BAND_ADJUSTMENT_KEYS, apply_curves)
 
 # Import optional libraries with fallbacks
 try:
@@ -561,6 +561,11 @@ class CCRImage:
                      band_settings=(s if any(s.get(k, 0)
                                              for k in BAND_ADJUSTMENT_KEYS)
                                     else None))
+        # Tone curves run after the slider pass, in RGB, before any B&W
+        # luminance collapse (Photoshop-like). No-op for identity curves.
+        curves = s.get('curves')
+        if curves:
+            adjusted = apply_curves(adjusted, curves)
         if profile == "bw":
             adjusted = self._to_grayscale(adjusted)
         return adjusted

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -2545,3 +2545,147 @@ def cleanup_opencl():
         print("OpenCL resources cleaned up")
     except Exception as e:
         print(f"Error cleaning up OpenCL resources: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Tone curves (Photoshop-style Curves control)
+#
+# Curve state is a dict of channel -> list of [x, y] control points in the
+# 0..255 display domain, e.g.
+#   {"rgb": [[0,0],[255,255]], "r": [...], "g": [...], "b": [...]}
+# "rgb" is the composite ("All") curve applied to every channel before the
+# per-channel r/g/b curves (matching Photoshop's compose order). Missing or
+# malformed channels are treated as identity. See spec/curves-tone-control.md.
+# ---------------------------------------------------------------------------
+
+_CURVE_CHANNELS = ("rgb", "r", "g", "b")
+_IDENTITY_POINTS = [[0.0, 0.0], [255.0, 255.0]]
+
+
+def _normalize_points(points):
+    """Sanitize a control-point list: keep finite [x,y] pairs, clamp to
+    [0,255], sort by x, drop duplicate-x points. Returns None if the result is
+    effectively the 2-point identity (so callers can skip it)."""
+    if not points:
+        return None
+    cleaned = []
+    for p in points:
+        try:
+            x = float(p[0]); y = float(p[1])
+        except (TypeError, ValueError, IndexError):
+            continue
+        if not (np.isfinite(x) and np.isfinite(y)):
+            continue
+        cleaned.append([min(255.0, max(0.0, x)), min(255.0, max(0.0, y))])
+    if len(cleaned) < 2:
+        return None
+    cleaned.sort(key=lambda q: q[0])
+    # Drop points sharing an x with the previous one (keep the first).
+    dedup = [cleaned[0]]
+    for q in cleaned[1:]:
+        if q[0] > dedup[-1][0]:
+            dedup.append(q)
+    if len(dedup) < 2:
+        return None
+    # Exactly the identity diagonal? Treat as no-op.
+    if dedup == _IDENTITY_POINTS:
+        return None
+    return dedup
+
+
+def _is_identity_curves(curves) -> bool:
+    """True when curves is None/empty or every channel is the identity."""
+    if not curves:
+        return True
+    for ch in _CURVE_CHANNELS:
+        if _normalize_points(curves.get(ch)) is not None:
+            return False
+    return True
+
+
+def _monotone_cubic(xs, ys, xq):
+    """Fritsch-Carlson monotone cubic interpolation of (xs, ys) at xq.
+    Prevents overshoot so the tone curve never inverts local contrast.
+    xs must be strictly increasing. Returns a float array shaped like xq."""
+    xs = np.asarray(xs, dtype=np.float64)
+    ys = np.asarray(ys, dtype=np.float64)
+    n = len(xs)
+    if n == 2:
+        # Straight line — exact, and the common (identity / single move) case.
+        return np.interp(xq, xs, ys)
+    h = np.diff(xs)
+    delta = np.diff(ys) / h
+    # Tangents
+    m = np.empty(n, dtype=np.float64)
+    m[1:-1] = (delta[:-1] + delta[1:]) / 2.0
+    m[0] = delta[0]
+    m[-1] = delta[-1]
+    # Enforce monotonicity (Fritsch-Carlson)
+    for i in range(n - 1):
+        if delta[i] == 0.0:
+            m[i] = 0.0
+            m[i + 1] = 0.0
+        else:
+            a = m[i] / delta[i]
+            b = m[i + 1] / delta[i]
+            s = a * a + b * b
+            if s > 9.0:
+                t = 3.0 / np.sqrt(s)
+                m[i] = t * a * delta[i]
+                m[i + 1] = t * b * delta[i]
+    xq = np.asarray(xq, dtype=np.float64)
+    # Segment index for each query point
+    idx = np.clip(np.searchsorted(xs, xq) - 1, 0, n - 2)
+    x0 = xs[idx]; x1 = xs[idx + 1]
+    y0 = ys[idx]; y1 = ys[idx + 1]
+    m0 = m[idx]; m1 = m[idx + 1]
+    hh = (x1 - x0)
+    t = (xq - x0) / hh
+    t2 = t * t
+    t3 = t2 * t
+    h00 = 2 * t3 - 3 * t2 + 1
+    h10 = t3 - 2 * t2 + t
+    h01 = -2 * t3 + 3 * t2
+    h11 = t3 - t2
+    return h00 * y0 + h10 * hh * m0 + h01 * y1 + h11 * hh * m1
+
+
+def build_channel_lut(points) -> np.ndarray:
+    """Build a 256-entry float curve (output 0..255) from control points in the
+    0..255 domain using monotone cubic interpolation. Returns the identity ramp
+    for an identity/invalid point set."""
+    pts = _normalize_points(points)
+    x = np.arange(256, dtype=np.float64)
+    if pts is None:
+        return x.astype(np.float32)
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    y = _monotone_cubic(xs, ys, x)
+    return np.clip(y, 0.0, 255.0).astype(np.float32)
+
+
+def apply_curves(img16: np.ndarray, curves) -> np.ndarray:
+    """Apply Photoshop-style tone curves to a 16-bit RGB image.
+
+    curves: dict of channel ("rgb"/"r"/"g"/"b") -> list of [x,y] points in the
+    0..255 domain. The composite "rgb" curve is applied first, then the
+    per-channel curve. Identity channels are skipped. Returns a uint16 array;
+    the input is returned unchanged when every channel is identity.
+    """
+    if _is_identity_curves(curves):
+        return img16
+
+    rgb_lut = build_channel_lut(curves.get("rgb"))     # 256 -> 0..255 float
+    sample = np.arange(65536, dtype=np.float32)
+    src_idx = np.arange(256, dtype=np.float32) * (65535.0 / 255.0)
+
+    out = np.empty_like(img16)
+    for c, key in enumerate(("r", "g", "b")):
+        # Compose per-channel curve over the composite curve in 0..255 space.
+        ch_lut = build_channel_lut(curves.get(key))
+        composed = ch_lut[np.clip(np.rint(rgb_lut), 0, 255).astype(np.intp)]
+        # Expand the 256-point composed curve to a full 16-bit LUT.
+        lut16 = np.interp(sample, src_idx,
+                          composed * (65535.0 / 255.0)).astype(np.uint16)
+        out[..., c] = lut16[img16[..., c]]
+    return out

--- a/src/widgets/curve_editor.py
+++ b/src/widgets/curve_editor.py
@@ -1,0 +1,355 @@
+"""Photoshop-style tone curve editor widget.
+
+Lets the user reshape image tonality by dragging control points on a curve, per
+composite channel ("All"/rgb) and per individual channel (R/G/B). The curve
+state is exposed as a plain dict of channel -> list of [x, y] control points in
+the 0..255 domain, matching what ccr_processor.apply_curves consumes.
+
+See spec/curves-tone-control.md for the interaction contract.
+"""
+
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPushButton
+from PySide6.QtCore import Qt, Signal, QPointF, QRectF
+from PySide6.QtGui import QPainter, QPen, QBrush, QColor, QPainterPath
+
+# Mirror ccr_processor's channel set / identity so the two agree by construction.
+CURVE_CHANNELS = ("rgb", "r", "g", "b")
+
+
+def _identity_points():
+    return [[0.0, 0.0], [255.0, 255.0]]
+
+
+def identity_curves():
+    return {ch: _identity_points() for ch in CURVE_CHANNELS}
+
+
+def _monotone_cubic(xs, ys, xq):
+    """Local copy of the Fritsch-Carlson interpolation used for drawing so the
+    rendered line matches ccr_processor.apply_curves. Pure-Python, small N."""
+    n = len(xs)
+    if n == 2:
+        # Linear
+        x0, x1 = xs[0], xs[1]
+        y0, y1 = ys[0], ys[1]
+        span = (x1 - x0) or 1.0
+        return [y0 + (y1 - y0) * (q - x0) / span for q in xq]
+    h = [xs[i + 1] - xs[i] for i in range(n - 1)]
+    delta = [(ys[i + 1] - ys[i]) / (h[i] or 1.0) for i in range(n - 1)]
+    m = [0.0] * n
+    m[0] = delta[0]
+    m[-1] = delta[-1]
+    for i in range(1, n - 1):
+        m[i] = (delta[i - 1] + delta[i]) / 2.0
+    for i in range(n - 1):
+        if delta[i] == 0.0:
+            m[i] = 0.0
+            m[i + 1] = 0.0
+        else:
+            a = m[i] / delta[i]
+            b = m[i + 1] / delta[i]
+            s = a * a + b * b
+            if s > 9.0:
+                t = 3.0 / (s ** 0.5)
+                m[i] = t * a * delta[i]
+                m[i + 1] = t * b * delta[i]
+    out = []
+    seg = 0
+    for q in xq:
+        while seg < n - 2 and q > xs[seg + 1]:
+            seg += 1
+        x0, x1 = xs[seg], xs[seg + 1]
+        y0, y1 = ys[seg], ys[seg + 1]
+        hh = (x1 - x0) or 1.0
+        t = (q - x0) / hh
+        t2 = t * t
+        t3 = t2 * t
+        h00 = 2 * t3 - 3 * t2 + 1
+        h10 = t3 - 2 * t2 + t
+        h01 = -2 * t3 + 3 * t2
+        h11 = t3 - t2
+        out.append(h00 * y0 + h10 * hh * m[seg] + h01 * y1 + h11 * hh * m[seg + 1])
+    return out
+
+
+class CurveCanvas(QWidget):
+    """The interactive drawing surface for one set of per-channel curves."""
+
+    POINT_HIT = 11          # px square hit area ("button size") around a point
+    POINT_RADIUS = 4
+
+    curveChanged = Signal()      # live, during a drag / on add / on remove
+    editFinished = Signal()      # drag released / edit settled
+
+    _LINE_COLORS = {
+        "rgb": QColor("#e8e8e8"),
+        "r": QColor("#d06666"),
+        "g": QColor("#66aa66"),
+        "b": QColor("#6688d0"),
+    }
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumSize(200, 200)
+        self.setFixedHeight(220)
+        self.setMouseTracking(True)
+        self._channel = "rgb"
+        self._points = identity_curves()
+        self._drag_index = None
+        self._enabled = True
+
+    # --- public API -------------------------------------------------------
+    def set_active_channel(self, channel: str):
+        if channel in CURVE_CHANNELS and channel != self._channel:
+            self._channel = channel
+            self.update()
+
+    def active_channel(self) -> str:
+        return self._channel
+
+    def get_curves(self):
+        """Return a fresh dict of non-identity channels, or None if every
+        channel is identity."""
+        out = {}
+        for ch in CURVE_CHANNELS:
+            pts = self._points[ch]
+            if pts != _identity_points():
+                out[ch] = [[float(x), float(y)] for x, y in pts]
+        return out or None
+
+    def set_curves(self, curves):
+        """Load curve state (None / missing channels => identity)."""
+        new = identity_curves()
+        if curves:
+            for ch in CURVE_CHANNELS:
+                pts = curves.get(ch)
+                if pts and len(pts) >= 2:
+                    cleaned = []
+                    for p in pts:
+                        try:
+                            x = float(p[0]); y = float(p[1])
+                        except (TypeError, ValueError, IndexError):
+                            continue
+                        cleaned.append([min(255.0, max(0.0, x)),
+                                        min(255.0, max(0.0, y))])
+                    cleaned.sort(key=lambda q: q[0])
+                    if len(cleaned) >= 2:
+                        new[ch] = cleaned
+        self._points = new
+        self._drag_index = None
+        self.update()
+
+    def reset(self):
+        self._points = identity_curves()
+        self._drag_index = None
+        self.update()
+        self.curveChanged.emit()
+        self.editFinished.emit()
+
+    def setEnabled(self, enabled: bool):  # noqa: N802 (Qt override style)
+        self._enabled = enabled
+        super().setEnabled(enabled)
+        self.update()
+
+    # --- geometry helpers -------------------------------------------------
+    def _plot_rect(self) -> QRectF:
+        m = 8.0
+        return QRectF(m, m, self.width() - 2 * m, self.height() - 2 * m)
+
+    def _to_widget(self, x, y) -> QPointF:
+        r = self._plot_rect()
+        wx = r.left() + (x / 255.0) * r.width()
+        wy = r.bottom() - (y / 255.0) * r.height()
+        return QPointF(wx, wy)
+
+    def _to_curve(self, pos) -> tuple:
+        r = self._plot_rect()
+        x = (pos.x() - r.left()) / r.width() * 255.0
+        y = (r.bottom() - pos.y()) / r.height() * 255.0
+        return (min(255.0, max(0.0, x)), min(255.0, max(0.0, y)))
+
+    def _point_at(self, pos):
+        """Index of the control point whose hit area contains pos, else None."""
+        pts = self._points[self._channel]
+        half = self.POINT_HIT / 2.0
+        for i, (x, y) in enumerate(pts):
+            w = self._to_widget(x, y)
+            if abs(w.x() - pos.x()) <= half and abs(w.y() - pos.y()) <= half:
+                return i
+        return None
+
+    # --- mouse ------------------------------------------------------------
+    def mousePressEvent(self, event):
+        if not self._enabled:
+            return
+        pts = self._points[self._channel]
+        idx = self._point_at(event.position())
+
+        if event.button() == Qt.RightButton:
+            # Remove an interior point; ignore endpoints / empty canvas.
+            if idx is not None and idx != 0 and idx != len(pts) - 1:
+                del pts[idx]
+                self._drag_index = None
+                self.update()
+                self.curveChanged.emit()
+                self.editFinished.emit()
+            return
+
+        if event.button() != Qt.LeftButton:
+            return
+
+        if idx is not None:
+            # Grab the existing point (no new point created).
+            self._drag_index = idx
+        else:
+            # Create a new point at the click and start dragging it.
+            x, y = self._to_curve(event.position())
+            # Keep strictly inside the endpoints.
+            x = min(254.0, max(1.0, x))
+            insert_at = 0
+            while insert_at < len(pts) and pts[insert_at][0] < x:
+                insert_at += 1
+            pts.insert(insert_at, [x, y])
+            self._drag_index = insert_at
+        self.update()
+        self.curveChanged.emit()
+
+    def mouseMoveEvent(self, event):
+        if not self._enabled or self._drag_index is None:
+            return
+        pts = self._points[self._channel]
+        i = self._drag_index
+        x, y = self._to_curve(event.position())
+        last = len(pts) - 1
+        if i == 0:
+            x = 0.0                      # endpoints: X locked, Y free
+        elif i == last:
+            x = 255.0
+        else:
+            lo = pts[i - 1][0] + 1.0
+            hi = pts[i + 1][0] - 1.0
+            x = min(hi, max(lo, x))
+        pts[i] = [x, min(255.0, max(0.0, y))]
+        self.update()
+        self.curveChanged.emit()
+
+    def mouseReleaseEvent(self, event):
+        if self._drag_index is not None:
+            self._drag_index = None
+            self.editFinished.emit()
+
+    # --- painting ---------------------------------------------------------
+    def paintEvent(self, event):
+        p = QPainter(self)
+        p.setRenderHint(QPainter.Antialiasing, True)
+        r = self._plot_rect()
+
+        # Background
+        p.fillRect(self.rect(), QColor("#2b2b2b"))
+        p.setPen(QPen(QColor("#555"), 1))
+        p.drawRect(r)
+
+        # Grid (4x4)
+        p.setPen(QPen(QColor("#3d3d3d"), 1))
+        for k in range(1, 4):
+            gx = r.left() + r.width() * k / 4.0
+            gy = r.top() + r.height() * k / 4.0
+            p.drawLine(QPointF(gx, r.top()), QPointF(gx, r.bottom()))
+            p.drawLine(QPointF(r.left(), gy), QPointF(r.right(), gy))
+
+        # Identity diagonal reference
+        p.setPen(QPen(QColor("#666"), 1, Qt.DashLine))
+        p.drawLine(self._to_widget(0, 0), self._to_widget(255, 255))
+
+        pts = self._points[self._channel]
+        xs = [pt[0] for pt in pts]
+        ys = [pt[1] for pt in pts]
+
+        # Smooth curve line (sample across the plot width)
+        n_samples = max(2, int(r.width()))
+        xq = [255.0 * s / (n_samples - 1) for s in range(n_samples)]
+        yq = _monotone_cubic(xs, ys, xq)
+        path = QPainterPath()
+        first = self._to_widget(xq[0], min(255.0, max(0.0, yq[0])))
+        path.moveTo(first)
+        for qx, qy in zip(xq[1:], yq[1:]):
+            path.lineTo(self._to_widget(qx, min(255.0, max(0.0, qy))))
+        line_color = self._LINE_COLORS.get(self._channel, QColor("#e8e8e8"))
+        if not self._enabled:
+            line_color = QColor("#555")
+        p.setPen(QPen(line_color, 2))
+        p.drawPath(path)
+
+        # Control points
+        p.setPen(QPen(QColor("#222"), 1))
+        p.setBrush(QBrush(QColor("#f0f0f0") if self._enabled else QColor("#777")))
+        for x, y in pts:
+            w = self._to_widget(x, y)
+            p.drawEllipse(w, self.POINT_RADIUS, self.POINT_RADIUS)
+        p.end()
+
+
+class CurveEditor(QWidget):
+    """Channel selector + curve canvas + Reset Curve button."""
+
+    curveChanged = Signal()
+    editFinished = Signal()
+
+    _CHANNEL_LABELS = (("rgb", "All"), ("r", "R"), ("g", "G"), ("b", "B"))
+    _BTN_TINT = {"rgb": "#bbbbbb", "r": "#d06666", "g": "#66aa66", "b": "#6688d0"}
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        # Channel selector buttons (mutually exclusive, checkable)
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(4)
+        self._channel_buttons = {}
+        for ch, label in self._CHANNEL_LABELS:
+            btn = QPushButton(label)
+            btn.setCheckable(True)
+            btn.setFixedHeight(22)
+            btn.setStyleSheet(
+                "QPushButton { background: #3a3a3a; border: 1px solid #222; "
+                f"border-radius: 3px; color: {self._BTN_TINT[ch]}; font-size: 11px; }}"
+                "QPushButton:checked { background: #555; border: 2px solid #eee; }")
+            btn.clicked.connect(lambda _=False, c=ch: self._on_channel(c))
+            btn_row.addWidget(btn)
+            self._channel_buttons[ch] = btn
+        layout.addLayout(btn_row)
+
+        self.canvas = CurveCanvas()
+        self.canvas.curveChanged.connect(self.curveChanged)
+        self.canvas.editFinished.connect(self.editFinished)
+        layout.addWidget(self.canvas)
+
+        self.reset_button = QPushButton("Reset Curve")
+        self.reset_button.clicked.connect(self.canvas.reset)
+        layout.addWidget(self.reset_button)
+
+        self._channel_buttons["rgb"].setChecked(True)
+
+    def _on_channel(self, channel: str):
+        for ch, btn in self._channel_buttons.items():
+            btn.setChecked(ch == channel)
+        self.canvas.set_active_channel(channel)
+
+    # Pass-through API used by SlidersPanel.
+    def get_curves(self):
+        return self.canvas.get_curves()
+
+    def set_curves(self, curves):
+        self.canvas.set_curves(curves)
+
+    def reset(self):
+        self.canvas.reset()
+
+    def setEnabled(self, enabled: bool):  # noqa: N802
+        self.canvas.setEnabled(enabled)
+        for btn in self._channel_buttons.values():
+            btn.setEnabled(enabled)
+        self.reset_button.setEnabled(enabled)
+        super().setEnabled(enabled)

--- a/src/widgets/curve_editor.py
+++ b/src/widgets/curve_editor.py
@@ -153,7 +153,11 @@ class CurveCanvas(QWidget):
     def reset(self):
         self._points = identity_curves()
         self._release_grab()
-        self.update()
+        # repaint() (synchronous) rather than update() (deferred): the
+        # curveChanged handler below reprocesses the image preview synchronously
+        # and would otherwise block the event loop before the scheduled canvas
+        # repaint runs, making the curve appear to reset only after a lag.
+        self.repaint()
         self.curveChanged.emit()
         self.editFinished.emit()
 

--- a/src/widgets/curve_editor.py
+++ b/src/widgets/curve_editor.py
@@ -77,6 +77,7 @@ class CurveCanvas(QWidget):
 
     POINT_HIT = 11          # px square hit area ("button size") around a point
     POINT_RADIUS = 4
+    CURVE_HIT = 8           # px vertical tolerance for "clicked on the line"
 
     curveChanged = Signal()      # live, during a drag / on add / on remove
     editFinished = Signal()      # drag released / edit settled
@@ -96,6 +97,7 @@ class CurveCanvas(QWidget):
         self._channel = "rgb"
         self._points = identity_curves()
         self._drag_index = None
+        self._grabbed = False
         self._enabled = True
 
     # --- public API -------------------------------------------------------
@@ -136,12 +138,18 @@ class CurveCanvas(QWidget):
                     if len(cleaned) >= 2:
                         new[ch] = cleaned
         self._points = new
-        self._drag_index = None
+        self._release_grab()
         self.update()
+
+    def _release_grab(self):
+        self._drag_index = None
+        if self._grabbed:
+            self.releaseMouse()
+            self._grabbed = False
 
     def reset(self):
         self._points = identity_curves()
-        self._drag_index = None
+        self._release_grab()
         self.update()
         self.curveChanged.emit()
         self.editFinished.emit()
@@ -153,8 +161,20 @@ class CurveCanvas(QWidget):
 
     # --- geometry helpers -------------------------------------------------
     def _plot_rect(self) -> QRectF:
-        m = 8.0
-        return QRectF(m, m, self.width() - 2 * m, self.height() - 2 * m)
+        # Larger right inset keeps the x=255 edge clear of the panel's vertical
+        # scrollbar, which overlays the canvas's rightmost pixels.
+        left = top = bottom = 10.0
+        right = 22.0
+        return QRectF(left, top,
+                      self.width() - left - right,
+                      self.height() - top - bottom)
+
+    def _curve_y_at(self, x_curve: float) -> float:
+        """Output (0..255) of the active channel's curve at input x_curve."""
+        pts = self._points[self._channel]
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        return _monotone_cubic(xs, ys, [x_curve])[0]
 
     def _to_widget(self, x, y) -> QPointF:
         r = self._plot_rect()
@@ -183,7 +203,8 @@ class CurveCanvas(QWidget):
         if not self._enabled:
             return
         pts = self._points[self._channel]
-        idx = self._point_at(event.position())
+        pos = event.position()
+        idx = self._point_at(pos)
 
         if event.button() == Qt.RightButton:
             # Remove an interior point; ignore endpoints / empty canvas.
@@ -193,6 +214,7 @@ class CurveCanvas(QWidget):
                 self.update()
                 self.curveChanged.emit()
                 self.editFinished.emit()
+            event.accept()
             return
 
         if event.button() != Qt.LeftButton:
@@ -202,17 +224,28 @@ class CurveCanvas(QWidget):
             # Grab the existing point (no new point created).
             self._drag_index = idx
         else:
-            # Create a new point at the click and start dragging it.
-            x, y = self._to_curve(event.position())
-            # Keep strictly inside the endpoints.
-            x = min(254.0, max(1.0, x))
+            # Create a point ONLY when the click lands on the curve line.
+            xc, yc = self._to_curve(pos)
+            curve_y = self._curve_y_at(xc)
+            on_line = abs(pos.y() - self._to_widget(xc, curve_y).y()) <= self.CURVE_HIT
+            if not on_line:
+                event.accept()
+                return  # empty space away from the line — do nothing
+            # New point sits exactly on the existing curve, strictly between
+            # the endpoints, then the drag reshapes it.
+            x = min(254.0, max(1.0, xc))
             insert_at = 0
             while insert_at < len(pts) and pts[insert_at][0] < x:
                 insert_at += 1
-            pts.insert(insert_at, [x, y])
+            pts.insert(insert_at, [x, curve_y])
             self._drag_index = insert_at
+        # The canvas sits inside the panel's QScrollArea; grab the mouse so move
+        # events keep coming to us for the whole drag instead of being stolen.
+        self.grabMouse()
+        self._grabbed = True
         self.update()
         self.curveChanged.emit()
+        event.accept()
 
     def mouseMoveEvent(self, event):
         if not self._enabled or self._drag_index is None:
@@ -232,11 +265,18 @@ class CurveCanvas(QWidget):
         pts[i] = [x, min(255.0, max(0.0, y))]
         self.update()
         self.curveChanged.emit()
+        event.accept()
 
     def mouseReleaseEvent(self, event):
+        # Always drop the grab if we hold it, even if _drag_index was cleared
+        # mid-drag (e.g. by a set_curves refresh), so the mouse can't get stuck.
+        if self._grabbed:
+            self.releaseMouse()
+            self._grabbed = False
         if self._drag_index is not None:
             self._drag_index = None
             self.editFinished.emit()
+            event.accept()
 
     # --- painting ---------------------------------------------------------
     def paintEvent(self, event):

--- a/src/widgets/curve_editor.py
+++ b/src/widgets/curve_editor.py
@@ -109,6 +109,9 @@ class CurveCanvas(QWidget):
     def active_channel(self) -> str:
         return self._channel
 
+    def is_dragging(self) -> bool:
+        return self._drag_index is not None
+
     def get_curves(self):
         """Return a fresh dict of non-identity channels, or None if every
         channel is identity."""
@@ -383,6 +386,9 @@ class CurveEditor(QWidget):
 
     def set_curves(self, curves):
         self.canvas.set_curves(curves)
+
+    def is_dragging(self) -> bool:
+        return self.canvas.is_dragging()
 
     def reset(self):
         self.canvas.reset()

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -6,6 +6,8 @@ from PySide6.QtCore import Qt, QTimer, QThread, Signal
 from PySide6.QtGui import QPixmap, QKeySequence, QShortcut
 from core.ccr_backend import ccr_backend
 from core.ccr_processor import COLOR_BANDS, BAND_PARAMS, BAND_ADJUSTMENT_KEYS
+from widgets.curve_editor import CurveEditor
+import copy
 
 # Setting groups offered by the "Sync to All" dialog. The adjustment-key
 # groups partition SlidersPanel.ADJUSTMENT_KEYS exactly; "crop" syncs the
@@ -25,6 +27,9 @@ SYNC_GROUPS = [
         "ch_b_shift", "ch_b_gain", "ch_b_blackpoint")),
     ("bands", "Subtractive Saturations (per color)",
      tuple(BAND_ADJUSTMENT_KEYS) + ("band_feather",)),
+    # "curves" lives outside ADJUSTMENT_KEYS (it's a nested structure, not a
+    # slider), so it's synced specially in _perform_sync_to_all, like crop.
+    ("curves", "Curves", ()),
 ]
 
 
@@ -483,6 +488,20 @@ class SlidersPanel(QWidget):
                                default_value=self._default_for("band_feather")))
         self._show_band_page("red")
 
+        # --- Curves collapsible section ---
+        curves_separator = QFrame()
+        curves_separator.setFrameShape(QFrame.HLine)
+        curves_separator.setFrameShadow(QFrame.Sunken)
+        curves_separator.setStyleSheet("margin-top: 8px; margin-bottom: 4px;")
+        scroll_layout.addWidget(curves_separator)
+
+        self.curves_section = CollapsibleSection("Curves")
+        scroll_layout.addWidget(self.curves_section)
+        self.curve_editor = CurveEditor()
+        self.curves_section.add_widget(self.curve_editor)
+        self.curve_editor.curveChanged.connect(self._on_curve_changed)
+        self.curve_editor.editFinished.connect(self._on_curve_edit_finished)
+
         # --- Signal connections ---
         self.reset_button.clicked.connect(self.on_reset_clicked)
         self.compare_button.pressed.connect(self.on_compare_pressed)
@@ -639,6 +658,9 @@ class SlidersPanel(QWidget):
         self.wb_picker_btn.setEnabled(enabled)
         self.crop_btn.setEnabled(enabled)
         self.color_profile_combo.setEnabled(enabled)
+        self.curve_editor.setEnabled(enabled)
+        if not enabled:
+            self.curve_editor.set_curves(None)
         for slider in self.sliders:
             slider.setEnabled(enabled)
             if not enabled:
@@ -667,6 +689,9 @@ class SlidersPanel(QWidget):
         self._sync_color_profile_combo(idx)
         adjustment = ccr_backend.get_adjustment_by_index(idx)
         print(f"Setting current index: {idx}, adjustment: {adjustment}")
+        # Tone curves live inside the adjustment dict; load them into the editor
+        # regardless of whether any sliders are set.
+        self.curve_editor.set_curves(adjustment.get("curves") if adjustment else None)
         if adjustment is None or not adjustment:
             # No adjustment yet: show each slider's default (0 for most,
             # 10 for band_feather).
@@ -699,6 +724,7 @@ class SlidersPanel(QWidget):
         """
         if self.current_idx is not None:
             adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
+            self._attach_curves(adjustment)
 
             # Immediate lightweight feedback - just store the adjustment settings
             if 0 <= self.current_idx < len(ccr_backend.images):
@@ -716,6 +742,36 @@ class SlidersPanel(QWidget):
             self._debounce_timer.stop()
             self._debounce_timer.start(150)  # Slightly longer debounce for heavy processing
     
+    def _attach_curves(self, adjustment: dict) -> dict:
+        """Re-attach the live tone-curve state from the editor onto a freshly
+        rebuilt adjustment dict (the slider->dict rebuild drops the nested
+        'curves' key otherwise). No-op for identity curves."""
+        curves = self.curve_editor.get_curves()
+        if curves:
+            adjustment["curves"] = curves
+        return adjustment
+
+    def _on_curve_changed(self):
+        """Live tone-curve edit — mirror on_slider_changed's feedback +
+        debounced heavy-processing path so a curve drag behaves like a slider
+        drag (single undo burst, coalesced reprocessing)."""
+        if self.current_idx is None:
+            return
+        adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
+        self._attach_curves(adjustment)
+        if 0 <= self.current_idx < len(ccr_backend.images):
+            self._begin_undo_burst(ccr_backend.images[self.current_idx])
+            ccr_backend.images[self.current_idx].adjustment_settings = adjustment
+        self.parent().parent().image_preview.update_preview(self.current_idx)
+        self._pending_adjustment = adjustment
+        self._pending_idx = self.current_idx
+        self._debounce_timer.stop()
+        self._debounce_timer.start(150)
+
+    def _on_curve_edit_finished(self):
+        """End the undo burst so the next discrete curve edit is its own step."""
+        self.end_undo_burst()
+
     def _process_pending_adjustment(self):
         """Process the pending adjustment if not already processing."""
         if not self._processing and self._pending_adjustment is not None:
@@ -777,6 +833,10 @@ class SlidersPanel(QWidget):
             slider.setValue(default)
             slider.blockSignals(False)
             self.slider_value_labels[i].setText(str(default))
+        # Full reset clears tone curves too (the dedicated "Reset Curve" button
+        # is the curve-only path). set_curves does not emit, so it won't start a
+        # competing undo burst here.
+        self.curve_editor.set_curves(None)
         # Save adjustment to backend and update preview
         if self.current_idx is not None:
             adjustment = {key: 0 for key in self.adjustment_keys}
@@ -841,6 +901,8 @@ class SlidersPanel(QWidget):
                 if selection.get(gid) for k in group_keys]
         sync_crop = bool(selection.get("crop"))
         sync_profile = bool(selection.get("profile"))
+        sync_curves = bool(selection.get("curves"))
+        src_curves = self.curve_editor.get_curves()  # None when identity
         current_adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
         src = ccr_backend.get_image_by_index(self.current_idx)
         crop_rect = src.crop_rect if src is not None else None
@@ -855,7 +917,8 @@ class SlidersPanel(QWidget):
             crop_changes = sync_crop and (img.crop_rect != crop_rect
                                           or getattr(img, "crop_angle", 0.0) != crop_angle)
             profile_changes = sync_profile and getattr(img, "color_profile", "color") != src_profile
-            if not adj_changes and not crop_changes and not profile_changes:
+            curves_changes = sync_curves and img.adjustment_settings.get("curves") != src_curves
+            if not adj_changes and not crop_changes and not profile_changes and not curves_changes:
                 continue  # nothing to change — and no dead undo snapshot
             img.push_undo_state()
             if adj_changes:
@@ -867,13 +930,23 @@ class SlidersPanel(QWidget):
                           for k in self.adjustment_keys}
                 for k in keys:
                     merged[k] = current_adjustment.get(k, self._default_for(k))
+                # Preserve the target's own tone curves across the slider-only
+                # rebuild (they're synced separately, just below).
+                existing_curves = img.adjustment_settings.get("curves")
+                if existing_curves is not None:
+                    merged["curves"] = existing_curves
                 img.adjustment_settings = merged
+            if curves_changes:
+                if src_curves:
+                    img.adjustment_settings["curves"] = copy.deepcopy(src_curves)
+                else:
+                    img.adjustment_settings.pop("curves", None)
             if sync_crop:
                 img.crop_rect = crop_rect
                 img.crop_angle = crop_angle
             if profile_changes:
                 img.color_profile = src_profile
-            if adj_changes or profile_changes:
+            if adj_changes or profile_changes or curves_changes:
                 # Crop is display/export-level only — no reprocessing needed
                 # when nothing but the crop changed. Adjustments and the color
                 # profile both change pixels, so they do.
@@ -1033,6 +1106,7 @@ class SlidersPanel(QWidget):
         if self.current_idx is not None:
             # Get the current adjustment settings from sliders
             self.copied_adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
+            self._attach_curves(self.copied_adjustment)
             print(f"Copied adjustment settings: {self.copied_adjustment}")
             self.set_temporary_hint("Adjustments Copied!", duration=4000)
         else:
@@ -1057,7 +1131,10 @@ class SlidersPanel(QWidget):
                     self.sliders[i].setValue(self.copied_adjustment[key])
                     self.sliders[i].blockSignals(False)
                     self.slider_value_labels[i].setText(str(self.copied_adjustment[key]))
-            
+            # Mirror the pasted tone curves into the editor (set_curves does not
+            # emit, so it won't re-trigger a save).
+            self.curve_editor.set_curves(self.copied_adjustment.get("curves"))
+
             # Save the adjustment to backend and update preview
             ccr_backend.set_adjustment_by_index(self.current_idx, self.copied_adjustment)
             self.parent().parent().image_preview.update_preview(self.current_idx)

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -777,8 +777,27 @@ class SlidersPanel(QWidget):
         self._debounce_timer.start(150)
 
     def _on_curve_edit_finished(self):
-        """End the undo burst so the next discrete curve edit is its own step."""
+        """Settle a finished curve edit (drag release, add/remove, Reset Curve).
+
+        update_preview() displays the cached resized_preview and only
+        regenerates it *afterwards* (via set_current_idx), so the live
+        _on_curve_changed path leaves the final state one render behind — for a
+        discrete edit nothing redraws it, so the image looked unchanged until the
+        user clicked the canvas. Mirror on_reset_clicked: regenerate the preview
+        first, then display it, so the result is shown immediately."""
         self.end_undo_burst()
+        if self.current_idx is None or not (0 <= self.current_idx < len(ccr_backend.images)):
+            return
+        # Cancel the pending debounced reprocess — we render the final state now.
+        self._debounce_timer.stop()
+        self._pending_adjustment = None
+        self._pending_idx = None
+        ccr_backend.images[self.current_idx].update_thumbnail_and_preview()
+        self.parent().parent().image_preview.update_preview(self.current_idx)
+        try:
+            self.parent().parent().thumbnail_list.update_thumbnail(self.current_idx)
+        except AttributeError:
+            pass
 
     def _process_pending_adjustment(self):
         """Process the pending adjustment if not already processing."""

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -379,16 +379,37 @@ class SlidersPanel(QWidget):
         sync_layout.addWidget(self.sync_to_all_button)
         scroll_layout.addLayout(sync_layout)
 
-        # --- Channel Levels collapsible section (sliders[10]–[21]) ---
-        od_separator = QFrame()
-        od_separator.setFrameShape(QFrame.HLine)
-        od_separator.setFrameShadow(QFrame.Sunken)
-        od_separator.setStyleSheet("margin-top: 8px; margin-bottom: 4px;")
-        scroll_layout.addWidget(od_separator)
+        # --- Collapsible sections ---
+        # Display order (top→bottom): Curves, Subtractive Saturations, Channel
+        # Levels (last). The section WIDGETS are placed here in display order,
+        # but their SLIDERS are created further below in the strict order that
+        # ADJUSTMENT_KEYS requires (Channel Levels before bands). Placement and
+        # population are decoupled because each CollapsibleSection holds its own
+        # content layout, so create_slider() append order is independent of where
+        # the section sits in scroll_layout.
+        def _section_separator():
+            sep = QFrame()
+            sep.setFrameShape(QFrame.HLine)
+            sep.setFrameShadow(QFrame.Sunken)
+            sep.setStyleSheet("margin-top: 8px; margin-bottom: 4px;")
+            return sep
 
+        scroll_layout.addWidget(_section_separator())
+        self.curves_section = CollapsibleSection("Curves")
+        scroll_layout.addWidget(self.curves_section)
+
+        scroll_layout.addWidget(_section_separator())
+        self.band_section = CollapsibleSection("Subtractive Saturations")
+        scroll_layout.addWidget(self.band_section)
+
+        scroll_layout.addWidget(_section_separator())
         self.od_section = CollapsibleSection("Channel Levels")
         scroll_layout.addWidget(self.od_section)
 
+        # --- Populate Channel Levels (sliders[10]–[21]) ---
+        # MUST be created before the band sliders to keep the ADJUSTMENT_KEYS
+        # positional mapping (channel keys precede band keys), regardless of the
+        # section's display position above.
         # Master group
         master_label = QLabel("Master")
         master_label.setStyleSheet("color: #888; font-size: 11px; margin-top: 4px;")
@@ -425,16 +446,7 @@ class SlidersPanel(QWidget):
         self.od_section.add_layout(self.create_slider("B Gain"))
         self.od_section.add_layout(self.create_slider("B Blackpoint"))
 
-        # --- Subtractive Saturations collapsible section (per-color bands) ---
-        band_separator = QFrame()
-        band_separator.setFrameShape(QFrame.HLine)
-        band_separator.setFrameShadow(QFrame.Sunken)
-        band_separator.setStyleSheet("margin-top: 8px; margin-bottom: 4px;")
-        scroll_layout.addWidget(band_separator)
-
-        self.band_section = CollapsibleSection("Subtractive Saturations")
-        scroll_layout.addWidget(self.band_section)
-
+        # --- Populate Subtractive Saturations (per-color bands) ---
         # A swatch button per color selects which band's sliders are shown;
         # all 24 sliders exist (and feed adjustment_settings) regardless.
         band_swatch_colors = {
@@ -488,15 +500,7 @@ class SlidersPanel(QWidget):
                                default_value=self._default_for("band_feather")))
         self._show_band_page("red")
 
-        # --- Curves collapsible section ---
-        curves_separator = QFrame()
-        curves_separator.setFrameShape(QFrame.HLine)
-        curves_separator.setFrameShadow(QFrame.Sunken)
-        curves_separator.setStyleSheet("margin-top: 8px; margin-bottom: 4px;")
-        scroll_layout.addWidget(curves_separator)
-
-        self.curves_section = CollapsibleSection("Curves")
-        scroll_layout.addWidget(self.curves_section)
+        # --- Populate Curves ---
         self.curve_editor = CurveEditor()
         self.curves_section.add_widget(self.curve_editor)
         self.curve_editor.curveChanged.connect(self._on_curve_changed)

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -690,8 +690,12 @@ class SlidersPanel(QWidget):
         adjustment = ccr_backend.get_adjustment_by_index(idx)
         print(f"Setting current index: {idx}, adjustment: {adjustment}")
         # Tone curves live inside the adjustment dict; load them into the editor
-        # regardless of whether any sliders are set.
-        self.curve_editor.set_curves(adjustment.get("curves") if adjustment else None)
+        # regardless of whether any sliders are set. Skip while a curve drag is
+        # active: update_preview() re-enters set_current_idx for the SAME image,
+        # and reloading would clear the drag mid-gesture (the editor is already
+        # the source of truth during a drag).
+        if not self.curve_editor.is_dragging():
+            self.curve_editor.set_curves(adjustment.get("curves") if adjustment else None)
         if adjustment is None or not adjustment:
             # No adjustment yet: show each slider's default (0 for most,
             # 10 for band_feather).

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Tests for the Curves (tone curve) feature.
+
+Curves are stored inside adjustment_settings under the "curves" key as a dict of
+channel -> list of [x, y] control points in the 0..255 domain. apply_curves
+builds composed per-channel 16-bit LUTs (composite "rgb" curve first, then the
+per-channel curve, Photoshop-style) and applies them. See
+spec/curves-tone-control.md.
+"""
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.ccr_processor import (apply_curves, build_channel_lut,  # noqa: E402
+                                _is_identity_curves)
+
+
+def _ramp_image():
+    """A small image spanning the full 16-bit range across both channels."""
+    vals = np.array([0, 8192, 16384, 32768, 49152, 65535], dtype=np.uint16)
+    img = np.stack([vals, vals, vals], axis=-1).reshape(2, 3, 3)
+    return img
+
+
+class TestIdentity:
+    def test_none_is_identity(self):
+        assert _is_identity_curves(None)
+        assert _is_identity_curves({})
+
+    def test_explicit_identity_points(self):
+        curves = {"rgb": [[0, 0], [255, 255]], "r": [[0, 0], [255, 255]]}
+        assert _is_identity_curves(curves)
+
+    def test_apply_identity_returns_input_unchanged(self):
+        img = _ramp_image()
+        out = apply_curves(img, None)
+        assert out is img  # fast path returns the same object
+        out2 = apply_curves(img, {"rgb": [[0, 0], [255, 255]]})
+        assert np.array_equal(out2, img)
+
+    def test_identity_lut_is_ramp(self):
+        lut = build_channel_lut([[0, 0], [255, 255]])
+        assert np.allclose(lut, np.arange(256), atol=1e-3)
+
+
+class TestApply:
+    def test_lift_black_point_raises_shadows(self):
+        # Move bottom-left endpoint up: (0,0) -> (0,64). Output min must rise.
+        curves = {"rgb": [[0, 64], [255, 255]]}
+        img = _ramp_image()
+        out = apply_curves(img, curves)
+        # Pure black input is lifted toward ~64/255 of full scale.
+        assert out[0, 0, 0] > 12000
+        # Output stays within range and is monotonic non-decreasing along ramp.
+        flat_in = img[..., 0].ravel()
+        flat_out = out[..., 0].ravel()
+        order = np.argsort(flat_in)
+        assert np.all(np.diff(flat_out[order].astype(np.int64)) >= 0)
+        assert out.max() <= 65535
+
+    def test_pull_white_point_lowers_highlights(self):
+        curves = {"rgb": [[0, 0], [255, 191]]}
+        img = _ramp_image()
+        out = apply_curves(img, curves)
+        # Pure white is pulled down to ~191/255.
+        assert out[1, 2, 0] < 52000
+        assert out[1, 2, 0] > 45000
+
+    def test_per_channel_only_affects_that_channel(self):
+        # Lift red only; green and blue stay identity.
+        curves = {"r": [[0, 0], [128, 200], [255, 255]]}
+        img = _ramp_image()
+        out = apply_curves(img, curves)
+        assert np.array_equal(out[..., 1], img[..., 1])
+        assert np.array_equal(out[..., 2], img[..., 2])
+        # Red midtones are lifted above the input.
+        assert out[1, 0, 0] > img[1, 0, 0]
+
+    def test_composite_then_channel_compose_order(self):
+        # Composite halves everything; red curve then doubles back.
+        # Net effect on red should be close to identity; green/blue halved.
+        curves = {
+            "rgb": [[0, 0], [255, 128]],   # scale ~0.5
+            "r":   [[0, 0], [128, 255]],   # scale ~2.0 over composite output
+        }
+        img = _ramp_image()
+        out = apply_curves(img, curves)
+        # Green is roughly halved at full white.
+        assert abs(int(out[1, 2, 1]) - 32768) < 4000
+        # Red recovers toward the original (much brighter than green).
+        assert out[1, 2, 0] > out[1, 2, 1]
+
+    def test_output_dtype_and_shape(self):
+        curves = {"rgb": [[0, 0], [128, 160], [255, 255]]}
+        out = apply_curves(_ramp_image(), curves)
+        assert out.dtype == np.uint16
+        assert out.shape == (2, 3, 3)
+
+
+class TestRobustness:
+    def test_unsorted_points_are_handled(self):
+        curves = {"rgb": [[255, 255], [0, 0], [128, 128]]}
+        out = apply_curves(_ramp_image(), curves)
+        # Sorted identity-ish -> unchanged ramp.
+        assert np.array_equal(out, _ramp_image())
+
+    def test_malformed_channel_treated_as_identity(self):
+        curves = {"rgb": [[0, 0]]}  # < 2 valid points
+        assert _is_identity_curves(curves)
+        out = apply_curves(_ramp_image(), curves)
+        assert np.array_equal(out, _ramp_image())
+
+    def test_out_of_range_points_clamped(self):
+        curves = {"rgb": [[0, -50], [255, 999]]}
+        out = apply_curves(_ramp_image(), curves)
+        assert out.min() >= 0 and out.max() <= 65535
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_sub_saturation_crop_undo.py
+++ b/tests/test_sub_saturation_crop_undo.py
@@ -164,7 +164,7 @@ class TestSyncGroups:
     def test_expected_group_ids(self):
         from widgets.sliders_panel import SYNC_GROUPS
         assert [gid for gid, _l, _k in SYNC_GROUPS] == [
-            "profile", "wb", "tone", "sat", "crop", "channels", "bands"]
+            "profile", "wb", "tone", "sat", "crop", "channels", "bands", "curves"]
 
 
 def _stub_image():


### PR DESCRIPTION
## Summary
Adds a Photoshop-style **Curves** tone control to the right adjustment panel.

- New collapsible **Curves** section (default collapsed) with a per-channel editor: **All / R / G / B**.
- Click on the curve line adds a draggable control point; right-click removes one; the two endpoints are non-removable (X locked, Y free).
- **Reset Curve** button resets only the curves (all channels to identity); the main **Reset** also clears curves.
- Curves affect preview, hi-res zoom, and export at every resolution, and persist through the catalog, undo/redo, copy/paste, and **Sync to All** (new "Curves" group).
- Right panel reordered: **Curves → Subtractive Saturations → Channel Levels** (Channel Levels last).

## Implementation
- `src/widgets/curve_editor.py` (new) — `CurveEditor` widget (canvas + channel selector + reset), Fritsch–Carlson monotone-cubic interpolation, `grabMouse` for reliable dragging inside the scroll area.
- `src/core/ccr_processor.py` — `build_channel_lut` / `apply_curves` / `_is_identity_curves`; composite curve composed before per-channel curves into 16-bit LUTs.
- `src/core/ccr_image.py` — applies curves in `apply_adjustments` after the slider pass, before any B&W collapse. Curve state lives in `adjustment_settings["curves"]`.
- `src/widgets/sliders_panel.py` — section wiring + persistence across slider rebuilds, sync, copy/paste; discrete edits regenerate-then-display so changes apply immediately.

## Notable fixes during review
- Drag was killed by re-entrant `set_current_idx` (`update_preview` side effect) clearing the drag state — guarded with `is_dragging()`.
- Create-point only when clicking the curve line, not empty space.
- Plot inset so the top-right point clears the panel scrollbar.
- Reset Curve repaints the canvas synchronously and applies to the image immediately.

## Tests
`tests/test_curves.py` (12 tests: identity, monotone interp, compose order, robustness) + updated the sync-group assertion. Full suite: **217 passed**.

Spec: `spec/curves-tone-control.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
