### PR TITLE
Crop: histogram reflects crop, Reset clears crop, sharp cropped view

### DIFF
--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -843,7 +843,11 @@ class CCRBackend:
                 dup.slice_parent = None
             if ((dup.contrast_base, dup.temperature_base, dup.brightness_base)
                     != (0, 0, -8) or img.adjustment_settings.get("tint")
+                    or dup.crop_rect is not None or dup.crop_angle
                     or any(a.get("enabled") for a in dup.area_layers)):
+                # crop_rect/crop_angle were assigned just above, after the
+                # constructor already built the histogram over the FULL image;
+                # the histogram is crop-aware now, so a crop needs a regen too.
                 dup.update_thumbnail_and_preview()
             self.images.insert(idx + 1, dup)
             created += 1

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -11,7 +11,7 @@ from PySide6.QtGui import QImage, QPixmap  # or from PySide6.QtGui import QImage
 #import lensfunpy  # Make sure lensfunpy is installed
 from core.ccr_processor import (adjust_image, adjust_image_opencl,
                                 BAND_ADJUSTMENT_KEYS, apply_curves,
-                                apply_area_layers)
+                                apply_area_layers, apply_crop_to_image)
 
 # Import optional libraries with fallbacks
 try:
@@ -470,11 +470,17 @@ class CCRImage:
         preview_img = self.resize_image_to_max_pixel(display_img, preview_size)
         qimage = self.generate_qimage_from_np_array_8(to_8bit(preview_img))
         self.resized_preview = QPixmap.fromImage(qimage)
-        # Calculate histogram for the 8-bit thumbnail (RGB)
+        # Calculate histogram for the 8-bit preview (RGB). When a crop is set,
+        # the histogram is computed over only the kept (cropped) region so it
+        # matches what the canvas shows. Same normalized-rect + angle contract
+        # as the display/export crop path; apply_crop_to_image returns the
+        # input unchanged when crop_rect is None.
         hist = {}
         preview_img_8bit = to_8bit(preview_img)
+        hist_source = apply_crop_to_image(
+            preview_img_8bit, self.crop_rect, getattr(self, "crop_angle", 0.0) or 0.0)
         for i, color in enumerate(['r', 'g', 'b']):
-            hist[color] = cv2.calcHist([preview_img_8bit], [i], None, [256], [0, 256]).flatten()
+            hist[color] = cv2.calcHist([hist_source], [i], None, [256], [0, 256]).flatten()
 
         # Generate a histogram image (RGB channels overlaid). Fully vectorized:
         # the previous per-column cv2.addWeighted loop took ~55 ms per call

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1006,7 +1006,16 @@ class ImagePreview(QWidget):
             self.apply_transformations()
             histogram = ccr_backend.get_histogram_image_by_index(idx)
             self.parent().parent().sliders_panel.set_histogram(histogram)
-            
+
+            # A confirmed crop magnifies the kept region even at the fitted
+            # view, so — like zooming in — request crop-matched hi-res detail
+            # instead of leaving the upscaled preview crop looking soft. The
+            # zoom paths handle their own requests; this covers crop-at-fit
+            # (apply/clear crop, undo, switching to an already-cropped image).
+            # Debounced; the request self-validates against current state.
+            if self._zoom <= 1.0 + 1e-9 and self._zoomed_in_enough():
+                self._hires_timer.start(200)
+
         else:
             self.rotation_slider.setEnabled(False)
 
@@ -1394,9 +1403,40 @@ class ImagePreview(QWidget):
             return None
         return self._view_scale() * ratio
 
+    # A confirmed crop that keeps less than this fraction of a side (i.e. more
+    # than ~15% cropped off width or height) magnifies the kept region enough
+    # at the fitted view that the upscaled 1080px preview reads as soft —
+    # worth fetching crop-matched hi-res detail, just like zooming in.
+    CROP_HIRES_KEEP_MAX = 0.85
+
     def _zoomed_in_enough(self):
