### PR TITLE
Dust Healing (spot & scratch removal)

### DIFF
--- a/spec/dust-healing.md
+++ b/spec/dust-healing.md
@@ -1,0 +1,605 @@
+# Spec: Dust Healing (Spot & Scratch Removal)
+
+Status: REFINED v2
+Owner: FreeCCR
+Feature branch: `feature/dust-healing`
+
+> §9 (Refinement) resolves open questions and **overrides** the v1 body where
+> they conflict — it is the authoritative source for the coordinate transform
+> (§9.1), brush sizing (§9.4), the inpaint solver (§9.2), tuned constants
+> (§9.7), and the added Visualize mode (§9.3).
+
+## 1. Summary
+
+Add a **Dust Healing** tool that removes the dust spots and scratches a DSLR
+"scan" of film leaves behind — small bright blobs and thin curly bright strings
+in the converted positive (e.g. white specks on a blue sky). The tool offers
+**automatic detection** of all spots in the current image, lets the user
+**reject any individual auto-detection** with a click, and lets the user **add
+heal strokes manually** (click a missed spot, or drag-trace a curly scratch).
+The healing is stored as a resolution-independent list of vector "strokes" on
+the image and replayed through the existing `apply_adjustments` hook so it shows
+identically in the preview, the hi-res zoom detail, and the exported file. The
+controls live in the top toolbar of `ImagePreview`, next to the other
+canvas-mode tools (Crop, Areas).
+
+## 2. Goals / Non-goals
+
+### Goals
+- A **Heal** toolbar toggle that enters/exits a dust-healing canvas mode (like
+  Crop / Area modes), gated to **converted** images.
+- An **Auto-Detect** toolbar button that finds all dust spots/scratches in the
+  current converted image and adds them as heal strokes.
+- A **sensitivity** control (Low / Medium / High) governing auto-detection.
+- A **Visualize** toggle that shows a high-contrast "find the dust" view while
+  curating (Lightroom-style), since dust is near-invisible at fit zoom (§9.3).
+- In heal mode, an **overlay** marks every heal stroke (auto vs. manual tinted
+  differently).
+- **Reject a single detection**: left-click a marked spot to remove that stroke.
+- **Manual heal**: left-click an unmarked spot to heal it; left-drag to paint a
+  stroke along a curly scratch. A **brush size** control (S / M / L) sets the
+  radius.
+- A **Clear Spots** toolbar button that removes all heal strokes for the image.
+- Healing affects the preview, the hi-res zoom detail, and the export, at every
+  resolution (resolution independent), applied **after** negative inversion and
+  **before** the user's tonal adjustments and crop.
+- Heal strokes persist in the catalog and participate in Undo.
+
+### Non-goals
+- **Not** a general content-aware fill / object-removal tool. The fill targets
+  small spots and thin scratches over locally smooth-ish backgrounds (sky,
+  smooth skin/fabric, defocused areas, uniform film grain). It is **not** meant
+  for dust sitting on fine texture (grass blades, foliage, bark, fabric weave,
+  text) where a synthesized patch reads as a smudge — heuristic: if the
+  background's texture wavelength is smaller than the defect, the fill will look
+  artificial. Large/textured defects are out of scope.
+- **Auto-detection is inherently imperfect** — with no IR channel, bright/dark
+  *real* scene detail (specular highlights, snow, white flowers, distant birds,
+  text, stars) can be flagged as dust, and faint dust can be missed. The
+  intended workflow is auto-detect → **curate** (reject false positives, add
+  misses). The tool optimizes for *easy curation*, not perfect recall/precision.
+- No infrared (Digital ICE / iSRD) channel — DSLR scans have no IR, so detection
+  is purely from the RGB positive (this is the fundamental constraint; see §5).
+- No clone-source picking / aligned-healing brush (always synthesized fill).
+- No cross-image "detect dust in all frames" batch and no Sync-to-All for heal
+  strokes — dust is physical to one captured frame, so strokes are per-image
+  only (see §9 once refined).
+- No GPU/OpenCL path; detection + tiled inpaint on the ≤1080 preview (and tiled
+  at export) are fast enough on CPU.
+- Healing is offered only on **converted** images (dust is meaningful on the
+  positive; the un-converted negative is the wrong space and the tool is
+  disabled there, like the Crop / Area tools).
+
+## 3. UX / Interaction
+
+### 3.1 Toolbar placement
+Four controls are added to the existing `ImagePreview` toolbar
+(`image_preview.py:588-703`), inserted **after the "Un-convert" action
+(`:668-671`) and before "Export…" (`:673`)**, each followed by `add_spacer()`,
+matching the existing toolbar idiom (`QAction` + `triggered.connect`):
+
+1. `self.heal_action` — checkable `QAction` "🩹 Heal" (text-only, like
+   "◯ Area"). Toggles dust-healing mode.
+2. `self.auto_dust_action` — `QAction` "Auto-Detect". Runs detection on the
+   current image.
+3. `self.clear_dust_action` — `QAction` "Clear Spots". Removes all strokes.
+4. A compact `QComboBox` **brush size** (`S / M / L`) and a compact `QComboBox`
+   **sensitivity** (`Low / Med / High`), inserted with the same
+   `insertWidget`/spacer idiom used by the zoom combo (`:679-701`).
+
+All five are enabled only when the current image is converted (wired into the
+existing `_update_unconvert_action_state()` enable/disable pass). `Auto-Detect`,
+`Clear Spots`, the brush combo, and the sensitivity combo are further enabled
+only while **Heal mode** is active (entering heal mode reveals the working
+controls; leaving it greys them).
+
+### 3.2 Entering / leaving heal mode
+`toggle_heal_mode(checked)` mirrors `enter_crop_mode` / `enter_area_mode`
+(`image_preview.py:2040-2078`, `2530-2551`):
+- On enter: cancel conflicting modes (crop, area, slice, bwpoint, wb-pick),
+  set `self.heal_mode = True` and `self.view.heal_mode = True`, set the canvas
+  cursor to a **brush-ring cursor** (a crosshair plus a live ring overlay sized
+  to the current brush radius — see §3.5), draw the stroke overlay
+  (`_draw_dust_overlay()`), and show a one-line hint via the existing
+  `sliders_panel` hint channel ("Click a marked spot to remove it; click or drag
+  to heal; Auto-Detect finds spots automatically").
+- On leave: clear `heal_mode`, restore the arrow cursor, remove the overlay and
+  the brush ring. Any external `update_preview` (image switch, slider change,
+  conversion, undo) leaves heal mode, exactly as crop/slice/area modes do via
+  the guards at `update_preview` (`:875-894`).
+
+### 3.3 Coordinate systems
+Heal strokes are authored on the displayed canvas but **stored in the same
+normalized, un-rotated / un-flipped / un-cropped `resized_raw` image space as
+`crop_rect`** (`ccr_processor.py:1303-1308`). **See §9.1 — the chain below is
+superseded** to also invert *fine rotation* (the v1 `_base_transform` chain
+handles only coarse 90°/flip). The authoritative chain uses the displayed
+`pixmap_item`'s own transform (coarse + fine rotation), reconstructed in preview
+space without prescale:
+
+1. viewport px → `view.mapToScene(event.pos())` → scene.
+2. scene → `_image_transform().inverted()[0].map(...)` → displayed-pixmap-local
+   — where `_image_transform()` is the coarse base + fine rotation built exactly
+   as `apply_transformations` builds `img_transform` (`image_preview.py:1100-1121`),
+   minus the prescale (scene relates to preview-local by `img_transform`, since
+   the prescale maps hi-res-local → preview footprint).
+3. local → `map_displayed_to_full(x, y)` (`:1970`) → full-image px (undoes the
+   display crop).
+4. full px → normalized: `nx = x / W`, `ny = y / H`, where `(W,H)` are the full
+   image dims (`current_pixmap` size when uncropped == `resized_raw` dims).
+
+The **radius** is stored normalized to the image's long side
+(`r_norm = r_px / max(W, H)`) so it scales correctly to any export resolution.
+
+For the **overlay** (drawing stored strokes back onto the canvas) the inverse is
+used, mirroring the reference-frame overlay at `update_preview:982-993` but with
+`_image_transform()` (not coarse-only) so markers track fine rotation: build the
+marker geometry in preview-local via `map_full_to_displayed` (new helper =
+inverse of `_crop_display_transform`), create the `QGraphicsItem`, and
+`setTransform(_image_transform())`. Markers scale with the displayed image
+(showing true heal footprint) with a bi-color cosmetic outline pen for
+visibility on any background.
+
+### 3.4 Mouse behaviour (heal mode)
+Handled by a new branch in `GraphicsImageView.mousePressEvent` /
+`mouseMoveEvent` / `mouseReleaseEvent` (`:127-410`), placed **before** the
+generic reference-draw branch (`:181`), guarded by `self.heal_mode`:
+
+- **Left-press**: convert to full-image px (§3.3) and hit-test existing strokes
+  (`HEAL_HIT` = the stroke's draw radius + 6 screen px, scaled by `_view_scale`).
+  - **On a stroke** → remove that stroke (reject detection / delete manual),
+    push one undo step, reprocess. No drag starts.
+  - **On empty canvas** → begin a new **manual** stroke: start `points=[p]`,
+    `_heal_drag = True`.
+- **Mouse-move with `_heal_drag`** → append the current point to the live stroke
+  when it is ≥ (brush radius) from the last point (throttle), and update a live
+  ghost overlay (a polyline of discs). No reprocessing during the drag.
+- **Left-release with `_heal_drag`** → commit the stroke
+  (`source="manual"`, `connect = len(points) > 1`, `radius` = current brush),
+  push one undo step, reprocess.
+- **Right-press on a stroke** → remove it (explicit alternative to left-click
+  toggle). **Right-press on empty** → ignored.
+- **Middle-drag** still pans (the existing `_mid_pan` guard at `:133-147`
+  already lists the interaction flags; add `heal_drag` there).
+
+A single click with no movement commits a one-point stroke (`connect=False`) —
+the manual "heal this missed spot" action.
+
+### 3.5 Brush ring + cursors
+While in heal mode, a `QGraphicsEllipseItem` ring follows the cursor at the
+brush radius (drawn in `mouseMoveEvent`, like the slice ghost line), with a
+bi-color (white-over-black) cosmetic pen so it is visible on bright sky or dark
+frames. **See §9.4** — the brush is sized in **long-side-normalized** units
+(image-relative), not fixed preview pixels, so it is stable across zoom and
+across source resolutions: `S/M/L = 0.004 / 0.008 / 0.016` of `max(W,H)`. The
+ring is drawn in image space so it scales naturally with the displayed image.
+Changing the brush updates the ring immediately and applies to the **next**
+stroke; the radius of an in-progress drag is fixed at drag start.
+
+### 3.6 Auto-Detect button
+`auto_detect_dust()` calls `ccr_backend.detect_dust_by_index(idx, sensitivity)`,
+which runs `dust_removal.detect_dust(img.resized_raw, ...)` on the converted
+positive preview, **replaces the existing auto strokes** (keeps manual strokes),
+stores the merged list on the image, pushes one undo step, reprocesses, and
+saves the catalog. A busy hint is shown for large images. If heal mode is off it
+is auto-entered so the user immediately sees and can curate the results.
+
+### 3.7 Clear Spots button
+`clear_dust()` removes **all** strokes (auto + manual), pushes one undo step,
+reprocesses, saves. (A future enhancement could offer "clear auto only".)
+
+## 4. Data model
+
+### 4.1 Storage
+A new dedicated attribute on `CCRImage` (NOT inside `adjustment_settings`, to
+avoid the slider-rebuild merge hazard that the Curves spec calls out in its
+§4.2):
+
+```python
+# CCRImage.__init__
+self.dust_heal_strokes: list[dict] = []   # [] = nothing to heal
+```
+
+Each stroke is a JSON-clean dict:
+
+```python
+{
+    "points": [[nx, ny], ...],  # normalized 0..1, un-rotated/un-cropped space
+    "radius": 0.0056,           # normalized to max(W, H)
+    "connect": False,           # True => also draw thick lines between points
+    "kind": "spot",             # "spot" | "scratch" (overlay shape hint)
+    "source": "auto",           # "auto" | "manual" (overlay tint + re-detect)
+}
+```
+
+Representations produced:
+- **Manual click** → `points=[p]`, `connect=False`, `kind="spot"`,
+  `source="manual"`.
+- **Manual drag** → ordered `points`, `connect=True`, `kind="scratch"`,
+  `source="manual"`.
+- **Auto round spot** → `points=[centroid]`, `radius = equiv_radius + pad`,
+  `connect=False`, `kind="spot"`, `source="auto"`.
+- **Auto elongated/curly component** → `points` = component pixels grid-sampled
+  at spacing ≈ the disc radius, `radius = half_thickness + pad`, `connect=False`
+  (overlapping discs cover the squiggle with no need for skeleton ordering),
+  `kind="scratch"`, `source="auto"`.
+
+### 4.2 Persistence
+`catalog.py` saves/loads `dust_heal_strokes` alongside the existing per-image
+state (mirroring `crop_rect` at `catalog.py:154-155` save / `:369-371` load):
+- save: `"dust_heal_strokes": img.dust_heal_strokes or []`
+- load: `img.dust_heal_strokes = state.get("dust_heal_strokes", []) or []`
+
+### 4.3 Undo
+`capture_undo_state` (`ccr_image.py:721`) gains a **deep-copied**
+`dust_heal_strokes` entry (each stroke nests a `points` list, so a shallow copy
+would alias live structure — same reasoning as `area_layers` at `:735`).
+`pop_undo_state` (`:749`) restores it. Every add/remove/auto-detect/clear pushes
+exactly one undo step **before** mutating, via the existing
+`push_undo_state()`.
+
+## 5. Processing / math
+
+New module **`src/core/dust_removal.py`** — pure `numpy`/`cv2`, no Qt, no new
+dependencies (OpenCV + NumPy are already required). The two public functions:
+
+### 5.1 `detect_dust(img_u16, sensitivity="med", brush_radius_norm=None) -> list[dict]`
+Input: the converted positive (`resized_raw`, uint16 RGB, ≤1080 px). Steps:
+
+1. **Luminance**: `lum = cv2.transform(img, _LUM_WEIGHTS)` (reuse the weights at
+   `ccr_processor.py:1352`), float32.
+2. **Morphological residuals** with an elliptical kernel sized to the image
+   (`k = odd(round(0.006 * L))`, clamped to `[5, 31]`, `L=max(H,W)`):
+   - `tophat = lum - open(lum, k)` → **bright** dust (the dominant case: bright
+     specks/strings on the positive).
+   - `blackhat = close(lum, k) - lum` → **dark** dust/scratches.
+   - `residual = max(tophat, blackhat)`.
+3. **Threshold** by a robust noise estimate: `thr = k_sens * MAD(residual)` where
+   `MAD` is the median absolute deviation over the whole residual and
+   `k_sens ∈ {Low:5.0, Med:3.5, High:2.5}`. `mask = residual > thr`.
+4. **Connected components** (`cv2.connectedComponentsWithStats`, 8-conn).
+   Filter by area: `min_area = max(2, round((0.0012*L)**2))`,
+   `max_area = round(0.0006 * H * W)` (≈ 0.06 % of the frame; bigger blobs are
+   not "dust").
+5. **Prominence gate** (false-positive control on textured detail): keep a
+   component only if its peak residual exceeds the surrounding annulus median by
+   `> thr` — naturally rejects busy texture where the annulus is itself bright.
+6. **Classify + vectorize** each kept component into a stroke (§4.1):
+   - bbox aspect `≤ 2` and high `solidity` → **spot**: centroid + equivalent
+     radius (`sqrt(area/π)`), `pad = 1px`.
+   - else → **scratch**: grid-sample the component's pixels at spacing
+     `s = max(1, round(half_thickness))` (half_thickness from the component's
+     distance transform), `radius = half_thickness + pad`.
+   Pixel coords → normalized; radius px → `/max(H,W)`.
+
+Returns a list of `source="auto"` strokes. Deterministic (no RNG).
+
+### 5.2 `inpaint_dust(img_u16, strokes, grain=0.5) -> np.ndarray`
+Input: any-resolution converted positive (preview, hi-res tile, or full export).
+
+1. If `not strokes` → return `img` unchanged (same object; preserves the
+   `apply_adjustments` fast path).
+2. **Rasterize** `mask` (uint8, H×W) via `rasterize_strokes(strokes, H, W)`:
+   for each stroke draw filled discs (`cv2.circle`) at every point at
+   `r_px = round(radius * max(H,W))`; if `connect`, also `cv2.line` thick
+   (`2*r_px`) between consecutive points. Dilate the mask by `HEAL_PAD = 2px` so
+   the inpaint covers each defect's soft edge.
+3. **Tile**: compute connected mask regions' bounding boxes, pad each by
+   `r_px + 8`, merge overlapping boxes. Inpaint each tile independently — only
+   small neighborhoods are touched, so cost is ∝ defect count, not image size
+   (important at full export resolution).
+4. **16-bit harmonic fill** per tile (`_inpaint_tile`), numpy/cv2 only, no
+   8-bit round-trip. **See §9.2 for the authoritative solver** (coarse-to-fine
+   seed + iteration formula + gradient-fidelity rationale). In brief: solve the
+   Laplace equation on the hole with Dirichlet BC (known pixels fixed) via a
+   `cv2.blur` relaxation seeded from a `pyrDown`/`pyrUp` coarse fill so few
+   fine-level iterations are needed. At convergence a harmonic fill **reproduces
+   a local linear gradient exactly** (linear ramps are harmonic), so a thin
+   defect across a sky gradient fills to the correct interpolation with no halo —
+   the v1 risk was under-convergence, fixed by the coarse seed.
+   - **Grain** (default on, `grain=0.3`): add deterministic zero-mean Gaussian
+     noise (per channel) scaled to the local std of the known boundary ring, only
+     on `hole`, so the patch isn't a tell-tale smooth blob (§9.2 pins the RNG).
+     `grain=0` disables. Grain is cosmetic and **not** resolution-matched across
+     preview vs. export in v1 (documented limitation).
+   - Write the tile's `hole` pixels back into a copy of `img` (clip to
+     `[0,65535]`, `uint16`).
+
+Telea/Navier-Stokes (`cv2.inpaint`) were considered but are 8-bit-only; the
+harmonic fill is 16-bit-native and ideal for thin defects on smooth backgrounds
+(the target), avoiding the smudgy look 8-bit inpaint can give film grain.
+
+### 5.3 Where it applies (the single hook)
+First step inside `CCRImage.apply_adjustments` (`ccr_image.py:556`), **before**
+the early-return fast path at `:570` so a heal-only edit (no sliders) still
+heals:
+
+```python
+def apply_adjustments(self, image, settings=None, ..., areas_override=None,
+                      dust_strokes_override=None):                 # NEW param
+    s = ...; cb = ...; tb = ...; bb = ...; profile = ...; areas = ...
+    has_areas = ...
+    strokes = (self.dust_heal_strokes if dust_strokes_override is None
+               else dust_strokes_override)                         # NEW
+    if strokes:
+        from core.dust_removal import inpaint_dust
+        image = inpaint_dust(image, strokes)                       # NEW
+    if not s and cb == 0 and tb == 0 and bb == 0 and not has_areas:
+        return self._to_grayscale(image) if profile == "bw" else image
+    adjusted = adjust_image_opencl(image, ...)
+    ...
+```
+
+The `dust_strokes_override` parameter mirrors `areas_override`: the zoom hi-res
+worker (`HiResDetailWorker`) snapshots a deep copy of `dust_heal_strokes` at
+request time and passes it, so a concurrent edit on the GUI thread can't race the
+worker (the worker must not read live `self.dust_heal_strokes`).
+
+This one hook covers **all** render paths automatically:
+- **Preview**: `update_thumbnail_and_preview` → `apply_adjustments(resized_raw)`
+  (`ccr_image.py:473`).
+- **Export**: `ccr_normalize_with_*` → `apply_adjustments(rgb_brightness_normalized)`
+  at full res (`ccr_processor.py:863`), **before** `apply_crop_to_image` (`:871`)
+  and the flips/rotation (`:876-894`) — so strokes in uncropped space line up.
+- **Zoom hi-res detail**: `render_hires_base` returns the converted,
+  pre-adjustment base (`ccr_image.py:663-716`); the zoom worker then calls
+  `apply_adjustments`, so the detail view is healed too.
+
+`_adjust_for_area` (`:621`) operates on the already-globally-adjusted (already
+healed) base and does **not** call `apply_adjustments`, so there is no
+double-healing.
+
+### 5.4 Performance
+Detection on ≤1080 px: a few morphology passes + one CC labeling, ~10–40 ms.
+Inpaint is tiled, so preview re-heal on each add/remove is dominated by a few
+small Jacobi solves (sub-10 ms typical). Export inpaint is the same tiles at
+full res — cost scales with total defect area, not image size.
+
+## 6. Integration points
+
+| Location | Change |
+|---|---|
+| `core/dust_removal.py` (**add**) | `detect_dust`, `inpaint_dust`, `rasterize_strokes`, `_inpaint_tile`, helpers. |
+| `core/ccr_image.py` `__init__` | add `self.dust_heal_strokes = []`. |
+| `core/ccr_image.py` `apply_adjustments:556` | call `inpaint_dust` before the early-return (§5.3). |
+| `core/ccr_image.py` `capture_undo_state:721` / `pop_undo_state:749` | deep-copy / restore `dust_heal_strokes`. |
+| `core/ccr_backend.py` | `detect_dust_by_index(idx, sensitivity)`, `set_dust_heal_strokes_by_index`, `add_dust_stroke_by_index`, `remove_dust_stroke_by_index`, `clear_dust_strokes_by_index`. |
+| `core/catalog.py` `serialize_image:141` / `_restore_image:347` | persist `dust_heal_strokes` (+ `_strokes_from_json` defensive loader, like `_areas_from_json`). |
+| `core/catalog.py` `_is_pristine:168` | add `and not state.get("dust_heal_strokes")` so a heal edit is saved. |
+| `widgets/image_preview.py` toolbar (after Un-convert, before Export) | add Heal toggle, Auto-Detect, Visualize toggle, Clear, brush & sensitivity combos. |
+| `widgets/image_preview.py` `_update_unconvert_action_state` | enable/disable the new controls on convert state + heal mode. |
+| `widgets/image_preview.py` handlers (**new**) | `toggle_heal_mode`, `auto_detect_dust`, `toggle_visualize`, `clear_dust`, `_set_brush`, `_set_sensitivity`, `_draw_dust_overlay`, `_image_transform`, `map_full_to_displayed`, `_heal_hit_test`, `_commit_manual_stroke`. |
+| `widgets/image_preview.py` `apply_transformations:1100-1121` | extract reusable `_image_transform()` (base + fine rotation, no prescale); reuse for authoring + overlay. |
+| `widgets/image_preview.py` `GraphicsImageView` `:127-410` | heal-mode branches in press/move/release + brush ring; `heal_mode`/`_heal_drag` state; add `heal_drag` to the mid-pan interaction guard `:137-141`. |
+| `widgets/image_preview.py` `update_preview:956-966` | reset `self._dust_overlay_items = []`; redraw overlay in `apply_transformations`. Escape-key exits heal mode. |
+| `widgets/image_preview.py` `HiResDetailWorker` | snapshot `dust_heal_strokes` (deep copy) and pass as `dust_strokes_override`. |
+| `tests/test_dust_removal.py` (**add**) | detection + inpaint unit tests (§8 + §9.6). |
+
+Backend API shape:
+
+```python
+# CCRBackend
+def detect_dust_by_index(self, idx, sensitivity="med") -> int   # returns #strokes
+def add_dust_stroke_by_index(self, idx, stroke) -> None
+def remove_dust_stroke_by_index(self, idx, stroke_index) -> None
+def clear_dust_strokes_by_index(self, idx) -> None
+def get_dust_strokes_by_index(self, idx) -> list[dict]
+```
+
+## 7. Files touched / added
+
+- **add** `src/core/dust_removal.py` — detection + 16-bit tiled harmonic inpaint.
+- **edit** `src/core/ccr_image.py` — attribute, `apply_adjustments` hook, undo.
+- **edit** `src/core/ccr_backend.py` — detect/add/remove/clear/get API.
+- **edit** `src/core/catalog.py` — persist `dust_heal_strokes`.
+- **edit** `src/widgets/image_preview.py` — toolbar controls, heal mode, mouse
+  handling, overlay, coordinate helper.
+- **add** `tests/test_dust_removal.py` — unit tests (synthetic injected dust).
+
+## 8. Test plan
+
+Unit (`tests/test_dust_removal.py`, pure numpy/cv2, no Qt — mirrors
+`tests/test_curves.py` / `test_area_editing.py` synthetic-image patterns):
+- **Detect single bright spot**: inject a bright disc on a noisy smooth gradient;
+  `detect_dust` returns ≥1 stroke whose point is within tolerance of the center.
+- **Detect multiple spots**: 3 injected spots → ≥3 strokes.
+- **Detect a curly/elongated streak**: inject a thin bright squiggle → a
+  `kind="scratch"` stroke whose disc-set, when rasterized, covers ≥80 % of the
+  injected streak pixels.
+- **No false positives on a clean image**: clean noisy gradient → ≤ small
+  tolerance (≤2) strokes; sensitivity Low stricter than High.
+- **Inpaint removes the spot**: `inpaint_dust` makes the healed region closer to
+  the pre-dust original (lower MAE) than the dusty input.
+- **Inpaint preserves untouched pixels**: pixels far from any stroke are exactly
+  unchanged (`array_equal` on far corners).
+- **Empty strokes is identity**: `inpaint_dust(img, [])` returns the same object.
+- **dtype/shape**: output is `uint16`, same shape.
+- **Resolution independence**: rasterizing the same normalized strokes at 1× and
+  2× yields geometrically matching masks (centroid/coverage scales correctly).
+
+Manual:
+- Heal toggle only enabled after Convert; entering shows the hint + overlay.
+- Auto-Detect marks the sky spots; Low/Med/High change how many are found.
+- Click a marked spot → it disappears (un-healed); the dust reappears.
+- Click an unmarked spot → it heals; drag along the curly string → it heals.
+- Brush S/M/L changes the ring + healed footprint.
+- Clear Spots removes everything; Undo restores; survives image switch, app
+  restart (catalog), and is visible in zoom detail + the exported TIFF/JPEG.
+- A cropped image heals correctly (strokes in uncropped space, healed before
+  crop); a rotated/flipped/B&W image heals in the right place.
+
+## 9. Refinement (v2) — resolved decisions & added detail
+
+### 9.1 Coordinate transform must invert fine rotation (correctness)
+The v1 §3.3 chain used the coarse-only `_base_transform` (the same one the Crop
+and B/W-point tools use), which does **not** invert the straighten "fine
+rotation". Healing, unlike crop, runs with fine rotation *displayed*, so a click
+on the rotated view would be stored in the wrong pixels. Verified against code:
+
+- The displayed `pixmap_item` carries `pre * img_transform`, where `img_transform`
+  = coarse base **+ fine rotation** (`apply_transformations`,
+  `image_preview.py:1100-1131`); `pre` is the hi-res prescale.
+- Scene relates to **preview-local** by `img_transform` alone (the prescale maps
+  hi-res-local → preview footprint), so the inverse map is
+  `_image_transform().inverted()` with `_image_transform()` = base + fine
+  rotation, **no prescale**. This works whether or not a hi-res pixmap is
+  displayed.
+
+So authoring uses `_image_transform().inverted()[0].map(scene)` →
+`map_displayed_to_full` → normalize; the overlay uses the forward
+`_image_transform()` on items built in preview-local via `map_full_to_displayed`.
+
+**Why this is correct at export for both conversion modes** (verified):
+- *Reference mode*: `resized_raw` is **not** fine-rotated; at export, fine
+  rotation is applied only to the 1080 reference copy for percentiles
+  (`ccr_processor.py:666-675`), and the working array reaching `apply_adjustments`
+  (`:863`) is **not** fine-rotated → same space as `resized_raw` → strokes align.
+- *B/W-point mode*: `resized_raw` **is** fine-rotated (baked at `:1029-1034`), and
+  the export array reaching `apply_adjustments` (`:1107`) is fine-rotated once
+  too → still the same space → strokes align. (The bwpoint export then rotates
+  the *already-healed* result again at `:1147-1160` — a **pre-existing**
+  double-rotation bug, out of scope here; healing rides along with the content.)
+
+**Constraint (documented):** author heal strokes *after* setting the straighten
+slider. In ref mode, changing fine rotation afterward is safe (strokes live in
+the non-rotated space; the view/export rotate the healed result as a whole). In
+bwpoint mode, changing fine rotation after authoring can shift strokes (its
+`resized_raw` is re-baked); the UI hint notes "straighten before healing".
+
+### 9.2 Inpaint solver — convergence, gradient fidelity, grain RNG
+`_inpaint_tile(tile_u16, hole_mask, grain)` solves Laplace with Dirichlet BC.
+A naïve mean-seeded `cv2.blur` Jacobi loop converges too slowly for wide holes
+(the v1 `iters = 3*thickness` was wrong). Authoritative algorithm:
+
+1. **Coarse-to-fine seed** (multigrid V-cycle, `cv2.pyrDown`/`pyrUp`, numpy/cv2
+   only): downsample tile+mask by 2 until the hole's max thickness ≤ 4 px (≤ 3
+   levels), fill the coarsest level by mean-seed + a few relaxations, then
+   `pyrUp` each level as the seed for the next and relax. This removes the
+   slow low-frequency error so the fine level needs few passes.
+2. **Fine relaxation** (per level): `filled = float32(tile)`;
+   `filled[hole] = cv2.blur(filled,(3,3))[hole]` for
+   `iters = clip(round(1.5 * level_thickness), 8, 64)` (`level_thickness` =
+   `2 * max(distanceTransform(hole))` at that level). Known pixels stay pinned
+   (Dirichlet), so the boundary tone/gradient is honored exactly.
+3. **Gradient fidelity:** at convergence the harmonic solution is exact for any
+   locally-linear ramp (linear functions are harmonic) — a thin scratch across a
+   sky gradient fills to the correct linear interpolation, no halo. The seam risk
+   is purely under-convergence, eliminated by step 1. Tested in §9.6.
+4. **Grain (cosmetic, default `GRAIN=0.3`):**
+   `rng = np.random.RandomState(int(tile.mean()) & 0xFFFFFFFF)`; per channel add
+   `rng.normal(0, GRAIN * std(known_ring), size=hole.sum())` to `filled[hole]`,
+   where `known_ring` = pixels within `dilate(hole, 6px) \ hole`. Deterministic
+   (reproducible tests). Not spectrum- or resolution-matched in v1 (limitation).
+
+### 9.3 Visualize Dust mode (added to v1)
+A checkable **Visualize** toolbar toggle (enabled only in heal mode). When on,
+`update_preview` renders a high-contrast "find dust" view instead of the normal
+positive: `vis = normalize(|lum - median_blur(lum, k)|)` stretched and shown
+desaturated, so specks/scratches pop. It is **display-only** (never stored,
+never exported), implemented as a branch in the preview compose path keyed on
+`self.dust_visualize`. Auto-Detect and manual healing operate on the real
+`resized_raw` regardless of the visualize toggle. This makes curation feasible
+(dust is otherwise sub-pixel at fit zoom).
+
+### 9.4 Brush sizing is image-relative (not preview pixels)
+Brush radius is stored **normalized to the long side** (`r_norm`), with
+`S/M/L = 0.004 / 0.008 / 0.016` (≈ 0.4 / 0.8 / 1.6 % of `max(W,H)`; ~24/48/96
+source px on a 6000 px scan, ~4/8/16 px on a 1080 preview). The ring is drawn in
+image space (transformed by `_image_transform()`), so it tracks the true footprint
+at every zoom — fixing the v1 "16 px ring dwarfs the dust at 100 %" problem.
+`Med` is the default.
+
+### 9.5 Interaction: disambiguation, exit, feedback
+- **Left-click toggle is retained** (the user's explicit ask is "click a detected
+  spot to remove it" / "click a missed spot to heal it"). Disambiguation: a
+  left-press whose image point is inside an existing stroke's core
+  (`HEAL_HIT` = stroke radius, in screen px via `_view_scale`) **removes** that
+  stroke; otherwise it **starts a heal**. Removal is non-destructive + a single
+  undo step; the hint always shows "Ctrl+Z undoes". **Right-click** is an explicit
+  remove-under-cursor.
+- **Escape** exits heal mode (handled like Crop/Area exit), in addition to the
+  implicit exit on any external `update_preview`.
+- **Feedback:** the hint shows live counts, e.g. "12 spots (9 auto, 3 manual) ·
+  click to remove/heal · Ctrl+Z undo · Esc exit". After Auto-Detect it shows
+  "Detected N spots (replaced M previous auto)".
+- **Re-run policy:** Auto-Detect replaces prior **auto** strokes, keeps manual.
+  This is undoable, and the count message states what was replaced, so a
+  sensitivity re-run is recoverable. (A merge dialog is a possible later
+  enhancement, not v1.)
+- **Brush mid-drag:** size change applies to the *next* stroke; the active drag
+  keeps its start radius.
+- **Overlay tints:** auto = `(0,180,255)` (cyan-blue), manual = `(0,210,0)`
+  (green), live drag ghost = `(255,210,0)` (amber); each with a 1 px black
+  cosmetic outline for contrast.
+
+### 9.6 Detection: shape classifier, false-positive control, round-trip
+- **Shape filter** (replaces vague "high solidity"): for each thresholded
+  component compute `aspect = max(w,h)/min(w,h)` and `solidity = area/hull_area`.
+  Keep as a **spot** iff `aspect ≤ 2 AND solidity ≥ 0.6`; keep as a **scratch**
+  iff `aspect > 2 AND area ≥ 4*min(w,h) AND solidity < 0.6`; otherwise **reject**
+  (rejects mid-size solid blobs that are usually real subject detail).
+- **Prominence gate** (concrete): `annulus` = `dilate(component, 3*half_thickness)
+  \ dilate(component, 1)`; keep only if `max(residual[component]) -
+  median(residual[annulus]) > thr`. Rejects components sitting on already-bright
+  texture.
+- **Curly round-trip:** scratch components are grid-sampled at spacing
+  `s = max(1, round(0.7 * radius_px))` so the rasterized discs (radius `r_px`)
+  always overlap (pitch `< 2·r_px`) → guaranteed coverage of curls/forks; radius
+  is normalized, so coverage scales at export.
+- **False positives are expected** (§2) and handled by curation; defaults err
+  toward fewer detections (Low/Med) to keep curation light.
+- **Added tests** (beyond §8): (a) thin 2 px scratch across a 50-level gradient →
+  healed gradient slope within ±5 % of the original (no halo); (b) synthetic
+  curly streak → detect → rasterize at 1×/2×/3× with matching strokes → IoU ≥ 0.8
+  at every scale; (c) two runs of `inpaint_dust` on the same input are bit-identical
+  (grain RNG determinism); (d) a bright "flower-like" solid blob (aspect≈1.3,
+  large area) is **rejected** by the shape filter at Med sensitivity.
+
+### 9.7 Tuned constants (module-level in `dust_removal.py`)
+Starting defaults, exposed as named constants for easy tuning (we cannot run a
+50-image empirical sweep here; these are conservative and curation covers the
+rest). `L = max(H, W)` of the array being processed.
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `MORPH_KERNEL` | `odd(round(0.006*L))`, clamp `[5, 51]` | top-hat/black-hat ellipse size |
+| `K_SENS` | `{low:5.0, med:3.5, high:2.5}` | threshold = `K_SENS * MAD(residual)` |
+| `MIN_AREA` | `max(2, round((0.0012*L)**2))` | reject sub-grain specks |
+| `MAX_AREA` | `round(0.0006*H*W)` | bigger ⇒ not "dust" |
+| `ASPECT_SPOT` / `SOLIDITY_SPOT` | `2.0` / `0.6` | spot vs. scratch split |
+| `SCRATCH_SAMPLE` | `0.7 * radius_px` | grid spacing for curly components |
+| `HEAL_PAD` | `max(1, round(0.002*L))` (~2 px@1080, ~6 px@3000) | mask dilation before fill |
+| `TILE_PAD` | `r_px + 8` (current res) | inpaint tile bbox padding |
+| `GRAIN` | `0.3` | grain strength (×local std); `0` disables |
+| `BRUSH_NORM` | `{S:0.004, M:0.008, L:0.016}` | brush radius / `L` |
+| `LUM_WEIGHTS` | Rec.601 (reuse `ccr_processor._LUM_WEIGHTS`) | luminance for detection |
+
+All sizes derive from `L`, so detection/fill behave consistently from the 1080
+preview up to a full-res export.
+
+### 9.8 Persistence / undo / worker / copy-paste integration
+- **Catalog:** `serialize_image` (`catalog.py:141`) adds
+  `"dust_heal_strokes": img.dust_heal_strokes or []`; `_restore_image`
+  (`:347`, after the crop restore at `:371`) sets
+  `img.dust_heal_strokes = _strokes_from_json(state.get("dust_heal_strokes"))`
+  (a new defensive loader mirroring `_areas_from_json`, dropping malformed
+  entries); `_is_pristine` (`:168`) gains `and not state.get("dust_heal_strokes")`.
+- **Undo:** `capture_undo_state` (`ccr_image.py:721`) adds
+  `"dust_heal_strokes": copy.deepcopy(self.dust_heal_strokes)` (deep, like
+  `area_layers` at `:735`); `pop_undo_state` (`:749`) restores a deep copy.
+- **Zoom worker:** `HiResDetailWorker` deep-copies `dust_heal_strokes` at
+  construction and passes `dust_strokes_override` (§5.3) so it never reads live
+  state.
+- **Copy/Paste adjustments & Sync-to-All:** these operate on
+  `adjustment_settings` only; since strokes are a **separate attribute**, they are
+  automatically excluded — which is correct, dust is physical to one frame. No
+  code needed; called out so a future refactor doesn't accidentally fold strokes
+  into the adjustment dict.
+
+### 9.9 Out-of-scope confirmations & known limitations
+- Clone-source picking, batch detect-across-frames, Sync-to-All of strokes,
+  per-point smoothing, and a GPU path remain non-goals.
+- **Known limitations:** (1) fills on fine *texture* read as smudges (§2); (2)
+  healed-region grain is not spectrum/resolution-matched (§9.2); (3) the
+  pre-existing bwpoint export double-fine-rotation bug is not fixed here; (4)
+  changing fine rotation *after* authoring can shift bwpoint strokes (§9.1).

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -162,6 +162,8 @@ def serialize_image(img) -> dict:
         "brightness_base": int(img.brightness_base),
         "tint_balance_factor": float(getattr(img, "tint_balance_factor", 1.0)),
         "reference_frame": list(img.reference_frame) if img.reference_frame else None,
+        "dust_heal_strokes": [dict(s) for s in
+                              (getattr(img, "dust_heal_strokes", None) or [])],
     }
 
 
