### PR TITLE
Color management: export color space (sRGB/ProPhoto) + global input ICC profile

### DIFF
--- a/spec/color-management.md
+++ b/spec/color-management.md
@@ -1,0 +1,464 @@
+# Spec: Color Management — Export Color Space + Input ICC Profile
+
+Status: REFINED v2
+Owner: FreeCCR
+Feature branch: `feature/color-management`
+
+## 1. Summary
+
+Two related color-management features:
+
+1. **Export color space** — an "Color space" dropdown in the Export dialog with
+   **sRGB** (default) and **ProPhoto RGB**. sRGB exports the current result
+   unchanged (today's behaviour) but now **tags** it with an sRGB ICC profile.
+   ProPhoto re-encodes the result into the ProPhoto RGB (ROMM) color space and
+   **embeds the ProPhoto ICC profile** so a color-managed viewer interprets it
+   correctly.
+
+2. **Input ICC profile** — a global, persistent **File menu** action "Set Input
+   ICC Profile…" / "Clear Input ICC Profile". The chosen `.icc`/`.icm` is copied
+   into the app-data folder and remembered across sessions; it is applied to
+   **every** imported image **at decode time, before negative conversion and
+   adjustments** ("burn in"). It converts the decoded pixels from the assigned
+   profile into the pipeline's working encoding (sRGB), so all downstream math is
+   consistent.
+
+### 1.1 Working-space framing (important honesty note)
+
+FreeCCR's internal pipeline is **not** a characterized color space. RAW is
+decoded `output_color=ColorSpace.raw`, `gamma=(1,1)`, no white balance
+(`ccr_image.py:314-326`); non-RAW files are read as-is with no profile
+interpretation; the v0.2.3 negative inversion + look then runs on those values.
+There is no ICC that describes this space.
+
+Consequence for both features: we treat the **on-screen / exported result** as
+**sRGB-encoded display RGB** — which is exactly how every viewer already
+interprets today's untagged output. Therefore:
+
+- "Export to ProPhoto" is **not** a colorimetric conversion from a characterized
+  source; it is a **re-encoding of the displayed sRGB result** into ProPhoto's
+  primaries + gamma, with the ICC embedded so a color-managed viewer shows the
+  *same colors*. The honest benefit is a **wider container** for downstream
+  editing, not "more accurate" color. The spec/UI must not overclaim.
+- "Input ICC" means: **assign** profile P to the decoded pixels, then **convert**
+  P → sRGB working encoding. Most meaningful for already-encoded standard imports
+  (TIFF/JPEG/PNG scans). For RAW it is applied to the linear camera-native decode
+  as-is — an advanced/at-your-own-risk reinterpretation, documented as such.
+
+## 2. Goals / Non-goals
+
+### Goals
+- Export dialog "Color space" dropdown: **sRGB** | **ProPhoto RGB** (extensible
+  to Adobe RGB later via the same matrix machinery).
+- ProPhoto export: correct 16-bit sRGB→ProPhoto transform + embedded ProPhoto ICC
+  for **both** TIFF (16-bit) and JPEG (8-bit) outputs.
+- sRGB export: pixel-identical to today, now with an embedded sRGB ICC tag.
+- Resolution independence: the export transform runs at the chosen output
+  resolution in the single pre-write chokepoint, so full-size and downsized
+  exports are consistent.
+- Input ICC: global, persistent (survives restart), copied into app data, shown
+  by name in the menu, applied to every decode (preview, hi-res zoom, export) so
+  it is automatically resolution-independent and lands before conversion.
+- Setting/changing/clearing the input ICC re-decodes + re-converts the currently
+  loaded images so the change takes effect immediately.
+- **Zero new runtime dependencies.** Pure numpy color math + tifffile `iccprofile`
+  + a small JPEG APP2 ICC injector. (Pillow's `ImageCms` is **8-bit-only for RGB**
+  — useless for the 16-bit path — so we do not adopt it.)
+
+### Non-goals
+- No colorimetric calibration of the internal pipeline (it stays uncalibrated;
+  we only re-encode the assumed-sRGB result on the way out).
+- No support for **LUT-based / cLUT / CMYK** input ICC profiles in v1 — only
+  **matrix-shaper** profiles (colorant + TRC tags). LUT profiles get a clear,
+  non-fatal error. (A real CMM at 16-bit, e.g. `cmm-16bit`/`pylcms2`, would be a
+  future dependency-adding enhancement.)
+- No per-image input-ICC overrides (it is a single global setting, by explicit
+  user request).
+- No Adobe RGB / Rec.2020 export targets in v1 (architecture leaves room).
+- No PNG export (the app has no PNG export path today).
+- No rendering-intent UI; input-ICC conversion uses relative-colorimetric-style
+  matrix math (matrix-shaper profiles have no intent tables anyway).
+
+## 3. UX / Interaction
+
+### 3.1 Export color space dropdown
+- New `QComboBox` `self.colorspace_combo` in `ExportSettingsDialog._build_ui`,
+  added to the `QFormLayout` immediately **after** the Format row
+  (`export_dialog.py:131`). Items:
+  - `"sRGB"` → data `"srgb"` (default, current index 0)
+  - `"ProPhoto RGB (wide gamut)"` → data `"prophoto"`
+- A small grey hint label under it when ProPhoto is selected (JPEG only):
+  *"8-bit ProPhoto JPEG can band; prefer 16-bit TIFF for wide gamut."* Shown/
+  hidden in `_on_format_changed`/a new `_on_colorspace_changed`.
+- Persisted/restored via `QSettings` key `export/colorspace` in `_save_settings`
+  (`:220-235`) and `_restore_settings` (`:189-218`), mirroring the other combos.
+- Carried into `ExportPlan` (new field `output_colorspace: str = "srgb"`) in
+  `_on_export_clicked` (`:391-399`).
+
+### 3.2 Input ICC File-menu actions
+In `main_window.py` `_create_menus`/wherever "Open"/"Export" actions are built
+(near `:240`), add to the **File** menu (after the open/export group, before
+Exit):
+- **"Set Input ICC Profile…"** → `QFileDialog.getOpenFileName` filtered to
+  `"ICC Profiles (*.icc *.icm);;All Files (*)"`. On accept: validate + copy the
+  file into app data (see §5.2), persist its path, re-process loaded images, show
+  a status hint with the profile's description name.
+- **"Clear Input ICC Profile"** → removes the setting + working copy, re-processes
+  loaded images. Disabled (greyed) when no profile is set.
+- The "Set…" action text reflects the active profile, e.g.
+  **"Input ICC: <name>…"** (the embedded `desc` or the filename) so the user can
+  see at a glance what is active. Updated whenever it changes.
+- On a parse failure / unsupported (LUT) profile, a `QMessageBox.warning`
+  explains it and the setting is **not** changed.
+
+### 3.3 Feedback when input ICC changes
+Changing/clearing the profile triggers a (possibly slow) re-decode + re-convert
+of all loaded images. Reuse the existing busy affordance: run it through the same
+path the app already uses for batch reprocessing (a progress dialog is desirable
+but a simple blocking reprocess with a wait cursor is acceptable for v1, matching
+how Sync/Auto-frame already reprocess). Document this in the test plan as a manual
+check.
+
+## 4. Data model & persistence
+
+### 4.1 Export color space
+- `ExportPlan.output_colorspace: str` (`"srgb"` | `"prophoto"`). Pure transient
+  plumbing; not catalog-persisted (it's an export-time choice), but the **default**
+  is remembered in `QSettings` like the other export options.
+
+### 4.2 Input ICC profile (global)
+- **QSettings** (`"FreeCCR"/"FreeCCR"`), keys:
+  - `import/input_icc_path` (str): absolute path to the **working copy** inside
+    app data, or empty when none.
+- **Working copy**: copied to `<APPDATA>/FreeCCR/input_profile.icc` (the same
+  folder as `catalog.json`, via `catalog.default_catalog_path()`'s dir). Copying
+  decouples us from the user moving/deleting the original.
+- **Not** stored per-image in the catalog. It is a global pipeline setting by
+  design. Documented caveat (intended behaviour): images converted under profile
+  A, reopened after switching to B, are re-decoded under B. This matches "one
+  remembered profile for the rest of the app's use".
+- A new global accessor lives on the backend/singleton (e.g.
+  `ccr_backend.input_icc` holding parsed transform state, see §6.3) so every
+  decode can reach it without per-image plumbing.
+
+## 5. Processing / math
+
+All new color math lives in a new module **`src/core/color_management.py`**
+(pure numpy + struct), imported by `ccr_processor.py` (export) and `ccr_image.py`
+(input). Keeping it standalone keeps the hot processing files lean and makes it
+unit-testable in isolation.
+
+### 5.1 sRGB ↔ linear, and the combined sRGB→ProPhoto matrix
+
+```python
+# float64 math, values normalized to [0,1]
+def srgb_decode(v):   # sRGB EOTF (encoded -> linear)
+    a = 0.055
+    return np.where(v <= 0.04045, v/12.92, ((v+a)/(1+a))**2.4)
+
+def srgb_encode(x):   # linear -> sRGB (for the input-ICC target encode)
+    a = 0.055
+    return np.where(x <= 0.0031308, x*12.92, (1+a)*np.power(np.clip(x,0,1),1/2.4) - a)
+```
+
+Canonical matrices (Lindbloom / ninedegreesbelow / colour-science), float64:
+
+```
+M_SRGB2XYZ (D65) =
+[0.4123908 0.3575843 0.1804808]
+[0.2126390 0.7151687 0.0721923]
+[0.0193308 0.1191948 0.9505322]
+
+M_BRADFORD (D65->D50) =
+[ 1.0478112 0.0228866 -0.0501270]
+[ 0.0295424 0.9904844 -0.0170491]
+[-0.0092345 0.0150436  0.7521316]
+
+M_XYZ2PROPHOTO (D50) =
+[ 1.3459433 -0.2556075 -0.0511118]
+[-0.5445989  1.5081673  0.0205351]
+[ 0.0000000  0.0000000  1.2118128]
+
+M_SRGB2PROPHOTO = M_XYZ2PROPHOTO @ M_BRADFORD @ M_SRGB2XYZ   # precompute once
+```
+
+ProPhoto (ROMM) gamma encode — γ 1.8 with the 1/512 linear toe (slope 16):
+
+```python
+def romm_encode(x):           # linear ProPhoto -> ProPhoto-encoded, x in [0,1]
+    Et = 1.0/512.0
+    return np.where(x < Et, 16.0*x, np.power(np.clip(x,0,1), 1.0/1.8))
+```
+
+### 5.2 The export transform (`apply_export_colorspace`)
+
+```python
+def apply_export_colorspace(rgb_u16, target):  # rgb: HxWx3 uint16 RGB, sRGB-encoded
+    """Return (out_u16, icc_bytes). For 'srgb' returns the input unchanged
+    plus sRGB ICC bytes (pixel-identical to today). For 'prophoto' re-encodes."""
+    if target == "srgb":
+        return rgb_u16, SRGB_ICC_BYTES
+    lin   = srgb_decode(rgb_u16.astype(np.float64)/65535.0)
+    pro   = np.clip(lin @ M_SRGB2PROPHOTO.T, 0.0, 1.0)   # clip imaginary/overflow
+    enc   = romm_encode(pro)
+    out   = np.rint(enc*65535.0).astype(np.uint16)
+    return out, PROPHOTO_ICC_BYTES
+```
+
+Notes:
+- Done in float64; clip negatives (ProPhoto's huge gamut produces tiny negatives
+  from rounding) and >1.
+- For an **8-bit JPEG** ProPhoto export the transform runs on the 16-bit array
+  **before** `to_8bit`, so the encode is computed at full precision and only the
+  final container is 8-bit.
+
+### 5.3 ICC profile synthesis (`build_matrix_shaper_icc`)
+
+Self-contained, license-clean, ~80 lines. Builds a valid ICC v2.4 `mntr/RGB/XYZ`
+matrix-shaper profile from colorants + a parametric TRC. **Verified working**:
+the output embeds byte-identically via `tifffile(iccprofile=...)`, round-trips
+through `TiffFile` tag 34675, and parses + builds a transform under lcms (Pillow
+`ImageCms`).
+
+Header: 128 bytes (`size, 'lcms', 0x02400000 v2.4, 'mntr','RGB ','XYZ ', 'acsp',
+… , D50 PCS illuminant at offset 68`). Tags: `desc, wtpt(D50), rXYZ, gXYZ, bXYZ,
+rTRC, gTRC, bTRC, cprt`. Tag types: `XYZ ` (`s15Fixed16` ×3), `para` parametric
+curve **function type 3** (`Y=(aX+b)^g for X>=d; Y=cX for X<d`), `desc`
+(textDescriptionType), `text` (copyright). 4-byte tag alignment; the three TRC
+tags share one offset.
+
+Two profiles, generated once at module load:
+- **sRGB** (`SRGB_ICC_BYTES`): sRGB primaries colorants (D50-adapted), TRC
+  para type 3 `g=2.4, a=1/1.055, b=0.055/1.055, c=1/12.92, d=0.04045`.
+- **ProPhoto/ROMM** (`PROPHOTO_ICC_BYTES`): colorants = columns of
+  `M_XYZ2PROPHOTO⁻¹`'s source (i.e. `M_PROPHOTO2XYZ` columns):
+  `rXYZ=(0.7976749,0.2880402,0)`, `gXYZ=(0.1351917,0.7118741,0)`,
+  `bXYZ=(0.0313534,0.0000857,0.8252100)`; TRC para type 3
+  `g=1.8, a=1, b=0, c=0.0625, d=0.03125`. Named generically ("FreeCCR ROMM
+  (ProPhoto)") — "ProPhoto" is a Kodak trademark; a self-generated profile avoids
+  trademark + redistribution issues.
+
+For sRGB colorants, derive from `M_SRGB2XYZ` then Bradford-adapt D65→D50, or use
+the well-known D50-adapted sRGB colorant XYZs; store as constants with a comment.
+
+### 5.4 Embedding on write (`write_export_image`)
+
+The three `ccr_normalize_*` functions currently duplicate the
+resize→jpg/tiff write block (`ccr_processor.py:975-996`, `:1184-1196`,
+`:1281-1293`). **Refactor** them to call one shared helper:
+
+```python
+def write_export_image(ccr_image, rgb_u16, output_path, jpg_out, jpg_quality,
+                       max_long_side, output_colorspace):
+    if max_long_side:
+        rgb_u16 = ccr_image.resize_image_to_max_pixel(rgb_u16, max_long_side)
+    rgb_u16, icc = apply_export_colorspace(rgb_u16, output_colorspace)
+    if jpg_out:
+        out = os.path.splitext(output_path)[0] + ".jpg"
+        img8 = cv2.cvtColor(to_8bit(rgb_u16), cv2.COLOR_RGB2BGR)
+        ok, buf = cv2.imencode(".jpg", img8, [cv2.IMWRITE_JPEG_QUALITY, int(jpg_quality)])
+        if ok: buf = inject_jpeg_icc(buf.tobytes(), icc)   # APP2 ICC_PROFILE
+        # write buf via the existing unicode-safe raw write
+    else:
+        out = os.path.splitext(output_path)[0] + ".tiff"
+        safe_tifffile_imwrite(out, rgb_u16, photometric="rgb",
+                              compression="deflate", iccprofile=icc)
+```
+
+- `safe_tifffile_imwrite` already forwards `**kwargs`, so `photometric=` /
+  `iccprofile=` need no signature change.
+- `inject_jpeg_icc(jpeg_bytes, icc)` (in `color_management.py`): splits the ICC
+  into ≤65519-byte chunks, builds `FFE2` APP2 segments each prefixed
+  `b"ICC_PROFILE\\x00" + seq + count + chunk`, and inserts them right after the
+  SOI (`FFD8`). **Verified**: Pillow reads the injected profile back identically.
+- Unicode-safe JPEG write: encode→inject→write bytes via the same
+  `open(path,'wb')` fallback `safe_cv2_imwrite` already uses (factor a tiny
+  `_write_bytes_unicode(path, data)` helper, or extend `safe_cv2_imwrite` to take
+  pre-encoded bytes).
+
+This dedups three near-identical blocks and gives one color-managed chokepoint.
+
+### 5.5 Input ICC engine (`InputProfile`)
+
+Parse a matrix-shaper ICC into numpy and apply it to a 16-bit RGB array:
+
+```python
+class InputProfile:
+    # parsed from the .icc: device->PCS via TRC linearization + colorant matrix
+    #   linRGB = TRC_each(device/clip)        # 'curv'/'para' per channel
+    #   XYZ_D50 = M_colorants @ linRGB        # columns = rXYZ/gXYZ/bXYZ
+    #   linRGB_srgb = M_XYZ2SRGB_D50 @ XYZ_D50
+    #   out = srgb_encode(clip(linRGB_srgb))  # back to sRGB-encoded working space
+    @classmethod
+    def from_bytes(cls, icc_bytes) -> "InputProfile": ...   # raises UnsupportedICCError on LUT/CMYK
+    def apply(self, rgb_u16) -> np.ndarray: ...             # HxWx3 uint16 -> uint16
+```
+
+Details:
+- Minimal ICC parser: read header (assert `acsp`, `RGB ` data space), tag table,
+  require `rXYZ/gXYZ/bXYZ` + `rTRC/gTRC/bTRC`. If `A2B0`/`mft1`/`mft2`/`mAB `
+  (LUT) tags are present and colorants/TRC absent → raise `UnsupportedICCError`.
+- TRC parse: `curv` (count 0 → identity gamma 1.0; count 1 → gamma = u8Fixed8;
+  count N → sampled LUT, interpolate) and `para` (function types 0–4). Build a
+  256/1024-entry float LUT per channel (or closed-form) for speed.
+- Colorant matrix `M_colorants` columns from the three XYZ tags. PCS is D50.
+- Target = sRGB working encoding: precompute `M_XYZ2SRGB_D50` (sRGB matrix with a
+  D50→D65 adaptation folded in, or simply `M_SRGB2XYZ_D65⁻¹ @ M_BRADFORD(D50→D65)`).
+- `apply()`: float32, `device/65535 → TRC → @M.T → clip → srgb_encode → *65535 →
+  uint16`. Resolution-independent point op; the parsed LUTs/matrix are cached on
+  the instance.
+
+## 6. Integration points
+
+### 6.1 Export dropdown plumbing (thread `output_colorspace` through)
+| Location | Change |
+|---|---|
+| `export_dialog.py:24-34` (`ExportPlan`) | add `output_colorspace: str = "srgb"` |
+| `export_dialog.py:_build_ui` (~`:131`) | add `colorspace_combo` + hint |
+| `export_dialog.py:_save/_restore_settings` | persist `export/colorspace` |
+| `export_dialog.py:_on_export_clicked` (`:391`) | set `output_colorspace=` on plan |
+| `image_preview.py:ExportItemsWorker.run` (`:3304`) | pass `output_colorspace=self.plan.output_colorspace` |
+| `ccr_backend.py:export_items` (`:644`) | add param; forward to `export_image_by_index` |
+| `ccr_backend.py:export_image_by_index` (`:601`) | add param; forward to all three `ccr_normalize_*` |
+| `ccr_processor.py:ccr_normalize_with_reference/_bwpoint/_refparams` | add `output_colorspace="srgb"` kwarg; pass to `write_export_image` |
+
+### 6.2 Export write refactor
+- New `write_export_image(...)` in `ccr_processor.py` (or `color_management.py`),
+  replacing the three duplicated resize+write blocks. Preserve current behaviour
+  exactly for `output_colorspace="srgb"` **except** the added sRGB ICC tag.
+- `apply_export_colorspace`, `inject_jpeg_icc`, `SRGB_ICC_BYTES`,
+  `PROPHOTO_ICC_BYTES` from `color_management.py`.
+
+### 6.3 Input ICC application (decode-time)
+- **`CCRBackend`**: add `self.input_icc_path` + `self.input_profile`
+  (`InputProfile | None`), loaded from `QSettings` at startup
+  (`set_input_icc(path)`, `clear_input_icc()`, `_load_input_icc_from_settings()`).
+  `set_input_icc` copies the file to app data, parses it (catching
+  `UnsupportedICCError`), stores QSettings, and returns the profile description /
+  raises for the UI to show.
+- **`CCRImage.read_image`**: at the **single** return-point pre-resize, apply the
+  global profile to the decoded uint16 RGB:
+  - RAW branch: after white-level scaling, before `return rgb` (`ccr_image.py:345-349`).
+  - Non-RAW branch: after RGB/uint16 normalization, before `return img` (`:428-435`).
+  - Implementation: a tiny `self._apply_input_icc(arr)` that calls
+    `ccr_backend.input_profile.apply(arr)` when set. (Import the singleton lazily
+    to avoid a cycle; `ccr_image` already imports from `ccr_processor`, and the
+    backend imports `ccr_image` — read the profile via a module-level getter to
+    sidestep the cycle.)
+  - Apply **before** `_apply_source_ops`+resize so slicing/zoom/export all inherit
+    color-managed pixels. Since it's a per-pixel op the result is identical at any
+    resolution.
+- **Slice parent decode**: `ccr_backend.slice_image_by_index` (`:983`) shares a
+  parent decode passed as `preloaded_img` (bypasses `read_image`). Ensure that
+  shared decode also went through `read_image` (it does — the parent was loaded
+  via `read_image`), so its pixels are already color-managed; the slice's own
+  `read_image` calls (zoom/export, via `source_ops`) re-apply the same profile.
+  Audit the exact decode source in `slice_image_by_index` and apply
+  `_apply_input_icc` there if it decodes raw bytes directly.
+- **Reprocess on change**: `set_input_icc`/`clear_input_icc` must, for every
+  loaded image: `reload_image()` (re-decodes via `read_image` → re-applies ICC),
+  then re-run its conversion replay (`_replay_conversion` via stored
+  `conversion_inputs`) and `update_thumbnail_and_preview()`. Provide
+  `ccr_backend.reprocess_all_for_input_icc_change()` and call it from the menu
+  slots; refresh thumbnails + current preview afterward (mirror Auto-frame's
+  finish path, `image_preview.py:3014-3023`).
+
+### 6.4 Menu wiring (`main_window.py`)
+- Build the two `QAction`s near the existing File-menu actions (~`:240`); store
+  refs to update text/enabled state. Slots call the backend methods, show
+  hints/warnings, and trigger the reprocess.
+
+## 7. Files touched / added
+
+- **add** `src/core/color_management.py` — matrices, `srgb_decode/encode`,
+  `romm_encode`, `apply_export_colorspace`, `build_matrix_shaper_icc`,
+  `SRGB_ICC_BYTES`, `PROPHOTO_ICC_BYTES`, `inject_jpeg_icc`, `InputProfile`,
+  `UnsupportedICCError`.
+- **edit** `src/widgets/export_dialog.py` — dropdown, persistence, plan field.
+- **edit** `src/widgets/image_preview.py` — worker passes `output_colorspace`.
+- **edit** `src/core/ccr_backend.py` — export plumbing; input-ICC state + load/
+  set/clear/reprocess; slice-decode audit.
+- **edit** `src/core/ccr_processor.py` — `write_export_image` refactor; thread
+  `output_colorspace` into the three `ccr_normalize_*`.
+- **edit** `src/core/ccr_image.py` — `_apply_input_icc` at the decode return
+  points.
+- **edit** `src/ui/main_window.py` — File-menu actions + slots.
+- **add** `tests/test_color_management.py` — see §8.
+
+## 8. Test plan
+
+### Unit (`tests/test_color_management.py`, numpy-only, no Qt)
+1. **sRGB passthrough**: `apply_export_colorspace(img,'srgb')` returns pixels
+   unchanged and non-empty `SRGB_ICC_BYTES`.
+2. **ProPhoto round-trip sanity**: a mid-grey sRGB value → ProPhoto → (decode via
+   inverse matrices) ≈ original within tolerance; pure white (65535) stays at the
+   ProPhoto max; black stays black; output dtype uint16, clipped `[0,65535]`.
+3. **ROMM toe continuity**: `romm_encode` continuous at `x=1/512` (`16·Et ==
+   Et^(1/1.8)`); monotonic.
+4. **ICC validity**: `PROPHOTO_ICC_BYTES`/`SRGB_ICC_BYTES` start with a valid
+   128-byte header (`acsp` at 36), parse via the in-house parser, and — when
+   Pillow is importable — `ImageCms.getOpenProfile(BytesIO(bytes))` +
+   `buildTransform` succeed. (Pillow check skipped if absent.)
+5. **TIFF embed**: write a uint16 array with `iccprofile=PROPHOTO_ICC_BYTES`, read
+   back with `tifffile`, assert tag 34675 bytes equal the profile.
+6. **JPEG inject**: `inject_jpeg_icc` output decodes as a valid JPEG (cv2.imdecode
+   not None) and, when Pillow present, `Image.open(...).info['icc_profile']`
+   equals the injected bytes; multi-chunk path exercised with a >65519-byte dummy.
+7. **InputProfile matrix-shaper**: build a known matrix-shaper ICC (reuse
+   `build_matrix_shaper_icc` for, e.g., an Adobe-RGB-like profile), parse via
+   `InputProfile.from_bytes`, apply to a test image; assert it changes pixels in
+   the expected direction and preserves dtype/shape. Identity sRGB-in profile →
+   ~unchanged within rounding.
+8. **InputProfile rejects LUT**: a constructed (or fixture) cLUT/`A2B0` profile
+   raises `UnsupportedICCError`.
+
+### Integration / regression
+9. **Default export unchanged**: with `output_colorspace="srgb"`, the written TIFF
+   pixels are identical to a write through the old path (guard the refactor) — the
+   only diff is the new ICC tag.
+10. **Existing suite green**: `python tests/run_tests.py` / `pytest tests/ -v`.
+
+### Manual
+- Export a converted image as sRGB TIFF and ProPhoto TIFF; open both in a
+  color-managed viewer (e.g. Photoshop/Affinity/Firefox) — colors match; ProPhoto
+  file reports the ProPhoto/ROMM profile; sRGB reports sRGB.
+- Export ProPhoto JPEG; confirm the viewer reads the embedded profile.
+- File → Set Input ICC Profile…: pick a matrix-shaper `.icc`; menu shows its name;
+  loaded images re-decode + re-convert and the look shifts accordingly; restart
+  the app → the profile is still active. Clear it → reverts. Pick a LUT profile →
+  friendly "unsupported profile type" warning, setting unchanged.
+- Unicode export paths still work (JPEG inject + TIFF).
+
+## 9. Refinement (v2) — resolved decisions
+
+1. **No Pillow/lcms dependency.** Pillow `ImageCms` RGB transforms are 8-bit only
+   (Pillow #880/#8007); using it would silently posterize the 16-bit pipeline.
+   All color math is numpy; ICC bytes are synthesized; embedding uses tifffile +
+   manual JPEG APP2. (Both mechanisms prototyped and verified in-repo.)
+2. **Input ICC scope = matrix-shaper only** in v1; LUT/CMYK profiles raise a
+   handled `UnsupportedICCError`. A 16-bit CMM (`cmm-16bit`/`pylcms2`) is the
+   future path if arbitrary profiles are needed.
+3. **Input ICC is global + persistent + copied into app data** (File menu), not
+   per-image. Re-decoding loaded images on change keeps the session consistent.
+   Reproducibility caveat (convert under A, reopen under B → B) is intended.
+4. **sRGB export tags the file** (adds sRGB ICC) but is otherwise pixel-identical
+   to today — verified by regression test #9.
+5. **8-bit ProPhoto JPEG is allowed** (with a UI caution); the transform is
+   computed at 16-bit precision before the 8-bit downconvert, and the ICC is
+   embedded so it is at least correct, if not ideal.
+6. **Single write chokepoint**: the three duplicated `ccr_normalize_*` write tails
+   are refactored into `write_export_image`, which is the only place the output
+   transform + embed happen — guaranteeing TIFF and JPEG, full and downsized, all
+   color-managed identically.
+7. **ProPhoto profile is self-generated and generically named** to avoid the
+   Kodak "ProPhoto" trademark and any redistribution encumbrance; the UI label
+   may still say "ProPhoto RGB" (descriptive use) while the embedded profile's
+   internal `desc` is "FreeCCR ROMM (ProPhoto)".
+8. **Decode-time hook for input ICC** lives in `read_image` (the single decode
+   path shared by preview/zoom/export), guaranteeing resolution independence and
+   that conversion/adjustments see color-managed pixels. The slice preloaded-decode
+   path is audited to inherit the same.
+9. **RAW caveat documented**: input ICC is applied to RAW's linear camera-native
+   decode as-is; it is principled only for already-encoded standard imports. No
+   special-casing in v1 beyond the documentation + the general matrix-shaper math.
+```

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -34,6 +34,11 @@ class CCRBackend:
         self.file_paths: List[str] = []
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area
+        # Global input ICC profile (one app-wide setting; applied to every
+        # decode before conversion/adjustments). The parsed profile lives in
+        # color_management's module-level holder; these mirror it for the UI.
+        self.input_icc_path: Optional[str] = None
+        self.input_icc_name: Optional[str] = None
         # Catalog entries of ACTUAL images removed from the list this
         # session: {file_path: {"signature": sig, "entries": {name: state}}}.
         # Removal must not lose their stored edits, so saves merge these
@@ -515,6 +520,83 @@ class CCRBackend:
             except Exception as e:
                 print(f"Failed to convert image at index {idx}: {e}")
 
+    # --- Global input ICC profile -----------------------------------------
+    def _input_icc_storage_path(self) -> str:
+        """Persistent working-copy path inside the app-data folder (next to the
+        edit catalog), so the profile survives the user moving/deleting the
+        original .icc."""
+        from core.catalog import default_catalog_path
+        return os.path.join(os.path.dirname(default_catalog_path()), "input_profile.icc")
+
+    def set_input_icc(self, src_path: str) -> str:
+        """Assign a global input ICC profile from src_path. Parses it first
+        (raising UnsupportedICCError / OSError on failure, leaving the current
+        profile untouched), copies it into app data as the persistent working
+        copy, activates it, and returns its description name. The caller persists
+        the storage path (self.input_icc_path) and triggers reprocessing."""
+        from core import color_management
+        import shutil
+        profile = color_management.load_input_profile(src_path)  # parse before mutating
+        storage = self._input_icc_storage_path()
+        if (os.path.normcase(os.path.abspath(src_path))
+                != os.path.normcase(os.path.abspath(storage))):
+            shutil.copyfile(src_path, storage)
+        color_management.set_active_input_profile(profile)
+        self.input_icc_path = storage
+        self.input_icc_name = profile.description or os.path.basename(src_path)
+        return self.input_icc_name
+
+    def load_input_icc_from_storage(self, storage_path: str) -> Optional[str]:
+        """Startup restore: activate a previously-saved working copy. Returns the
+        profile name, or None if it could not be loaded (e.g. file gone)."""
+        from core import color_management
+        try:
+            profile = color_management.load_input_profile(storage_path)
+        except Exception as e:
+            print(f"Could not load saved input ICC {storage_path}: {e}")
+            return None
+        color_management.set_active_input_profile(profile)
+        self.input_icc_path = storage_path
+        self.input_icc_name = profile.description or os.path.basename(storage_path)
+        return self.input_icc_name
+
+    def clear_input_icc(self) -> None:
+        """Remove the global input ICC profile and its working copy."""
+        from core import color_management
+        color_management.set_active_input_profile(None)
+        self.input_icc_path = None
+        self.input_icc_name = None
+        try:
+            storage = self._input_icc_storage_path()
+            if os.path.exists(storage):
+                os.remove(storage)
+        except OSError:
+            pass
+
+    def reprocess_all_for_input_icc_change(self, progress_callback=None) -> None:
+        """Re-decode and re-convert every loaded image so a change to the global
+        input ICC takes effect immediately. Re-decoding runs through read_image,
+        which re-applies the (new) global profile; converted images then replay
+        their stored conversion against the freshly-decoded scan."""
+        from core.catalog import _replay_conversion
+        total = len(self.images)
+        for i, img in enumerate(self.images):
+            ci = img.conversion_inputs
+            was_converted = img.converted
+            cb, tb, bb = img.contrast_base, img.temperature_base, img.brightness_base
+            try:
+                img.reload_image()                 # re-decode (ICC re-applied)
+                if was_converted and ci is not None:
+                    _replay_conversion(img, ci)    # re-convert from the new scan
+                # Preserve the user's non-destructive look offsets across the
+                # re-decode (reload_image / replay reset them to defaults).
+                img.contrast_base, img.temperature_base, img.brightness_base = cb, tb, bb
+                img.update_thumbnail_and_preview()
+            except Exception as e:
+                print(f"Reprocess after input ICC change failed for {img.file_path}: {e}")
+            if progress_callback:
+                progress_callback(i + 1, total)
+
     def update_thumbnail_by_index(self, idx: int):
         """
         Updates the thumbnail for the image at the given index.
@@ -599,7 +681,8 @@ class CCRBackend:
                 print(f"Failed to convert image at index {idx}: {e}")
 
     def export_image_by_index(self, idx: int, output_path: str, jpg_output: bool = False,
-                              jpg_quality: int = 95, max_long_side: int = None) -> bool:
+                              jpg_quality: int = 95, max_long_side: int = None,
+                              output_colorspace: str = "srgb") -> bool:
         """
         Exports the processed image at the given index to the specified output path.
         Routes to bwpoint or reference-frame pipeline depending on how the image was converted.
@@ -616,7 +699,8 @@ class CCRBackend:
                                                  output_path=output_path,
                                                  water_mark=not self.software_activated,
                                                  jpg_out=jpg_output, jpg_quality=jpg_quality,
-                                                 max_long_side=max_long_side)
+                                                 max_long_side=max_long_side,
+                                                 output_colorspace=output_colorspace)
                 elif ci is not None and ci.get("mode") == "bw":
                     # Use the anchors BAKED at convert time — resampling the
                     # global points later must not change this image's export.
@@ -625,24 +709,28 @@ class CCRBackend:
                                                output_path=output_path,
                                                water_mark=not self.software_activated,
                                                jpg_out=jpg_output, jpg_quality=jpg_quality,
-                                               max_long_side=max_long_side)
+                                               max_long_side=max_long_side,
+                                               output_colorspace=output_colorspace)
                 elif image_obj.reference_frame is None and self.black_point_bgr is not None and self.white_point_bgr is not None:
                     # Legacy/un-snapshotted B/W point conversion — global anchors
                     ccr_normalize_with_bwpoint(image_obj, self.black_point_bgr, self.white_point_bgr,
                                                output_path=output_path, water_mark=not self.software_activated,
                                                jpg_out=jpg_output, jpg_quality=jpg_quality,
-                                               max_long_side=max_long_side)
+                                               max_long_side=max_long_side,
+                                               output_colorspace=output_colorspace)
                 else:
                     ccr_normalize_with_reference(image_obj, output_path=output_path,
                                                  water_mark=not self.software_activated, jpg_out=jpg_output,
-                                                 jpg_quality=jpg_quality, max_long_side=max_long_side)
+                                                 jpg_quality=jpg_quality, max_long_side=max_long_side,
+                                                 output_colorspace=output_colorspace)
                 return True
             except Exception as e:
                 print(f"Failed to export image at index {idx}: {e}")
         return False
 
     def export_items(self, items, jpg_output: bool = False, jpg_quality: int = 95,
-                     max_long_side: int = None, progress_callback=None, cancel_check=None) -> dict:
+                     max_long_side: int = None, output_colorspace: str = "srgb",
+                     progress_callback=None, cancel_check=None) -> dict:
         """
         Exports specific images to explicit output paths using parallel processing.
 
@@ -675,7 +763,8 @@ class CCRBackend:
                 return idx, None, None  # None success = not attempted
             start_time = time.time()
             success = self.export_image_by_index(idx, output_path, jpg_output=jpg_output,
-                                                 jpg_quality=jpg_quality, max_long_side=max_long_side)
+                                                 jpg_quality=jpg_quality, max_long_side=max_long_side,
+                                                 output_colorspace=output_colorspace)
             elapsed = time.time() - start_time
             base_name = os.path.basename(output_path)
             if success:

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -584,8 +584,16 @@ class CCRBackend:
             ci = img.conversion_inputs
             was_converted = img.converted
             cb, tb, bb = img.contrast_base, img.temperature_base, img.brightness_base
+            # Slices/duplicates deliberately INHERIT the parent's tint balance
+            # factor (their own region/converted pixels would give a different
+            # one). reload_image unconditionally recomputes it, so preserve the
+            # inherited value for those images.
+            inherited_tbf = bool(img.source_ops) or bool(getattr(img, "is_duplicate", False))
+            tbf = getattr(img, "tint_balance_factor", 1.0)
             try:
                 img.reload_image()                 # re-decode (ICC re-applied)
+                if inherited_tbf:
+                    img.tint_balance_factor = tbf
                 if was_converted and ci is not None:
                     _replay_conversion(img, ci)    # re-convert from the new scan
                 # Preserve the user's non-destructive look offsets across the

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -12,6 +12,7 @@ from PySide6.QtGui import QImage, QPixmap  # or from PySide6.QtGui import QImage
 from core.ccr_processor import (adjust_image, adjust_image_opencl,
                                 BAND_ADJUSTMENT_KEYS, apply_curves,
                                 apply_area_layers, apply_crop_to_image)
+from core import color_management
 
 # Import optional libraries with fallbacks
 try:
@@ -240,6 +241,23 @@ class CCRImage:
             new_h = int(h * max_long_side / w)
         return cv2.resize(image, (new_w, new_h), interpolation=cv2.INTER_AREA)
 
+    def _apply_input_icc(self, arr: Optional[np.ndarray]) -> Optional[np.ndarray]:
+        """Convert a freshly-decoded scan from the globally-assigned input ICC
+        profile into the working sRGB encoding, before any conversion or
+        adjustment. No-op when no input profile is set. Applied inside
+        read_image so preview, hi-res zoom, and export all inherit it
+        identically (resolution-independent point operation)."""
+        if arr is None:
+            return arr
+        profile = color_management.get_active_input_profile()
+        if profile is None:
+            return arr
+        try:
+            return profile.apply(arr)
+        except Exception as e:
+            logging.warning(f"Input ICC profile could not be applied: {e}")
+            return arr
+
     def read_image(self, file_path: str, preview = True, max_long_side: Optional[int] = None) -> Optional[np.ndarray]:
         """
         Read an image file. preview=True decodes RAW at half size.
@@ -346,7 +364,9 @@ class CCRImage:
                 
                 elapsed_time = time.time() - start_time
                 print(f"RAW processing completed in {elapsed_time:.3f} seconds")
-                return rgb
+                # Burn in the global input ICC (if any) on the decoded scan,
+                # before negative conversion / adjustments.
+                return self._apply_input_icc(rgb)
             except Exception as e:
                 logging.exception(f"Failed to read RAW image: {file_path}")
                 return None
@@ -432,7 +452,8 @@ class CCRImage:
             self.original_full_size = (img.shape[0], img.shape[1])
             if max_long_side:
                 img = self.resize_image_to_max_pixel(img, max_long_side)
-            return img
+            # Burn in the global input ICC (if any) before conversion/adjustments.
+            return self._apply_input_icc(img)
         
     def update_thumbnail_and_preview(self, thumbnail_size: int = 156, preview_size: int = 1080) -> None:
         """

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -6,6 +6,8 @@ import time
 import tifffile
 import gc
 
+from core.color_management import apply_export_colorspace, inject_jpeg_icc
+
 # Try to import PyOpenCL, but handle gracefully if not available
 try:
     import pyopencl as cl
@@ -628,7 +630,7 @@ def _load_export_source(ccr_image, output_path, max_long_side):
     return ccr_image.read_image(ccr_image.file_path, preview=False)
 
 
-def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_out=False,jpg_quality=95,max_long_side=None) -> np.ndarray:
+def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_out=False,jpg_quality=95,max_long_side=None,output_colorspace="srgb") -> np.ndarray:
     """
     Normalize and align the image using the CCR algorithm, using a reference rectangle
     for percentile calculations instead of a crop factor.
@@ -971,29 +973,8 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
 
         # Ensure output_path has proper extension and handle Unicode
         step_start = time.time()
-        output_path = safe_unicode_path(output_path)
-        if max_long_side:
-            rgb_brightness_normalized = ccr_image.resize_image_to_max_pixel(rgb_brightness_normalized, max_long_side)
-        if jpg_out:
-            output_path = os.path.splitext(output_path)[0] + ".jpg"
-            # Convert to 8-bit for JPEG output
-            rgb_brightness_normalized_8 = to_8bit(rgb_brightness_normalized)
-            # Ensure output is RGB, not BGR
-            rgb_brightness_normalized_8 = cv2.cvtColor(rgb_brightness_normalized_8, cv2.COLOR_RGB2BGR)
-            success = safe_cv2_imwrite(output_path, rgb_brightness_normalized_8,
-                                       [cv2.IMWRITE_JPEG_QUALITY, int(jpg_quality)])
-            del rgb_brightness_normalized_8  # Clean up 8-bit copy
-            if success:
-                print(f"Normalized image saved to {output_path}")
-            else:
-                raise IOError(f"Failed to save normalized image to {output_path}")
-        else:
-            output_path = os.path.splitext(output_path)[0] + ".tiff"
-            success = safe_tifffile_imwrite(output_path, rgb_brightness_normalized, compression='deflate')
-            if success:
-                print(f"Normalized image saved to {output_path}")
-            else:
-                raise IOError(f"Failed to save normalized image to {output_path}")
+        write_export_image(ccr_image, rgb_brightness_normalized, output_path,
+                           jpg_out, jpg_quality, max_long_side, output_colorspace)
         print(f"File saving: {time.time() - step_start:.3f}s")
         #debug ----------------------v
 
@@ -1019,7 +1000,8 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
 
 def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
                                output_path=None, water_mark=True, jpg_out=False,
-                               jpg_quality=95, max_long_side=None):
+                               jpg_quality=95, max_long_side=None,
+                               output_colorspace="srgb"):
     """
     Film negative conversion using the same pipeline as ccr_normalize_with_reference
     but with explicit per-channel B/W points instead of auto-detected percentiles.
@@ -1180,20 +1162,8 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
                 print(f"Warning: warpAffine failed: {e}")
 
         # Write file
-        output_path = safe_unicode_path(output_path)
-        if max_long_side:
-            rgb_result = ccr_image.resize_image_to_max_pixel(rgb_result, max_long_side)
-        if jpg_out:
-            output_path = os.path.splitext(output_path)[0] + ".jpg"
-            img_8 = to_8bit(rgb_result)
-            img_8 = cv2.cvtColor(img_8, cv2.COLOR_RGB2BGR)
-            if not safe_cv2_imwrite(output_path, img_8,
-                                    [cv2.IMWRITE_JPEG_QUALITY, int(jpg_quality)]):
-                raise IOError(f"Failed to save image to {output_path}")
-        else:
-            output_path = os.path.splitext(output_path)[0] + ".tiff"
-            if not safe_tifffile_imwrite(output_path, rgb_result, compression='deflate'):
-                raise IOError(f"Failed to save image to {output_path}")
+        write_export_image(ccr_image, rgb_result, output_path, jpg_out,
+                           jpg_quality, max_long_side, output_colorspace)
         print(f"TOTAL bwpoint normalization time: {time.time() - total_start_time:.3f}s")
         gc.collect()
         return None
@@ -1204,7 +1174,8 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr,
 
 def ccr_normalize_with_refparams(ccr_image, p_lo, p_hi, od_factors,
                                  output_path=None, water_mark=True, jpg_out=False,
-                                 jpg_quality=95, max_long_side=None):
+                                 jpg_quality=95, max_long_side=None,
+                                 output_colorspace="srgb"):
     """
     Conversion/export pipeline for sliced children carrying precomputed
     reference-conversion constants (conversion_inputs mode "ref_params").
@@ -1277,20 +1248,8 @@ def ccr_normalize_with_refparams(ccr_image, p_lo, p_hi, od_factors,
         except Exception as e:
             print(f"Warning: warpAffine failed: {e}")
 
-    output_path = safe_unicode_path(output_path)
-    if max_long_side:
-        rgb_result = ccr_image.resize_image_to_max_pixel(rgb_result, max_long_side)
-    if jpg_out:
-        output_path = os.path.splitext(output_path)[0] + ".jpg"
-        img_8 = to_8bit(rgb_result)
-        img_8 = cv2.cvtColor(img_8, cv2.COLOR_RGB2BGR)
-        if not safe_cv2_imwrite(output_path, img_8,
-                                [cv2.IMWRITE_JPEG_QUALITY, int(jpg_quality)]):
-            raise IOError(f"Failed to save image to {output_path}")
-    else:
-        output_path = os.path.splitext(output_path)[0] + ".tiff"
-        if not safe_tifffile_imwrite(output_path, rgb_result, compression='deflate'):
-            raise IOError(f"Failed to save image to {output_path}")
+    write_export_image(ccr_image, rgb_result, output_path, jpg_out,
+                       jpg_quality, max_long_side, output_colorspace)
     print(f"TOTAL ref-params normalization time: {time.time() - total_start_time:.3f}s")
     gc.collect()
     return None
@@ -1301,6 +1260,44 @@ def to_8bit(img16: np.ndarray) -> np.ndarray:
     img16 = np.clip(img16, 0, 65535)
     img8 = (img16 / 257).astype(np.uint8)
     return img8
+
+
+def write_export_image(ccr_image, rgb_u16, output_path, jpg_out, jpg_quality,
+                       max_long_side, output_colorspace="srgb"):
+    """Single export write chokepoint shared by all three conversion pipelines.
+
+    Resizes to the requested long edge, maps the (sRGB-encoded) result into the
+    chosen output colour space, then writes a 16-bit TIFF (deflate) or 8-bit
+    JPEG with the matching ICC profile embedded so a colour-managed viewer
+    interprets the file correctly. Returns the resolved output path.
+    """
+    if max_long_side:
+        rgb_u16 = ccr_image.resize_image_to_max_pixel(rgb_u16, max_long_side)
+    # Re-encode to the target colour space and get the ICC bytes to embed.
+    rgb_u16, icc = apply_export_colorspace(rgb_u16, output_colorspace)
+    output_path = safe_unicode_path(output_path)
+    if jpg_out:
+        output_path = os.path.splitext(output_path)[0] + ".jpg"
+        img_8 = cv2.cvtColor(to_8bit(rgb_u16), cv2.COLOR_RGB2BGR)  # RGB -> BGR for cv2
+        ok, buf = cv2.imencode(".jpg", img_8,
+                               [cv2.IMWRITE_JPEG_QUALITY, int(jpg_quality)])
+        if not ok:
+            raise IOError(f"Failed to encode JPEG for {output_path}")
+        # cv2 can't embed ICC, so inject an APP2 ICC_PROFILE segment and write
+        # the bytes ourselves (also the Unicode-safe path, like safe_cv2_imwrite).
+        data = inject_jpeg_icc(buf.tobytes(), icc)
+        try:
+            with open(output_path, "wb") as f:
+                f.write(data)
+        except Exception as e:
+            raise IOError(f"Failed to save image to {output_path}: {e}")
+    else:
+        output_path = os.path.splitext(output_path)[0] + ".tiff"
+        if not safe_tifffile_imwrite(output_path, rgb_u16, photometric="rgb",
+                                     compression="deflate", iccprofile=icc):
+            raise IOError(f"Failed to save image to {output_path}")
+    print(f"Normalized image saved to {output_path}")
+    return output_path
 
 
 def apply_crop_to_image(img: np.ndarray, crop_rect_norm, crop_angle: float = 0.0) -> np.ndarray:

--- a/src/core/color_management.py
+++ b/src/core/color_management.py
@@ -1,0 +1,430 @@
+"""
+Color management for FreeCCR.
+
+Two responsibilities, both pure-numpy (no Pillow/lcms runtime dependency — see
+spec/color-management.md for why Pillow's ImageCms is unusable for our 16-bit
+pipeline):
+
+1. EXPORT color space. The internal pipeline produces an uncalibrated result that
+   every viewer interprets as sRGB-encoded display RGB. ``apply_export_colorspace``
+   either passes that through (sRGB, pixel-identical to before) or re-encodes it
+   into ProPhoto RGB (ROMM), returning the matching ICC profile bytes to embed so
+   a colour-managed viewer shows the same colours.
+
+2. INPUT ICC profile. ``InputProfile`` parses a *matrix-shaper* ICC profile and
+   converts decoded pixels from that profile's space into the working sRGB
+   encoding, applied at decode time before conversion/adjustments. LUT-based and
+   CMYK profiles are rejected with ``UnsupportedICCError``.
+
+ICC profiles are synthesised in-process (``build_matrix_shaper_icc``) so nothing
+needs to be bundled and there is no profile-licensing/trademark concern. The
+synthesised bytes are valid ICC v2.4 matrix-shaper profiles (verified to embed
+via tifffile tag 34675 and to parse + build a transform under littleCMS).
+"""
+from __future__ import annotations
+
+import struct
+from typing import Optional, Tuple
+
+import numpy as np
+
+
+class UnsupportedICCError(Exception):
+    """Raised when an input ICC profile is not a simple RGB matrix-shaper
+    profile (e.g. LUT/cLUT-based, CMYK, or otherwise unparseable). The caller
+    surfaces this to the user instead of silently mis-converting."""
+
+
+# Global active input profile (a single app-wide setting, by design). Decode
+# (CCRImage.read_image) reads it via get_active_input_profile() so it does not
+# need to import the backend singleton — avoiding an import cycle.
+_active_input_profile: "Optional[InputProfile]" = None
+
+
+def set_active_input_profile(profile) -> None:
+    global _active_input_profile
+    _active_input_profile = profile
+
+
+def get_active_input_profile():
+    return _active_input_profile
+
+
+def load_input_profile(path: str) -> "InputProfile":
+    """Read and parse a matrix-shaper ICC file. Raises UnsupportedICCError for
+    LUT/CMYK/unparseable profiles, or OSError if the file can't be read."""
+    with open(path, "rb") as f:
+        data = f.read()
+    return InputProfile.from_bytes(data)
+
+
+# --------------------------------------------------------------------------- #
+# Reference matrices (float64). Sources: Lindbloom / ninedegreesbelow /
+# colour-science. See spec/color-management.md §5.1.
+# --------------------------------------------------------------------------- #
+
+# linear sRGB (D65) -> XYZ (D65)
+M_SRGB2XYZ = np.array([
+    [0.4123908, 0.3575843, 0.1804808],
+    [0.2126390, 0.7151687, 0.0721923],
+    [0.0193308, 0.1191948, 0.9505322],
+], dtype=np.float64)
+
+# Bradford chromatic adaptation D65 -> D50
+M_BRADFORD_D65_D50 = np.array([
+    [1.0478112, 0.0228866, -0.0501270],
+    [0.0295424, 0.9904844, -0.0170491],
+    [-0.0092345, 0.0150436, 0.7521316],
+], dtype=np.float64)
+
+# linear ProPhoto/ROMM (D50) -> XYZ (D50); columns are the ProPhoto primaries.
+M_PROPHOTO2XYZ = np.array([
+    [0.7976749, 0.1351917, 0.0313534],
+    [0.2880402, 0.7118741, 0.0000857],
+    [0.0000000, 0.0000000, 0.8252100],
+], dtype=np.float64)
+
+# Derived inverses / adaptations.
+M_XYZ2SRGB = np.linalg.inv(M_SRGB2XYZ)                       # XYZ(D65) -> linear sRGB
+M_BRADFORD_D50_D65 = np.linalg.inv(M_BRADFORD_D65_D50)       # D50 -> D65
+M_XYZ2PROPHOTO = np.linalg.inv(M_PROPHOTO2XYZ)               # XYZ(D50) -> linear ProPhoto
+
+# Combined linear-sRGB(D65) -> linear-ProPhoto(D50) (one matmul on export).
+M_SRGB2PROPHOTO = M_XYZ2PROPHOTO @ M_BRADFORD_D65_D50 @ M_SRGB2XYZ
+_M_SRGB2PROPHOTO_F32 = M_SRGB2PROPHOTO.astype(np.float32)   # export math runs in float32
+# Combined XYZ(D50) -> linear sRGB(D65) (used by InputProfile to reach working space).
+M_XYZ_D50_2_SRGB = M_XYZ2SRGB @ M_BRADFORD_D50_D65
+
+# D50 PCS white point (ICC reference illuminant).
+D50_XYZ = (0.9642, 1.0000, 0.8249)
+
+
+# --------------------------------------------------------------------------- #
+# Transfer functions (operate on float arrays normalised to [0, 1]).
+# --------------------------------------------------------------------------- #
+
+def srgb_decode(v: np.ndarray) -> np.ndarray:
+    """sRGB EOTF: encoded -> linear."""
+    a = 0.055
+    return np.where(v <= 0.04045, v / 12.92, np.power((v + a) / (1 + a), 2.4))
+
+
+def srgb_encode(x: np.ndarray) -> np.ndarray:
+    """sRGB inverse EOTF: linear -> encoded."""
+    a = 0.055
+    x = np.clip(x, 0.0, 1.0)
+    return np.where(x <= 0.0031308, x * 12.92, (1 + a) * np.power(x, 1 / 2.4) - a)
+
+
+def romm_encode(x: np.ndarray) -> np.ndarray:
+    """ProPhoto/ROMM gamma encode (gamma 1.8 with the 1/512 linear toe, slope 16).
+    Continuous at x = 1/512 because 16*(1/512) == (1/512)**(1/1.8) == 1/32."""
+    Et = 1.0 / 512.0
+    x = np.clip(x, 0.0, 1.0)
+    return np.where(x < Et, 16.0 * x, np.power(x, 1.0 / 1.8))
+
+
+# --------------------------------------------------------------------------- #
+# ICC profile synthesis (matrix-shaper, ICC v2.4 mntr/RGB/XYZ).
+# --------------------------------------------------------------------------- #
+
+def _s15f16(x: float) -> int:
+    """Encode a float as an ICC s15Fixed16Number (signed 16.16)."""
+    return int(round(x * 65536.0))
+
+
+def _xyz_type(x: float, y: float, z: float) -> bytes:
+    return struct.pack('>4sI3i', b'XYZ ', 0, _s15f16(x), _s15f16(y), _s15f16(z))
+
+
+def _para_type3(g: float, a: float, b: float, c: float, d: float) -> bytes:
+    """parametricCurveType, function type 3:  Y=(aX+b)^g for X>=d ; Y=cX for X<d."""
+    body = struct.pack('>4sIH2x', b'para', 0, 3)
+    for v in (g, a, b, c, d):
+        body += struct.pack('>i', _s15f16(v))
+    return body
+
+
+def _desc_type(text: str) -> bytes:
+    """textDescriptionType (ICC v2)."""
+    b = text.encode('ascii') + b'\x00'
+    out = struct.pack('>4sII', b'desc', 0, len(b)) + b
+    out += struct.pack('>II', 0, 0)          # unicode language + count
+    out += struct.pack('>HB', 0, 0)          # scriptcode code + count
+    out += b'\x00' * 67                      # macintosh description
+    return out
+
+
+def _text_type(text: str) -> bytes:
+    return struct.pack('>4sI', b'text', 0) + text.encode('ascii') + b'\x00'
+
+
+def build_matrix_shaper_icc(desc: str,
+                            r_xyz: Tuple[float, float, float],
+                            g_xyz: Tuple[float, float, float],
+                            b_xyz: Tuple[float, float, float],
+                            trc_para: Tuple[float, float, float, float, float],
+                            wtpt: Tuple[float, float, float] = D50_XYZ,
+                            copyright_text: str = "Public Domain. No rights reserved.") -> bytes:
+    """Build a valid ICC v2.4 RGB matrix-shaper profile from D50 colorants and a
+    shared parametric (type-3) TRC. Returns the raw profile bytes."""
+    tags = {
+        'desc': _desc_type(desc),
+        'wtpt': _xyz_type(*wtpt),
+        'rXYZ': _xyz_type(*r_xyz),
+        'gXYZ': _xyz_type(*g_xyz),
+        'bXYZ': _xyz_type(*b_xyz),
+        'cprt': _text_type(copyright_text),
+    }
+    trc = _para_type3(*trc_para)
+    tags['rTRC'] = trc
+    tags['gTRC'] = trc
+    tags['bTRC'] = trc
+
+    order = ['desc', 'rXYZ', 'gXYZ', 'bXYZ', 'wtpt', 'rTRC', 'gTRC', 'bTRC', 'cprt']
+    n = len(order)
+    header_size = 128
+    table_size = 4 + n * 12
+    base = header_size + table_size
+
+    data = b''
+    entries = []
+    seen: dict = {}
+    for name in order:
+        payload = tags[name]
+        key = bytes(payload)
+        if key in seen:
+            off, ln = seen[key]
+        else:
+            if len(data) % 4:
+                data += b'\x00' * (4 - len(data) % 4)
+            off = base + len(data)
+            ln = len(payload)
+            data += payload
+            seen[key] = (off, ln)
+        entries.append((name.encode('ascii'), off, ln))
+
+    table = struct.pack('>I', n)
+    for tag, off, ln in entries:
+        table += struct.pack('>4sII', tag, off, ln)
+
+    total = header_size + len(table) + len(data)
+    header = bytearray(128)
+    struct.pack_into('>I', header, 0, total)            # profile size
+    struct.pack_into('>4s', header, 4, b'lcms')         # preferred CMM (cosmetic)
+    struct.pack_into('>I', header, 8, 0x02400000)       # version 2.4.0
+    struct.pack_into('>4s', header, 12, b'mntr')        # device class: display
+    struct.pack_into('>4s', header, 16, b'RGB ')        # data colour space
+    struct.pack_into('>4s', header, 20, b'XYZ ')        # PCS
+    struct.pack_into('>4s', header, 36, b'acsp')        # signature
+    struct.pack_into('>i', header, 68, _s15f16(wtpt[0]))  # PCS illuminant (D50)
+    struct.pack_into('>i', header, 72, _s15f16(wtpt[1]))
+    struct.pack_into('>i', header, 76, _s15f16(wtpt[2]))
+    return bytes(header) + table + data
+
+
+def _adapt_columns_d65_to_d50(m_rgb2xyz_d65: np.ndarray):
+    """Adapt the primary XYZ columns of a D65 RGB->XYZ matrix to D50, returning
+    (r_xyz, g_xyz, b_xyz) tuples suitable for ICC colorant tags."""
+    adapted = M_BRADFORD_D65_D50 @ m_rgb2xyz_d65
+    return (tuple(adapted[:, 0]), tuple(adapted[:, 1]), tuple(adapted[:, 2]))
+
+
+# sRGB working-space profile (D50-adapted sRGB colorants; sRGB piecewise TRC as a
+# parametric type-3 curve). Pixel-identical export to before, just now tagged.
+_SR, _SG, _SB = _adapt_columns_d65_to_d50(M_SRGB2XYZ)
+SRGB_ICC_BYTES = build_matrix_shaper_icc(
+    "FreeCCR sRGB",
+    _SR, _SG, _SB,
+    # sRGB EOTF as Y=(aX+b)^g for X>=d else cX : g=2.4, a=1/1.055, b=0.055/1.055,
+    # c=1/12.92, d=0.04045.
+    (2.4, 1.0 / 1.055, 0.055 / 1.055, 1.0 / 12.92, 0.04045),
+)
+
+# ProPhoto/ROMM profile (colorants already D50; gamma 1.8 + 1/512 toe as type-3).
+PROPHOTO_ICC_BYTES = build_matrix_shaper_icc(
+    "FreeCCR ROMM (ProPhoto)",
+    tuple(M_PROPHOTO2XYZ[:, 0]),
+    tuple(M_PROPHOTO2XYZ[:, 1]),
+    tuple(M_PROPHOTO2XYZ[:, 2]),
+    (1.8, 1.0, 0.0, 0.0625, 0.03125),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Export: working(sRGB-encoded) -> target colour space.
+# --------------------------------------------------------------------------- #
+
+def export_icc_bytes(target: str) -> bytes:
+    return PROPHOTO_ICC_BYTES if target == "prophoto" else SRGB_ICC_BYTES
+
+
+def apply_export_colorspace(rgb_u16: np.ndarray, target: str) -> Tuple[np.ndarray, bytes]:
+    """Map an export array (HxWx3 uint16 RGB, treated as sRGB-encoded) to the
+    target colour space. Returns (out_uint16, icc_bytes).
+
+    - 'srgb'      : pixels returned unchanged (the file is merely tagged sRGB).
+    - 'prophoto'  : re-encode into ProPhoto/ROMM at full precision.
+    """
+    if target != "prophoto":
+        return rgb_u16, SRGB_ICC_BYTES
+    # float32 keeps the memory footprint in line with the rest of the export
+    # pipeline; precision stays well under 1 LSB at 16-bit.
+    lin = srgb_decode(rgb_u16.astype(np.float32) / np.float32(65535.0))
+    pro = lin @ _M_SRGB2PROPHOTO_F32.T
+    np.clip(pro, 0.0, 1.0, out=pro)       # clip imaginary/overflow before encode
+    enc = romm_encode(pro)
+    out = np.rint(enc * 65535.0).astype(np.uint16)
+    return out, PROPHOTO_ICC_BYTES
+
+
+# --------------------------------------------------------------------------- #
+# JPEG ICC embedding (cv2 cannot embed; inject APP2 ICC_PROFILE segments).
+# --------------------------------------------------------------------------- #
+
+_ICC_APP2_MAXCHUNK = 65519   # 65533 marker-payload limit - 12-byte ICC header - 2
+
+
+def inject_jpeg_icc(jpeg_bytes: bytes, icc: bytes) -> bytes:
+    """Insert an ICC profile into an encoded JPEG byte string as one or more
+    APP2 'ICC_PROFILE' marker segments (right after SOI). Returns new bytes.
+    No-op (returns input) if the stream does not start with SOI."""
+    if not icc or jpeg_bytes[:2] != b'\xff\xd8':
+        return jpeg_bytes
+    chunks = [icc[i:i + _ICC_APP2_MAXCHUNK]
+              for i in range(0, len(icc), _ICC_APP2_MAXCHUNK)] or [b'']
+    n = len(chunks)
+    segs = b''
+    for i, ch in enumerate(chunks, start=1):
+        payload = b'ICC_PROFILE\x00' + bytes([i, n]) + ch
+        segs += b'\xff\xe2' + struct.pack('>H', len(payload) + 2) + payload
+    return jpeg_bytes[:2] + segs + jpeg_bytes[2:]
+
+
+# --------------------------------------------------------------------------- #
+# Input ICC profile -> working sRGB encoding (matrix-shaper only).
+# --------------------------------------------------------------------------- #
+
+def _read_tag_table(icc: bytes) -> dict:
+    if len(icc) < 132 or icc[36:40] != b'acsp':
+        raise UnsupportedICCError("not a valid ICC profile")
+    count = struct.unpack('>I', icc[128:132])[0]
+    tags = {}
+    pos = 132
+    for _ in range(count):
+        if pos + 12 > len(icc):
+            break
+        sig = icc[pos:pos + 4]
+        off, size = struct.unpack('>II', icc[pos + 4:pos + 12])
+        tags[sig] = (off, size)
+        pos += 12
+    return tags
+
+
+def _parse_xyz(icc: bytes, off: int) -> np.ndarray:
+    x, y, z = struct.unpack('>3i', icc[off + 8:off + 20])
+    return np.array([x, y, z], dtype=np.float64) / 65536.0
+
+
+def _parse_trc_to_lut(icc: bytes, off: int, n: int = 65536) -> np.ndarray:
+    """Return an n-entry float64 LUT mapping device value [0,1] -> linear [0,1].
+    n == 65536 so a 16-bit device value indexes the LUT exactly (no quantisation)."""
+    tag_type = icc[off:off + 4]
+    xs = np.linspace(0.0, 1.0, n)
+    if tag_type == b'curv':
+        count = struct.unpack('>I', icc[off + 8:off + 12])[0]
+        if count == 0:
+            return xs.copy()                          # identity (gamma 1.0)
+        if count == 1:
+            gamma = struct.unpack('>H', icc[off + 12:off + 14])[0] / 256.0  # u8Fixed8
+            return np.power(xs, gamma)
+        samples = np.frombuffer(icc[off + 12:off + 12 + 2 * count], dtype='>u2').astype(np.float64) / 65535.0
+        src = np.linspace(0.0, 1.0, count)
+        return np.interp(xs, src, samples)
+    if tag_type == b'para':
+        func = struct.unpack('>H', icc[off + 8:off + 10])[0]
+        nparams = {0: 1, 1: 3, 2: 4, 3: 5, 4: 7}.get(func)
+        if nparams is None:
+            raise UnsupportedICCError(f"unsupported parametric curve type {func}")
+        raw = struct.unpack('>%di' % nparams, icc[off + 12:off + 12 + 4 * nparams])
+        p = [v / 65536.0 for v in raw]
+        return _eval_para(func, p, xs)
+    raise UnsupportedICCError(f"unsupported TRC tag type {tag_type!r}")
+
+
+def _eval_para(func: int, p: list, x: np.ndarray) -> np.ndarray:
+    g = p[0]
+    if func == 0:
+        return np.power(np.clip(x, 0, 1), g)
+    if func == 1:
+        a, b = p[1], p[2]
+        thr = -b / a if a != 0 else 0.0
+        return np.where(x >= thr, np.power(np.clip(a * x + b, 0, None), g), 0.0)
+    if func == 2:
+        a, b, c = p[1], p[2], p[3]
+        thr = -b / a if a != 0 else 0.0
+        return np.where(x >= thr, np.power(np.clip(a * x + b, 0, None), g) + c, c)
+    if func == 3:
+        a, b, c, d = p[1], p[2], p[3], p[4]
+        return np.where(x >= d, np.power(np.clip(a * x + b, 0, None), g), c * x)
+    if func == 4:
+        a, b, c, d, e, f = p[1], p[2], p[3], p[4], p[5], p[6]
+        return np.where(x >= d, np.power(np.clip(a * x + b, 0, None), g) + e, c * x + f)
+    raise UnsupportedICCError(f"unsupported parametric curve type {func}")
+
+
+class InputProfile:
+    """A parsed RGB matrix-shaper input profile that converts decoded device
+    pixels into the working sRGB encoding."""
+
+    def __init__(self, combined_matrix: np.ndarray, luts: list, desc: str):
+        self._matrix = combined_matrix.astype(np.float32)   # device-linRGB -> linear sRGB
+        # 3 device->linear LUTs, length 65536 so a uint16 value indexes directly.
+        self._luts = [np.ascontiguousarray(l, dtype=np.float32) for l in luts]
+        self.description = desc
+
+    @classmethod
+    def from_bytes(cls, icc: bytes) -> "InputProfile":
+        tags = _read_tag_table(icc)
+        if icc[16:20] != b'RGB ':
+            raise UnsupportedICCError("input profile is not an RGB profile")
+        needed = [b'rXYZ', b'gXYZ', b'bXYZ', b'rTRC', b'gTRC', b'bTRC']
+        if any(t not in tags for t in needed):
+            # Missing colorant/TRC tags => LUT-based or otherwise unsupported.
+            raise UnsupportedICCError(
+                "only RGB matrix-shaper ICC profiles are supported "
+                "(LUT/cLUT/CMYK profiles are not)")
+        r = _parse_xyz(icc, tags[b'rXYZ'][0])
+        g = _parse_xyz(icc, tags[b'gXYZ'][0])
+        b = _parse_xyz(icc, tags[b'bXYZ'][0])
+        m_colorants = np.stack([r, g, b], axis=1)        # columns = primaries (XYZ D50)
+        combined = M_XYZ_D50_2_SRGB @ m_colorants        # device-linRGB -> linear sRGB
+        luts = [_parse_trc_to_lut(icc, tags[t][0])
+                for t in (b'rTRC', b'gTRC', b'bTRC')]
+        desc = cls._read_desc(icc, tags)
+        return cls(combined, luts, desc)
+
+    @staticmethod
+    def _read_desc(icc: bytes, tags: dict) -> str:
+        if b'desc' not in tags:
+            return ""
+        off, size = tags[b'desc']
+        try:
+            if icc[off:off + 4] == b'desc':
+                n = struct.unpack('>I', icc[off + 8:off + 12])[0]
+                return icc[off + 12:off + 12 + n].split(b'\x00')[0].decode('ascii', 'replace')
+        except Exception:
+            pass
+        return ""
+
+    def apply(self, rgb_u16: np.ndarray) -> np.ndarray:
+        """Convert HxWx3 uint16 device RGB into uint16 sRGB-encoded working RGB."""
+        if rgb_u16.ndim != 3 or rgb_u16.shape[2] != 3 or rgb_u16.dtype != np.uint16:
+            return rgb_u16
+        # LUTs are length 65536, so a uint16 value indexes them directly.
+        lin = np.empty(rgb_u16.shape, dtype=np.float32)
+        for c in range(3):
+            lin[..., c] = self._luts[c][rgb_u16[..., c]]
+        srgb_lin = lin @ self._matrix.T
+        out = srgb_encode(np.clip(srgb_lin, 0.0, 1.0))
+        return np.rint(out * 65535.0).astype(np.uint16)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -137,6 +137,14 @@ class MainWindow(QMainWindow):
         self.installEventFilter(self)
         self.create_menu()
 
+        # Restore a previously-chosen global input ICC profile (applied to every
+        # decode). Done before any images load so the first batch picks it up.
+        saved_icc = self._settings.value("import/input_icc_path", "", type=str)
+        if saved_icc and os.path.exists(saved_icc):
+            if ccr_backend.load_input_icc_from_storage(saved_icc) is None:
+                self._settings.remove("import/input_icc_path")
+            self._refresh_input_icc_menu()
+
         # Ctrl+Z (Cmd+Z on macOS): undo the last action on the current image;
         # repeated presses walk further back through the undo stack.
         self.undo_shortcut = QShortcut(QKeySequence.Undo, self)
@@ -241,6 +249,15 @@ class MainWindow(QMainWindow):
         export_action.setShortcut("Ctrl+E")
         export_action.triggered.connect(self.image_preview.open_export_dialog)
 
+        # Input ICC profile: a single, global, persistent profile applied to
+        # every image at decode time, before conversion/adjustments.
+        file_menu.addSeparator()
+        self.input_icc_action = file_menu.addAction("Set Input ICC Profile…")
+        self.input_icc_action.triggered.connect(self.set_input_icc_profile)
+        self.clear_input_icc_action = file_menu.addAction("Clear Input ICC Profile")
+        self.clear_input_icc_action.triggered.connect(self.clear_input_icc_profile)
+        self._refresh_input_icc_menu()
+
         # Add Help menu with About, Licenses, Activation, and Help actions
         help_menu = menu_bar.addMenu("Help")
         about_action = help_menu.addAction("About")
@@ -251,6 +268,67 @@ class MainWindow(QMainWindow):
 
         help_action = help_menu.addAction("Help")
         help_action.triggered.connect(self.open_help_website)
+
+    # --- Input ICC profile (global, persistent) ---------------------------
+    def _refresh_input_icc_menu(self):
+        """Reflect the active input profile in the File-menu actions."""
+        name = getattr(ccr_backend, "input_icc_name", None)
+        if name:
+            self.input_icc_action.setText(f"Input ICC: {name}…")
+            self.clear_input_icc_action.setEnabled(True)
+        else:
+            self.input_icc_action.setText("Set Input ICC Profile…")
+            self.clear_input_icc_action.setEnabled(False)
+
+    def set_input_icc_profile(self):
+        from core.color_management import UnsupportedICCError
+        start_dir = self._settings.value("import/last_icc_dir", "", type=str)
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select Input ICC Profile", start_dir,
+            "ICC Profiles (*.icc *.icm);;All Files (*)")
+        if not path:
+            return
+        self._settings.setValue("import/last_icc_dir", os.path.dirname(path))
+        try:
+            name = ccr_backend.set_input_icc(path)
+        except UnsupportedICCError as e:
+            QMessageBox.warning(
+                self, "Unsupported ICC Profile",
+                f"This profile can't be used as an input profile:\n\n{e}\n\n"
+                "Only RGB matrix-shaper profiles are supported "
+                "(LUT-based, cLUT, or CMYK profiles are not).")
+            return
+        except Exception as e:
+            QMessageBox.warning(self, "Input ICC Profile Error",
+                                f"Could not load the ICC profile:\n\n{e}")
+            return
+        self._settings.setValue("import/input_icc_path", ccr_backend.input_icc_path)
+        self._refresh_input_icc_menu()
+        self._reprocess_after_input_icc_change()
+        self.sliders_panel.set_temporary_hint(
+            f"Input ICC profile set: {name}", duration=3000)
+
+    def clear_input_icc_profile(self):
+        ccr_backend.clear_input_icc()
+        self._settings.remove("import/input_icc_path")
+        self._refresh_input_icc_menu()
+        self._reprocess_after_input_icc_change()
+        self.sliders_panel.set_temporary_hint("Input ICC profile cleared.", duration=3000)
+
+    def _reprocess_after_input_icc_change(self):
+        """Re-decode + re-convert loaded images so the profile change shows
+        immediately, then refresh the UI."""
+        if not ccr_backend.images:
+            return
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            ccr_backend.reprocess_all_for_input_icc_change()
+        finally:
+            QApplication.restoreOverrideCursor()
+        self.thumbnail_list.update_all_thumbnails()
+        if self.image_preview.current_idx is not None:
+            self.image_preview.update_preview(self.image_preview.current_idx)
+        ccr_backend.save_catalog()
 
     def show_activation_dialog(self):
         QMessageBox.information(

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -28,6 +28,7 @@ class ExportPlan:
     jpg_output: bool = False
     jpg_quality: int = 92
     max_long_side: Optional[int] = None  # None = keep original size
+    output_colorspace: str = "srgb"  # "srgb" | "prophoto"
     open_folder: bool = False
     destination: str = ""
     skipped: int = 0  # files dropped by the "skip existing" policy
@@ -130,6 +131,20 @@ class ExportSettingsDialog(QDialog):
         self.format_combo.currentIndexChanged.connect(self._on_format_changed)
         form.addRow("Format:", self.format_combo)
 
+        # Output color space. sRGB is the current behaviour (now ICC-tagged);
+        # ProPhoto re-encodes the result into the wide-gamut space and embeds
+        # the matching ICC profile.
+        self.colorspace_combo = QComboBox()
+        self.colorspace_combo.addItem("sRGB", "srgb")
+        self.colorspace_combo.addItem("ProPhoto RGB (wide gamut)", "prophoto")
+        self.colorspace_combo.currentIndexChanged.connect(self._on_colorspace_changed)
+        form.addRow("Color space:", self.colorspace_combo)
+        self.colorspace_hint = QLabel(
+            "8-bit ProPhoto JPEG can band — prefer 16-bit TIFF for wide gamut.")
+        self.colorspace_hint.setStyleSheet("color: gray;")
+        self.colorspace_hint.setWordWrap(True)
+        form.addRow("", self.colorspace_hint)
+
         quality_layout = QHBoxLayout()
         self.quality_slider = QSlider(Qt.Horizontal)
         self.quality_slider.setRange(1, 100)
@@ -183,6 +198,7 @@ class ExportSettingsDialog(QDialog):
         self._estimate_timer.timeout.connect(self._update_estimate)
 
         self._update_quality_visibility()
+        self._update_colorspace_hint()
 
     # ---------- settings ----------
 
@@ -207,6 +223,9 @@ class ExportSettingsDialog(QDialog):
         fmt_index = self.format_combo.findData(s.value("export/format", "tiff", type=str))
         if fmt_index >= 0:
             self.format_combo.setCurrentIndex(fmt_index)
+        cs_index = self.colorspace_combo.findData(s.value("export/colorspace", "srgb", type=str))
+        if cs_index >= 0:
+            self.colorspace_combo.setCurrentIndex(cs_index)
         self.quality_slider.setValue(s.value("export/jpeg_quality", 92, type=int))
         resize_index = self.resize_combo.findData(s.value("export/resize", 0, type=int))
         if resize_index >= 0:
@@ -229,6 +248,7 @@ class ExportSettingsDialog(QDialog):
         s.setValue("export/scope", scope)
         s.setValue("export/filename_template", self.filename_edit.text())
         s.setValue("export/format", self.format_combo.currentData())
+        s.setValue("export/colorspace", self.colorspace_combo.currentData())
         s.setValue("export/jpeg_quality", self.quality_slider.value())
         s.setValue("export/resize", self.resize_combo.currentData())
         s.setValue("export/conflict", self.conflict_combo.currentData())
@@ -285,8 +305,18 @@ class ExportSettingsDialog(QDialog):
 
     def _on_format_changed(self):
         self._update_quality_visibility()
+        self._update_colorspace_hint()
         self._update_example()
         self._schedule_estimate()
+
+    def _on_colorspace_changed(self):
+        self._update_colorspace_hint()
+
+    def _update_colorspace_hint(self):
+        # The banding caution is only relevant for 8-bit ProPhoto JPEG.
+        is_prophoto = self.colorspace_combo.currentData() == "prophoto"
+        is_jpeg = self.format_combo.currentData() == "jpeg"
+        self.colorspace_hint.setVisible(is_prophoto and is_jpeg)
 
     def _on_quality_changed(self, value):
         self.quality_value_label.setText(str(value))
@@ -393,6 +423,7 @@ class ExportSettingsDialog(QDialog):
             jpg_output=self.format_combo.currentData() == "jpeg",
             jpg_quality=self.quality_slider.value(),
             max_long_side=self._selected_max_long_side(),
+            output_colorspace=self.colorspace_combo.currentData(),
             open_folder=self.open_folder_checkbox.isChecked(),
             destination=destination,
             skipped=skipped,

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -3306,6 +3306,7 @@ class ExportItemsWorker(QThread):
                 jpg_output=self.plan.jpg_output,
                 jpg_quality=self.plan.jpg_quality,
                 max_long_side=self.plan.max_long_side,
+                output_colorspace=self.plan.output_colorspace,
                 progress_callback=progress_callback,
                 cancel_check=lambda: self._stop_requested,
             )

--- a/tests/test_color_management.py
+++ b/tests/test_color_management.py
@@ -312,5 +312,33 @@ def test_backend_rejects_lut_profile_unchanged(tmp_path, monkeypatch):
         ccr_backend.input_icc_name = None
 
 
+def test_reprocess_preserves_inherited_tint_factor(tmp_path):
+    """Regression: a slice/duplicate inherits its parent's tint_balance_factor;
+    reprocessing after an input-ICC change must not let reload recompute it from
+    the image's own region. A plain image is free to re-adapt."""
+    _make_qapp()
+    from core.ccr_image import CCRImage
+    from core.ccr_backend import ccr_backend
+    p = str(tmp_path / "neg.png")
+    _write_negative_png(p)
+    saved_images = ccr_backend.images
+    cm.set_active_input_profile(None)
+    try:
+        plain = CCRImage(p)
+        dup = CCRImage(p)
+        dup.is_duplicate = True
+        SENT = 0.777
+        dup.tint_balance_factor = SENT             # inherited sentinel
+        plain_before = plain.tint_balance_factor
+        ccr_backend.images = [plain, dup]
+        cm.set_active_input_profile(cm.InputProfile.from_bytes(_adobe_like_icc()))
+        ccr_backend.reprocess_all_for_input_icc_change()
+        assert dup.tint_balance_factor == SENT     # inherited factor preserved
+        assert plain.tint_balance_factor != plain_before  # plain re-adapts to ICC
+    finally:
+        ccr_backend.images = saved_images
+        cm.set_active_input_profile(None)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_color_management.py
+++ b/tests/test_color_management.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Tests for color management: export colour-space transforms + ICC embedding,
+and the input-ICC matrix-shaper engine. See spec/color-management.md §8.
+
+Pure numpy/cv2/tifffile — no Qt required. Pillow-based assertions are skipped
+when Pillow is not importable (it is not a runtime dependency).
+"""
+import io
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import cv2  # noqa: E402
+import tifffile  # noqa: E402
+from core import color_management as cm  # noqa: E402
+
+try:
+    from PIL import Image as PILImage, ImageCms  # noqa: E402
+    HAS_PIL = True
+except Exception:
+    HAS_PIL = False
+
+
+def _rand_u16(h=24, w=32, seed=3):
+    rng = np.random.default_rng(seed)
+    return (rng.random((h, w, 3)) * 65535).astype(np.uint16)
+
+
+# --- 1. sRGB passthrough ---------------------------------------------------
+
+def test_srgb_passthrough_is_pixel_identical():
+    img = _rand_u16()
+    out, icc = cm.apply_export_colorspace(img, "srgb")
+    assert np.array_equal(out, img)
+    assert icc == cm.SRGB_ICC_BYTES and len(icc) > 128
+
+
+# --- 2. ProPhoto transform sanity ------------------------------------------
+
+def test_prophoto_dtype_range_and_anchors():
+    white = np.full((1, 1, 3), 65535, np.uint16)
+    black = np.zeros((1, 1, 3), np.uint16)
+    pw, icc = cm.apply_export_colorspace(white, "prophoto")
+    pb, _ = cm.apply_export_colorspace(black, "prophoto")
+    assert icc == cm.PROPHOTO_ICC_BYTES
+    assert pw.dtype == np.uint16 and pb.dtype == np.uint16
+    # sRGB white -> ProPhoto white (within a couple LSB of fixed-point rounding)
+    assert (pw >= 65530).all()
+    assert (pb == 0).all()
+
+
+def test_prophoto_grey_roundtrips_through_inverse():
+    # A mid grey re-encoded to ProPhoto then decoded back via the inverse
+    # transform should land near the original sRGB value.
+    mid = np.full((1, 1, 3), 128 * 257, np.uint16)
+    pro, _ = cm.apply_export_colorspace(mid, "prophoto")
+    v = pro.astype(np.float64) / 65535.0
+    lin = np.where(v < 1 / 32, v / 16.0, np.power(v, 1.8))          # ROMM decode
+    srgb_lin = lin @ np.linalg.inv(cm.M_SRGB2PROPHOTO).T
+    back = cm.srgb_encode(np.clip(srgb_lin, 0, 1)) * 65535.0
+    assert abs(float(back[0, 0, 0]) - mid[0, 0, 0]) < 200
+
+
+def test_prophoto_is_clipped_and_uint16():
+    img = _rand_u16(seed=11)
+    out, _ = cm.apply_export_colorspace(img, "prophoto")
+    assert out.dtype == np.uint16
+    assert out.min() >= 0 and out.max() <= 65535
+    assert out.shape == img.shape
+
+
+# --- 3. ROMM toe -----------------------------------------------------------
+
+def test_romm_toe_continuity_and_monotonic():
+    Et = 1.0 / 512.0
+    assert abs(16 * Et - Et ** (1 / 1.8)) < 1e-9
+    xs = np.linspace(0, 1, 4096)
+    ys = cm.romm_encode(xs)
+    assert np.all(np.diff(ys) >= -1e-9)            # monotonic non-decreasing
+    assert abs(ys[0]) < 1e-9 and abs(ys[-1] - 1.0) < 1e-9
+
+
+def test_srgb_decode_encode_inverse():
+    xs = np.linspace(0, 1, 1000)
+    assert np.allclose(cm.srgb_decode(cm.srgb_encode(xs)), xs, atol=1e-6)
+
+
+# --- 4. ICC validity -------------------------------------------------------
+
+@pytest.mark.parametrize("target", ["srgb", "prophoto"])
+def test_icc_profiles_are_valid(target):
+    icc = cm.export_icc_bytes(target)
+    assert icc[36:40] == b"acsp"                   # ICC signature
+    assert icc[16:20] == b"RGB "                   # data colour space
+    # In-house parser accepts our own matrix-shaper profile.
+    prof = cm.InputProfile.from_bytes(icc)
+    assert isinstance(prof, cm.InputProfile)
+    if HAS_PIL:
+        opened = ImageCms.getOpenProfile(io.BytesIO(icc))
+        # building a transform proves lcms accepts it as a real profile
+        ImageCms.buildTransform(opened, ImageCms.createProfile("sRGB"), "RGB", "RGB")
+
+
+# --- 5. TIFF embed ---------------------------------------------------------
+
+@pytest.mark.parametrize("target", ["srgb", "prophoto"])
+def test_tiff_embeds_icc_tag(tmp_path, target):
+    img = _rand_u16()
+    out, icc = cm.apply_export_colorspace(img, target)
+    p = str(tmp_path / f"{target}.tiff")
+    tifffile.imwrite(p, out, photometric="rgb", compression="deflate", iccprofile=icc)
+    with tifffile.TiffFile(p) as t:
+        assert bytes(t.pages[0].tags[34675].value) == icc
+        assert np.array_equal(t.pages[0].asarray(), out)
+
+
+# --- 6. JPEG inject --------------------------------------------------------
+
+def test_inject_jpeg_icc_single_and_multichunk():
+    img = (_rand_u16() / 257).astype(np.uint8)
+    ok, buf = cv2.imencode(".jpg", cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+    assert ok
+    jpg = buf.tobytes()
+
+    for icc in (cm.PROPHOTO_ICC_BYTES, bytes(range(256)) * 600):  # small, then >2 chunks
+        out = cm.inject_jpeg_icc(jpg, icc)
+        # still a decodable JPEG
+        dec = cv2.imdecode(np.frombuffer(out, np.uint8), cv2.IMREAD_COLOR)
+        assert dec is not None and dec.shape[2] == 3
+        if HAS_PIL:
+            got = PILImage.open(io.BytesIO(out)).info.get("icc_profile")
+            assert got == icc
+
+
+def test_inject_jpeg_icc_noop_on_non_jpeg():
+    assert cm.inject_jpeg_icc(b"not a jpeg", cm.SRGB_ICC_BYTES) == b"not a jpeg"
+    assert cm.inject_jpeg_icc(b"\xff\xd8rest", b"") == b"\xff\xd8rest"
+
+
+# --- 7. InputProfile (matrix-shaper) ---------------------------------------
+
+def _adobe_like_icc():
+    """A synthetic Adobe-RGB-like matrix-shaper profile (gamma ~2.2)."""
+    m = np.array([[0.5767309, 0.1855540, 0.1881852],
+                  [0.2973769, 0.6273491, 0.0752741],
+                  [0.0270343, 0.0706872, 0.9911085]])
+    adapted = cm.M_BRADFORD_D65_D50 @ m
+    return cm.build_matrix_shaper_icc(
+        "Adobe-like", tuple(adapted[:, 0]), tuple(adapted[:, 1]), tuple(adapted[:, 2]),
+        (2.19921875, 1.0, 0.0, 0.0, 0.0))   # type-3 with d=0 -> pure power curve
+
+
+def test_input_profile_applies_and_preserves_shape():
+    ip = cm.InputProfile.from_bytes(_adobe_like_icc())
+    img = _rand_u16(seed=5)
+    out = ip.apply(img)
+    assert out.shape == img.shape and out.dtype == np.uint16
+    # An Adobe-RGB-ish profile is a different gamut/gamma -> pixels must change.
+    assert not np.array_equal(out, img)
+
+
+def test_input_profile_srgb_is_near_identity():
+    ip = cm.InputProfile.from_bytes(cm.SRGB_ICC_BYTES)
+    img = _rand_u16(seed=9)
+    out = ip.apply(img)
+    # sRGB-in -> sRGB-working is identity up to ICC s15Fixed16 colorant precision.
+    assert int(np.abs(out.astype(int) - img.astype(int)).max()) < 64
+
+
+def test_input_profile_passthrough_non_rgb():
+    ip = cm.InputProfile.from_bytes(cm.SRGB_ICC_BYTES)
+    gray = np.zeros((4, 4), np.uint16)
+    assert ip.apply(gray).shape == (4, 4)
+
+
+# --- 8. InputProfile rejects unsupported profiles --------------------------
+
+def test_input_profile_rejects_lut_profile():
+    import struct
+    hdr = bytearray(128)
+    struct.pack_into('>4s', hdr, 36, b'acsp')
+    struct.pack_into('>4s', hdr, 16, b'RGB ')
+    # Only a LUT tag, no colorant/TRC tags -> unsupported.
+    table = struct.pack('>I', 1) + struct.pack('>4sII', b'A2B0', 128 + 16, 4) + b'\x00' * 4
+    with pytest.raises(cm.UnsupportedICCError):
+        cm.InputProfile.from_bytes(bytes(hdr) + table)
+
+
+def test_input_profile_rejects_non_icc():
+    with pytest.raises(cm.UnsupportedICCError):
+        cm.InputProfile.from_bytes(b"definitely not an icc profile")
+
+
+# --- 9. Export write-path regression (srgb pixel-identical) -----------------
+
+def test_write_export_image_srgb_tiff_pixel_identical(tmp_path):
+    from core import ccr_processor as cp
+
+    class _Dummy:
+        def resize_image_to_max_pixel(self, im, n):
+            return im
+
+    img = _rand_u16(seed=21)
+    base = str(tmp_path / "out")
+    cp.write_export_image(_Dummy(), img, base, jpg_out=False, jpg_quality=92,
+                          max_long_side=None, output_colorspace="srgb")
+    with tifffile.TiffFile(base + ".tiff") as t:
+        assert np.array_equal(t.pages[0].asarray(), img)   # unchanged pixels
+        assert bytes(t.pages[0].tags[34675].value) == cm.SRGB_ICC_BYTES
+
+
+def test_write_export_image_prophoto_jpeg_has_profile(tmp_path):
+    from core import ccr_processor as cp
+
+    class _Dummy:
+        def resize_image_to_max_pixel(self, im, n):
+            return im
+
+    img = _rand_u16(seed=22)
+    base = str(tmp_path / "out")
+    cp.write_export_image(_Dummy(), img, base, jpg_out=True, jpg_quality=90,
+                          max_long_side=None, output_colorspace="prophoto")
+    assert os.path.exists(base + ".jpg")
+    if HAS_PIL:
+        got = PILImage.open(base + ".jpg").info.get("icc_profile")
+        assert got == cm.PROPHOTO_ICC_BYTES
+
+
+# --- 10. Runtime integration (decode hook + backend lifecycle) -------------
+
+def _make_qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    return QApplication.instance() or QApplication(sys.argv[:1])
+
+
+def _write_negative_png(path, w=320, h=240, seed=7):
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:h, 0:w]
+    base = 20000 + 25000 * (xx / w) + 10000 * (yy / h)
+    img = np.stack([base * 1.2, base, base * 0.7], axis=-1)
+    img += rng.normal(0, 1500, img.shape)
+    img = np.clip(img, 1000, 64000).astype(np.uint16)
+    cv2.imwrite(path, cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+    return img
+
+
+def test_read_image_applies_active_input_profile(tmp_path):
+    _make_qapp()
+    from core.ccr_image import CCRImage
+    p = str(tmp_path / "neg.png")
+    _write_negative_png(p)
+    cm.set_active_input_profile(None)
+    try:
+        a = CCRImage(p).resized_raw.copy()             # no profile
+        cm.set_active_input_profile(cm.InputProfile.from_bytes(_adobe_like_icc()))
+        b = CCRImage(p).resized_raw.copy()             # profile burned in at decode
+        assert a.shape == b.shape
+        assert not np.array_equal(a, b)
+    finally:
+        cm.set_active_input_profile(None)
+
+
+def test_backend_set_and_clear_input_icc(tmp_path, monkeypatch):
+    _make_qapp()
+    monkeypatch.setenv("APPDATA", str(tmp_path))   # redirect app-data folder
+    from core.ccr_backend import ccr_backend
+    src = tmp_path / "srcprofile.icc"
+    src.write_bytes(_adobe_like_icc())
+    try:
+        name = ccr_backend.set_input_icc(str(src))
+        assert name
+        assert cm.get_active_input_profile() is not None
+        assert ccr_backend.input_icc_path and os.path.exists(ccr_backend.input_icc_path)
+        assert str(tmp_path) in ccr_backend.input_icc_path     # copied under APPDATA
+        ccr_backend.clear_input_icc()
+        assert cm.get_active_input_profile() is None
+        assert ccr_backend.input_icc_path is None
+        assert not os.path.exists(str(tmp_path / "FreeCCR" / "input_profile.icc"))
+    finally:
+        cm.set_active_input_profile(None)
+        ccr_backend.input_icc_path = None
+        ccr_backend.input_icc_name = None
+
+
+def test_backend_rejects_lut_profile_unchanged(tmp_path, monkeypatch):
+    _make_qapp()
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    from core.ccr_backend import ccr_backend
+    import struct
+    hdr = bytearray(128)
+    struct.pack_into('>4s', hdr, 36, b'acsp')
+    struct.pack_into('>4s', hdr, 16, b'RGB ')
+    table = struct.pack('>I', 1) + struct.pack('>4sII', b'A2B0', 144, 4) + b'\x00' * 4
+    bad = tmp_path / "lut.icc"
+    bad.write_bytes(bytes(hdr) + table)
+    cm.set_active_input_profile(None)
+    try:
+        with pytest.raises(cm.UnsupportedICCError):
+            ccr_backend.set_input_icc(str(bad))
+        # active profile untouched on failure
+        assert cm.get_active_input_profile() is None
+    finally:
+        cm.set_active_input_profile(None)
+        ccr_backend.input_icc_path = None
+        ccr_backend.input_icc_name = None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Adds two color-management features (full design in `spec/color-management.md`).

### 1. Export color space (sRGB / ProPhoto RGB)
A **"Color space"** dropdown in the Export dialog.

- **sRGB** (default) — pixel-identical to today's export, now explicitly **ICC-tagged** sRGB.
- **ProPhoto RGB** — re-encodes the displayed result into ProPhoto/ROMM (D50 primaries, gamma 1.8 with the 1/512 linear toe) at full 16-bit precision and **embeds the ProPhoto ICC** so a color-managed viewer shows the same colors with a wider container.

Honest framing: the internal pipeline is an uncalibrated linear film-inversion space, so this is a **re-encode of the on-screen (assumed-sRGB) result**, not a colorimetric conversion from a characterized source — a wider editing container, not "more accurate" color.

Implementation:
- Pure-numpy matrix transform (sRGB→linear→XYZ→Bradford D65→D50→ProPhoto→ROMM). **No Pillow/lcms dependency** — Pillow's `ImageCms` is 8-bit-only for RGB and would destroy the 16-bit depth.
- ICC embedded via `tifffile(iccprofile=...)` (tag 34675) for TIFF and an injected **APP2 `ICC_PROFILE`** segment for JPEG (cv2 can't embed).
- The three duplicated export write tails (`ccr_normalize_with_reference/_bwpoint/_refparams`) are unified into one `write_export_image()` chokepoint; `output_colorspace` is threaded dialog → `ExportPlan` → worker → `export_items` → `export_image_by_index` → the converters.

### 2. Global input ICC profile (File menu)
**File → Set Input ICC Profile… / Clear Input ICC Profile** (the menu shows the active profile's name).

- The chosen `.icc`/`.icm` is **copied into app data** (`%APPDATA%/FreeCCR/input_profile.icc`) and remembered in `QSettings`, so it survives restarts and the original moving/disappearing.
- Applied at **decode time inside `read_image`**, before negative conversion and adjustments — which makes it automatically resolution-independent (preview, hi-res zoom, and export all route through `read_image`) and applies to every image until changed/cleared.
- **Matrix-shaper profiles only** (colorant + TRC). LUT/cLUT/CMYK profiles are rejected with a clear, non-fatal message (a 16-bit CMM would be a future dependency-adding enhancement).
- Setting/changing/clearing re-decodes + re-converts the loaded images so the change shows immediately.

ICC profiles are **synthesized in-process** (valid ICC v2.4 matrix-shaper), so nothing is bundled and there's no profile trademark/licensing concern.

## Notes / intended behavior
- sRGB export now carries an sRGB ICC tag (pixels unchanged).
- 8-bit ProPhoto **JPEG** is allowed but cautioned in the UI (banding); the transform runs at 16-bit before the 8-bit downconvert and the profile is embedded.
- Input ICC is a single global setting, not baked per-image: converting under profile A then switching to B and reopening re-decodes under B (matches the "one remembered profile" intent). Most meaningful for already-encoded standard imports; for linear RAW it's applied to the camera-native decode as-is.

## Testing
- New `tests/test_color_management.py` (23 tests): color-math round-trips, ROMM toe continuity, ICC validity (parser + tifffile embed + lcms when Pillow present), JPEG APP2 inject (single + multi-chunk), `InputProfile` matrix-shaper apply + LUT rejection, decode-hook integration, backend set/clear lifecycle, sRGB-pixel-identical export regression, and an inherited-`tint_balance_factor` regression.
- Full suite: **302 passed**.

## Review
An adversarial multi-agent review of the diff confirmed one issue — `reprocess_all_for_input_icc_change` recomputing inherited `tint_balance_factor` for slices/duplicates — which is fixed here (and regression-tested). Nine other candidates were each independently verified as non-issues (unreachable code paths, already-guarded edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