-        """True when preview pixels are magnified — i.e. detail would help."""
-        return self._zoom > 1.0 and self._view_scale() > 1.05
+        """True when preview pixels are magnified on screen — i.e. higher-res
+        detail would help. Magnification comes from zooming in, or from cropping
+        into the image (the kept region is scaled up to fill the view even at
+        the fitted zoom)."""
+        if self._view_scale() <= 1.05:
+            return False
+        return self._zoom > 1.0 or self._crop_wants_hires()
+
+    def _crop_wants_hires(self):
+        """At the fitted view a confirmed crop magnifies the kept region. Worth
+        a crop-matched hi-res fetch when the crop removes a meaningful slice
+        (>15% of a side) and the source carries more detail than the preview.
+        Crop/slice/area modes show the FULL image, so no crop magnification."""
+        if self.crop_mode or self.slice_mode or self.area_mode:
+            return False
+        img = (ccr_backend.get_image_by_index(self.current_idx)
+               if self.current_idx is not None else None)
+        if img is None or not getattr(img, "converted", False):
+            return False
+        crop = getattr(img, "crop_rect", None)
+        if crop is None:
+            return False
+        if min(crop[2] - crop[0], crop[3] - crop[1]) > self.CROP_HIRES_KEEP_MAX:
+            return False
+        # Only worthwhile if a higher-resolution decode actually exists.
+        ratio = self._preview_to_source_ratio()
+        return ratio is not None and ratio < 0.98
 
     def _update_hires_state(self):
         # Keep any rendered detail in memory until the image is switched
@@ -2408,6 +2448,10 @@ class ImagePreview(QWidget):
             else:
                 too_small = True
         self._exit_crop_mode()
+        if applied and img_obj is not None:
+            # The kept pixel region changed, so the histogram (computed over
+            # the cropped area) is stale — regenerate it before the redraw.
+            img_obj.update_thumbnail_and_preview()
         self.update_preview(self.current_idx)
         if cleared:
             hint = "Crop cleared. Ctrl+Z to undo."
@@ -2432,12 +2476,18 @@ class ImagePreview(QWidget):
     def clear_crop(self):
         """Right-click in crop mode: remove the crop entirely."""
         img_obj = ccr_backend.get_image_by_index(self.current_idx)
+        cleared = False
         if img_obj is not None and (img_obj.crop_rect is not None
                                     or getattr(img_obj, "crop_angle", 0.0)):
             img_obj.push_undo_state()
             img_obj.crop_rect = None
             img_obj.crop_angle = 0.0
+            cleared = True
         self._exit_crop_mode()
+        if cleared:
+            # Histogram is computed over the cropped region — regenerate it now
+            # that the whole image is kept again.
+            img_obj.update_thumbnail_and_preview()
         self.update_preview(self.current_idx)
 
     def _exit_crop_mode(self):

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -1085,6 +1085,14 @@ class SlidersPanel(QWidget):
         img = ccr_backend.get_image_by_index(self.current_idx) if self.current_idx is not None else None
         if img is not None:
             img.push_undo_state()
+            # Reset clears the crop too, but only when resetting the Whole Image
+            # layer — the crop is an image-global property, so resetting an
+            # individual area leaves it (and the crop) untouched. Folded into the
+            # single undo snapshot pushed above.
+            if img.active_area_id is None and (img.crop_rect is not None
+                                               or getattr(img, "crop_angle", 0.0)):
+                img.crop_rect = None
+                img.crop_angle = 0.0
         # Reset every slider to its default (0 for most, 10 for band_feather).
         for i, slider in enumerate(self.sliders):
             key = self.adjustment_keys[i] if i < len(self.adjustment_keys) else None
@@ -1238,10 +1246,11 @@ class SlidersPanel(QWidget):
                 img.crop_angle = crop_angle
             if profile_changes:
                 img.color_profile = src_profile