@@ -174,7 +176,8 @@ def _is_pristine(state: dict) -> bool:
             and state["crop_rect"] is None
             and state["rotation_angle"] == 0 and state["fine_rotation_angle"] == 0
             and not state["horizontal_mirrored"] and not state["vertical_mirrored"]
-            and state["reference_frame"] is None)
+            and state["reference_frame"] is None
+            and not state.get("dust_heal_strokes"))
 
 
 def _prune(catalog: dict) -> None:
@@ -369,6 +372,8 @@ def _restore_image(file_path: str, state: dict):
     crop = state.get("crop_rect")
     img.crop_rect = tuple(crop) if crop else None
     img.crop_angle = state.get("crop_angle", 0.0) or 0.0
+    from core.dust_removal import clean_strokes
+    img.dust_heal_strokes = clean_strokes(state.get("dust_heal_strokes"))
     img.tint_balance_factor = state.get("tint_balance_factor",
                                         getattr(img, "tint_balance_factor", 1.0))
 

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -426,6 +426,52 @@ class CCRBackend:
         if reprocess:
             img.update_thumbnail_and_preview()
 
+    # --- Dust healing (see core/dust_removal.py, spec/dust-healing.md) ------
+    def get_dust_strokes_by_index(self, idx: int) -> list:
+        img = self._image_at(idx)
+        return list(getattr(img, "dust_heal_strokes", []) or []) if img else []
+
+    def detect_dust_by_index(self, idx: int, sensitivity: str = "med") -> tuple:
+        """Auto-detect dust on the converted positive. Replaces previous AUTO
+        strokes, keeps manual ones. Returns (n_detected, n_replaced)."""
+        img = self._image_at(idx)
+        if img is None or not getattr(img, "converted", False) \
+                or img.resized_raw is None:
+            return (0, 0)
+        from core.dust_removal import detect_dust
+        detected = detect_dust(img.resized_raw, sensitivity)
+        prev = list(getattr(img, "dust_heal_strokes", []) or [])
+        manual = [s for s in prev if s.get("source") != "auto"]
+        n_replaced = len(prev) - len(manual)
+        img.dust_heal_strokes = manual + detected
+        img.update_thumbnail_and_preview()
+        return (len(detected), n_replaced)
+
+    def add_dust_stroke_by_index(self, idx: int, stroke: dict) -> None:
+        img = self._image_at(idx)
+        if img is None:
+            return
+        img.dust_heal_strokes = (list(getattr(img, "dust_heal_strokes", []) or [])
+                                 + [dict(stroke)])
+        img.update_thumbnail_and_preview()
+
+    def remove_dust_stroke_by_index(self, idx: int, stroke_index: int) -> None:
+        img = self._image_at(idx)
+        if img is None:
+            return
+        strokes = list(getattr(img, "dust_heal_strokes", []) or [])
+        if 0 <= stroke_index < len(strokes):
+            del strokes[stroke_index]
+            img.dust_heal_strokes = strokes
+            img.update_thumbnail_and_preview()
+
+    def clear_dust_strokes_by_index(self, idx: int) -> None:
+        img = self._image_at(idx)
+        if img is None:
+            return
+        img.dust_heal_strokes = []
+        img.update_thumbnail_and_preview()
+
     def get_image_count(self) -> int:
         return len(self.images)
     

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -112,6 +112,12 @@ class CCRImage:
         # The global adjustment_settings is the implicit "whole image" layer;
         # areas composite additively on top of it (see spec/area-editing.md).
         self.area_layers: List[Dict[str, Any]] = list(areas) if areas else []
