### PR TITLE
ci(release): add macOS/Windows install instructions to every release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,26 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: win_installer/FreeCCR_Install_*.exe
+          # Install instructions shown on every release page.
+          # KEEP IN SYNC with the macOS job's upload step below.
+          body: |
+            ## Install
+
+            ### Windows
+            Download the installer (`FreeCCR_Install_*.exe`) from the **Assets** below and run it.
+
+            ### macOS (Apple Silicon)
+            Download `FreeCCR_macOS_*.zip` from the **Assets**, unzip it, and move `FreeCCR.app` into your **Applications** folder.
+
+            ⚠️ **macOS may say the app is "damaged and can't be opened" — it isn't.** FreeCCR isn't notarized by Apple, so Gatekeeper blocks unsigned downloads on first launch. Clear the quarantine flag once by running this in **Terminal**:
+
+            ```
+            xattr -r -d com.apple.quarantine /Applications/FreeCCR.app
+            ```
+
+            Then open the app normally.
+
+            *Alternative:* right-click the app → **Open** → **Open**. On macOS Sequoia (15), if no "Open" button appears, use the Terminal command above, or go to **System Settings → Privacy & Security → Open Anyway**.
 
   build-macos:
     runs-on: macos-latest  # ARM64 (Apple Silicon)
@@ -121,3 +141,23 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: FreeCCR_macOS_*.zip
+          # Install instructions shown on every release page.
+          # KEEP IN SYNC with the Windows job's upload step above.
+          body: |
+            ## Install
+
+            ### Windows
+            Download the installer (`FreeCCR_Install_*.exe`) from the **Assets** below and run it.
+
+            ### macOS (Apple Silicon)
+            Download `FreeCCR_macOS_*.zip` from the **Assets**, unzip it, and move `FreeCCR.app` into your **Applications** folder.
+
+            ⚠️ **macOS may say the app is "damaged and can't be opened" — it isn't.** FreeCCR isn't notarized by Apple, so Gatekeeper blocks unsigned downloads on first launch. Clear the quarantine flag once by running this in **Terminal**:
+
+            ```
+            xattr -r -d com.apple.quarantine /Applications/FreeCCR.app
+            ```
+
+            Then open the app normally.
+
+            *Alternative:* right-click the app → **Open** → **Open**. On macOS Sequoia (15), if no "Open" button appears, use the Terminal command above, or go to **System Settings → Privacy & Security → Open Anyway**.


### PR DESCRIPTION
## Summary
Every release page now includes **install instructions**, so macOS users stop getting stuck on the unsigned-app / Gatekeeper "damaged and can't be opened" block.

## Change
`.github/workflows/release.yml` — both upload steps (`softprops/action-gh-release@v2`, Windows + macOS jobs) now set an identical `body`:
- Windows: download + run the installer.
- macOS: unzip, move to Applications, then clear quarantine with `xattr -r -d com.apple.quarantine /Applications/FreeCCR.app` (plus right-click→Open and Sequoia "Open Anyway" alternatives).

Previously release bodies were empty. Bodies are duplicated across both jobs (with a "keep in sync" comment) so the instructions appear even if only one platform's build succeeds.

## Notes
- Applies automatically to all future `v*` tags.
- The in-flight v0.3.1 release was built against the old workflow, so its notes are being set manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