-            if adj_changes or profile_changes or curves_changes:
-                # Crop is display/export-level only — no reprocessing needed
-                # when nothing but the crop changed. Adjustments and the color
-                # profile both change pixels, so they do.
+            if adj_changes or profile_changes or curves_changes or crop_changes:
+                # Adjustments, curves, and the color profile all change pixels;
+                # a crop change moves the region the histogram is computed over
+                # (it samples only the cropped area). Any of these needs a
+                # reprocess so the cached preview/histogram stays in step.
                 try:
                     img.update_thumbnail_and_preview()
                 except Exception as e:

--- a/tests/test_crop_hires.py
+++ b/tests/test_crop_hires.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Tests for crop-driven hi-res detail: a confirmed crop magnifies the kept
+region at the fitted view, so (like zooming in) the display should fetch
+crop-matched hi-res detail rather than upscaling the 1080px preview crop.
+
+These exercise the decision gates (_crop_wants_hires / _zoomed_in_enough),
+not the threaded decode itself.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import (QApplication, QWidget, QVBoxLayout,  # noqa: E402
+                               QGraphicsPixmapItem)
+from PySide6.QtGui import QPixmap, QColor, QTransform  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+from widgets.image_preview import ImagePreview  # noqa: E402
+
+
+class _StubPanel:
+    def set_sliders_enabled(self, *a):
+        pass
+
+
+class _Host(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.sliders_panel = _StubPanel()
+        self.mid = QWidget(self)
+
+
+class _ImgStub:
+    """Carries just the attributes the hi-res crop gates read."""
+    def __init__(self, crop_rect, converted=True,
+                 full=(6000, 4000), preview_shape=(720, 1080, 3)):
+        self.crop_rect = crop_rect
+        self.crop_angle = 0.0
+        self.converted = converted
+        self.original_full_size = full
+        self.resized_raw = np.zeros(preview_shape, np.uint16)
+
+
+_HOSTS = []
+
+
+def _make_preview(w=540, h=360):
+    host = _Host()
+    _HOSTS.append(host)
+    layout = QVBoxLayout(host)
+    layout.addWidget(host.mid)
+    mid_layout = QVBoxLayout(host.mid)
+    ip = ImagePreview(host.mid)
+    mid_layout.addWidget(ip)
+    pm = QPixmap(w, h)
+    pm.fill(QColor(128, 128, 128))
+    ip.current_pixmap = pm
+    ip.pixmap_item = QGraphicsPixmapItem(pm)
+    ip.scene.addItem(ip.pixmap_item)
+    ip.current_rotation = 0
+    ip.current_horizontal_flip = False
+    ip.current_vertical_flip = False
+    ip.crop_mode = False
+    ip.slice_mode = False
+    ip.area_mode = False
+    return ip
+
+
+def _setup(ip, img, view_scale=1.5, zoom=1.0):
+    ccr_backend.images = [img]
+    ip.current_idx = 0
+    ip._zoom = zoom
+    ip.view.setTransform(QTransform().scale(view_scale, view_scale))
+
+
+class TestCropWantsHires:
+    def test_heavy_crop_wants_hires(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.0, 0.0, 0.5, 0.5)))   # keeps 50% — >15% off
+        assert ip._crop_wants_hires() is True
+
+    def test_light_crop_does_not(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.0, 0.0, 0.9, 0.95)))  # keeps >=90% on both sides
+        assert ip._crop_wants_hires() is False
+
+    def test_threshold_boundary(self):
+        ip = _make_preview()
+        # keeps >85% on both sides (<15% off) -> preview is sharp enough
+        _setup(ip, _ImgStub((0.0, 0.0, 0.88, 1.0)))
+        assert ip._crop_wants_hires() is False
+        # keeps <85% on a side (>15% off) -> crosses the threshold
+        _setup(ip, _ImgStub((0.0, 0.0, 0.80, 1.0)))
+        assert ip._crop_wants_hires() is True
+
+    def test_no_crop(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub(None))
+        assert ip._crop_wants_hires() is False
+
+    def test_unconverted_image(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.0, 0.0, 0.5, 0.5), converted=False))
+        assert ip._crop_wants_hires() is False
+
+    def test_no_higher_res_source(self):
+        ip = _make_preview()
+        # source no bigger than the preview -> a hi-res decode adds nothing
+        _setup(ip, _ImgStub((0.0, 0.0, 0.5, 0.5),
+                            full=(1080, 720), preview_shape=(720, 1080, 3)))
+        assert ip._crop_wants_hires() is False
+
+    def test_crop_mode_shows_full_image(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.0, 0.0, 0.5, 0.5)))
+        ip.crop_mode = True                 # full image shown, no crop magnify
+        assert ip._crop_wants_hires() is False
+
+
+class TestZoomedInEnoughWithCrop:
+    def test_heavy_crop_at_fit_is_enough(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.0, 0.0, 0.5, 0.5)), view_scale=1.5, zoom=1.0)
+        assert ip._zoomed_in_enough() is True
+
+    def test_crop_not_magnified_on_screen_is_not_enough(self):
+        ip = _make_preview()
+        # crop is heavy, but the view isn't actually upscaling preview pixels
+        _setup(ip, _ImgStub((0.0, 0.0, 0.5, 0.5)), view_scale=0.9, zoom=1.0)
+        assert ip._zoomed_in_enough() is False
+
+    def test_no_crop_at_fit_is_not_enough(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub(None), view_scale=1.5, zoom=1.0)
+        assert ip._zoomed_in_enough() is False
+
+    def test_zoomed_in_path_unchanged(self):
+        ip = _make_preview()
+        # No crop, but genuinely zoomed in -> the existing behaviour holds.
+        _setup(ip, _ImgStub(None), view_scale=2.0, zoom=2.0)
+        assert ip._zoomed_in_enough() is True
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_histogram_crop.py
+++ b/tests/test_histogram_crop.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Tests for two crop-related behaviours:
+
+1. The preview histogram reflects the *cropped* region — `update_thumbnail_and_preview`
+   computes it over the kept pixels (via `apply_crop_to_image`), not the full frame.
+2. The Reset button clears the crop together with the sliders/curves, but only
+   when the Whole Image layer is active (the crop is image-global, so resetting
+   an individual area leaves it alone).
+"""
+
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import cv2  # noqa: E402
+from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout  # noqa: E402
+from PySide6.QtGui import QImage  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+from widgets.sliders_panel import SlidersPanel  # noqa: E402
+
+
+def _ccr_image(tmp_path, name="scan.png"):
+    """Construct a CCRImage from a tiny uniform on-disk scan so __init__
+    succeeds; callers overwrite resized_raw with deterministic content."""
+    path = str(tmp_path / name)
+    base = np.full((40, 60, 3), 20000, np.uint16)
+    cv2.imwrite(path, cv2.cvtColor(base, cv2.COLOR_RGB2BGR))
+    return CCRImage(path)
+
+
+def _half_image(h=40, w=60):
+    """Left half pure red, right half pure blue: the per-channel histograms of
+    the two halves are maximally different, so a crop must change the result."""
+    a = np.zeros((h, w, 3), np.uint16)
+    a[:, : w // 2] = (60000, 0, 0)      # red
+    a[:, w // 2:] = (0, 0, 60000)       # blue
+    return a
+
+
+def _hist_bytes(img):
+    qimg = img.histogram_image.toImage().convertToFormat(QImage.Format_RGB888)
+    return bytes(qimg.constBits())
+
+
+class TestHistogramReflectsCrop:
+    def test_crop_changes_histogram(self, tmp_path):
+        img = _ccr_image(tmp_path)
+        img.converted = True            # skip the preview-only auto-brightness
+        img.adjustment_settings = {}
+        img.resized_raw = _half_image()
+
+        img.crop_rect = None
+        img.update_thumbnail_and_preview()
+        full = _hist_bytes(img)
+
+        img.crop_rect = (0.0, 0.0, 0.5, 1.0)   # left (red) half only
+        img.update_thumbnail_and_preview()
+        left = _hist_bytes(img)
+
+        img.crop_rect = (0.5, 0.0, 1.0, 1.0)   # right (blue) half only
+        img.update_thumbnail_and_preview()
+        right = _hist_bytes(img)
+
+        assert full != left
+        assert full != right
+        assert left != right
+
+    def test_cropped_histogram_matches_native_region(self, tmp_path):
+        """Cropping to the right half must yield the same histogram as an image
+        whose pixels ARE only that right half — i.e. the histogram is computed
+        over the kept region, not a re-weighting of the whole frame."""
+        full = _half_image()
+
+        img = _ccr_image(tmp_path, "a.png")
+        img.converted = True
+        img.adjustment_settings = {}
+        img.resized_raw = full.copy()
+        img.crop_rect = (0.5, 0.0, 1.0, 1.0)
+        img.update_thumbnail_and_preview()
+        cropped = _hist_bytes(img)
+
+        ref = _ccr_image(tmp_path, "b.png")
+        ref.converted = True
+        ref.adjustment_settings = {}
+        ref.resized_raw = full[:, full.shape[1] // 2:].copy()   # native right half
+        ref.crop_rect = None
+        ref.update_thumbnail_and_preview()
+        native = _hist_bytes(ref)
+
+        assert cropped == native
+
+
+# --------------------------------------------------------------------------
+# Reset clears the crop
+# --------------------------------------------------------------------------
+class _ImagePreviewStub:
+    def __init__(self):
+        self.updated = []
+
+    def update_preview(self, idx):
+        self.updated.append(idx)
+
+
+class _Host(QWidget):
+    """parent().parent() target on_reset_clicked reaches for image_preview."""
+    def __init__(self):
+        super().__init__()
+        self.image_preview = _ImagePreviewStub()
+        self.mid = QWidget(self)
+
+
+_HOSTS = []
+
+
+def _panel():
+    host = _Host()
+    _HOSTS.append(host)               # keep alive for the test's lifetime
+    # The panel's Qt parent is set by being added to a layout (its constructor
+    # ignores the parent arg), so on_reset_clicked's parent().parent() resolves
+    # to the host that carries image_preview.
+    mid_layout = QVBoxLayout(host.mid)
+    panel = SlidersPanel(host.mid)
+    mid_layout.addWidget(panel)
+    return panel
+
+
+class TestResetClearsCrop:
+    def test_reset_clears_crop_on_whole_image(self, tmp_path):
+        img = _ccr_image(tmp_path)
+        img.crop_rect = (0.1, 0.1, 0.9, 0.9)
+        img.crop_angle = 5.0
+        img.active_area_id = None             # Whole Image layer active
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0
+        panel.on_reset_clicked()
+
+        assert img.crop_rect is None
+        assert img.crop_angle == 0.0
+
+    def test_reset_of_area_leaves_crop(self, tmp_path):
+        img = _ccr_image(tmp_path)
+        img.crop_rect = (0.1, 0.1, 0.9, 0.9)
+        img.crop_angle = 5.0
+        img.area_layers = [{"id": "a1", "kind": "circle", "enabled": True,
+                            "feather": 0.25, "angle": 0.0,
+                            "geometry": {"cx": 0.5, "cy": 0.5, "rx": 0.25, "ry": 0.25},
+                            "settings": {"exposure": 40}}]
+        img.active_area_id = "a1"             # an area layer is active
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0
+        panel.on_reset_clicked()
+
+        # Crop is image-global — resetting an area must not touch it.
+        assert img.crop_rect == (0.1, 0.1, 0.9, 0.9)
+        assert img.crop_angle == 5.0
+
+    def test_reset_crop_is_undoable(self, tmp_path):
+        img = _ccr_image(tmp_path)
+        img.crop_rect = (0.2, 0.2, 0.8, 0.8)
+        img.crop_angle = 0.0
+        img.active_area_id = None
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0
+        panel.on_reset_clicked()
+        assert img.crop_rect is None
+
+        # The crop clear shares the single undo snapshot Reset pushes.
+        assert img.pop_undo_state()
+        assert img.crop_rect == (0.2, 0.2, 0.8, 0.8)
+
+
+# --------------------------------------------------------------------------
+# Other crop-setting paths must keep the crop-aware histogram in step
+# --------------------------------------------------------------------------
+class TestDuplicateCropHistogram:
+    def test_duplicate_of_crop_only_image_has_cropped_histogram(self, tmp_path):
+        """Duplicating an image whose only edit is a crop must give the copy a
+        histogram over the cropped region — the copy's crop is assigned after
+        its constructor already built the full-image histogram."""
+        full = _half_image()
+        img = _ccr_image(tmp_path)
+        img.converted = True
+        img.adjustment_settings = {}
+        img.resized_raw = full.copy()
+        img.crop_rect = (0.5, 0.0, 1.0, 1.0)
+        img.update_thumbnail_and_preview()
+        src_cropped = _hist_bytes(img)
+
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+        assert ccr_backend.duplicate_images_by_indices([0]) == 1
+        dup = ccr_backend.images[1]
+
+        assert dup.crop_rect == (0.5, 0.0, 1.0, 1.0)
+        assert _hist_bytes(dup) == src_cropped
+
+
+class TestSyncToAllCropHistogram:
+    def test_crop_only_sync_updates_target_histogram(self, tmp_path):
+        """Syncing only the crop group to all images must regenerate each
+        target's crop-aware histogram, not just copy the crop value."""
+        full = _half_image()
+
+        src = _ccr_image(tmp_path, "src.png")
+        src.converted = True
+        src.adjustment_settings = {}
+        src.resized_raw = full.copy()
+        src.crop_rect = (0.5, 0.0, 1.0, 1.0)
+        src.update_thumbnail_and_preview()
+        src_cropped = _hist_bytes(src)
+
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        tgt.converted = True
+        tgt.adjustment_settings = {}
+        tgt.resized_raw = full.copy()
+        tgt.crop_rect = None
+        tgt.update_thumbnail_and_preview()
+        tgt_full = _hist_bytes(tgt)
+        assert tgt_full != src_cropped        # precondition: differ before sync
+
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0                 # src is the sync source
+        panel._sync_group_selection = {"crop": True}
+        panel._perform_sync_to_all()
+
+        assert tgt.crop_rect == (0.5, 0.0, 1.0, 1.0)
+        assert _hist_bytes(tgt) == src_cropped