+        # Dust healing: a list of resolution-independent vector "strokes" (see
+        # core/dust_removal.py and spec/dust-healing.md). Normalized coords in
+        # the same un-rotated/un-cropped space as crop_rect; replayed in
+        # apply_adjustments so healing shows at every resolution. Per-image
+        # only (dust is physical to one frame) — excluded from copy/paste/sync.
+        self.dust_heal_strokes: List[Dict[str, Any]] = []
         # Which layer the adjustment panel currently edits: None = global
         # (whole image); otherwise the id of an area in area_layers. Session
         # state only — never persisted; always defaults to global on load.
@@ -555,7 +561,8 @@ class CCRImage:
 
     def apply_adjustments(self, image: np.ndarray, settings=None, contrast_base=None,
                           temperature_base=None, brightness_base=None,
-                          color_profile=None, areas_override=None) -> np.ndarray:
+                          color_profile=None, areas_override=None,
+                          dust_strokes_override=None) -> np.ndarray:
         """Apply the slider adjustments. The optional overrides let the zoom
         hi-res worker render from a snapshot taken at request time instead of
         live state the GUI thread may be mutating concurrently."""
@@ -567,6 +574,14 @@ class CCRImage:
         areas = (getattr(self, "area_layers", []) if areas_override is None
                  else areas_override)
         has_areas = bool(areas) and any(a.get("enabled") for a in areas)
+        # Dust healing runs FIRST (on the converted positive), before the
+        # early-return, so a heal-only edit still applies. Resolution
+        # independent: strokes are normalized to this array's dimensions.
+        strokes = (getattr(self, "dust_heal_strokes", None)
+                   if dust_strokes_override is None else dust_strokes_override)
+        if strokes:
+            from core.dust_removal import inpaint_dust
+            image = inpaint_dust(image, strokes)
         if not s and cb == 0 and tb == 0 and bb == 0 and not has_areas:
             # No slider/base/area adjustments — but Black & White still has to
             # map the image to a single luminance channel.
@@ -733,6 +748,9 @@ class CCRImage:
             # sub-dict) and a geometry dict — a shallow copy would alias the
             # live structure and a later edit would corrupt the snapshot.
             "area_layers": copy.deepcopy(getattr(self, "area_layers", [])),
+            # Each stroke nests a points list — deep-copy so a later edit
+            # can't corrupt the snapshot (same reasoning as area_layers).
+            "dust_heal_strokes": copy.deepcopy(getattr(self, "dust_heal_strokes", [])),
         }
 
     def push_undo_state(self) -> None:
@@ -761,6 +779,7 @@ class CCRImage:
         self.horizontal_mirrored = state["horizontal_mirrored"]
         self.vertical_mirrored = state["vertical_mirrored"]
         self.area_layers = copy.deepcopy(state.get("area_layers", []))
+        self.dust_heal_strokes = copy.deepcopy(state.get("dust_heal_strokes", []))
         # The previously-active area may have been added back/removed by this
         # undo; the panel re-resolves None -> global if the id is now stale.
         active_id = getattr(self, "active_area_id", None)

--- a/src/core/dust_removal.py
+++ b/src/core/dust_removal.py
@@ -1,0 +1,393 @@
+"""Dust & scratch detection + 16-bit inpainting for FreeCCR.
+
+Pure ``numpy`` + OpenCV (no Qt, no scipy/skimage) so it stays Nuitka-friendly
+and unit-testable headless. Operates on the CONVERTED POSITIVE (uint16 RGB),
+where film dust shows as small bright specks and thin bright/dark scratches.
+
+Heal strokes are resolution-independent vectors stored on ``CCRImage`` and
+replayed through ``CCRImage.apply_adjustments`` at preview, zoom, and export
+resolutions. A stroke dict::
+
+    {"points":  [[nx, ny], ...],   # normalized 0..1, resized_raw (un-cropped) space
+     "radius":  float,             # normalized to max(H, W)
+     "connect": bool,              # also draw thick lines between consecutive pts
+     "kind":    "spot" | "scratch",
+     "source":  "auto" | "manual"}
+
+See ``spec/dust-healing.md`` (§5, §9) for the full design.
+"""
+from __future__ import annotations
+
+import numpy as np
+import cv2
+
+# --- tunable constants (spec §9.7) -----------------------------------------
+SENSITIVITY_K = {"low": 6.0, "med": 4.5, "high": 3.0}
+KERNEL_FRAC = 0.01           # morphology kernel ~ this fraction of the long side
+                             # (detects dust up to ~half the kernel in radius)
+MIN_KERNEL = 5
+MAX_KERNEL = 51
+MIN_AREA_FRAC = 0.0012       # min defect "radius" ~ this fraction of L (squared -> area)
+MAX_AREA_FRAC = 0.05         # generous backstop; thin scratches are large-area but valid
+                             # (real size gate is thickness, MAX_THICK_KERNELS below)
+MAX_THICK_KERNELS = 1.0      # reject components thicker (inscribed radius) than this x kernel
+                             # — a blob fatter than the morphology kernel isn't dust
+ASPECT_SPOT = 2.0            # bbox aspect <= this AND solid enough -> spot, else scratch
+SOLIDITY_SPOT = 0.6
+SCRATCH_SAMPLE = 0.7         # grid spacing for scratch disc-sets, x the disc radius
+HEAL_PAD_FRAC = 0.002        # mask dilation before inpaint ~ this fraction of L
+TILE_EXTRA_PAD = 8           # extra px around each inpaint tile bbox
+GRAIN = 0.3                  # grain strength (x local boundary std); 0 disables
+MG_MAX_LEVELS = 3            # coarse-to-fine pyramid depth cap for the harmonic fill
+
+# Brush radii for the manual heal tool, normalized to the image long side.
+BRUSH_NORM = {"S": 0.004, "M": 0.008, "L": 0.016}
+
+# Rec.601 luminance (matches ccr_processor._LUM_WEIGHTS).
+_LUM_WEIGHTS = np.array([[0.299, 0.587, 0.114]], dtype=np.float32)
+
+
+# --- small helpers ---------------------------------------------------------
+def _odd(n: float) -> int:
+    n = int(round(n))
+    return n + 1 if n % 2 == 0 else n
+
+
+def _luminance(img_u16: np.ndarray) -> np.ndarray:
+    """HxWx3 uint16 RGB -> HxW float32 luminance."""
+    return cv2.transform(img_u16.astype(np.float32), _LUM_WEIGHTS)
+
+
+def _half_thickness(comp_u8: np.ndarray) -> float:
+    """Inscribed-circle radius (half the local thickness) of a binary mask.
+    A zero border is added first so a component that fills its bbox still has a
+    background to measure against — otherwise distanceTransform returns FLT_MAX."""
+    padded = cv2.copyMakeBorder(comp_u8, 1, 1, 1, 1, cv2.BORDER_CONSTANT, value=0)
+    dt = cv2.distanceTransform(padded, cv2.DIST_L2, 3)
+    return float(dt.max())
+
+
+def _grid_subsample(xs: np.ndarray, ys: np.ndarray, spacing: int) -> list:
+    """Return indices keeping one point per ``spacing``-sized grid cell, so the
+    kept points are at most ~sqrt(2)*spacing apart — discs of radius >= spacing
+    then overlap and fully cover the component (spec §9.6)."""
+    spacing = max(1, int(spacing))
+    seen = set()
+    keep = []
+    gx = (xs // spacing).astype(np.int64)
+    gy = (ys // spacing).astype(np.int64)
+    for i in range(xs.shape[0]):
+        key = (int(gx[i]), int(gy[i]))
+        if key in seen:
+            continue
+        seen.add(key)
+        keep.append(i)
+    return keep
+
+
+def clean_strokes(strokes) -> list:
+    """Drop malformed/empty strokes and coerce types — defensive against
+    hand-edited or legacy catalogs (used by the catalog loader too)."""
+    out = []
+    for s in (strokes or []):
+        if not isinstance(s, dict):
+            continue
+        pts = s.get("points")
+        if not isinstance(pts, (list, tuple)) or not pts:
+            continue
+        clean_pts = []
+        for p in pts:
+            try:
+                x, y = float(p[0]), float(p[1])
+            except (TypeError, ValueError, IndexError):
+                continue
+            clean_pts.append([x, y])
+        if not clean_pts:
+            continue
+        try:
+            radius = float(s.get("radius", 0.006))
+        except (TypeError, ValueError):
+            radius = 0.006
+        out.append({
+            "points": clean_pts,
+            "radius": max(1e-4, radius),
+            "connect": bool(s.get("connect", False)),
+            "kind": s.get("kind", "spot"),
+            "source": s.get("source", "manual"),
+        })
+    return out
+
+
+# --- detection -------------------------------------------------------------
+def detect_dust(img_u16: np.ndarray, sensitivity: str = "med") -> list:
+    """Detect dust spots and scratches on a converted positive (uint16 RGB).
+
+    Returns a list of ``source="auto"`` stroke dicts (normalized coords).
+    Deterministic; no RNG.
+    """
+    if img_u16 is None or getattr(img_u16, "ndim", 0) != 3:
+        return []
+    h, w = img_u16.shape[:2]
+    L = max(h, w)
+
+    k = int(np.clip(_odd(KERNEL_FRAC * L), MIN_KERNEL, MAX_KERNEL))
+    lum = _luminance(img_u16)
+    # Light pre-smooth so isolated 1-2 px film grain doesn't read as dust
+    # (real specks are several px and survive a 3x3 blur).
+    lum = cv2.GaussianBlur(lum, (3, 3), 0)
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k, k))
+    tophat = cv2.morphologyEx(lum, cv2.MORPH_TOPHAT, kernel)
+    blackhat = cv2.morphologyEx(lum, cv2.MORPH_BLACKHAT, kernel)
+    residual = np.maximum(tophat, blackhat)
+
+    # Robust threshold from the median absolute deviation (noise-adaptive).
+    med = float(np.median(residual))
+    mad = float(np.median(np.abs(residual - med)))
+    spread = 1.4826 * mad + 1e-6          # ~ robust std
+    k_sens = SENSITIVITY_K.get(sensitivity, SENSITIVITY_K["med"])
+    thr = med + k_sens * spread
+    mask = (residual > thr).astype(np.uint8)
+    if int(mask.sum()) == 0:
+        return []
+
+    min_area = max(4, int(round((MIN_AREA_FRAC * L) ** 2)))
+    max_area = max(min_area + 1, int(round(MAX_AREA_FRAC * h * w)))
+
+    num, labels, stats, centroids = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    strokes = []
+    for lbl in range(1, num):
+        area = int(stats[lbl, cv2.CC_STAT_AREA])
+        if area < min_area or area > max_area:
+            continue
+        x = int(stats[lbl, cv2.CC_STAT_LEFT])
+        y = int(stats[lbl, cv2.CC_STAT_TOP])
+        cw = int(stats[lbl, cv2.CC_STAT_WIDTH])
+        ch = int(stats[lbl, cv2.CC_STAT_HEIGHT])
+        comp = (labels[y:y + ch, x:x + cw] == lbl).astype(np.uint8)
+
+        # Half-thickness (inscribed-circle radius). A component fatter than the
+        # morphology kernel is a blob/real subject, not dust — reject it. This is
+        # the true size gate (area would wrongly reject long thin scratches).
+        half_thk = _half_thickness(comp)
+        if half_thk > MAX_THICK_KERNELS * k:
+            continue
+
+        # Shape descriptors.
+        aspect = max(cw, ch) / max(1, min(cw, ch))
+        cnts, _ = cv2.findContours(comp, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not cnts:
+            continue
+        cnt = max(cnts, key=cv2.contourArea)
+        hull_area = cv2.contourArea(cv2.convexHull(cnt))
+        solidity = (area / hull_area) if hull_area > 0 else 1.0
+
+        # Prominence gate: the peak must stand above its local surroundings.
+        if not _is_prominent(residual, labels, lbl, x, y, cw, ch,
+                             half_thk, k_sens * spread):
+            continue
+
+        is_spot = (aspect <= ASPECT_SPOT and solidity >= SOLIDITY_SPOT)
+        if is_spot:
+            cx, cy = float(centroids[lbl][0]), float(centroids[lbl][1])
+            r_px = max(half_thk, float(np.sqrt(area / np.pi))) + 1.0
+            strokes.append({
+                "points": [[cx / w, cy / h]],
+                "radius": r_px / L,
+                "connect": False,
+                "kind": "spot",
+                "source": "auto",
+            })
+        else:
+            r_px = max(1.0, half_thk) + 1.0
+            spacing = max(1, int(round(SCRATCH_SAMPLE * r_px)))
+            ys, xs = np.nonzero(comp)
+            keep = _grid_subsample(xs, ys, spacing)
+            pts = [[(x + int(xs[i])) / w, (y + int(ys[i])) / h] for i in keep]
+            if not pts:
+                pts = [[(x + cw / 2.0) / w, (y + ch / 2.0) / h]]
+            strokes.append({
+                "points": pts,
+                "radius": r_px / L,
+                "connect": False,
+                "kind": "scratch",
+                "source": "auto",
+            })
+    return strokes
+
+
+def _is_prominent(residual, labels, lbl, x, y, cw, ch, half_thk, bar) -> bool:
+    """True if the component's peak residual exceeds its surrounding-annulus
+    median by more than ``bar`` (rejects detail sitting on bright texture)."""
+    pad = int(min(50, max(2, round(3 * max(1.0, half_thk)))))
+    y0 = max(0, y - pad)
+    x0 = max(0, x - pad)
+    y1 = min(residual.shape[0], y + ch + pad)
+    x1 = min(residual.shape[1], x + cw + pad)
+    sub_lbl = labels[y0:y1, x0:x1]
+    sub_res = residual[y0:y1, x0:x1]
+    comp = (sub_lbl == lbl)
+    if not comp.any():
+        return False
+    comp_u8 = comp.astype(np.uint8)
+    ker = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3))
+    dil1 = cv2.dilate(comp_u8, ker, iterations=1)
+    big = cv2.dilate(comp_u8, ker, iterations=pad)
+    annulus = (big > 0) & (dil1 == 0)
+    if not annulus.any():
+        return True
+    peak = float(sub_res[comp].max())
+    ann_med = float(np.median(sub_res[annulus]))
+    return (peak - ann_med) > bar
+
+
+# --- rasterization + inpainting -------------------------------------------
+def rasterize_strokes(strokes, h: int, w: int, pad_px: int = 0) -> np.ndarray:
+    """Render strokes to a uint8 {0,255} mask of shape (h, w). Discs at every
+    point (+ thick lines between consecutive points when ``connect``); finally
+    dilated by ``pad_px`` so the inpaint covers each defect's soft edge."""
+    mask = np.zeros((h, w), np.uint8)
+    L = max(h, w)
+    for st in (strokes or []):
+        r = max(1, int(round(float(st.get("radius", 0.006)) * L)))
+        pts = [(int(round(px * w)), int(round(py * h)))
+               for px, py in st.get("points", [])]
+        for (px, py) in pts:
+            cv2.circle(mask, (px, py), r, 255, -1)
+        if st.get("connect") and len(pts) >= 2:
+            for a, b in zip(pts, pts[1:]):
+                cv2.line(mask, a, b, 255, thickness=2 * r)
+    if pad_px > 0 and mask.any():
+        ker = cv2.getStructuringElement(cv2.MORPH_ELLIPSE,
+                                        (2 * pad_px + 1, 2 * pad_px + 1))
+        mask = cv2.dilate(mask, ker)
+    return mask
+
+
+def inpaint_dust(img_u16: np.ndarray, strokes, grain: float = GRAIN) -> np.ndarray:
+    """Heal ``strokes`` on a converted positive of any resolution. Returns the
+    input unchanged (same object) when there is nothing to heal."""
+    if not strokes:
+        return img_u16
+    if img_u16.dtype != np.uint16:
+        img_u16 = img_u16.astype(np.uint16)
+    h, w = img_u16.shape[:2]
+    L = max(h, w)
+    pad = max(1, int(round(HEAL_PAD_FRAC * L)))
+    mask = rasterize_strokes(strokes, h, w, pad_px=pad)
+    if not mask.any():
+        return img_u16
+
+    out = img_u16.copy()
+    # Tile by connected mask regions so cost scales with defect area, not image.
+    num, labels, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    tile_pad = TILE_EXTRA_PAD + pad
+    for lbl in range(1, num):
+        x = int(stats[lbl, cv2.CC_STAT_LEFT])
+        y = int(stats[lbl, cv2.CC_STAT_TOP])
+        cw = int(stats[lbl, cv2.CC_STAT_WIDTH])
+        ch = int(stats[lbl, cv2.CC_STAT_HEIGHT])
+        y0 = max(0, y - tile_pad)
+        x0 = max(0, x - tile_pad)
+        y1 = min(h, y + ch + tile_pad)
+        x1 = min(w, x + cw + tile_pad)
+        tile = out[y0:y1, x0:x1]                      # view into out
+        tmask = (labels[y0:y1, x0:x1] == lbl).astype(np.uint8)
+        if not tmask.any():
+            continue
+        filled = _inpaint_tile(tile, tmask, grain)
+        hole = tmask.astype(bool)
+        tile[hole] = np.clip(filled, 0, 65535).astype(np.uint16)[hole]
+    return out
+
+
+def _inpaint_tile(tile_u16: np.ndarray, hole_mask: np.ndarray,
+                  grain: float) -> np.ndarray:
+    """16-bit harmonic fill of one tile (float32 result, known pixels exact)."""
+    f = tile_u16.astype(np.float32)
+    hole = hole_mask.astype(bool)
+    known = ~hole
+    if not hole.any():
+        return f
+    if not known.any():
+        f[:] = float(f.mean())
+        return f
+    filled = _harmonic_fill(f, hole)
+    if grain > 0:
+        _add_grain(filled, hole, f, grain)
+    return filled
+
+
+def _jacobi(f: np.ndarray, hole: np.ndarray, iters: int) -> np.ndarray:
+    """Relax ``f`` toward the harmonic solution, keeping known pixels fixed."""
+    if iters <= 0:
+        return f
+    hole3 = np.repeat(hole[..., None], f.shape[2], axis=2)
+    for _ in range(iters):
+        blur = cv2.blur(f, (3, 3))
+        f[hole3] = blur[hole3]
+    return f
+
+
+def _harmonic_fill(f: np.ndarray, hole: np.ndarray) -> np.ndarray:
+    """Solve Laplace on the hole with Dirichlet BC via a coarse-to-fine seed,
+    so wide holes converge in few fine iterations (spec §9.2). Reproduces a
+    local linear gradient exactly, so thin defects on a sky gradient heal with
+    no halo."""
+    h, w = hole.shape
+    dt = cv2.distanceTransform(hole.astype(np.uint8), cv2.DIST_L2, 3)
+    thick = 2.0 * float(dt.max())
+
+    # Mean-seed the hole interior (known pixels stay exact).
+    known = ~hole
+    for c in range(f.shape[2]):
+        ch = f[..., c]
+        ch[hole] = float(ch[known].mean())
+
+    # Decide pyramid depth.
+    levels = 0
+    while (thick / (2 ** levels)) > 4 and (min(h, w) >> (levels + 1)) >= 8 \
+            and levels < MG_MAX_LEVELS:
+        levels += 1
+
+    pyr_f = [f]
+    pyr_hole = [hole]
+    for _ in range(levels):
+        pyr_f.append(cv2.pyrDown(pyr_f[-1]))
+        ph, pw = pyr_f[-1].shape[:2]
+        hm = cv2.resize(pyr_hole[-1].astype(np.uint8), (pw, ph),
+                        interpolation=cv2.INTER_AREA)
+        pyr_hole.append(hm > 0)
+
+    for lvl in range(levels, -1, -1):
+        fl = pyr_f[lvl]
+        hl = pyr_hole[lvl]
+        if lvl < levels:
+            up = cv2.resize(pyr_f[lvl + 1], (fl.shape[1], fl.shape[0]),
+                            interpolation=cv2.INTER_LINEAR)
+            h3 = np.repeat(hl[..., None], fl.shape[2], axis=2)
+            fl[h3] = up[h3]
+        local_thick = thick / (2 ** lvl)
+        iters = int(np.clip(round(1.5 * local_thick), 8, 64))
+        pyr_f[lvl] = _jacobi(fl, hl, iters)
+    return pyr_f[0]
+
+
+def _add_grain(filled: np.ndarray, hole: np.ndarray, original: np.ndarray,
+               grain: float) -> None:
+    """Add deterministic zero-mean noise to the healed pixels, scaled to the
+    local boundary-ring std, so the patch isn't a tell-tale smooth blob."""
+    ker = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (13, 13))   # ~6 px ring
+    dil = cv2.dilate(hole.astype(np.uint8), ker)
+    ring = (dil > 0) & (~hole)
+    if not ring.any():
+        return
+    seed = int(filled.mean()) & 0xFFFFFFFF
+    rng = np.random.RandomState(seed)
+    idx = np.nonzero(hole)
+    n = idx[0].size
+    for c in range(filled.shape[2]):
+        sd = float(original[..., c][ring].std())
+        if sd <= 0:
+            continue
+        noise = rng.normal(0.0, grain * sd, size=n).astype(np.float32)
+        filled[..., c][idx] += noise

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1503,7 +1503,14 @@ class ImagePreview(QWidget):
         if t is None or dims is None:
             return None
         local = t.inverted()[0].map(scene_pos)