### PR DESCRIPTION
## Summary

Three crop-related fixes (reported as bugs):

1. **Histogram reflects the crop.** `update_thumbnail_and_preview` now computes the histogram over the cropped region (`apply_crop_to_image`) instead of the full preview. Every path that changes the crop regenerates the cached histogram: `confirm_crop`/`clear_crop`, sync-to-all and **Reset** (sliders), and duplicate. Undo/catalog-load already did.

2. **Reset clears the crop.** The Reset button now also clears `crop_rect`/`crop_angle`, scoped to the **Whole Image** layer (`active_area_id is None`) so resetting an individual area leaves the image-global crop alone. Folded into Reset's single undo snapshot.

3. **Cropped view is no longer soft.** A confirmed crop magnifies the kept region at the fitted view, so — like zooming — it now requests crop-matched hi-res detail when the crop removes >15% of a side and a higher-res source exists. Reuses the existing zoom hi-res pipeline.

## Testing

- New `tests/test_histogram_crop.py` (histogram reflects crop; Reset clears crop incl. area-scoping and undo; duplicate + sync-to-all keep histogram in step).
- New `tests/test_crop_hires.py` (crop hi-res decision gates; zoom path unchanged).
- Full suite: **279 passed**.

Adversarially reviewed (multi-agent); follow-up completeness gaps (sync-to-all, duplicate histograms) were fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