-        return self.map_displayed_to_full(local.x(), local.y())
+        fx, fy = self.map_displayed_to_full(local.x(), local.y())
+        # Reject clicks outside the image (e.g. the gray margin around a
+        # displayed crop) so they can't spuriously match/delete a stroke or
+        # author one off-canvas.
+        W, H = dims
+        if not (0 <= fx < W and 0 <= fy < H):
+            return None
+        return fx, fy
 
     def _heal_hit_test(self, fx, fy):
         """Index of the topmost stroke whose footprint contains (fx, fy), or None."""
@@ -1628,6 +1635,8 @@ class ImagePreview(QWidget):
 
     def _draw_heal_ghost(self):
         self._remove_heal_ghost()
+        if self.current_pixmap is None or self.current_pixmap.isNull():
+            return
         t = self._image_transform()
         dims = self._full_dims()
         if t is None or dims is None or not self._heal_stroke_pts:
@@ -1733,6 +1742,8 @@ class ImagePreview(QWidget):
     def _visualize_pixmap(self, pixmap):
         """A high-contrast 'find the dust' rendering of the displayed pixmap
         (same geometry — coordinates are unaffected)."""
+        if pixmap is None or pixmap.isNull():
+            return pixmap
         try:
             import numpy as np
             import cv2

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -17,6 +17,12 @@ import os
 
 _eyedropper_cursor_cache = None
 
+# Dust-healing overlay tints (RGB; QColor built lazily to avoid pre-QApplication
+# construction). auto = cyan-blue, manual = green, live drag ghost = amber.
+_HEAL_AUTO_RGB = (0, 180, 255)
+_HEAL_MANUAL_RGB = (0, 210, 0)
+_HEAL_GHOST_RGB = (255, 210, 0)
+
 def _eyedropper_cursor():
     """Small painter-drawn eyedropper cursor, hotspot at the tip (bottom-left)."""
     global _eyedropper_cursor_cache
@@ -138,7 +144,8 @@ class GraphicsImageView(QGraphicsView):
                                   or self._bw_drag_start is not None
                                   or self.parent_widget.crop_mode
                                   or self.parent_widget._area_drag is not None
-                                  or self.parent_widget._slice_drag is not None)
+                                  or self.parent_widget._slice_drag is not None
+                                  or self.parent_widget.heal_mode)
             if not interaction_active:
                 self._mid_pan = True
                 self._mid_pan_last = event.pos()
@@ -164,6 +171,12 @@ class GraphicsImageView(QGraphicsView):
                 self.parent_widget.slice_press(self.mapToScene(event.pos()))
             elif event.button() == Qt.RightButton:
                 self.parent_widget.slice_delete_at(self.mapToScene(event.pos()))
+            return
+        if self.parent_widget.heal_mode and self.parent_widget.pixmap_item is not None:
+            if event.button() == Qt.LeftButton:
+                self.parent_widget.heal_press(self.mapToScene(event.pos()))
+            elif event.button() == Qt.RightButton:
+                self.parent_widget.heal_remove_at(self.mapToScene(event.pos()))
             return
         if event.button() == Qt.LeftButton and self.wb_pick_mode and self.parent_widget.pixmap_item is not None:
             scene_pos = self.mapToScene(event.pos())
@@ -231,6 +244,9 @@ class GraphicsImageView(QGraphicsView):
             return
         if self.parent_widget.slice_mode:
             self.parent_widget.slice_move(self.mapToScene(event.pos()))
+            return
+        if self.parent_widget.heal_mode:
+            self.parent_widget.heal_move(self.mapToScene(event.pos()))
             return
         if self.bwpoint_mode and self._bw_drag_start is not None:
             self._bw_drag_end = self.mapToScene(event.pos())
@@ -341,6 +357,10 @@ class GraphicsImageView(QGraphicsView):
         if self.parent_widget.slice_mode:
             if event.button() == Qt.LeftButton:
                 self.parent_widget.slice_release()
+            return
+        if self.parent_widget.heal_mode:
+            if event.button() == Qt.LeftButton:
+                self.parent_widget.heal_release(self.mapToScene(event.pos()))
             return
         if self.bwpoint_mode and event.button() == Qt.LeftButton and self._bw_drag_start is not None:
             drag_start_scene = self._bw_drag_start
@@ -507,6 +527,8 @@ class GraphicsImageView(QGraphicsView):
         pw = self.parent_widget
         if pw is not None and pw.crop_mode:
             self.setCursor(Qt.CrossCursor)
+        elif pw is not None and pw.heal_mode:
+            self.setCursor(Qt.BlankCursor)   # the brush ring is the cursor
         elif self.wb_pick_mode:
             self.setCursor(_eyedropper_cursor())
         elif self.bwpoint_mode:
@@ -670,6 +692,54 @@ class ImagePreview(QWidget):
         self.toolbar.addAction(self.unconvert_action)
         add_spacer()
 
+        # --- Dust healing tools (gated to converted images) ---------------
+        self.heal_action = QAction("🩹 Heal", self)
+        self.heal_action.setCheckable(True)
+        self.heal_action.setToolTip(
+            "Dust healing: auto-detect spots, click a marked spot to remove the "
+            "detection, or click/drag to heal a missed spot or scratch.")
+        self.heal_action.toggled.connect(self.toggle_heal_mode)
+        self.toolbar.addAction(self.heal_action)
+        add_spacer()
+
+        self.auto_dust_action = QAction("Auto-Detect", self)
+        self.auto_dust_action.setToolTip("Automatically detect dust spots and "
+                                         "scratches on the current image.")
+        self.auto_dust_action.triggered.connect(self.auto_detect_dust)
+        self.toolbar.addAction(self.auto_dust_action)
+        add_spacer()
+
+        self.visualize_action = QAction("Visualize", self)
+        self.visualize_action.setCheckable(True)
+        self.visualize_action.setToolTip("Show a high-contrast view that makes "
+                                         "dust easy to spot (display only).")
+        self.visualize_action.toggled.connect(self.toggle_visualize)
+        self.toolbar.addAction(self.visualize_action)
+        add_spacer()
+
+        self.clear_dust_action = QAction("Clear Spots", self)
+        self.clear_dust_action.setToolTip("Remove all dust heal strokes.")
+        self.clear_dust_action.triggered.connect(self.clear_dust)
+        self.toolbar.addAction(self.clear_dust_action)
+        add_spacer()
+
+        self.brush_combo = QComboBox()
+        self.brush_combo.addItems(["Brush S", "Brush M", "Brush L"])
+        self.brush_combo.setCurrentIndex(1)   # M
+        self.brush_combo.setFixedWidth(78)
+        self.brush_combo.setToolTip("Manual heal brush size.")
+        self.brush_combo.currentIndexChanged.connect(self._on_brush_changed)
+        self.toolbar.addWidget(self.brush_combo)
+        add_spacer()
+
+        self.sensitivity_combo = QComboBox()
+        self.sensitivity_combo.addItems(["Sens Low", "Sens Med", "Sens High"])
+        self.sensitivity_combo.setCurrentIndex(1)   # Med
+        self.sensitivity_combo.setFixedWidth(86)
+        self.sensitivity_combo.setToolTip("Auto-detect sensitivity.")
+        self.toolbar.addWidget(self.sensitivity_combo)
+        add_spacer()
+
         self.export_action = QAction("Export…", self)
         self.export_action.triggered.connect(self.open_export_dialog)
         self.toolbar.addAction(self.export_action)
@@ -778,6 +848,18 @@ class ImagePreview(QWidget):
         self._slice_drag = None          # line dict being dragged, or None
         self._slice_worker = None
 
+        # Dust healing mode: click a marked spot to remove its detection, or
+        # click/drag to heal. Strokes live on the image (normalized, un-cropped
+        # space) and replay through apply_adjustments. See spec/dust-healing.md.
+        self.heal_mode = False
+        self.dust_visualize = False      # high-contrast "find the dust" view
+        self._heal_drag = False          # a manual stroke is being drawn
+        self._heal_stroke_pts = []       # in-progress stroke, full-image coords
+        self._heal_ring_item = None      # brush-size ring following the cursor
+        self._heal_ghost_items = []      # live preview of the stroke being drawn
+        self._dust_overlay_items = []    # markers for committed strokes
+        self._last_cursor_scene = None   # last cursor scene pos (for brush ring)
+
         # Coalesce a fine-rotation drag into a single undo step
         self._fine_rot_burst_active = False
         self._fine_rot_burst_timer = QTimer(self)
@@ -829,6 +911,11 @@ class ImagePreview(QWidget):
             self._exit_slice_mode()
         if self.area_mode:
             self._exit_area_mode()
+        if self.heal_mode:
+            self._exit_heal_mode()
+            self.heal_action.blockSignals(True)
+            self.heal_action.setChecked(False)
+            self.heal_action.blockSignals(False)
         self._release_hires(refresh=False)
         self.current_idx = None
         self._current_image_ref = None
@@ -864,6 +951,8 @@ class ImagePreview(QWidget):
         elif self.area_mode:
             # Esc leaves area editing: deselect back to the Whole Image layer.
             self._select_whole_image_layer()
+        elif self.heal_mode:
+            self.heal_action.setChecked(False)   # toggled -> toggle_heal_mode(False)
 
     def update_preview(self, idx):
         ''' Update the UI image based on the backend, using the index from the thumbnail list. '''
@@ -946,6 +1035,14 @@ class ImagePreview(QWidget):
             self._zoom = 1.0
             self._release_hires(refresh=False)
 
+        # Visualize mode: swap in a high-contrast "find the dust" rendering.
+        # Same geometry as the normal pixmap, so all heal coordinates are
+        # unaffected; display-only (never stored/exported).
+        if (self.dust_visualize and preview_img is not None
+                and not preview_img.isNull()
+                and ccr_backend.images[idx].converted):
+            preview_img = self._visualize_pixmap(preview_img)
+
         self.current_pixmap = preview_img
         self.current_fine_rotation = ccr_backend.get_image_fine_rotation_by_index(idx)
         self.rotation_slider.setValue(self.current_fine_rotation)
@@ -962,6 +1059,10 @@ class ImagePreview(QWidget):
         self._area_overlay_items = []
         self._slice_ghost_item = None
         self._slice_dim_item = None
+        # scene.clear() above dropped the dust overlay / brush ring / ghost items
+        self._dust_overlay_items = []
+        self._heal_ring_item = None
+        self._heal_ghost_items = []
         for _slice_line in self._slice_lines:
             _slice_line["item"] = None
 
@@ -1076,6 +1177,9 @@ class ImagePreview(QWidget):
         # Same for the area-edit overlay (handles sized from the view scale).
         if self.area_mode:
             self._draw_area_overlay()
+        # Dust heal markers are redrawn here too (scene.clear / zoom rescale).
+        if self.heal_mode:
+            self._draw_dust_overlay()
         # Slice overlay follows the (possibly changed) display transform; the
         # ghost is simply dropped (it reappears on the next mouse move). The
         # dim cast is rebuilt first so the lines render on top of it.
@@ -1242,11 +1346,410 @@ class ImagePreview(QWidget):
         self.current_converted = ccr_backend.get_converted_state_by_index(self.current_idx) if self.current_idx is not None else False
         self.unconvert_action.setEnabled(self.current_converted)
         self.export_action.setEnabled(any(img.converted for img in ccr_backend.images))
+        # Dust healing is only meaningful on the converted positive.
+        conv = self.current_converted
+        for w in (self.heal_action, self.auto_dust_action, self.visualize_action,
+                  self.clear_dust_action, self.brush_combo, self.sensitivity_combo):
+            w.setEnabled(conv)
+        if not conv and (self.heal_mode or self.dust_visualize):
+            # Leaving the converted state drops out of heal/visualize cleanly,
+            # without re-entering update_preview (we're often inside it here).
+            self._exit_heal_mode()
+            for act in (self.heal_action, self.visualize_action):
+                act.blockSignals(True)
+                act.setChecked(False)
+                act.blockSignals(False)
         parent = self.parent()
         if hasattr(parent.parent(), "sliders_panel"):
             print("Setting sliders enabled based on current_converted:", self.current_converted)
             parent.parent().sliders_panel.set_sliders_enabled(self.current_converted)
-        
+
+
+    # ===== Dust healing ===================================================
+    # Click a marked spot to remove its detection; click/drag to heal a missed
+    # spot or scratch. Strokes live on the image in normalized, un-cropped space
+    # and replay through apply_adjustments. Coordinate authoring/overlay use
+    # _image_transform() (coarse + fine rotation) so they are correct even when
+    # the straighten slider is non-zero. See spec/dust-healing.md.
+
+    def _image_transform(self):
+        """Scene<->preview-local map including coarse AND fine rotation (no
+        prescale): scene == img_transform(preview_local). Use this, not the
+        coarse-only _base_transform, for heal authoring and overlays."""
+        base = self._base_transform()
+        if base is None:
+            return None
+        t = QTransform(base)
+        if self.current_fine_rotation:
+            cx = self.current_pixmap.width() / 2.0
+            cy = self.current_pixmap.height() / 2.0
+            t.translate(cx, cy)
+            t.rotate(self.current_fine_rotation / 100.0)
+            t.translate(-cx, -cy)
+        return t if t.isInvertible() else None
+
+    def map_full_to_displayed(self, x, y):
+        """Inverse of map_displayed_to_full: full-image -> displayed-pixmap
+        coords (identity when no crop is being displayed)."""
+        if self._crop_display_transform is None:
+            return x, y
+        p = self._crop_display_transform.inverted()[0].map(QPointF(x, y))
+        return p.x(), p.y()
+
+    def _full_dims(self):
+        """(W, H) of the full un-cropped working image (resized_raw), or None."""
+        img = (ccr_backend.get_image_by_index(self.current_idx)
+               if self.current_idx is not None else None)
+        if img is None or img.resized_raw is None:
+            return None
+        h, w = img.resized_raw.shape[:2]
+        return w, h
+
+    def _brush_radius_norm(self):
+        from core.dust_removal import BRUSH_NORM
+        key = {0: "S", 1: "M", 2: "L"}.get(self.brush_combo.currentIndex(), "M")
+        return BRUSH_NORM[key]
+
+    def _on_brush_changed(self, _idx):
+        if self.heal_mode and self._last_cursor_scene is not None:
+            self._update_brush_ring(self._last_cursor_scene)
+
+    # ---- mode enter/leave ----
+    def toggle_heal_mode(self, checked):
+        if checked:
+            if self.current_idx is None or not getattr(self, "current_converted", False):
+                self.heal_action.blockSignals(True)
+                self.heal_action.setChecked(False)
+                self.heal_action.blockSignals(False)
+                return
+            if self.crop_mode:
+                self._exit_crop_mode()
+            if self.slice_mode:
+                self._exit_slice_mode()
+            if self.area_mode:
+                self._exit_area_mode()
+            self.view.bwpoint_mode = None
+            self.view.wb_pick_mode = False
+            self.heal_mode = True
+            self.update_preview(self.current_idx)   # redraws the stroke overlay
+            self.view.setCursor(Qt.BlankCursor)
+            self._heal_hint()
+        else:
+            self._exit_heal_mode()
+            if self.current_idx is not None:
+                self.update_preview(self.current_idx)
+
+    def _exit_heal_mode(self):
+        """Pure cleanup — never re-enters update_preview (callers refresh)."""
+        self.heal_mode = False
+        self._heal_drag = False
+        self._heal_stroke_pts = []
+        self._remove_brush_ring()
+        self._remove_heal_ghost()
+        self._remove_dust_overlay_items()
+        self.view.setCursor(Qt.ArrowCursor)
+
+    def toggle_visualize(self, checked):
+        self.dust_visualize = bool(checked) and getattr(self, "current_converted", False)
+        if self.current_idx is not None:
+            self.update_preview(self.current_idx)
+
+    # ---- toolbar actions ----
+    def auto_detect_dust(self):
+        if self.current_idx is None or not getattr(self, "current_converted", False):
+            return
+        if not self.heal_mode:
+            self.heal_action.setChecked(True)   # enters heal mode (via toggled)
+        key = {0: "low", 1: "med", 2: "high"}.get(
+            self.sensitivity_combo.currentIndex(), "med")
+        self._push_undo_for_current()
+        n_detected, n_replaced = ccr_backend.detect_dust_by_index(self.current_idx, key)
+        self._after_heal_change()
+        panel = self._sliders_panel()
+        if panel is not None:
+            msg = f"Detected {n_detected} spot(s)"
+            if n_replaced:
+                msg += f" (replaced {n_replaced} previous auto)"
+            try:
+                panel.set_temporary_hint(
+                    msg + ". Click a marked spot to remove it; click/drag to heal.",
+                    duration=5000)
+            except AttributeError:
+                pass
+
+    def clear_dust(self):
+        if self.current_idx is None:
+            return
+        if not ccr_backend.get_dust_strokes_by_index(self.current_idx):
+            return
+        self._push_undo_for_current()
+        ccr_backend.clear_dust_strokes_by_index(self.current_idx)
+        self._after_heal_change()
+
+    def _after_heal_change(self):
+        """Strokes changed: refresh canvas + thumbnail, update hint, persist."""
+        self.update_preview(self.current_idx)
+        try:
+            self.parent().parent().thumbnail_list.update_thumbnail(self.current_idx)
+        except Exception:
+            pass
+        self._heal_hint()
+        ccr_backend.save_catalog()
+
+    # ---- canvas interaction (called by GraphicsImageView) ----
+    def _heal_scene_to_full(self, scene_pos):
+        t = self._image_transform()
+        dims = self._full_dims()
+        if t is None or dims is None:
+            return None
+        local = t.inverted()[0].map(scene_pos)
+        return self.map_displayed_to_full(local.x(), local.y())
+
+    def _heal_hit_test(self, fx, fy):
+        """Index of the topmost stroke whose footprint contains (fx, fy), or None."""
+        dims = self._full_dims()
+        if dims is None:
+            return None
+        W, H = dims
+        L = max(W, H)
+        tol_img = 8.0 / max(self._view_scale(), 1e-6)
+        strokes = ccr_backend.get_dust_strokes_by_index(self.current_idx)
+        best = None
+        for i, st in enumerate(strokes):
+            hit = max(2.0, st.get("radius", 0.006) * L) + tol_img
+            for nx, ny in st.get("points", []):
+                if (nx * W - fx) ** 2 + (ny * H - fy) ** 2 <= hit * hit:
+                    best = i
+                    break
+        return best
+
+    def heal_press(self, scene_pos):
+        full = self._heal_scene_to_full(scene_pos)
+        if full is None:
+            return
+        hit = self._heal_hit_test(*full)
+        if hit is not None:
+            self._remove_stroke(hit)
+            self._heal_drag = False
+            self._heal_stroke_pts = []
+            return
+        self._heal_drag = True
+        self._heal_stroke_pts = [tuple(full)]
+        self._draw_heal_ghost()
+
+    def heal_move(self, scene_pos):
+        self._update_brush_ring(scene_pos)
+        if not self._heal_drag:
+            return
+        full = self._heal_scene_to_full(scene_pos)
+        if full is None:
+            return
+        fx, fy = full
+        dims = self._full_dims()
+        L = max(dims) if dims else 1080
+        min_gap = max(1.0, 0.5 * self._brush_radius_norm() * L)
+        if self._heal_stroke_pts:
+            lx, ly = self._heal_stroke_pts[-1]
+            if (fx - lx) ** 2 + (fy - ly) ** 2 < min_gap * min_gap:
+                return
+        self._heal_stroke_pts.append((fx, fy))
+        self._draw_heal_ghost()
+
+    def heal_release(self, scene_pos):
+        if not self._heal_drag:
+            return
+        full = self._heal_scene_to_full(scene_pos)
+        if full is not None:
+            self._heal_stroke_pts.append(tuple(full))
+        self._heal_drag = False
+        self._remove_heal_ghost()
+        self._commit_manual_stroke()
+
+    def heal_remove_at(self, scene_pos):
+        full = self._heal_scene_to_full(scene_pos)
+        if full is None:
+            return
+        hit = self._heal_hit_test(*full)
+        if hit is not None:
+            self._remove_stroke(hit)
+
+    def _remove_stroke(self, index):
+        self._push_undo_for_current()
+        ccr_backend.remove_dust_stroke_by_index(self.current_idx, index)
+        self._after_heal_change()
+
+    def _commit_manual_stroke(self):
+        pts = self._heal_stroke_pts
+        self._heal_stroke_pts = []
+        dims = self._full_dims()
+        if not pts or dims is None:
+            return
+        W, H = dims
+        norm = [[min(1.0, max(0.0, x / W)), min(1.0, max(0.0, y / H))]
+                for x, y in pts]
+        stroke = {
+            "points": norm,
+            "radius": self._brush_radius_norm(),
+            "connect": len(norm) > 1,
+            "kind": "scratch" if len(norm) > 1 else "spot",
+            "source": "manual",
+        }
+        self._push_undo_for_current()
+        ccr_backend.add_dust_stroke_by_index(self.current_idx, stroke)
+        self._after_heal_change()
+
+    # ---- overlay drawing ----
+    def _update_brush_ring(self, scene_pos):
+        self._last_cursor_scene = scene_pos
+        dims = self._full_dims()
+        if dims is None or not self.heal_mode:
+            self._remove_brush_ring()
+            return
+        r = self._brush_radius_norm() * max(dims)
+        rect = QRectF(scene_pos.x() - r, scene_pos.y() - r, 2 * r, 2 * r)
+        if self._heal_ring_item is None:
+            self._heal_ring_item = QGraphicsEllipseItem(rect)
+            pen = QPen(QColor(255, 255, 255, 235), 0, Qt.DashLine)
+            pen.setCosmetic(True)
+            self._heal_ring_item.setPen(pen)
+            self._heal_ring_item.setBrush(QBrush(QColor(255, 255, 255, 25)))
+            self._heal_ring_item.setZValue(50)
+            self.scene.addItem(self._heal_ring_item)
+        else:
+            self._heal_ring_item.setRect(rect)
+
+    def _remove_brush_ring(self):
+        if self._heal_ring_item is not None:
+            try:
+                self.scene.removeItem(self._heal_ring_item)
+            except Exception:
+                pass
+            self._heal_ring_item = None
+
+    def _draw_heal_ghost(self):
+        self._remove_heal_ghost()
+        t = self._image_transform()
+        dims = self._full_dims()
+        if t is None or dims is None or not self._heal_stroke_pts:
+            return
+        r = max(1.0, self._brush_radius_norm() * max(dims))
+        disp = [self.map_full_to_displayed(x, y) for x, y in self._heal_stroke_pts]
+        path = QPainterPath()
+        if len(disp) >= 2:
+            path.moveTo(disp[0][0], disp[0][1])
+            for dx, dy in disp[1:]:
+                path.lineTo(dx, dy)
+            item = QGraphicsPathItem(path)
+            pen = QPen(QColor(*_HEAL_GHOST_RGB, 130), 2 * r)
+            pen.setCapStyle(Qt.RoundCap)
+            pen.setJoinStyle(Qt.RoundJoin)
+            item.setPen(pen)
+        else:
+            path.addEllipse(QPointF(disp[0][0], disp[0][1]), r, r)
+            item = QGraphicsPathItem(path)
+            item.setPen(QPen(QColor(*_HEAL_GHOST_RGB, 200), 0))
+            item.setBrush(QBrush(QColor(*_HEAL_GHOST_RGB, 90)))
+        item.setTransform(t)
+        item.setZValue(40)
+        self.scene.addItem(item)
+        self._heal_ghost_items.append(item)
+
+    def _remove_heal_ghost(self):
+        for it in self._heal_ghost_items:
+            try:
+                self.scene.removeItem(it)
+            except Exception:
+                pass
+        self._heal_ghost_items = []
+
+    def _draw_dust_overlay(self):
+        self._remove_dust_overlay_items()
+        if (not self.heal_mode or self.current_pixmap is None
+                or self.current_idx is None):
+            return
+        t = self._image_transform()
+        dims = self._full_dims()
+        if t is None or dims is None:
+            return
+        strokes = ccr_backend.get_dust_strokes_by_index(self.current_idx)
+        if not strokes:
+            return
+        W, H = dims
+        L = max(W, H)
+        scale = self._view_scale()
+        for st in strokes:
+            r = max(1.0, st.get("radius", 0.006) * L)
+            rgb = _HEAL_AUTO_RGB if st.get("source") == "auto" else _HEAL_MANUAL_RGB
+            disp = [self.map_full_to_displayed(nx * W, ny * H)
+                    for nx, ny in st.get("points", [])]
+            if not disp:
+                continue
+            path = QPainterPath()
+            if st.get("connect") and len(disp) >= 2:
+                path.moveTo(disp[0][0], disp[0][1])
+                for dx, dy in disp[1:]:
+                    path.lineTo(dx, dy)
+                item = QGraphicsPathItem(path)
+                pen = QPen(QColor(*rgb, 110), 2 * r)
+                pen.setCapStyle(Qt.RoundCap)
+                pen.setJoinStyle(Qt.RoundJoin)
+                item.setPen(pen)
+            else:
+                for dx, dy in disp:
+                    path.addEllipse(QPointF(dx, dy), r, r)
+                item = QGraphicsPathItem(path)
+                item.setPen(QPen(QColor(*rgb, 235), max(1.2 / scale, 0.4)))
+                item.setBrush(QBrush(QColor(*rgb, 70)))
+            item.setTransform(t)
+            item.setZValue(30)
+            self.scene.addItem(item)
+            self._dust_overlay_items.append(item)
+
+    def _remove_dust_overlay_items(self):
+        for it in self._dust_overlay_items:
+            try:
+                self.scene.removeItem(it)
+            except Exception:
+                pass
+        self._dust_overlay_items = []
+
+    def _heal_hint(self):
+        panel = self._sliders_panel()
+        if panel is None or self.current_idx is None:
+            return
+        strokes = ccr_backend.get_dust_strokes_by_index(self.current_idx)
+        n_auto = sum(1 for s in strokes if s.get("source") == "auto")
+        n_manual = len(strokes) - n_auto
+        try:
+            panel.set_hint(
+                f"<b>Dust healing.</b> {len(strokes)} spot(s) "
+                f"({n_auto} auto, {n_manual} manual).<br>"
+                "Click a marked spot to remove it; click or drag to heal a "
+                "missed spot/scratch. <b>Auto-Detect</b> finds spots; "
+                "<b>Visualize</b> reveals them. Ctrl+Z undo · Esc to exit.")
+        except AttributeError:
+            pass
+
+    def _visualize_pixmap(self, pixmap):
+        """A high-contrast 'find the dust' rendering of the displayed pixmap
+        (same geometry — coordinates are unaffected)."""
+        try:
+            import numpy as np
+            import cv2
+            qimg = pixmap.toImage().convertToFormat(QImage.Format_RGB888)
+            w, h = qimg.width(), qimg.height()
+            bpl = qimg.bytesPerLine()
+            buf = np.frombuffer(qimg.constBits(), np.uint8, count=bpl * h)
+            arr = buf.reshape(h, bpl)[:, :w * 3].reshape(h, w, 3)
+            gray = cv2.cvtColor(arr, cv2.COLOR_RGB2GRAY).astype(np.float32)
+            hp = np.abs(gray - cv2.GaussianBlur(gray, (0, 0), 2.0))
+            hp = np.clip(hp * 8.0, 0, 255).astype(np.uint8)
+            vis = np.ascontiguousarray(cv2.cvtColor(hp, cv2.COLOR_GRAY2RGB))
+            out = QImage(vis.data, w, h, w * 3, QImage.Format_RGB888).copy()
+            return QPixmap.fromImage(out)
+        except Exception as e:
+            print(f"Dust visualize failed: {e}")
+            return pixmap
 
     def set_bwpoint_mode(self, mode):
         """mode: 'black' | 'white' | None"""
@@ -3151,6 +3654,7 @@ class HiResDetailWorker(QThread):
         # Deep copy: each area nests settings + geometry dicts the GUI thread
         # may mutate while this worker runs.
         self._areas = copy.deepcopy(getattr(img_obj, "area_layers", []))
+        self._dust_strokes = copy.deepcopy(getattr(img_obj, "dust_heal_strokes", []))
         self._contrast_base = img_obj.contrast_base
         self._temperature_base = img_obj.temperature_base
         self._brightness_base = img_obj.brightness_base
@@ -3177,7 +3681,8 @@ class HiResDetailWorker(QThread):
                 contrast_base=self._contrast_base,
                 temperature_base=self._temperature_base,
                 brightness_base=self._brightness_base,
-                areas_override=self._areas)
+                areas_override=self._areas,
+                dust_strokes_override=self._dust_strokes)
             if not self._converted:
                 # Mirror the preview pipeline: adjustments first, then the
                 # display-only auto-brightness stretch for raw negatives

--- a/tests/test_dust_integration.py
+++ b/tests/test_dust_integration.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Integration tests for dust healing wiring into CCRImage / catalog (no canvas).
+
+Verifies the single apply_adjustments hook heals, and that strokes round-trip
+through serialize + the undo snapshot. CCRImage pulls QtGui, so a headless
+QApplication is created, but no widgets are shown.
+"""
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np  # noqa: E402
+import cv2  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+from core import catalog  # noqa: E402
+from core.dust_removal import clean_strokes  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+
+def _load_blank(tmp_path, h=200, w=300):
+    """Construct a CCRImage from a flat synthetic file, then return it."""
+    flat = np.full((h, w, 3), 40000, np.uint16)
+    path = str(tmp_path / "scan.png")
+    cv2.imwrite(path, cv2.cvtColor(flat, cv2.COLOR_RGB2BGR))
+    return CCRImage(path)
+
+
+def _positive_with_spot(h=200, w=300, cy=100, cx=150, r=4, seed=1):
+    rng = np.random.default_rng(seed)
+    base = np.full((h, w, 3), 40000.0) + rng.normal(0, 300, (h, w, 3))
+    img = np.clip(base, 0, 65535).astype(np.uint16)
+    yy, xx = np.ogrid[:h, :w]
+    m = (yy - cy) ** 2 + (xx - cx) ** 2 <= r ** 2
+    img[m] = 62000
+    return img, m
+
+
+def _spot_stroke(cy, cx, r, h, w, source="manual"):
+    return {"points": [[cx / w, cy / h]], "radius": (r + 2) / max(h, w),
+            "connect": False, "kind": "spot", "source": source}
+
+
+def test_apply_adjustments_heals_with_no_other_edits(tmp_path):
+    ci = _load_blank(tmp_path)
+    ci.converted = True
+    ci.brightness_base = 0          # isolate healing from the default look offset
+    img16, m = _positive_with_spot()
+    ci.resized_raw = img16
+    ci.dust_heal_strokes = [_spot_stroke(100, 150, 4, 200, 300)]
+    out = ci.apply_adjustments(ci.resized_raw)
+    assert out[m].mean() < 50000                       # spot pulled to background
+    np.testing.assert_array_equal(out[:20, :20], img16[:20, :20])   # far corner exact
+
+
+def test_no_strokes_is_passthrough_identity(tmp_path):
+    ci = _load_blank(tmp_path)
+    ci.converted = True
+    ci.brightness_base = 0
+    img16, _ = _positive_with_spot()
+    ci.resized_raw = img16
+    out = ci.apply_adjustments(ci.resized_raw)
+    assert out is ci.resized_raw                        # early-return fast path
+
+
+def test_serialize_includes_strokes_and_loader_roundtrips(tmp_path):
+    ci = _load_blank(tmp_path)
+    ci.dust_heal_strokes = [_spot_stroke(100, 150, 4, 200, 300, source="auto"),
+                            _spot_stroke(40, 60, 3, 200, 300, source="manual")]
+    state = catalog.serialize_image(ci)
+    assert len(state["dust_heal_strokes"]) == 2
+    assert not catalog._is_pristine(state)
+    loaded = clean_strokes(state["dust_heal_strokes"])
+    assert [s["source"] for s in loaded] == ["auto", "manual"]
+
+
+def test_undo_roundtrip_strokes(tmp_path):
+    ci = _load_blank(tmp_path)
+    ci.push_undo_state()                       # snapshot: no strokes
+    ci.dust_heal_strokes = [_spot_stroke(100, 150, 4, 200, 300)]
+    ci.push_undo_state()                       # snapshot: one stroke
+    ci.dust_heal_strokes = []
+    ci.pop_undo_state()                        # restore one-stroke snapshot
+    assert len(ci.dust_heal_strokes) == 1
+    ci.pop_undo_state()                        # restore empty snapshot
+    assert ci.dust_heal_strokes == []
+
+
+def test_pristine_until_strokes_added(tmp_path):
+    ci = _load_blank(tmp_path)
+    assert catalog._is_pristine(catalog.serialize_image(ci))
+    ci.dust_heal_strokes = [_spot_stroke(100, 150, 4, 200, 300)]
+    assert not catalog._is_pristine(catalog.serialize_image(ci))
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Tests for the dust detection + inpainting module (src/core/dust_removal.py).
+
+Pure numpy/cv2 — no Qt required. Synthesizes converted-positive-like images
+with known injected dust (bright specks and curly streaks) and asserts that
+detection finds them, inpainting removes them while preserving untouched
+pixels, and the vector strokes round-trip across resolutions.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import cv2  # noqa: E402
+from core.dust_removal import (  # noqa: E402
+    detect_dust, inpaint_dust, rasterize_strokes, clean_strokes, BRUSH_NORM,
+)
+
+
+# --- synthetic image helpers -----------------------------------------------
+def _clean_positive(h=400, w=600, seed=7, noise=500.0):
+    """A smooth-ish converted positive: a gentle 2D gradient + mild grain,
+    sitting mid-range in 16-bit (like blue sky)."""
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:h, 0:w]
+    base = 30000 + 12000 * (xx / w) + 6000 * (yy / h)
+    img = np.stack([base * 0.95, base, base * 1.08], axis=-1)   # cool, sky-like
+    img += rng.normal(0, noise, img.shape)
+    return np.clip(img, 1000, 64000).astype(np.uint16)
+
+
+def _inject_spot(img, cy, cx, radius=2, amp=18000):
+    """Add a bright circular speck (dust on the positive reads bright)."""
+    img = img.copy()
+    yy, xx = np.ogrid[:img.shape[0], :img.shape[1]]
+    m = (yy - cy) ** 2 + (xx - cx) ** 2 <= radius ** 2
+    vals = img[m].astype(np.int32) + amp
+    img[m] = np.clip(vals, 0, 65535).astype(np.uint16)
+    return img, m
+
+
+def _inject_streak(img, amp=16000, thickness=2):
+    """Add a thin curly bright streak (a sine squiggle), like a hair/scratch."""
+    img = img.copy()
+    h, w = img.shape[:2]
+    mask = np.zeros((h, w), np.uint8)
+    xs = np.arange(w // 4, 3 * w // 4)
+    ys = (h // 2 + (h // 8) * np.sin(xs / 18.0)).astype(np.int32)
+    pts = np.stack([xs, ys], axis=1).reshape(-1, 1, 2)
+    cv2.polylines(mask, [pts], False, 255, thickness=thickness)
+    m = mask.astype(bool)
+    vals = img[m].astype(np.int32) + amp
+    img[m] = np.clip(vals, 0, 65535).astype(np.uint16)
+    return img, m
+
+
+# --- detection -------------------------------------------------------------
+class TestDetect:
+    def test_single_spot(self):
+        img = _clean_positive()
+        dusty, _ = _inject_spot(img, 200, 300, radius=3)
+        strokes = detect_dust(dusty, "med")
+        assert len(strokes) >= 1
+        # at least one detected point lands near the injected centre
+        h, w = dusty.shape[:2]
+        hits = [(p[0] * w, p[1] * h) for s in strokes for p in s["points"]]
+        assert any(abs(px - 300) < 12 and abs(py - 200) < 12 for px, py in hits)
+
+    def test_multiple_spots(self):
+        img = _clean_positive()
+        for (cy, cx) in [(60, 80), (150, 420), (320, 250), (250, 540)]:
+            img, _ = _inject_spot(img, cy, cx, radius=2)
+        strokes = detect_dust(img, "med")
+        assert len(strokes) >= 4
+
+    def test_curly_streak_detected_and_covered(self):
+        img = _clean_positive()
+        dusty, streak = _inject_streak(img)
+        strokes = detect_dust(dusty, "med")
+        assert any(s["kind"] == "scratch" for s in strokes)
+        h, w = dusty.shape[:2]
+        covered = rasterize_strokes(strokes, h, w, pad_px=2).astype(bool)
+        recall = (covered & streak).sum() / max(1, streak.sum())
+        assert recall >= 0.8
+
+    def test_clean_image_few_false_positives(self):
+        img = _clean_positive(seed=21)
+        assert len(detect_dust(img, "med")) <= 8
+
+    def test_sensitivity_ordering(self):
+        img = _clean_positive(seed=3)
+        for (cy, cx) in [(100, 100), (200, 300), (300, 500)]:
+            img, _ = _inject_spot(img, cy, cx, radius=2, amp=9000)  # faint
+        low = detect_dust(img, "low")
+        high = detect_dust(img, "high")
+        assert len(high) >= len(low)
+
+    def test_large_blob_rejected_by_area(self):
+        img = _clean_positive()
+        dusty, _ = _inject_spot(img, 200, 300, radius=30)   # far above max_area
+        # The big blob must not be auto-detected as dust.
+        strokes = detect_dust(dusty, "med")
+        h, w = dusty.shape[:2]
+        for s in strokes:
+            for p in s["points"]:
+                assert not (abs(p[0] * w - 300) < 25 and abs(p[1] * h - 200) < 25)
+
+    def test_round_spot_classified_as_spot(self):
+        img = _clean_positive()
+        dusty, _ = _inject_spot(img, 200, 300, radius=3)
+        h, w = dusty.shape[:2]
+        near = [s for s in detect_dust(dusty, "med") for p in [s["points"][0]]
+                if abs(p[0] * w - 300) < 12 and abs(p[1] * h - 200) < 12]
+        assert near and all(s["kind"] == "spot" for s in near)
+
+
+# --- inpainting ------------------------------------------------------------
+class TestInpaint:
+    def test_removes_spot(self):
+        img = _clean_positive()
+        dusty, m = _inject_spot(img, 200, 300, radius=3)
+        strokes = detect_dust(dusty, "med")
+        healed = inpaint_dust(dusty, strokes, grain=0.0)
+        # healed region must be closer to the clean original than the dusty one
+        reg = (slice(190, 211), slice(290, 311))
+        mae_dust = np.abs(dusty[reg].astype(np.int32) - img[reg]).mean()
+        mae_heal = np.abs(healed[reg].astype(np.int32) - img[reg]).mean()
+        assert mae_heal < mae_dust
+
+    def test_preserves_untouched_pixels(self):
+        img = _clean_positive()
+        dusty, _ = _inject_spot(img, 200, 300, radius=3)
+        strokes = detect_dust(dusty, "med")
+        healed = inpaint_dust(dusty, strokes, grain=0.0)
+        # a corner far from any stroke is byte-for-byte unchanged
+        np.testing.assert_array_equal(healed[:20, :20], dusty[:20, :20])
+
+    def test_empty_strokes_is_identity(self):
+        img = _clean_positive()
+        assert inpaint_dust(img, []) is img
+
+    def test_dtype_and_shape(self):
+        img = _clean_positive()
+        dusty, _ = _inject_spot(img, 100, 100, radius=2)
+        out = inpaint_dust(dusty, detect_dust(dusty, "med"))
+        assert out.dtype == np.uint16
+        assert out.shape == img.shape
+
+    def test_gradient_fidelity_no_halo(self):
+        # A thin horizontal scratch across a vertical gradient should heal to
+        # the exact linear interpolation (harmonic fill), with no halo.
+        h, w = 300, 300
+        yy = np.mgrid[0:h, 0:w][0]
+        base = (2000 + (60000 - 2000) * yy / h).astype(np.uint16)
+        img = np.stack([base, base, base], axis=-1)
+        dusty = img.copy()
+        dusty[148:151, 30:270] = 65000              # bright horizontal scratch
+        stroke = {"points": [[30 / w, 149 / h], [269 / w, 149 / h]],
+                  "radius": 3 / max(h, w), "connect": True,
+                  "kind": "scratch", "source": "manual"}
+        healed = inpaint_dust(dusty, [stroke], grain=0.0)
+        band = healed[146:153, 40:260].astype(np.int32)
+        ref = img[146:153, 40:260].astype(np.int32)
+        assert np.abs(band - ref).max() < 600        # < ~1% of full range
+
+    def test_grain_is_deterministic(self):
+        img = _clean_positive()
+        dusty, _ = _inject_spot(img, 200, 300, radius=4)
+        strokes = detect_dust(dusty, "med")
+        a = inpaint_dust(dusty, strokes, grain=0.4)
+        b = inpaint_dust(dusty, strokes, grain=0.4)
+        np.testing.assert_array_equal(a, b)
+
+
+# --- rasterization / resolution independence -------------------------------
+class TestRasterize:
+    def test_resolution_independent(self):
+        strokes = [
+            {"points": [[0.3, 0.4]], "radius": 0.02, "connect": False,
+             "kind": "spot", "source": "manual"},
+            {"points": [[0.6, 0.6], [0.7, 0.65], [0.8, 0.6]], "radius": 0.015,
+             "connect": True, "kind": "scratch", "source": "manual"},
+        ]
+        h, w = 200, 300
+        m1 = rasterize_strokes(strokes, h, w)
+        m2 = rasterize_strokes(strokes, 2 * h, 2 * w)
+        m2_down = cv2.resize(m2, (w, h), interpolation=cv2.INTER_AREA) > 64
+        m1b = m1 > 64
+        inter = (m1b & m2_down).sum()
+        union = (m1b | m2_down).sum()
+        assert union > 0 and inter / union >= 0.8
+
+    def test_clean_strokes_drops_malformed(self):
+        raw = [
+            {"points": [[0.1, 0.2]], "radius": 0.01},          # ok
+            {"points": []},                                     # empty -> drop
+            "not a dict",                                       # drop
+            {"points": [["x", "y"]]},                           # bad coords -> drop
+            {"points": [[0.5, 0.5]], "radius": "oops"},         # bad radius -> coerced
+        ]
+        out = clean_strokes(raw)
+        assert len(out) == 2
+        assert out[0]["source"] == "manual"        # default filled in
+        assert out[1]["radius"] > 0
+
+
+def test_brush_constants_present():
+    assert set(BRUSH_NORM) == {"S", "M", "L"}
+    assert BRUSH_NORM["S"] < BRUSH_NORM["M"] < BRUSH_NORM["L"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_dust_widget.py
+++ b/tests/test_dust_widget.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Widget-level smoke test for the dust-healing canvas workflow.
+
+Drives the real ImagePreview/MainWindow (offscreen) through the full loop:
+enter heal mode -> auto-detect -> manual heal -> click-to-remove -> clear,
+asserting the backend strokes and the scene overlay update as expected. This
+guards the signal wiring and coordinate/canvas code the pure-numpy tests can't.
+"""
+import os
+import sys
+import tempfile
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np  # noqa: E402
+import cv2  # noqa: E402
+import pytest  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+from PySide6.QtCore import QPointF  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+
+@pytest.fixture
+def converted_image(tmp_path):
+    """Append a synthetic converted positive (one bright spot) to the backend;
+    yield (main_window, idx); restore the singleton afterward."""
+    from core.ccr_backend import ccr_backend
+    from core.ccr_image import CCRImage
+    from ui.main_window import MainWindow
+
+    path = str(tmp_path / "scan.png")
+    cv2.imwrite(path, cv2.cvtColor(np.full((200, 300, 3), 40000, np.uint16),
+                                   cv2.COLOR_RGB2BGR))
+    img = CCRImage(path)
+    pos = (np.full((200, 300, 3), 40000.0)
+           + np.random.default_rng(0).normal(0, 300, (200, 300, 3)))
+    pos = np.clip(pos, 0, 65535).astype(np.uint16)
+    yy, xx = np.ogrid[:200, :300]
+    pos[(yy - 100) ** 2 + (xx - 150) ** 2 <= 9] = 62000   # spot at (150, 100)
+    img.resized_raw = pos
+    img.converted = True
+    img.conversion_inputs = {"mode": "bw",
+                             "bw": ((1000, 1000, 1000), (60000, 60000, 60000)),
+                             "fine_rot": 0}
+    img.update_thumbnail_and_preview()
+
+    n0 = len(ccr_backend.images)
+    mw = MainWindow()
+    ccr_backend.images.append(img)
+    idx = n0
+    mw.image_preview.update_preview(idx)
+    try:
+        yield mw, idx
+    finally:
+        del ccr_backend.images[n0:]
+
+
+def test_full_heal_workflow(converted_image):
+    from core.ccr_backend import ccr_backend
+    mw, idx = converted_image
+    ip = mw.image_preview
+    assert ip.current_converted
+
+    # enter heal mode
+    ip.heal_action.setChecked(True)
+    assert ip.heal_mode
+
+    # auto-detect finds the spot and draws an overlay marker
+    ip.auto_detect_dust()
+    assert len(ccr_backend.get_dust_strokes_by_index(idx)) >= 1
+    assert len(ip._dust_overlay_items) >= 1
+
+    # manual heal at an empty location (no crop/rotation -> scene==full coords)
+    n = len(ccr_backend.get_dust_strokes_by_index(idx))
+    ip.heal_press(QPointF(30, 30))
+    ip.heal_release(QPointF(30, 30))
+    assert len(ccr_backend.get_dust_strokes_by_index(idx)) == n + 1
+
+    # click the detected spot to remove that detection
+    n = len(ccr_backend.get_dust_strokes_by_index(idx))
+    ip.heal_press(QPointF(150, 100))
+    assert len(ccr_backend.get_dust_strokes_by_index(idx)) == n - 1
+
+    # visualize toggles without error; clear removes everything
+    ip.toggle_visualize(True)
+    ip.update_preview(idx)
+    ip.clear_dust()
+    assert ccr_backend.get_dust_strokes_by_index(idx) == []
+
+
+def test_heal_mode_blocked_until_converted(converted_image):
+    from core.ccr_backend import ccr_backend
+    mw, idx = converted_image
+    ip = mw.image_preview
+    ccr_backend.images[idx].converted = False
+    ip.update_preview(idx)            # refresh -> controls disable
+    assert not ip.heal_action.isEnabled()
+    ip.heal_action.setChecked(True)   # guarded: cannot enter heal mode
+    assert not ip.heal_mode
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_dust_widget.py
+++ b/tests/test_dust_widget.py
@@ -94,6 +94,46 @@ def test_full_heal_workflow(converted_image):
     assert ccr_backend.get_dust_strokes_by_index(idx) == []
 
 
+def test_autodetect_preserves_manual_strokes(converted_image):
+    """Re-running Auto-Detect (even at a new sensitivity) keeps manual strokes
+    and replaces — not accumulates — the auto ones (spec §3.6 / §9.5)."""
+    from core.ccr_backend import ccr_backend
+    mw, idx = converted_image
+    ip = mw.image_preview
+    ip.heal_action.setChecked(True)
+
+    ip.heal_press(QPointF(30, 30))      # a manual heal far from the spot
+    ip.heal_release(QPointF(30, 30))
+    manual_before = [s for s in ccr_backend.get_dust_strokes_by_index(idx)
+                     if s["source"] == "manual"]
+    assert len(manual_before) == 1
+
+    ip.sensitivity_combo.setCurrentIndex(2)   # High
+    ip.auto_detect_dust()
+    ip.sensitivity_combo.setCurrentIndex(0)   # Low
+    ip.auto_detect_dust()
+
+    strokes = ccr_backend.get_dust_strokes_by_index(idx)
+    manual_after = [s for s in strokes if s["source"] == "manual"]
+    autos = [s for s in strokes if s["source"] == "auto"]
+    assert len(manual_after) == 1                       # preserved
+    assert manual_after[0]["points"] == manual_before[0]["points"]
+    assert len(autos) <= 3                              # replaced, not accumulated
+
+
+def test_clicks_outside_image_are_noops(converted_image):
+    """Clicking far outside the image bounds must not create/delete strokes."""
+    from core.ccr_backend import ccr_backend
+    mw, idx = converted_image
+    ip = mw.image_preview
+    ip.heal_action.setChecked(True)
+    assert ip._heal_scene_to_full(QPointF(-500, -500)) is None
+    n = len(ccr_backend.get_dust_strokes_by_index(idx))
+    ip.heal_press(QPointF(-500, -500))
+    ip.heal_release(QPointF(-500, -500))
+    assert len(ccr_backend.get_dust_strokes_by_index(idx)) == n
+
+
 def test_heal_mode_blocked_until_converted(converted_image):
     from core.ccr_backend import ccr_backend
     mw, idx = converted_image


### PR DESCRIPTION
## Dust Healing (Spot & Scratch Removal)

Adds a **Dust Healing** tool that removes the dust spots and scratches a DSLR "scan" of film leaves behind — small bright specks and thin curly bright strings in the converted positive (e.g. white motes on a blue sky).

Spec: `spec/dust-healing.md` (authored → adversarially reviewed → refined to v2 before implementation, per the project workflow).

### What it does
- **🩹 Heal** toolbar toggle enters a canvas mode (gated to converted images), like Crop/Areas.
- **Auto-Detect** finds all spots/scratches at a chosen **sensitivity** (Low/Med/High).
- **Curate**: left-click a marked spot to remove that detection; left-click a missed spot to heal it; left-drag to trace a curly scratch (**brush** S/M/L).
- **Visualize** shows a high-contrast "find the dust" view (display-only) so faint dust is easy to see.
- **Clear Spots** removes all strokes. Everything is **Undoable** (Ctrl+Z) and **Esc** exits.

### How it works
- Heal strokes are stored as resolution-independent vectors on `CCRImage` (normalized to the same un-cropped space as `crop_rect`) and replayed through a single hook — the first step of `CCRImage.apply_adjustments` — so healing appears identically in the **preview, the hi-res zoom detail, and the export**, applied after inversion and before tonal adjustments/crop.
- Detection (`src/core/dust_removal.py`, pure numpy/cv2 — **no new dependencies**, Nuitka-safe): top-hat/black-hat morphology + MAD threshold + prominence gate + shape/thickness classification (round spot vs. curly scratch).
- Inpainting: tiled **16-bit harmonic fill** (multigrid coarse-to-fine seed) that reproduces local gradients with no halo, plus optional deterministic grain.
- Coordinate authoring/overlay use a fine-rotation-correct transform (`_image_transform` + `map_full_to_displayed`), verified for ref and B/W-point conversion modes, crop, flip, and zoom.

### Files
- **add** `src/core/dust_removal.py` — detection + 16-bit tiled inpaint.
- **edit** `src/core/ccr_image.py` — `dust_heal_strokes`, `apply_adjustments` hook (+ `dust_strokes_override`), undo.
- **edit** `src/core/ccr_backend.py` — detect/add/remove/clear/get API.
- **edit** `src/core/catalog.py` — persist strokes (defensive loader) + `_is_pristine`.
- **edit** `src/widgets/image_preview.py` — toolbar controls, heal mode, mouse handling, overlay, Visualize, hi-res-worker snapshot.
- **add** `tests/test_dust_removal.py`, `tests/test_dust_integration.py`, `tests/test_dust_widget.py`.

### Testing
- 27 new tests (detection, gradient-fidelity healing, determinism, resolution-independent round-trip, model/catalog/undo wiring, and a headless widget smoke test of the full auto-detect → curate → clear loop). Full suite: **327 passed**.
- Implementation diff was adversarially reviewed; the one confirmed bug (margin clicks outside a displayed crop) and a test gap (manual strokes preserved across auto-detect re-runs) are fixed and regression-tested.

### Known limitations (documented in the spec)
- Auto-detection is inherently imperfect without an IR channel — bright/dark real detail can be flagged; the workflow optimizes for easy curation.
- Fills on fine texture (grass, foliage) read as smudges; the tool targets small spots/scratches on smoother backgrounds.
- Healed-region grain is not spectrum/resolution-matched in v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
