### PR TITLE
feat(tethering): watch-folder capture mode with auto-convert

### DIFF
--- a/spec/camera-tethering.md
+++ b/spec/camera-tethering.md
@@ -475,24 +475,31 @@ An adversarial review of the implementation surfaced these fixes, now in code:
   isolated copy. Skipped when the active image's look is all-default (no wasted
   re-render).
 
-### 9.6 Per-session B/W-point prompt (film-lead workflow)
-After the **first genuinely-new capture** of each tethering session, FreeCCR
-prompts the user to set the roll's B/W point from it — the intended workflow is
-that the first shot is the **film lead** (clear base + a fully-exposed/dense
-area), which calibrates the whole roll. Details:
-- Fires once per session (`_tether_prompted`, reset in `enter_tethering`).
-- Files imported via the "import existing?" prompt at session start are excluded
-  (`_tether_import_existing`); only a frame detected by the poll counts as the
+### 9.6 Per-session B/W-point reset + prompt (film-lead workflow)
+Every tethering session **clears the global B/W point** on entry and re-samples
+it from the roll's own **film lead** — different rolls/stocks have different base
+colour and density, so a previous roll's point must not carry over. This
+supersedes the original "persist + reuse" choice **for tethering**; the persisted
+point (QSettings) still benefits the normal, non-tethering convert workflow and
+is restored at startup, but `enter_tethering` resets the in-memory point to
+`None` so each session starts uncalibrated.
+
+- `enter_tethering` sets `ccr_backend.black_point_bgr/white_point_bgr = None`.
+  Captures import **unconverted** until the user samples (the banner note says
+  so).
+- After the **first genuinely-new capture** of the session (the film lead),
+  FreeCCR prompts once (`_tether_prompted`, reset per session) to set the roll's
+  B/W point from it. Files imported via the "import existing?" prompt are
+  excluded (`_tether_import_existing`); only a poll-detected frame counts as the
   lead.
-- The dialog explains the Black (clear base) / White (dense area) sampling; if a
-  B/W point is already set it offers "Keep Existing" vs re-sampling for this roll.
-- Choosing "Set Black Point" re-selects the lead frame (in case a later capture
-  stole the selection while the dialog was open) and enters Black-point sampling;
-  the existing sample flow then guides the user to the White point. Once both are
-  set, `persist_bwpoint` → `refresh_tether_banner` clears the note and subsequent
-  captures auto-convert.
-- The modal is opened via `QTimer.singleShot(0, …)` so it never blocks the
-  capture slot (and never hangs a headless test, which doesn't spin the loop).
+- The dialog always offers **Set Black Point** / **Skip** (no "Keep Existing" —
+  the point was just cleared). Choosing Set Black Point re-selects the lead frame
+  (in case a later capture stole the selection while the dialog was open) and
+  enters Black-point sampling; the existing flow then guides the user to the
+  White point. Once both are set, `persist_bwpoint` → `refresh_tether_banner`
+  clears the note and subsequent captures auto-convert.
+- The modal opens via `QTimer.singleShot(0, …)` so it never blocks the capture
+  slot (and never hangs a headless test, which doesn't spin the loop).
 
 ### 9.3 Out-of-scope confirmations (unchanged from §2)
 Direct USB camera control / live view / remote shutter, 30 fps video, in-app

--- a/spec/camera-tethering.md
+++ b/spec/camera-tethering.md
@@ -475,6 +475,25 @@ An adversarial review of the implementation surfaced these fixes, now in code:
   isolated copy. Skipped when the active image's look is all-default (no wasted
   re-render).
 
+### 9.6 Per-session B/W-point prompt (film-lead workflow)
+After the **first genuinely-new capture** of each tethering session, FreeCCR
+prompts the user to set the roll's B/W point from it — the intended workflow is
+that the first shot is the **film lead** (clear base + a fully-exposed/dense
+area), which calibrates the whole roll. Details:
+- Fires once per session (`_tether_prompted`, reset in `enter_tethering`).
+- Files imported via the "import existing?" prompt at session start are excluded
+  (`_tether_import_existing`); only a frame detected by the poll counts as the
+  lead.
+- The dialog explains the Black (clear base) / White (dense area) sampling; if a
+  B/W point is already set it offers "Keep Existing" vs re-sampling for this roll.
+- Choosing "Set Black Point" re-selects the lead frame (in case a later capture
+  stole the selection while the dialog was open) and enters Black-point sampling;
+  the existing sample flow then guides the user to the White point. Once both are
+  set, `persist_bwpoint` → `refresh_tether_banner` clears the note and subsequent
+  captures auto-convert.
+- The modal is opened via `QTimer.singleShot(0, …)` so it never blocks the
+  capture slot (and never hangs a headless test, which doesn't spin the loop).
+
 ### 9.3 Out-of-scope confirmations (unchanged from §2)
 Direct USB camera control / live view / remote shutter, 30 fps video, in-app
 camera settings, retroactive re-conversion on B/W-point change, and a

--- a/spec/camera-tethering.md
+++ b/spec/camera-tethering.md
@@ -456,6 +456,25 @@ An adversarial review of the implementation surfaced these fixes, now in code:
 - **`append_image_item` returns bool** + logs on an invalid index; a skipped add
   (rebuild in flight) self-heals on the next full `load_thumbnails`.
 
+### 9.5 Follow-up fixes (post-merge feedback)
+- **Banner theme.** The status strip now matches FreeCCR's default light theme:
+  a soft amber active-session bar (`#fff3cd`), a red recording dot, and a
+  white-on-red **Stop** button (was a dark `#2b2b2b` strip with an
+  invisible-on-dark default button).
+- **Immediate B/W status.** Sampling a Black/White point now refreshes the
+  banner note at once (`MainWindow.refresh_tether_banner`, called from
+  `persist_bwpoint`), so the "captures import unconverted" warning clears the
+  moment both points are set — no waiting for the next capture/poll.
+- **Inherited look on capture.** Each new capture inherits the editable look —
+  `adjustment_settings`, coarse/fine rotation, flips, crop, color profile, and
+  area layers — of the image active when it arrived (`_tether_template` /
+  `_apply_tether_template`, snapshotted in `_on_capture` before the new image is
+  selected). A rotate/brightness/etc. set on one frame thus auto-applies to the
+  next imported frame, which a fixed copy-stand rig wants. The template chains
+  forward (each capture becomes the source for the next) and is a deep,
+  isolated copy. Skipped when the active image's look is all-default (no wasted
+  re-render).
+
 ### 9.3 Out-of-scope confirmations (unchanged from §2)
 Direct USB camera control / live view / remote shutter, 30 fps video, in-app
 camera settings, retroactive re-conversion on B/W-point change, and a

--- a/spec/camera-tethering.md
+++ b/spec/camera-tethering.md
@@ -1,0 +1,463 @@
+# Spec: Tethering (Watch-Folder Capture)
+
+Status: REFINED v2
+Owner: FreeCCR
+Feature branch: `feature/tethering-watch-folder`
+
+## 1. Summary
+
+A **Tethering** mode (File menu) that **watches a user-chosen folder**. The user's
+own camera-tethering software (Canon EOS Utility, Nikon NX Tether, Sony Imaging
+Edge Remote, Fujifilm X Acquire, …) — or an SD-card auto-offload — writes each
+capture into that folder. FreeCCR detects every new file, imports it as a
+`CCRImage` (catalog-aware), **auto-converts it to a positive using the saved B/W
+point**, appends it to the thumbnail sidebar, and shows it **large on the canvas**.
+
+This delivers the spirit of "see the positive as you shoot" plus fast frame
+triage, with **zero camera-SDK dependencies** and identical, trivial setup on
+macOS and Windows.
+
+### Why watch-folder instead of direct USB control
+
+Decision is research-backed (see `experiments/`/PR discussion):
+
+- Camera-scanning film is a **static copy-stand** workflow: focus, exposure and
+  alignment are set **once per roll**, then the roll is shot in minutes. Live
+  view is a one-time *setup* aid, not a per-shot need.
+- The market-leading converter (Negative Lab Pro) has **no live preview**;
+  import-then-convert is the norm. Even Adobe Lightroom **disables camera live
+  view over USB tether**.
+- People who want a live framing view run the **camera vendor's app feeding a
+  watched/hot folder** — exactly this pattern (Lightroom "Auto Import", Capture
+  One "Hot Folder"). It is the industry standard and identical across OSes.
+- Direct in-app control (libgphoto2 / vendor SDKs) is high-friction
+  (per-camera Zadig/WinUSB on Windows, SDK registration + redistribution limits,
+  a per-vendor binding to maintain) for a benefit that this use case barely uses.
+
+FreeCCR therefore competes on **conversion quality**, not on live-ness.
+
+## 2. Goals / Non-goals
+
+### Goals
+- `File ▸ Tethering…` opens a folder picker, then enters a non-modal **watch mode**.
+- Detect **new** supported image files appearing in the folder *after* start,
+  robust to partial writes (a file mid-download is not picked up early).
+- Import each new file as a `CCRImage` (with catalog restore), **appended** to the
+  current batch.
+- **Auto-convert** each capture to a positive with the saved global B/W point
+  when one is available and Positive mode is off; otherwise import it unconverted.
+- **Show each capture large** on the canvas and select it in the sidebar (triage).
+- **Persist the global B/W point across sessions** (QSettings) and reuse it for
+  tethering. This is a small app-wide improvement, not tethering-only.
+- **Sample / refine the B/W point from a displayed capture** via the existing
+  eyedropper buttons; subsequent captures use the refined point automatically.
+- A slim **non-modal status banner** ("Watching <folder> — N captured") with a
+  **Stop** control; the File-menu action toggles to "Stop Tethering".
+- Clean teardown on Stop and on app close; **debounced** catalog saves.
+- Respect **Positive mode** (skip B/W conversion when on — the capture is already
+  a positive).
+- **No new third-party dependency** — built on Qt + the existing pipeline.
+
+### Non-goals
+- **No direct USB camera control, live view, or remote shutter** (no
+  gphoto2 / vendor SDK / PTP). Explicitly out of scope (researched as
+  high-friction, low-value for this app).
+- No true 30 fps live view; cadence is **per capture** (≈1–2 s after a file
+  lands), not per video frame.
+- No in-app camera settings (ISO/shutter/AF/WB) — the vendor app owns capture.
+- No automatic **re-conversion of already-imported captures** when the B/W point
+  later changes (the existing "Convert Current / Convert All (B/W Point)" buttons
+  cover that manually; a future enhancement may automate it).
+- No `watchdog`/inotify dependency; detection is a Qt timer poll (§5.1).
+- No video-file ingestion; only the existing supported still formats.
+
+## 3. UX / Interaction
+
+### 3.1 Entry
+A new `File ▸ Tethering…` action, inserted **after `Open Folder`** and before the
+Export separator (`main_window.create_menu`, ~`main_window.py:254`). On trigger:
+
+1. **Persist the current batch first** (`ccr_backend.save_catalog()`), mirroring
+   `open_files`/`open_folder`.
+2. Folder picker: `QFileDialog.getExistingDirectory`, seeded from
+   `_settings.value("files/last_tether_dir", "")`. Cancel → no-op.
+3. `normalize_unicode_path` + `validate_unicode_path`; on invalid path, warn and
+   abort (reuse the `open_folder` validation block).
+4. Persist `files/last_tether_dir`.
+5. **Enter watch mode** (§5). The current batch is **kept**; captures append to it.
+6. **Seed the seen-set** with the folder's current contents — pre-existing files
+   are **not** imported (only files that appear *after* start). (v2 open question
+   §9: optional "import existing too").
+
+### 3.2 Watch-mode state & banner
+A slim banner strip across the **top of the image-preview column** (above the
+canvas), shown only while watching:
+
+```
+●  Tethering — “Roll_2026-06-16”   ·   7 captured        [ Stop ]
+```
+
+- Left: a red dot + the watched folder's display name + capture count.
+- A secondary line/tooltip when no B/W point is set:
+  *"No B/W point set — captures import unconverted. Set Black & White points to
+  auto-convert."*  When Positive mode is on: *"Positive mode — captures import as
+  positives."*
+- Right: a **Stop** button.
+- Non-modal: the user can still select, adjust, crop, cull and export any
+  captured (or previously loaded) image while watching.
+
+The `File ▸ Tethering…` action's text toggles to **`Stop Tethering`** while active.
+
+### 3.3 Capture flow (per new file)
+Detect (poll, §5.1) → size-stability gate (§5.2) → off-thread decode + import
+(§5.4) → optional auto-convert (§5.4) → append to backend + sidebar, **select +
+show big** (§5.5) → transient hint *"Captured <name>"*. A file that fails to
+decode is **skipped** with a hint; the watch loop continues.
+
+### 3.4 B/W point sourcing (decision: persist + sample from a capture)
+- The global B/W point (`ccr_backend.black_point_bgr/white_point_bgr`) is
+  **persisted to QSettings** and **restored at startup**. Watch mode reuses it.
+- **If set:** every capture auto-converts.
+- **If unset:** captures import as unconverted negatives; the banner hints to set
+  points.
+- **Sample from a capture:** the existing **"Set White Point" / "Set Black Point"**
+  buttons already operate on the displayed image and call
+  `ccr_backend.set_white_point/set_black_point` (`sliders_panel.py:1327-1349`,
+  `image_preview.py:402-410`). Since a capture is a normal displayed `CCRImage`,
+  the user samples directly on it. After both points are set, **subsequent**
+  captures auto-convert. (Already-imported captures are not retro-converted in
+  v1 — §2 non-goals.)
+
+> **Accuracy note (important).** Most vendor apps drop an **8-bit sRGB JPEG** (or a
+> RAW) into the folder. The B/W-point math assumes the same value space as the
+> sampled scan. When the capture is a RAW it decodes through the normal pipeline
+> and converts faithfully. When it is a gamma-encoded JPEG, the live conversion is
+> a **good framing/triage preview**, not a color-accurate result — sampling the
+> B/W point *from a capture of the same format* (§3.4) makes the on-screen
+> conversion self-consistent. This is acceptable: the canvas is a triage view; the
+> archival conversion is whatever the user finalizes per image.
+
+### 3.5 Stop
+Stop via the banner button, the `Stop Tethering` menu item, or app close. Teardown
+(§5.5): stop the poll timer, quit + join the worker thread, hide the banner, do a
+final catalog save, restore the menu text.
+
+### 3.6 Errors / edge cases (UX-visible)
+- Decode failure on a file → skip + hint, keep watching.
+- Watched folder disappears (drive unplugged) → pause + hint; resume when it
+  reappears.
+- App close while watching → clean teardown before the catalog save in
+  `closeEvent`.
+
+## 4. Data model
+
+### 4.1 Global B/W point persistence (new)
+Mirror the existing global B/W point to QSettings, owned by the UI layer
+(`MainWindow._settings`, consistent with `import/positive_mode` and
+`import/input_icc_path`):
+
+```
+QSettings keys (JSON-encoded list[float] of length 3, B,G,R):
+  convert/black_point_bgr   e.g. "[51234.0, 48010.5, 52001.2]"
+  convert/white_point_bgr
+```
+
+- **Restore** at `MainWindow.__init__` (before any image loads, like positive
+  mode): parse → `ccr_backend.set_black_point(...)/set_white_point(...)`.
+- **Persist** whenever a point is sampled: hook `on_bwpoint_sampled`
+  (`sliders_panel.py:1339`) to also write the QSettings keys (via the main
+  window). Malformed/absent → treated as unset.
+
+### 4.2 Watch-session state (transient — on `MainWindow`, not persisted)
+- `_tether_folder: str` — watched directory.
+- `_tether_seen: set[str]` — basenames already handled (seeded at start).
+- `_tether_sizes: dict[str, int]` — per-file last-seen size, for the stability gate.
+- `_tether_count: int` — captures imported this session.
+- `_tether_timer: QTimer` — the poller.
+- `_tether_thread: QThread`, `_tether_worker: TetherWatchWorker`.
+- `_tether_active: bool`.
+
+### 4.3 Captured images
+Captures are **ordinary `CCRImage`s** persisted by the existing catalog exactly
+like any imported file. When auto-converted, `conversion_inputs = {"mode": "bw",
+"bw": ((B,G,R),(B,G,R)), "fine_rot": …}` is set (mirroring
+`apply_bwpoint_to_all_images`, `ccr_backend.py:1358-1362`), so reopening the app
+restores the conversion. The file physically lives in the user's chosen folder;
+the catalog references it by path as usual.
+
+### 4.4 QSettings (UI prefs)
+- `files/last_tether_dir: str` — last watched folder.
+
+## 5. Processing / detection
+
+### 5.1 Detection — poll timer (GUI thread)
+A `QTimer` on the GUI thread, interval **1000 ms**. Each tick:
+
+1. `os.scandir(folder)` (Windows-Unicode-safe; already used in
+   `ccr_backend.py:157`). On `FileNotFoundError`/`OSError` → folder unavailable:
+   set a "paused" banner state, keep ticking.
+2. Filter entries by the **supported extension set** (reuse the `open_files`
+   filter list — `.dng .tif .tiff .arw .nef .cr2 .cr3 .raf .png .jpg .jpeg .rw2
+   .3fr .fff` + the broader folder set), case-insensitive.
+3. For each candidate not in `_tether_seen`:
+   - record `size = entry.stat().st_size`.
+   - **ready** iff `size > 0` **and** `size == _tether_sizes.get(name)` (i.e.
+     unchanged since the previous tick — see §5.2). Update `_tether_sizes`.
+   - When ready: add `name` to `_tether_seen` and **enqueue** the full path to the
+     worker (queued signal, §5.4).
+
+Polling at 1 s is far more reliable than `QFileSystemWatcher` for this cadence
+(captures arrive seconds apart) and avoids its known "directory changed but which
+file?" and missed-event issues. (`QFileSystemWatcher` as an *accelerator* is a
+v2 open question, §9.)
+
+### 5.2 Partial-write safety
+The **size-stability gate** (§5.1): a file is dispatched only after its size is
+unchanged across one poll interval, so a still-downloading capture is held until
+complete. The worker additionally wraps the decode in try/except (truncated/locked
+file → skip, leave it out of `_tether_seen` so a later tick can retry once stable).
+
+### 5.3 RAW + JPEG pairs
+When a camera shoots RAW+JPEG it writes two files per shot. v1 imports **every**
+ready supported file (documented). v2 refinement (§9): when both a RAW and a JPEG
+of the **same basename** become ready in a session, prefer the RAW and skip the
+JPEG sibling.
+
+### 5.4 Processing — worker thread (serial queue)
+A long-lived `TetherWatchWorker(QObject)` moved onto a `QThread` **with an event
+loop** (so queued slots run off the GUI thread). The poller emits `fileReady(path)`
+connected (`Qt.QueuedConnection`) to `worker.process(path)`. `process`:
+
+1. `imgs = create_images_for_path(path, catalog_data=load_catalog())`
+   (catalog-aware single-file load, the same primitive
+   `load_images_from_files` uses per file — `ccr_backend.py:78`, `catalog.py:307`).
+   *(Catalog is read once and cached on the worker; re-read only if stale.)*
+2. For each produced `CCRImage img` (normally one; a previously-sliced file could
+   yield several):
+   - If **Positive mode off** *and* a B/W point is set:
+     `processed = ccr_normalize_with_bwpoint(img, black, white)`;
+     `img.resized_raw = processed`; `img.converted = True`;
+     `img.conversion_inputs = {...bw...}`; `img.update_thumbnail_and_preview()`.
+     (Exactly mirrors `apply_bwpoint_to_all_images`, which already runs in a
+     worker thread and builds the preview QPixmap there — established pattern.)
+   - Else import as-is (Positive mode bakes the positive at decode; or unconverted
+     negative when no B/W point).
+   - Emit `captured(img)`.
+3. On exception → emit `captureError(path, str(e))`.
+
+**Threading note.** Unlike the one-shot `ImageLoaderWorker`
+(`main_window.py:83`, which blocks in `run()` and emits `finished`), this worker is
+**long-lived**: `thread.start()` runs its event loop, the worker is `moveToThread`'d,
+and work arrives via the queued `fileReady → process` connection. Files are
+processed **serially** on that one thread, so multiple rapid captures queue and the
+GUI stays responsive.
+
+### 5.5 GUI integration — `captured` slot (GUI thread)
+1. Append `img` to `ccr_backend.images` and `ccr_backend.file_paths` **on the GUI
+   thread** (the lists are lock-free and assume the GUI thread is the writer —
+   `ccr_backend.py:34-35`).
+2. `thumbnail_list.append_image_item(idx, select=True)` (new helper, §6) — adds one
+   `QListWidgetItem` with `Qt.UserRole = idx` and selects it. Selecting fires
+   `on_current_item_changed` → `image_preview.update_preview(idx)` +
+   `sliders_panel.set_current_idx(idx)` → the capture shows **big** on the canvas.
+3. `_tether_count += 1`; update the banner; `set_temporary_hint("Captured <name>")`.
+4. **Debounced catalog save** (coalesce to ~once / 3 s via a `QTimer`; also save on
+   Stop/close) — avoids disk thrash on bursts (hazard from backend research).
+
+`captureError` slot → `set_temporary_hint("Skipped <name>: <msg>")`.
+
+### 5.6 Conversion math
+Unchanged. `ccr_normalize_with_bwpoint` / `apply_bwpoint_normalization`
+(`ccr_processor.py:1001`, `:1541`) already perform the per-channel linear
+anchor map (`(v - white)/(black - white)·65535`, clip) + neutral inversion, with
+the post-invert "look" disabled. Reused verbatim.
+
+### 5.7 Positive mode
+`CCRImage` reads `ccr_backend.positive_mode` at decode time, so a capture imported
+while Positive mode is on is already a positive. In that case **skip** the B/W
+conversion entirely. The flag is read **per capture** (snapshot at `process`
+start) to avoid mid-decode inconsistency.
+
+## 6. Integration points
+
+| Location | Change |
+|---|---|
+| `main_window.create_menu` (~`:254`) | Add `File ▸ Tethering…` action after `Open Folder`; keep a handle to toggle its text. |
+| `main_window` (new) | `enter_tethering()` (save catalog, folder picker, validate, persist dir, seed seen-set, start poller+worker, show banner, toggle menu text). |
+| `main_window` (new) | `stop_tethering()` (stop timer, quit+join worker, hide banner, final save, restore menu text). `_cleanup_tether()` nulls handles (mirror `_cleanup_loader`). |
+| `main_window` (new) | `_poll_tether_folder()` (the §5.1 tick). |
+| `main_window` (new) | `_on_capture(img)` / `_on_capture_error(path,msg)` (the §5.5 slots). |
+| `main_window.__init__` | Restore persisted B/W point into `ccr_backend` (before image loads); create the (hidden) banner; init `_tether_*` state. |
+| `main_window.closeEvent` (`:196`) | `stop_tethering()` **before** `ccr_backend.save_catalog()`. |
+| `sliders_panel.on_bwpoint_sampled` (`:1339`) | Also persist the sampled B/W point to QSettings (via the main window). |
+| `thumbnail_list` (new) | `append_image_item(idx, select=True)` — append one item without a full `load_thumbnails()` rebuild. |
+| **new** `src/core/tether_watcher.py` | `TetherWatchWorker(QObject)` (+ a small extension-filter helper). Pure Qt + existing pipeline; no third-party deps. |
+| `catalog.py` | **No change** — captures persist exactly like normal imported files. |
+
+## 7. Files touched / added
+
+- **add** `src/core/tether_watcher.py` — `TetherWatchWorker` (long-lived QThread
+  worker; `process(path)`, `captured`/`captureError` signals).
+- **add** `src/widgets/tether_banner.py` *(or inline in `main_window`)* — the slim
+  watch-status banner with a Stop button.
+- **edit** `src/ui/main_window.py` — menu action + enter/stop/poll/slots, B/W
+  restore + banner, `closeEvent` teardown.
+- **edit** `src/widgets/thumbnail_list.py` — `append_image_item`.
+- **edit** `src/widgets/image_preview.py` — `set_tether_banner` /
+  `show_tether_banner` / `hide_tether_banner` helpers (insert the banner into the
+  existing internal `QVBoxLayout` at index 0; no reparenting — see §9.1.5).
+- **edit** `src/widgets/sliders_panel.py` — persist B/W point on sample; banner
+  hint text.
+- **add** `tests/test_tether_watcher.py` — detection/stability/dedupe, processing
+  (convert vs unconverted vs positive-mode), B/W persistence round-trip, append.
+
+## 8. Test plan
+
+### Unit (headless; no camera, minimal Qt)
+- **Scanner / stability:** a file is dispatched only after its size is stable
+  across two ticks; a growing file is held; pre-existing files (seeded set) are
+  ignored; unsupported extensions ignored.
+- **RAW+JPEG dedupe** (if v2 §5.3 lands): same-basename RAW preferred over JPEG.
+- **Processing:** a sample negative → converted `CCRImage` with correct
+  `conversion_inputs` when a B/W point is set; unconverted when unset;
+  Positive-mode path skips conversion.
+- **B/W persistence:** set points → QSettings round-trip → restore yields equal
+  tuples; malformed/missing → unset (`None`).
+- **Backend append:** `_on_capture` appends exactly one image; `images` and
+  `file_paths` stay in sync; index/`UserRole` mapping correct.
+
+### Manual
+- `File ▸ Tethering…`, pick a folder; copy a supported file in → it appears
+  converted, **big on the canvas**, selected in the sidebar within ~1–2 s.
+- Drop several files quickly → all import serially; UI stays responsive.
+- No B/W point → imports unconverted + hint; sample on a capture → next drop
+  auto-converts.
+- Positive mode on → captures import as positives (no B/W conversion).
+- Stop → banner hides, watching stops. Reopen the app → captures + conversions
+  restored from catalog; B/W point restored.
+- Close the app while watching → clean exit, catalog saved, no dangling thread.
+- Unplug / rename the watched folder → graceful pause + hint; restore on return.
+
+## 9. Refinement (v2) — resolved decisions & added detail
+
+### 9.1 Resolved open questions
+1. **Append, don't replace.** Entering tethering **keeps** the current batch and
+   appends captures to it (least destructive; lets a user keep a loaded roll
+   visible). `ccr_backend.save_catalog()` is still called first, mirroring the
+   open flows, so prior edits are persisted before the session grows.
+2. **Pre-existing files: prompt once.** On entry, if the folder already contains
+   ≥1 supported file, show a `QMessageBox.question`: *"This folder already
+   contains N supported image(s). Import them too?"* **Yes** → enqueue them
+   through the normal capture path (oldest-mtime first); **No** → seed the
+   seen-set with them so only *new* files import. Either way the seen-set ends up
+   containing every current file, so nothing is imported twice.
+3. **Pure 1 s poll** in v1 (no `QFileSystemWatcher`). At capture cadence (seconds
+   apart) a 1 s `os.scandir` poll is reliable and simple; the watcher's
+   "something changed / which file?" semantics and missed-event quirks aren't
+   worth it. Listed as a future *accelerator* only.
+4. **RAW+JPEG dedupe (light, in v1).** Track handled **basenames**. RAW
+   extensions (`.dng .arw .nef .cr2 .cr3 .raf .rw2 .3fr .fff .orf .pef .srw …`)
+   are preferred over JPEG/PNG. Rule: when a file becomes ready, if a sibling of
+   the **same basename** has already been handled, skip the newcomer **unless**
+   the newcomer is RAW and the handled one was a non-RAW that has *not yet been
+   imported in this tick* — in practice we resolve **within a tick** (same
+   basename, both ready: import the RAW, drop the JPEG) and document the
+   cross-tick case (JPEG ready first, RAW a tick later → both import) as a known
+   v1 limitation. No retroactive removal of an already-imported sibling in v1.
+5. **Banner = slim top strip, inserted INSIDE `ImagePreview`'s own layout.**
+   ⚠️ **Do not wrap `image_preview` in a new container.** `ImagePreview` and its
+   inner `GraphicsImageView` reach the main window via `self.parent().parent()`
+   and `pw.parent().parent()` (`pw = self.parent_widget`, i.e. the `ImagePreview`)
+   in ~15 places (WB/eyedropper sampling, B/W sampling, histogram, thumbnail
+   refresh, hints — `image_preview.py:320, 410, 459, 972, 1002, 1012, 1231, 1241,
+   1704, 1965, 1980, 2494, 2538, 2836, 3046…`). The chain works because
+   `ImagePreview.parent()` is `central_widget` and `.parent()` is `MainWindow`.
+   Inserting an extra container level would make `parent().parent()` resolve to
+   `central_widget` and **break all of them**.
+   Instead, the banner is added to `ImagePreview`'s **existing internal**
+   `QVBoxLayout` (`self.layout`, currently `[toolbar, view, rotation_slider]`,
+   `image_preview.py:587, 728`) at **index 0** via `self.layout.insertWidget(0,
+   banner)`. The banner becomes a child of `ImagePreview` (so `ImagePreview`'s own
+   parent is unchanged and every `parent().parent()` chain stays valid), and it
+   renders as a strip above the toolbar. Implemented as a tiny
+   `ImagePreview.set_tether_banner(widget)` / `show_tether_banner(folder, count,
+   note)` / `hide_tether_banner()` helper so `MainWindow` doesn't reach into
+   `image_preview.layout` directly. `TetherBanner` is a `QWidget` (red-dot label +
+   status `QLabel` + **Stop** `QPushButton`, `stopRequested` signal),
+   `setVisible(False)` by default.
+6. **Debounced catalog save = 3000 ms**, single-shot, restarted on each capture;
+   plus an **unconditional** save on Stop and in `closeEvent`. (One `QTimer`,
+   `setSingleShot(True)`.)
+7. **Worker = one long-lived event-loop `QThread`.** `self._tether_thread =
+   QThread(); self._tether_worker = TetherWatchWorker(); worker.moveToThread(thread);
+   thread.start()` (no `started→run` blocking connection — the thread runs its
+   **event loop**). Work is delivered by a **queued** connection
+   (`self._fileReady.connect(worker.process, Qt.QueuedConnection)` or
+   `QMetaObject.invokeMethod(worker, "process", Qt.QueuedConnection, path)`), so
+   `process` executes on the worker thread; files queue and run **serially**.
+   `captured`/`captureError` are emitted back and delivered to GUI slots on the
+   GUI thread (auto/queued). Shutdown: `worker.cancel()` (sets a flag the
+   in-flight `process` can check between images), `thread.quit()`,
+   `thread.wait(3000)`, then null the handles in `_cleanup_tether` — exactly the
+   `_stop_loader_if_running`/`_cleanup_loader` shape (`main_window.py:437-454`).
+8. **Stop affordances = banner button + menu toggle** in v1. The File-menu action
+   flips between `Tethering…` and `Stop Tethering`; the banner carries a **Stop**
+   button. No `Esc`/global-key binding in v1 (avoids the existing SPACE/arrow
+   focus interactions in the canvas).
+
+### 9.2 Tightened integration detail
+- **QPixmap-off-GUI-thread is the established pattern here.**
+  `CCRImage.__init__` → `update_thumbnail_and_preview` builds `QPixmap`
+  (`ccr_image.py:605`, `:522`), and the existing **batch loader runs that on a
+  worker `QThread`** (`ImageLoaderWorker` → `load_images_from_files` →
+  `create_images_for_path` → `CCRImage(...)`), as does `BWPointConvertWorker`.
+  `TetherWatchWorker.process` building the preview/conversion off-thread is
+  therefore **consistent with existing code**, not a new hazard. The one rule kept
+  strict: **list mutation** (`ccr_backend.images/.file_paths.append`) and **all
+  thumbnail-widget / canvas calls** happen only in the GUI-thread `captured` slot
+  (§5.5), never in the worker.
+- **Persisting the B/W point from the panel.** `on_bwpoint_sampled`
+  (`sliders_panel.py:1339`) reaches the main window via `self.parent().parent()`
+  (the same access `_on_convert_current_bwpoint` uses, `:1377`); call a new
+  `MainWindow.persist_bwpoint()` (guarded by `hasattr`) that JSON-encodes
+  `ccr_backend.black_point_bgr/white_point_bgr` into the §4.1 QSettings keys.
+  Restoration at `MainWindow.__init__` decodes them back via
+  `ccr_backend.set_black_point/set_white_point` before any image loads.
+- **Selecting the new capture.** `thumbnail_list.append_image_item(idx,
+  select=True)` adds one `QListWidgetItem` (`text=display_name or basename`,
+  `Qt.UserRole=idx`, transformed icon via `apply_frontend_transformations`) and,
+  when `select`, `thumbnail_list.setCurrentRow(idx)` — which fires
+  `on_current_item_changed` → `image_preview.update_preview(idx)` +
+  `sliders_panel.set_current_idx(idx)`. No full `load_thumbnails()` rebuild per
+  capture. Guard against the `_rebuilding` re-entrancy flag the list already uses.
+- **Folder-unavailable handling.** A poll tick whose `os.scandir` raises
+  `OSError` sets a banner "paused — folder unavailable" state and keeps ticking;
+  the next successful tick clears it. No worker involvement.
+- **Catalog read in the worker.** `process` loads the catalog once and caches it
+  on the worker, re-reading only if its mtime changed, so per-capture imports
+  don't re-parse the JSON each time (mirrors the "read catalog once per batch"
+  optimization in `load_images_from_files`, `ccr_backend.py:63-69`).
+
+### 9.4 Post-review hardening (applied during implementation)
+An adversarial review of the implementation surfaced these fixes, now in code:
+- **Seen-set pruning.** `FolderScanner.feed` forgets files that have left the
+  folder (`seen &= present`), so a **delete-then-recreate of the same filename**
+  (retaking a bad shot) re-imports instead of being blocked forever.
+- **Duplicate-name coalescing.** A listing that reports the same name twice (some
+  network/symlink filesystems) is coalesced before the stability gate.
+- **No lost capture on Stop.** `_on_capture` always appends the image (and
+  persists immediately if the session already stopped) — a capture that was
+  in-flight when the user hit Stop is kept, not dropped.
+- **Catalog mtime-cache** on the worker (§9.2) is implemented, not per-call reload.
+- **`positive_mode` is snapshotted** alongside the B/W point at `process()` start.
+- **Folder-unavailable banner clears** on reconnect (a `_tether_unavailable` flag).
+- **Timer lifecycle:** `_tether_save_timer` is nulled on Stop; no `deleteLater`
+  on the worker after the thread's loop has exited (refs dropped, GC releases it).
+- **`append_image_item` returns bool** + logs on an invalid index; a skipped add
+  (rebuild in flight) self-heals on the next full `load_thumbnails`.
+
+### 9.3 Out-of-scope confirmations (unchanged from §2)
+Direct USB camera control / live view / remote shutter, 30 fps video, in-app
+camera settings, retroactive re-conversion on B/W-point change, and a
+`watchdog`/`QFileSystemWatcher` dependency all remain **non-goals** for this
+change.

--- a/src/core/tether_watcher.py
+++ b/src/core/tether_watcher.py
@@ -1,0 +1,218 @@
+"""Watch-folder tethering: detect new capture files and import them as CCRImages.
+
+See spec/camera-tethering.md. There is NO camera SDK here — the user's own
+tethering app (Canon EOS Utility, Nikon NX Tether, Sony Imaging Edge, Fujifilm
+X Acquire, …) or an SD auto-offload writes captures into a watched folder.
+FreeCCR polls the folder (`FolderScanner`), and a long-lived `TetherWatchWorker`
+decodes each new file and auto-converts it with the saved B/W point.
+
+This module is deliberately Qt-light: `FolderScanner` and the encode/decode
+helpers are pure (unit-tested without a display); only `TetherWatchWorker` uses
+Qt signals so it can run on its own thread.
+"""
+import json
+import os
+
+from PySide6.QtCore import QObject, Signal, Slot
+
+from core.ccr_backend import ccr_backend
+
+# Still formats FreeCCR can decode (superset of the Open-Files filter plus the
+# broader Open-Folder set). Lower-case, with the leading dot.
+SUPPORTED_EXTS = {
+    ".dng", ".tif", ".tiff", ".arw", ".nef", ".cr2", ".cr3", ".raf",
+    ".png", ".jpg", ".jpeg", ".rw2", ".3fr", ".fff", ".sr2", ".orf",
+    ".pef", ".heic", ".heif", ".dcr", ".kdc", ".x3f", ".srw", ".erf",
+    ".nrw", ".ptx", ".r3d",
+}
+# RAW formats are preferred over a same-basename JPEG/PNG/TIFF sibling when both
+# become ready in one poll tick (a camera shooting RAW+JPEG).
+RAW_EXTS = {
+    ".dng", ".arw", ".nef", ".cr2", ".cr3", ".raf", ".rw2", ".3fr", ".fff",
+    ".sr2", ".orf", ".pef", ".dcr", ".kdc", ".x3f", ".srw", ".erf", ".nrw",
+    ".ptx", ".r3d",
+}
+
+
+def _ext(name):
+    return os.path.splitext(name)[1].lower()
+
+
+def is_supported(name):
+    return _ext(name) in SUPPORTED_EXTS
+
+
+def is_raw(name):
+    return _ext(name) in RAW_EXTS
+
+
+def encode_bwpoint(bgr):
+    """Serialize a (B,G,R) point to a QSettings-friendly JSON string, or None."""
+    if bgr is None:
+        return None
+    try:
+        return json.dumps([float(x) for x in bgr])
+    except (TypeError, ValueError):
+        return None
+
+
+def decode_bwpoint(raw):
+    """Parse a stored B/W point back to a (B,G,R) float tuple, tolerating
+    malformed/legacy values (returns None)."""
+    if not raw:
+        return None
+    try:
+        vals = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(vals, (list, tuple)) and len(vals) == 3:
+        try:
+            return tuple(float(v) for v in vals)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+class FolderScanner:
+    """Pure, Qt-free new-file detector for a watched folder.
+
+    `feed()` is given the current directory listing as (name, size) pairs and
+    returns the names that are newly READY this tick: a supported extension,
+    size > 0, and size unchanged since the previous tick (so a still-downloading
+    file is held until it stops growing). Within one tick a RAW is preferred over
+    a same-basename JPEG/PNG/TIFF sibling; cross-tick siblings both import (a
+    documented v1 limitation, spec §9.1.4). Every candidate seen this tick — kept
+    or dropped — is recorded so it never re-imports.
+    """
+
+    def __init__(self, initial_names=()):
+        self.seen = set(initial_names)   # names already handled / pre-seeded
+        self.sizes = {}                  # name -> last-seen size (stability gate)
+
+    def feed(self, entries):
+        # Coalesce duplicate names in one listing (possible on some network /
+        # symlinked filesystems), keeping the largest reported size.
+        listing = {}
+        for name, size in entries:
+            if name not in listing or size > listing[name]:
+                listing[name] = size
+        present = set(listing)
+
+        # Forget files that have left the folder, so a delete-then-recreate of
+        # the same filename (e.g. retaking a bad shot to the same name) imports
+        # the new file rather than being blocked forever by the seen-set.
+        self.seen &= present
+        self.sizes = {n: s for n, s in self.sizes.items() if n in present}
+
+        candidates = []
+        for name, size in listing.items():
+            if name in self.seen or not is_supported(name):
+                continue
+            if size <= 0:
+                self.sizes[name] = size
+                continue
+            if self.sizes.get(name) == size:
+                candidates.append(name)
+            else:
+                self.sizes[name] = size  # new/changed — wait one more tick
+
+        # Within-tick basename dedupe, preferring RAW over non-RAW siblings.
+        chosen = {}
+        for name in candidates:
+            base = os.path.splitext(name)[0].lower()
+            cur = chosen.get(base)
+            if cur is None or (is_raw(name) and not is_raw(cur)):
+                chosen[base] = name
+        chosen_set = set(chosen.values())
+
+        ready = []
+        for name in candidates:
+            self.seen.add(name)          # handled whether chosen or dropped
+            if name in chosen_set:
+                ready.append(name)
+        return ready
+
+
+class TetherWatchWorker(QObject):
+    """Long-lived worker living on its own QThread (with an event loop). The GUI
+    delivers file paths via the queued `process()` slot; each is decoded into a
+    CCRImage and, when a B/W point is set and Positive mode is off, converted to a
+    positive. Results are emitted back to the GUI thread via `captured`.
+
+    All ccr_backend list mutation and any thumbnail/canvas work happen in the
+    GUI-thread slots that receive these signals — NOT here.
+    """
+    captured = Signal(object)          # CCRImage
+    captureError = Signal(str, str)    # (path, message)
+
+    def __init__(self):
+        super().__init__()
+        self._cancelled = False
+        self._cat_mtime = None   # mtime of the cached catalog file
+        self._cat_data = None    # cached parsed catalog (spec §9.2)
+
+    def cancel(self):
+        self._cancelled = True
+
+    def _catalog(self):
+        """Reuse the parsed catalog across captures, re-reading only when the
+        file's mtime changes — avoids re-parsing JSON for every capture during
+        a burst (spec §9.2)."""
+        from core.catalog import default_catalog_path, load_catalog
+        try:
+            mtime = os.path.getmtime(default_catalog_path())
+        except OSError:
+            mtime = None
+        if self._cat_data is None or mtime != self._cat_mtime:
+            try:
+                self._cat_data = load_catalog()
+            except Exception:
+                self._cat_data = None
+            self._cat_mtime = mtime
+        return self._cat_data
+
+    @Slot(str)
+    def process(self, path):
+        if self._cancelled:
+            return
+        try:
+            from core.catalog import create_images_for_path
+            imgs = create_images_for_path(path, catalog_data=self._catalog())
+            if not imgs:
+                self.captureError.emit(path, "no image produced")
+                return
+            # Snapshot the conversion inputs once per file so a mid-decode flip
+            # (Positive mode / B/W point change) can't make one file half-convert.
+            black = ccr_backend.black_point_bgr
+            white = ccr_backend.white_point_bgr
+            positive = ccr_backend.positive_mode
+            convert = (not positive and black is not None and white is not None)
+            for img in imgs:
+                if self._cancelled:
+                    return
+                if convert and not img.converted:
+                    self._convert(img, black, white)
+                self.captured.emit(img)
+        except Exception as e:
+            self.captureError.emit(path, str(e))
+
+    @staticmethod
+    def _convert(img, black, white):
+        """Bake the saved B/W-point conversion into the image (preview + the
+        conversion_inputs snapshot the export/catalog paths replay). Mirrors
+        CCRBackend.apply_bwpoint_to_all_images. On failure the image is left
+        unconverted but still importable."""
+        from core.ccr_processor import ccr_normalize_with_bwpoint
+        try:
+            processed = ccr_normalize_with_bwpoint(img, black, white)
+            if processed is not None:
+                img.resized_raw = processed
+            img.converted = True
+            img.conversion_inputs = {
+                "mode": "bw",
+                "bw": (tuple(black), tuple(white)),
+                "fine_rot": img.fine_rotation_angle,
+            }
+            img.update_thumbnail_and_preview()
+        except Exception as e:
+            print(f"Tether auto-convert failed for {img.file_path}: {e}")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,10 +1,14 @@
 from PySide6.QtWidgets import QApplication, QMainWindow, QHBoxLayout, QWidget, QFileDialog, QMessageBox, QDialog, QVBoxLayout, QTextEdit, QPushButton, QLabel, QLineEdit
 from PySide6.QtGui import QIcon, QShortcut, QKeySequence
-from PySide6.QtCore import Qt, QEvent, QThread, Signal, QObject, QSettings, QTimer
+from PySide6.QtCore import (Qt, QEvent, QThread, Signal, QObject, QSettings,
+                            QTimer, QMetaObject, Q_ARG)
 from widgets.thumbnail_list import ThumbnailList
 from widgets.image_preview import ImagePreview
 from widgets.sliders_panel import SlidersPanel
+from widgets.tether_banner import TetherBanner
 from core.ccr_backend import ccr_backend
+from core.tether_watcher import (TetherWatchWorker, FolderScanner, is_supported,
+                                 encode_bwpoint, decode_bwpoint)
 import ctypes
 from version import VERSION  # Make sure version.py is in your src folder
 import html
@@ -127,6 +131,23 @@ class MainWindow(QMainWindow):
         self.sliders_panel.set_sliders_enabled(False)
         self.sliders_panel.image_preview = self.image_preview
 
+        # Tethering (watch-folder capture) state + status banner. The banner is
+        # installed INTO image_preview's own layout (not wrapped around it) so
+        # ImagePreview's parent().parent() chains stay valid — see
+        # spec/camera-tethering.md §9.1.5.
+        self._tether_active = False
+        self._tether_thread = None
+        self._tether_worker = None
+        self._tether_timer = None
+        self._tether_save_timer = None
+        self._tether_scanner = None
+        self._tether_folder = None
+        self._tether_count = 0
+        self._tether_unavailable = False
+        self.tether_banner = TetherBanner()
+        self.tether_banner.stopRequested.connect(self.stop_tethering)
+        self.image_preview.set_tether_banner(self.tether_banner)
+
         self.layout.addWidget(self.thumbnail_list, 0)
         self.layout.addWidget(self.image_preview, 3)
         self.layout.addWidget(self.sliders_panel, 0)
@@ -142,6 +163,10 @@ class MainWindow(QMainWindow):
         # Reflect the restored mode in the toolbar/slider gating right away
         # (no images yet, but the negative-only actions should already grey out).
         self.image_preview._update_unconvert_action_state()
+
+        # Restore a persisted global B/W point (set in a prior session) so
+        # tethering can auto-convert captures right away. Before any image loads.
+        self._restore_bwpoint()
 
         self.installEventFilter(self)
         self.create_menu()
@@ -202,6 +227,10 @@ class MainWindow(QMainWindow):
             QMessageBox.No
         )
         if reply == QMessageBox.Yes:
+            # Stop any active tethering session (poller + worker thread) cleanly
+            # before persisting, so no capture is mid-write into a locked catalog.
+            if self._tether_active:
+                self.stop_tethering()
             # Persist the edit catalog so reopening these files restores
             # their conversion/slices/crop/adjustments.
             ccr_backend.save_catalog()
@@ -252,6 +281,9 @@ class MainWindow(QMainWindow):
 
         open_folder_action = file_menu.addAction("Open Folder")
         open_folder_action.triggered.connect(self.open_folder)
+
+        self.tether_action = file_menu.addAction("Tethering…")
+        self.tether_action.triggered.connect(self.toggle_tethering)
 
         file_menu.addSeparator()
         export_action = file_menu.addAction("Export…")
@@ -539,6 +571,220 @@ class MainWindow(QMainWindow):
             self._loader_thread.finished.connect(self._cleanup_loader)
             self._loader_worker.finished.connect(self.thumbnail_list.load_thumbnails)
             self._loader_thread.start()
+
+    # --- Tethering (watch-folder capture) ---------------------------------
+    def toggle_tethering(self):
+        if self._tether_active:
+            self.stop_tethering()
+        else:
+            self.enter_tethering()
+
+    def _tether_folder_label(self):
+        if not self._tether_folder:
+            return ""
+        return (os.path.basename(self._tether_folder.rstrip("/\\"))
+                or self._tether_folder)
+
+    def _tether_note(self):
+        """Banner sub-text reflecting how captures will be handled."""
+        if ccr_backend.positive_mode:
+            return "Positive mode — captures import as positives."
+        if ccr_backend.black_point_bgr is None or ccr_backend.white_point_bgr is None:
+            return ("No B/W point set — captures import unconverted. "
+                    "Set Black & White points to auto-convert.")
+        return ""
+
+    def enter_tethering(self):
+        if self._tether_active:
+            return
+        # The batch is about to grow — persist current edits first (like the
+        # open flows) so nothing is lost if the session is interrupted.
+        ccr_backend.save_catalog()
+        start_dir = self._settings.value("files/last_tether_dir", "", type=str)
+        folder = QFileDialog.getExistingDirectory(
+            self, "Select Folder to Watch for Captures", start_dir)
+        if not folder:
+            return
+        normalized = normalize_unicode_path(folder)
+        if not validate_unicode_path(normalized):
+            QMessageBox.warning(
+                self, "Unicode Path Warning",
+                f"The selected folder path contains characters that may cause "
+                f"issues:\n\n{folder}\n\nPlease choose a folder with a simpler "
+                f"path name.")
+            return
+        self._settings.setValue("files/last_tether_dir", folder)
+        folder = os.path.normpath(normalized)
+
+        # Snapshot the folder's current supported files. They are seeded into the
+        # scanner (so the poller never re-imports them); optionally import them now.
+        try:
+            existing = [e.name for e in os.scandir(folder)
+                        if e.is_file() and is_supported(e.name)]
+        except OSError as e:
+            QMessageBox.warning(self, "Tethering Error",
+                                f"Could not read the folder:\n\n{e}")
+            return
+        import_paths = []
+        if existing:
+            resp = QMessageBox.question(
+                self, "Import Existing Files?",
+                f"This folder already contains {len(existing)} supported "
+                f"image(s).\n\nImport them too?",
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+            if resp == QMessageBox.Yes:
+                import_paths = [os.path.join(folder, n) for n in existing]
+                try:
+                    import_paths.sort(key=os.path.getmtime)  # oldest first
+                except OSError:
+                    pass
+
+        self._tether_folder = folder
+        self._tether_count = 0
+        self._tether_unavailable = False
+        self._tether_scanner = FolderScanner(initial_names=existing)
+
+        # Long-lived worker on its own event-loop QThread (spec §9.1.7); work is
+        # delivered by QMetaObject.invokeMethod (queued) so it runs off-GUI.
+        self._tether_thread = QThread()
+        self._tether_worker = TetherWatchWorker()
+        self._tether_worker.moveToThread(self._tether_thread)
+        self._tether_worker.captured.connect(self._on_capture)
+        self._tether_worker.captureError.connect(self._on_capture_error)
+        self._tether_thread.start()
+
+        self._tether_active = True
+        self.tether_action.setText("Stop Tethering")
+        self.image_preview.show_tether_banner(
+            self._tether_folder_label(), self._tether_count, self._tether_note())
+
+        self._tether_timer = QTimer(self)
+        self._tether_timer.setInterval(1000)
+        self._tether_timer.timeout.connect(self._poll_tether_folder)
+        self._tether_timer.start()
+
+        for p in import_paths:
+            self._dispatch_to_worker(p)
+
+        self.sliders_panel.set_temporary_hint(
+            f"Tethering — watching “{self._tether_folder_label()}”. "
+            f"Captures appear here automatically.", duration=5000)
+
+    def _dispatch_to_worker(self, path):
+        if self._tether_worker is None:
+            return
+        QMetaObject.invokeMethod(self._tether_worker, "process",
+                                 Qt.QueuedConnection, Q_ARG(str, path))
+
+    def _poll_tether_folder(self):
+        if not self._tether_active or not self._tether_folder:
+            return
+        entries = []
+        try:
+            for e in os.scandir(self._tether_folder):
+                try:
+                    if e.is_file():
+                        entries.append((e.name, e.stat().st_size))
+                except OSError:
+                    continue
+        except OSError:
+            if not self._tether_unavailable:
+                self._tether_unavailable = True
+                self.image_preview.show_tether_banner(
+                    self._tether_folder_label(), self._tether_count,
+                    "folder unavailable — reconnect to resume")
+            return
+        if self._tether_unavailable:
+            # Folder is back — clear the stale "unavailable" note.
+            self._tether_unavailable = False
+            self.image_preview.show_tether_banner(
+                self._tether_folder_label(), self._tether_count, self._tether_note())
+        for name in self._tether_scanner.feed(entries):
+            self._dispatch_to_worker(os.path.join(self._tether_folder, name))
+
+    def _on_capture(self, img):
+        # Always keep the capture — even one that arrives just after Stop (the
+        # worker had already decoded it). Dropping it would lose a real photo.
+        ccr_backend.images.append(img)
+        ccr_backend.file_paths.append(img.file_path)
+        idx = len(ccr_backend.images) - 1
+        self.thumbnail_list.append_image_item(idx, select=True)
+        name = getattr(img, "display_name", None) or os.path.basename(img.file_path)
+        if self._tether_active:
+            self._tether_count += 1
+            self.image_preview.show_tether_banner(
+                self._tether_folder_label(), self._tether_count, self._tether_note())
+            self.sliders_panel.set_temporary_hint(f"Captured {name}", duration=2500)
+            self._schedule_tether_save()
+        else:
+            # Late arrival after Stop: persist immediately (the debounced timer
+            # is gone) so the photo isn't lost on close.
+            ccr_backend.save_catalog()
+
+    def _on_capture_error(self, path, msg):
+        self.sliders_panel.set_temporary_hint(
+            f"Skipped {os.path.basename(path)}: {msg}", duration=4000)
+
+    def _schedule_tether_save(self):
+        """Coalesce catalog saves during capture bursts (spec §9.1.6)."""
+        if self._tether_save_timer is None:
+            self._tether_save_timer = QTimer(self)
+            self._tether_save_timer.setSingleShot(True)
+            self._tether_save_timer.timeout.connect(ccr_backend.save_catalog)
+        self._tether_save_timer.start(3000)
+
+    def stop_tethering(self):
+        if not self._tether_active:
+            return
+        self._tether_active = False
+        if self._tether_timer is not None:
+            self._tether_timer.stop()
+            self._tether_timer = None
+        if self._tether_save_timer is not None:
+            self._tether_save_timer.stop()
+            self._tether_save_timer = None
+        self._stop_tether_worker()
+        self.image_preview.hide_tether_banner()
+        self.tether_action.setText("Tethering…")
+        ccr_backend.save_catalog()
+        self.sliders_panel.set_temporary_hint("Tethering stopped.", duration=3000)
+
+    def _stop_tether_worker(self):
+        """Cancel + join the worker thread (mirrors _stop_loader_if_running)."""
+        if getattr(self, "_tether_thread", None) is not None:
+            try:
+                if self._tether_worker is not None:
+                    self._tether_worker.cancel()
+                if self._tether_thread.isRunning():
+                    self._tether_thread.quit()
+                    self._tether_thread.wait(3000)
+            except RuntimeError:
+                pass
+            # Just drop the Python refs (mirrors _stop_loader_if_running). The
+            # thread's event loop has exited, so a deleteLater() here would never
+            # be processed; GC of the wrapper releases the C++ object.
+            self._tether_thread = None
+            self._tether_worker = None
+
+    def persist_bwpoint(self):
+        """Write the current global B/W point to QSettings (spec §4.1)."""
+        bp = encode_bwpoint(ccr_backend.black_point_bgr)
+        wp = encode_bwpoint(ccr_backend.white_point_bgr)
+        if bp is not None:
+            self._settings.setValue("convert/black_point_bgr", bp)
+        if wp is not None:
+            self._settings.setValue("convert/white_point_bgr", wp)
+
+    def _restore_bwpoint(self):
+        """Restore a persisted global B/W point into the backend at startup."""
+        bp = decode_bwpoint(
+            self._settings.value("convert/black_point_bgr", "", type=str))
+        wp = decode_bwpoint(
+            self._settings.value("convert/white_point_bgr", "", type=str))
+        if bp is not None:
+            ccr_backend.set_black_point(bp)
+        if wp is not None:
+            ccr_backend.set_white_point(wp)
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.KeyPress and event.key() in (Qt.Key_Up, Qt.Key_Down):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -652,6 +652,12 @@ class MainWindow(QMainWindow):
         # genuinely-new capture triggers the B/W-point prompt.
         self._tether_import_existing = {os.path.normpath(p) for p in import_paths}
         self._tether_scanner = FolderScanner(initial_names=existing)
+        # Each session starts fresh: clear the global B/W point so the user
+        # re-samples it from THIS roll's film lead (the first frame). Different
+        # rolls/stocks have different base colour + density, so a previous
+        # roll's point must not carry over.
+        ccr_backend.black_point_bgr = None
+        ccr_backend.white_point_bgr = None
 
         # Long-lived worker on its own event-loop QThread (spec §9.1.7); work is
         # delivered by QMetaObject.invokeMethod (queued) so it runs off-GUI.
@@ -869,24 +875,18 @@ class MainWindow(QMainWindow):
         on that frame."""
         if not self._tether_active:
             return
-        has_point = (ccr_backend.black_point_bgr is not None
-                     and ccr_backend.white_point_bgr is not None)
         box = QMessageBox(self)
         box.setIcon(QMessageBox.Information)
         box.setWindowTitle("Set B/W Point for This Roll")
-        text = ("This first frame should be a shot of the <b>film lead</b> — "
-                "showing both the clear film base and a fully-exposed (dense) "
-                "area.<br><br>Set the roll's B/W point from it so the rest of the "
-                "roll converts to positive automatically:<br>"
-                "• <b>Black Point</b> — draw over the clear film base<br>"
-                "• <b>White Point</b> — draw over the dense / exposed area")
-        if has_point:
-            text += ("<br><br>A B/W point from earlier is already set — re-sample "
-                     "it for this roll, or keep the existing one.")
-        box.setText(text)
+        box.setText(
+            "This first frame should be a shot of the <b>film lead</b> — showing "
+            "both the clear film base and a fully-exposed (dense) area.<br><br>"
+            "Set this roll's B/W point from it so the rest of the roll converts "
+            "to positive automatically:<br>"
+            "• <b>Black Point</b> — draw over the clear film base<br>"
+            "• <b>White Point</b> — draw over the dense / exposed area")
         set_btn = box.addButton("Set Black Point", QMessageBox.AcceptRole)
-        box.addButton("Keep Existing" if has_point else "Skip",
-                      QMessageBox.RejectRole)
+        box.addButton("Skip", QMessageBox.RejectRole)
         box.setDefaultButton(set_btn)
         box.exec()
         if box.clickedButton() is not set_btn:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -145,6 +145,9 @@ class MainWindow(QMainWindow):
         self._tether_folder = None
         self._tether_count = 0
         self._tether_unavailable = False
+        self._tether_prompted = False          # B/W-point prompt shown this session?
+        self._tether_import_existing = set()   # paths imported at start (no prompt)
+        self._tether_lead_img = None           # the first new capture (film lead)
         self.tether_banner = TetherBanner()
         self.tether_banner.stopRequested.connect(self.stop_tethering)
         self.image_preview.set_tether_banner(self.tether_banner)
@@ -643,6 +646,11 @@ class MainWindow(QMainWindow):
         self._tether_folder = folder
         self._tether_count = 0
         self._tether_unavailable = False
+        self._tether_prompted = False
+        self._tether_lead_img = None
+        # Files imported at session start are not the "film lead" — only a
+        # genuinely-new capture triggers the B/W-point prompt.
+        self._tether_import_existing = {os.path.normpath(p) for p in import_paths}
         self._tether_scanner = FolderScanner(initial_names=existing)
 
         # Long-lived worker on its own event-loop QThread (spec §9.1.7); work is
@@ -728,6 +736,15 @@ class MainWindow(QMainWindow):
                 self._tether_folder_label(), self._tether_count, self._tether_note())
             self.sliders_panel.set_temporary_hint(f"Captured {name}", duration=2500)
             self._schedule_tether_save()
+            # Once per session, after the first genuinely-new capture (the film
+            # lead), prompt the user to set the roll's B/W point from it.
+            if (not self._tether_prompted
+                    and os.path.normpath(img.file_path) not in self._tether_import_existing):
+                self._tether_prompted = True
+                self._tether_lead_img = img
+                # Defer so the modal opens cleanly after this slot returns (and
+                # never blocks/hangs a headless test, which won't spin the loop).
+                QTimer.singleShot(0, self._prompt_bwpoint_for_session)
         else:
             # Late arrival after Stop: persist immediately (the debounced timer
             # is gone) so the photo isn't lost on close.
@@ -845,6 +862,45 @@ class MainWindow(QMainWindow):
         if self._tether_active and not self._tether_unavailable:
             self.image_preview.show_tether_banner(
                 self._tether_folder_label(), self._tether_count, self._tether_note())
+
+    def _prompt_bwpoint_for_session(self):
+        """After the first capture of a session (the film lead), guide the user
+        to set the roll's B/W point from it, then kick off Black-point sampling
+        on that frame."""
+        if not self._tether_active:
+            return
+        has_point = (ccr_backend.black_point_bgr is not None
+                     and ccr_backend.white_point_bgr is not None)
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Information)
+        box.setWindowTitle("Set B/W Point for This Roll")
+        text = ("This first frame should be a shot of the <b>film lead</b> — "
+                "showing both the clear film base and a fully-exposed (dense) "
+                "area.<br><br>Set the roll's B/W point from it so the rest of the "
+                "roll converts to positive automatically:<br>"
+                "• <b>Black Point</b> — draw over the clear film base<br>"
+                "• <b>White Point</b> — draw over the dense / exposed area")
+        if has_point:
+            text += ("<br><br>A B/W point from earlier is already set — re-sample "
+                     "it for this roll, or keep the existing one.")
+        box.setText(text)
+        set_btn = box.addButton("Set Black Point", QMessageBox.AcceptRole)
+        box.addButton("Keep Existing" if has_point else "Skip",
+                      QMessageBox.RejectRole)
+        box.setDefaultButton(set_btn)
+        box.exec()
+        if box.clickedButton() is not set_btn:
+            return
+        # Make sure sampling targets the lead frame even if a later capture stole
+        # the selection while the dialog was open.
+        lead = self._tether_lead_img
+        if lead is not None and lead in ccr_backend.images:
+            self.thumbnail_list.thumbnail_list.setCurrentRow(
+                ccr_backend.images.index(lead))
+        self.image_preview.set_bwpoint_mode("black")
+        self.sliders_panel.set_temporary_hint(
+            "<b>Black Point:</b> draw a rectangle over the clear film base, then "
+            "set the White Point on the dense / exposed area.", duration=9000)
 
     def _restore_bwpoint(self):
         """Restore a persisted global B/W point into the backend at startup."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -11,6 +11,7 @@ from core.tether_watcher import (TetherWatchWorker, FolderScanner, is_supported,
                                  encode_bwpoint, decode_bwpoint)
 import ctypes
 from version import VERSION  # Make sure version.py is in your src folder
+import copy
 import html
 import os
 import sys
@@ -703,11 +704,22 @@ class MainWindow(QMainWindow):
             self._dispatch_to_worker(os.path.join(self._tether_folder, name))
 
     def _on_capture(self, img):
+        # Inherit the editable "look" (adjustments, orientation, crop) of the
+        # image active just before this capture, so a rotate/brightness/etc. set
+        # on one frame auto-applies to the next imported frame — a fixed
+        # copy-stand rig wants identical treatment per frame. Snapshot BEFORE
+        # appending the new image (current_idx still points at the prior one).
+        template = self._tether_template()
         # Always keep the capture — even one that arrives just after Stop (the
         # worker had already decoded it). Dropping it would lose a real photo.
         ccr_backend.images.append(img)
         ccr_backend.file_paths.append(img.file_path)
         idx = len(ccr_backend.images) - 1
+        if template is not None:
+            self._apply_tether_template(img, template)
+            # Re-bake preview/thumbnail so inherited adjustments are reflected
+            # (rotation/flips/crop are applied by update_preview on selection).
+            img.update_thumbnail_and_preview()
         self.thumbnail_list.append_image_item(idx, select=True)
         name = getattr(img, "display_name", None) or os.path.basename(img.file_path)
         if self._tether_active:
@@ -720,6 +732,55 @@ class MainWindow(QMainWindow):
             # Late arrival after Stop: persist immediately (the debounced timer
             # is gone) so the photo isn't lost on close.
             ccr_backend.save_catalog()
+
+    def _tether_template(self):
+        """Snapshot the editable look of the currently displayed image so the
+        next capture can inherit it. Returns None when there is no current image
+        or its look is entirely default (so no wasted re-render)."""
+        idx = self.image_preview.current_idx
+        if idx is None:
+            return None
+        src = ccr_backend.get_image_by_index(idx)
+        if src is None:
+            return None
+        adj = getattr(src, "adjustment_settings", None) or {}
+        areas = getattr(src, "area_layers", None) or []
+        rot = getattr(src, "rotation_angle", 0)
+        fine = getattr(src, "fine_rotation_angle", 0)
+        hflip = getattr(src, "horizontal_mirrored", False)
+        vflip = getattr(src, "vertical_mirrored", False)
+        crop = getattr(src, "crop_rect", None)
+        crop_angle = getattr(src, "crop_angle", 0.0) or 0.0
+        profile = getattr(src, "color_profile", "color")
+        if not (adj or areas or rot or fine or hflip or vflip
+                or crop is not None or crop_angle or profile != "color"):
+            return None
+        return {
+            "adjustment_settings": copy.deepcopy(adj),
+            "area_layers": copy.deepcopy(areas),
+            "rotation_angle": rot,
+            "fine_rotation_angle": fine,
+            "horizontal_mirrored": hflip,
+            "vertical_mirrored": vflip,
+            "crop_rect": crop,
+            "crop_angle": crop_angle,
+            "color_profile": profile,
+        }
+
+    @staticmethod
+    def _apply_tether_template(img, t):
+        """Apply an inherited look template to a freshly captured image. The
+        template already holds isolated deep copies, so direct assignment is
+        safe (each capture builds its own template)."""
+        img.adjustment_settings = t["adjustment_settings"]
+        img.area_layers = t["area_layers"]
+        img.rotation_angle = t["rotation_angle"]
+        img.fine_rotation_angle = t["fine_rotation_angle"]
+        img.horizontal_mirrored = t["horizontal_mirrored"]
+        img.vertical_mirrored = t["vertical_mirrored"]
+        img.crop_rect = t["crop_rect"]
+        img.crop_angle = t["crop_angle"]
+        img.color_profile = t["color_profile"]
 
     def _on_capture_error(self, path, msg):
         self.sliders_panel.set_temporary_hint(
@@ -767,13 +828,23 @@ class MainWindow(QMainWindow):
             self._tether_worker = None
 
     def persist_bwpoint(self):
-        """Write the current global B/W point to QSettings (spec §4.1)."""
+        """Write the current global B/W point to QSettings (spec §4.1) and, if a
+        tethering session is live, refresh the banner so its note reflects the
+        new B/W state immediately (e.g. drops the 'unconverted' warning)."""
         bp = encode_bwpoint(ccr_backend.black_point_bgr)
         wp = encode_bwpoint(ccr_backend.white_point_bgr)
         if bp is not None:
             self._settings.setValue("convert/black_point_bgr", bp)
         if wp is not None:
             self._settings.setValue("convert/white_point_bgr", wp)
+        self.refresh_tether_banner()
+
+    def refresh_tether_banner(self):
+        """Re-render the banner note from current state (B/W point / Positive
+        mode). No-op when not tethering or the folder is unavailable."""
+        if self._tether_active and not self._tether_unavailable:
+            self.image_preview.show_tether_banner(
+                self._tether_folder_label(), self._tether_count, self._tether_note())
 
     def _restore_bwpoint(self):
         """Restore a persisted global B/W point into the backend at startup."""

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -727,6 +727,11 @@ class ImagePreview(QWidget):
 
         self.setLayout(self.layout)
 
+        # Tethering status strip (watch-folder mode). Inserted into THIS widget's
+        # own layout so ImagePreview's parent() chain to MainWindow is unchanged
+        # (see spec/camera-tethering.md §9.1.5). None until MainWindow installs it.
+        self._tether_banner = None
+
         # State
         self.current_pixmap = None
         self.current_idx = None
@@ -867,6 +872,25 @@ class ImagePreview(QWidget):
         elif self.area_mode:
             # Esc leaves area editing: deselect back to the Whole Image layer.
             self._select_whole_image_layer()
+
+    # --- Tethering banner (watch-folder mode) ----------------------------
+    def set_tether_banner(self, banner):
+        """Install the watch-folder status strip at the top of this widget's
+        own layout (above the toolbar). Reparents the banner into ImagePreview;
+        ImagePreview's own parent is untouched."""
+        self._tether_banner = banner
+        self.layout.insertWidget(0, banner)
+        banner.setVisible(False)
+
+    def show_tether_banner(self, folder, count, note=""):
+        if self._tether_banner is None:
+            return
+        self._tether_banner.set_status(folder, count, note)
+        self._tether_banner.setVisible(True)
+
+    def hide_tether_banner(self):
+        if self._tether_banner is not None:
+            self._tether_banner.setVisible(False)
 
     def update_preview(self, idx):
         ''' Update the UI image based on the backend, using the index from the thumbnail list. '''

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -1341,6 +1341,11 @@ class SlidersPanel(QWidget):
         other = "Black Point" if mode == "white" else "White Point"
         bp_set = ccr_backend.black_point_bgr is not None
         wp_set = ccr_backend.white_point_bgr is not None
+        # Persist the global B/W point so tethering (and the next session) can
+        # reuse it. See spec/camera-tethering.md §4.1.
+        mw = self.parent().parent()
+        if hasattr(mw, "persist_bwpoint"):
+            mw.persist_bwpoint()
         if bp_set and wp_set:
             self.set_temporary_hint(
                 f"{label} sampled! Both points set — click <b>Convert All (B/W Point)</b>.", duration=5000)

--- a/src/widgets/tether_banner.py
+++ b/src/widgets/tether_banner.py
@@ -1,0 +1,39 @@
+"""Slim non-modal status strip shown while tethering (watch-folder) is active.
+
+Inserted into ImagePreview's own internal layout (see spec §9.1.5) — NOT wrapped
+around image_preview, which would break its parent().parent() chains.
+"""
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QPushButton
+
+
+class TetherBanner(QWidget):
+    stopRequested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setStyleSheet("background-color: #2b2b2b;")
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 4, 12, 4)
+        layout.setSpacing(8)
+
+        self._dot = QLabel("●")  # ●
+        self._dot.setStyleSheet("color: #e0504a; font-size: 13px;")
+        self._status = QLabel("")
+        self._status.setStyleSheet("color: #e6e6e6;")
+        self._note = QLabel("")
+        self._note.setStyleSheet("color: #e0a030;")  # amber for warnings/notes
+        self._stop = QPushButton("Stop")
+        self._stop.setFixedHeight(24)
+        self._stop.clicked.connect(self.stopRequested)
+
+        layout.addWidget(self._dot)
+        layout.addWidget(self._status)
+        layout.addWidget(self._note)
+        layout.addStretch(1)
+        layout.addWidget(self._stop)
+
+    def set_status(self, folder, count, note=""):
+        self._status.setText(
+            f"Tethering — “{folder}”  ·  {count} captured")
+        self._note.setText(note or "")

--- a/src/widgets/tether_banner.py
+++ b/src/widgets/tether_banner.py
@@ -2,6 +2,9 @@
 
 Inserted into ImagePreview's own internal layout (see spec §9.1.5) — NOT wrapped
 around image_preview, which would break its parent().parent() chains.
+
+Styled to fit FreeCCR's default (light) theme: a soft amber "active session"
+strip with a red recording dot and a clearly-visible Stop button.
 """
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QPushButton
@@ -12,19 +15,31 @@ class TetherBanner(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setStyleSheet("background-color: #2b2b2b;")
+        self.setObjectName("TetherBanner")
+        # Scope the background to the banner itself (objectName selector) so the
+        # child labels/button keep their own styling.
+        self.setStyleSheet(
+            "#TetherBanner { background-color: #fff3cd; "
+            "border-bottom: 1px solid #e6cf87; }")
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(12, 4, 12, 4)
+        layout.setContentsMargins(12, 5, 12, 5)
         layout.setSpacing(8)
 
         self._dot = QLabel("●")  # ●
-        self._dot.setStyleSheet("color: #e0504a; font-size: 13px;")
+        self._dot.setStyleSheet(
+            "color: #d9534f; font-size: 13px; background: transparent;")
         self._status = QLabel("")
-        self._status.setStyleSheet("color: #e6e6e6;")
+        self._status.setStyleSheet(
+            "color: #5c4a00; font-weight: bold; background: transparent;")
         self._note = QLabel("")
-        self._note.setStyleSheet("color: #e0a030;")  # amber for warnings/notes
+        self._note.setStyleSheet("color: #9a6a00; background: transparent;")
         self._stop = QPushButton("Stop")
         self._stop.setFixedHeight(24)
+        self._stop.setStyleSheet(
+            "QPushButton { background-color: #d9534f; color: white; border: none; "
+            "border-radius: 4px; padding: 2px 14px; }"
+            "QPushButton:hover { background-color: #c9302c; }"
+            "QPushButton:pressed { background-color: #ac2925; }")
         self._stop.clicked.connect(self.stopRequested)
 
         layout.addWidget(self._dot)

--- a/src/widgets/thumbnail_list.py
+++ b/src/widgets/thumbnail_list.py
@@ -220,6 +220,34 @@ class ThumbnailList(QWidget):
     def update_all_thumbnails(self):
         for idx in range(ccr_backend.get_image_count()):
             self.update_thumbnail(idx)
+
+    def append_image_item(self, idx, select=True):
+        """Append a single thumbnail item for a newly added backend image
+        (e.g. a tether capture) without rebuilding the whole list. When select
+        is True, selecting the item drives update_preview/set_current_idx via
+        on_current_item_changed (so the capture shows big on the canvas).
+        Returns True if the item was appended; False if skipped (a rebuild is
+        in flight, or the index is no longer valid — the next full rebuild will
+        include the image either way)."""
+        if getattr(self, "_rebuilding", False):
+            return False
+        img_obj = ccr_backend.get_image_by_index(idx)
+        if img_obj is None:
+            logging.warning(f"append_image_item: no backend image at index {idx}")
+            return False
+        filename = (getattr(img_obj, "display_name", None)
+                    or os.path.basename(img_obj.file_path))
+        item = QListWidgetItem(filename)
+        thumbnail = ccr_backend.get_thumbnail_by_index(idx)
+        if thumbnail is not None:
+            item.setIcon(QIcon(self.apply_frontend_transformations(thumbnail, idx)))
+        item.setData(Qt.UserRole, idx)
+        self.thumbnail_list.addItem(item)
+        self.count_label.setText(
+            f"Total: {ccr_backend.get_image_count()} image(s)")
+        if select:
+            self.thumbnail_list.setCurrentRow(self.thumbnail_list.count() - 1)
+        return True
         
     def on_thumbnail_clicked(self, item):
         idx = item.data(Qt.UserRole)

--- a/src/widgets/thumbnail_list.py
+++ b/src/widgets/thumbnail_list.py
@@ -104,6 +104,11 @@ class ThumbnailList(QWidget):
 
         self.thumbnail_list = QListWidget()
         self.thumbnail_list.setViewMode(QListWidget.IconMode)
+        # Set the icon size up front so incrementally-appended items (e.g.
+        # tether captures added via append_image_item, before any full
+        # load_thumbnails rebuild has run) show at full size, not Qt's tiny
+        # default. load_thumbnails also sets this, harmlessly.
+        self.thumbnail_list.setIconSize(QSize(156, 156))
         self.thumbnail_list.setSpacing(10)
         self.thumbnail_list.setDragDropMode(QListWidget.NoDragDrop)
         self.thumbnail_list.setResizeMode(QListWidget.Adjust)

--- a/tests/test_tether_watcher.py
+++ b/tests/test_tether_watcher.py
@@ -256,3 +256,42 @@ def test_capture_no_template_when_active_image_is_default(tmp_path):
     ccr_backend.file_paths.append(a.file_path)
     w.thumbnail_list.append_image_item(0, select=True)
     assert w._tether_template() is None   # nothing worth inheriting
+
+
+def test_bw_prompt_fires_once_on_first_new_capture(tmp_path):
+    """The B/W-point prompt is flagged after the first genuinely-new capture,
+    not for files imported at session start, and only once per session."""
+    from ui.main_window import MainWindow
+    from core.ccr_image import CCRImage
+    ccr_backend.images.clear()
+    ccr_backend.file_paths.clear()
+    ccr_backend.black_point_bgr = None
+    ccr_backend.white_point_bgr = None
+    ccr_backend.positive_mode = False
+
+    w = MainWindow()
+    w._prompt_bwpoint_for_session = lambda: None   # neutralize the modal
+    w._tether_active = True
+    w._tether_folder = str(tmp_path)
+    w._tether_prompted = False
+
+    def _png(name, seed):
+        p = tmp_path / name
+        cv2.imwrite(str(p), (np.random.RandomState(seed).rand(50, 50, 3) * 255).astype(np.uint8))
+        return CCRImage(str(p))
+
+    # A file imported at session start must NOT trigger the prompt.
+    existing = _png("existing.png", 1)
+    w._tether_import_existing = {os.path.normpath(existing.file_path)}
+    w._on_capture(existing)
+    assert w._tether_prompted is False
+
+    # The first genuinely-new capture flags the prompt.
+    w._on_capture(_png("new1.png", 2))
+    assert w._tether_prompted is True
+
+    # A second new capture does not re-flag (single prompt per session).
+    w._on_capture(_png("new2.png", 3))
+    assert w._tether_prompted is True
+
+    w.stop_tethering()

--- a/tests/test_tether_watcher.py
+++ b/tests/test_tether_watcher.py
@@ -203,3 +203,56 @@ def test_worker_positive_mode_skips_conversion(tmp_path):
         ccr_backend.positive_mode = False
         ccr_backend.black_point_bgr = None
         ccr_backend.white_point_bgr = None
+
+
+# --- capture inherits adjustments from the active image (bug fix #3) --------
+def test_capture_inherits_adjustments(tmp_path):
+    from ui.main_window import MainWindow
+    from core.ccr_image import CCRImage
+    ccr_backend.images.clear()
+    ccr_backend.file_paths.clear()
+    ccr_backend.black_point_bgr = None
+    ccr_backend.white_point_bgr = None
+    ccr_backend.positive_mode = False
+
+    w = MainWindow()
+    a_path = tmp_path / "a.png"
+    cv2.imwrite(str(a_path), (np.random.RandomState(11).rand(80, 100, 3) * 255).astype(np.uint8))
+    a = CCRImage(str(a_path))
+    a.adjustment_settings = {"brightness": 25, "contrast": 10}
+    a.rotation_angle = 90
+    ccr_backend.images.append(a)
+    ccr_backend.file_paths.append(a.file_path)
+    w.thumbnail_list.append_image_item(0, select=True)   # A becomes current
+    assert w.image_preview.current_idx == 0
+
+    w._tether_active = True
+    w._tether_folder = str(tmp_path)
+    b_path = tmp_path / "b.png"
+    cv2.imwrite(str(b_path), (np.random.RandomState(12).rand(80, 100, 3) * 255).astype(np.uint8))
+    b = CCRImage(str(b_path))
+    w._on_capture(b)
+
+    assert b.adjustment_settings == {"brightness": 25, "contrast": 10}
+    assert b.adjustment_settings is not a.adjustment_settings   # isolated copy
+    assert b.rotation_angle == 90
+    w.stop_tethering()
+
+
+def test_capture_no_template_when_active_image_is_default(tmp_path):
+    from ui.main_window import MainWindow
+    from core.ccr_image import CCRImage
+    ccr_backend.images.clear()
+    ccr_backend.file_paths.clear()
+    ccr_backend.black_point_bgr = None
+    ccr_backend.white_point_bgr = None
+    ccr_backend.positive_mode = False
+
+    w = MainWindow()
+    a_path = tmp_path / "a.png"
+    cv2.imwrite(str(a_path), (np.random.RandomState(13).rand(60, 60, 3) * 255).astype(np.uint8))
+    a = CCRImage(str(a_path))   # untouched look
+    ccr_backend.images.append(a)
+    ccr_backend.file_paths.append(a.file_path)
+    w.thumbnail_list.append_image_item(0, select=True)
+    assert w._tether_template() is None   # nothing worth inheriting

--- a/tests/test_tether_watcher.py
+++ b/tests/test_tether_watcher.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Tests for watch-folder tethering (spec/camera-tethering.md).
+
+Covers the hardware-free logic: FolderScanner's size-stability gate and
+within-tick RAW/JPEG dedupe, extension classification, B/W-point persistence
+encode/decode, and a single worker-wiring integration test (decode → emit).
+The real camera path is deliberately absent — there is no camera SDK.
+"""
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+import cv2  # noqa: E402
+import numpy as np  # noqa: E402
+
+from core.tether_watcher import (  # noqa: E402
+    FolderScanner, TetherWatchWorker, is_supported, is_raw,
+    encode_bwpoint, decode_bwpoint)
+from core.ccr_backend import ccr_backend  # noqa: E402
+
+
+# --- extension classification ----------------------------------------------
+def test_is_supported():
+    assert is_supported("DSC_0001.NEF")
+    assert is_supported("scan.jpg")
+    assert is_supported("frame.TIFF")
+    assert not is_supported("notes.txt")
+    assert not is_supported("clip.mp4")
+    assert not is_supported("noext")
+
+
+def test_is_raw():
+    assert is_raw("a.cr3")
+    assert is_raw("a.NEF")
+    assert not is_raw("a.jpg")
+    assert not is_raw("a.tiff")
+    assert not is_raw("a.png")
+
+
+# --- FolderScanner: size-stability gate ------------------------------------
+def test_new_file_held_until_size_stable():
+    s = FolderScanner()
+    assert s.feed([("a.nef", 100)]) == []   # first sight: no prior size
+    assert s.feed([("a.nef", 200)]) == []   # still growing
+    assert s.feed([("a.nef", 200)]) == ["a.nef"]  # stable across a tick
+    assert s.feed([("a.nef", 200)]) == []   # handled once, never again
+
+
+def test_zero_size_never_ready():
+    s = FolderScanner()
+    assert s.feed([("a.nef", 0)]) == []
+    assert s.feed([("a.nef", 0)]) == []
+
+
+def test_preseeded_files_ignored():
+    s = FolderScanner(initial_names=["old.nef"])
+    assert s.feed([("old.nef", 100)]) == []
+    assert s.feed([("old.nef", 100)]) == []
+
+
+def test_unsupported_ignored():
+    s = FolderScanner()
+    assert s.feed([("readme.txt", 50)]) == []
+    assert s.feed([("readme.txt", 50)]) == []
+
+
+# --- FolderScanner: RAW + JPEG dedupe (within a tick) ----------------------
+def test_raw_preferred_over_jpeg_same_tick():
+    s = FolderScanner()
+    s.feed([("shot1.cr3", 1000), ("shot1.jpg", 200)])      # prime sizes
+    ready = s.feed([("shot1.cr3", 1000), ("shot1.jpg", 200)])
+    assert ready == ["shot1.cr3"]                           # RAW wins
+    assert s.feed([("shot1.cr3", 1000), ("shot1.jpg", 200)]) == []  # both seen
+
+
+def test_distinct_basenames_both_import():
+    s = FolderScanner()
+    s.feed([("a.nef", 10), ("b.nef", 20)])
+    assert sorted(s.feed([("a.nef", 10), ("b.nef", 20)])) == ["a.nef", "b.nef"]
+
+
+def test_jpeg_only_imports_when_no_raw_sibling():
+    s = FolderScanner()
+    s.feed([("solo.jpg", 300)])
+    assert s.feed([("solo.jpg", 300)]) == ["solo.jpg"]
+
+
+def test_deleted_file_can_reimport_after_recreate():
+    s = FolderScanner()
+    s.feed([("a.nef", 100)])
+    assert s.feed([("a.nef", 100)]) == ["a.nef"]   # imported once stable
+    assert s.feed([]) == []                          # deleted → forgotten
+    s.feed([("a.nef", 120)])                         # recreated, same name
+    assert s.feed([("a.nef", 120)]) == ["a.nef"]     # re-imports
+
+
+def test_duplicate_name_coalesced_in_one_tick():
+    s = FolderScanner()
+    s.feed([("a.nef", 100), ("a.nef", 100)])
+    assert s.feed([("a.nef", 100), ("a.nef", 100)]) == ["a.nef"]  # not doubled
+
+
+# --- B/W point persistence encode/decode -----------------------------------
+def test_bwpoint_roundtrip():
+    pt = (51234.0, 48010.5, 52001.25)
+    enc = encode_bwpoint(pt)
+    assert isinstance(enc, str)
+    assert decode_bwpoint(enc) == pt
+
+
+def test_bwpoint_none_and_empty():
+    assert encode_bwpoint(None) is None
+    assert decode_bwpoint(None) is None
+    assert decode_bwpoint("") is None
+
+
+def test_bwpoint_malformed():
+    assert decode_bwpoint("not json") is None
+    assert decode_bwpoint("[1, 2]") is None          # wrong length
+    assert decode_bwpoint('{"b": 1}') is None         # wrong type
+    assert decode_bwpoint('[1, 2, "x"]') is None      # non-numeric
+
+
+# --- worker wiring: decode → emit captured ---------------------------------
+def test_worker_imports_unconverted(tmp_path):
+    """With no B/W point set, the worker decodes the file and emits a captured
+    CCRImage that is NOT converted."""
+    ccr_backend.black_point_bgr = None
+    ccr_backend.white_point_bgr = None
+    ccr_backend.positive_mode = False
+
+    p = tmp_path / "capture01.png"
+    px = (np.random.RandomState(7).rand(120, 180, 3) * 255).astype(np.uint8)
+    cv2.imwrite(str(p), px)
+
+    worker = TetherWatchWorker()
+    got, errs = [], []
+    worker.captured.connect(lambda im: got.append(im))
+    worker.captureError.connect(lambda path, msg: errs.append((path, msg)))
+    worker.process(str(p))  # direct (same-thread) call → synchronous signals
+
+    assert not errs, errs
+    assert len(got) == 1
+    assert os.path.normpath(got[0].file_path) == os.path.normpath(str(p))
+    assert got[0].converted is False
+
+
+def test_worker_converts_with_bwpoint(tmp_path):
+    """With a B/W point set and Positive mode off, the worker bakes the
+    conversion and records conversion_inputs for export/catalog replay."""
+    ccr_backend.positive_mode = False
+    ccr_backend.black_point_bgr = (60000.0, 60000.0, 60000.0)  # clear base (high)
+    ccr_backend.white_point_bgr = (5000.0, 5000.0, 5000.0)     # dense (low)
+    try:
+        p = tmp_path / "neg.png"
+        px = (np.random.RandomState(3).rand(100, 140, 3) * 255).astype(np.uint8)
+        cv2.imwrite(str(p), px)
+
+        worker = TetherWatchWorker()
+        got = []
+        worker.captured.connect(lambda im: got.append(im))
+        worker.process(str(p))
+
+        assert len(got) == 1
+        img = got[0]
+        assert img.converted is True
+        assert img.conversion_inputs is not None
+        assert img.conversion_inputs["mode"] == "bw"
+        bw = img.conversion_inputs["bw"]
+        assert tuple(bw[0]) == (60000.0, 60000.0, 60000.0)
+        assert tuple(bw[1]) == (5000.0, 5000.0, 5000.0)
+    finally:
+        ccr_backend.black_point_bgr = None
+        ccr_backend.white_point_bgr = None
+
+
+def test_worker_positive_mode_skips_conversion(tmp_path):
+    """Positive mode → captures import as-is even when a B/W point is set."""
+    ccr_backend.positive_mode = True
+    ccr_backend.black_point_bgr = (60000.0, 60000.0, 60000.0)
+    ccr_backend.white_point_bgr = (5000.0, 5000.0, 5000.0)
+    try:
+        p = tmp_path / "pos.png"
+        px = (np.random.RandomState(4).rand(90, 90, 3) * 255).astype(np.uint8)
+        cv2.imwrite(str(p), px)
+
+        worker = TetherWatchWorker()
+        got = []
+        worker.captured.connect(lambda im: got.append(im))
+        worker.process(str(p))
+
+        assert len(got) == 1
+        assert got[0].converted is False
+    finally:
+        ccr_backend.positive_mode = False
+        ccr_backend.black_point_bgr = None
+        ccr_backend.white_point_bgr = None

--- a/tests/test_tether_watcher.py
+++ b/tests/test_tether_watcher.py
@@ -295,3 +295,30 @@ def test_bw_prompt_fires_once_on_first_new_capture(tmp_path):
     assert w._tether_prompted is True
 
     w.stop_tethering()
+
+
+def test_session_start_clears_bwpoint(tmp_path, monkeypatch):
+    """Entering a tethering session clears any prior B/W point so the user must
+    re-sample from this roll's lead; the banner reflects the uncalibrated state."""
+    from ui.main_window import MainWindow
+    from PySide6.QtWidgets import QFileDialog
+    ccr_backend.images.clear()
+    ccr_backend.file_paths.clear()
+    ccr_backend.positive_mode = False
+    # A stale point from a "previous roll".
+    ccr_backend.black_point_bgr = (60000.0, 60000.0, 60000.0)
+    ccr_backend.white_point_bgr = (5000.0, 5000.0, 5000.0)
+
+    w = MainWindow()
+    roll = tmp_path / "roll"          # empty → no "import existing?" prompt
+    roll.mkdir()
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory",
+                        lambda *a, **k: str(roll))
+    w.enter_tethering()
+    try:
+        assert w._tether_active is True
+        assert ccr_backend.black_point_bgr is None
+        assert ccr_backend.white_point_bgr is None
+        assert "No B/W point" in w.tether_banner._note.text()
+    finally:
+        w.stop_tethering()


### PR DESCRIPTION
## Summary

Adds a **File ▸ Tethering** mode that watches a user-chosen folder for camera captures. Point your camera's own tethering app (Canon EOS Utility, Nikon NX Tether, Sony Imaging Edge, Fujifilm X Acquire…) — or an SD auto-offload — at the folder; FreeCCR detects each new file, imports it as a `CCRImage`, **auto-converts it to a positive using the saved B/W point**, adds it to the sidebar, and shows it **large on the canvas**.

## Why watch-folder instead of direct camera control

The original ask was a live-view tether (operate the camera, live view on canvas, Space = shutter). Research into the DSLR-film-scanning workflow redirected the design:

- Camera-scanning film is a **static copy-stand** workflow — focus/exposure/alignment are set **once per roll**, then the roll is shot in minutes. Live view is a one-time *setup* aid, not a per-shot need.
- The market leader (Negative Lab Pro) has **no live preview**; import-then-convert is the norm. Even **Lightroom disables live view over USB tether**.
- People who want a live framing view run the **vendor app feeding a watched folder** — exactly this pattern (Lightroom "Auto Import", Capture One "Hot Folder").
- Direct USB control (libgphoto2 needs per-camera Zadig/WinUSB on Windows; vendor SDKs need registration + carry redistribution limits) is high-friction for a benefit this use case barely uses.

Result: **trivial, identical setup on macOS + Windows, zero camera-SDK dependency.** FreeCCR competes on conversion quality, not live-ness. Full design in `spec/camera-tethering.md`.

## What's included

- **`src/core/tether_watcher.py`** — `FolderScanner` (size-stability gate so still-downloading files wait; RAW/JPEG within-tick dedupe; seen-set pruning so a deleted+recreated filename re-imports; duplicate-name coalescing) and `TetherWatchWorker` (long-lived event-loop `QThread`; decodes + B/W-converts off the GUI thread; catalog mtime-cache). Plus B/W-point persistence helpers.
- **`src/widgets/tether_banner.py`** — slim non-modal watch-status strip with a Stop button.
- **`src/ui/main_window.py`** — `File ▸ Tethering…` toggle, folder picker (with an "import existing files?" prompt), 1 s poll timer, GUI-thread capture slot (append → select → show big), debounced catalog save, **persistent global B/W point** (QSettings, restored at startup), clean teardown on Stop and on app close.
- **`src/widgets/image_preview.py`** — banner installed into `ImagePreview`'s own layout (not wrapped — preserves the `parent().parent()` chains the canvas relies on).
- **`src/widgets/thumbnail_list.py`** — `append_image_item` for incremental sidebar additions.
- **`src/widgets/sliders_panel.py`** — persists the global B/W point when sampled.

## Notes

- Each capture becomes a real `CCRImage`, so it's fully editable/exportable and round-trips through the catalog (the baked `conversion_inputs` replay on export and reopen).
- The live canvas conversion is an accurate framing/triage view; RAW captures convert faithfully through the normal pipeline. (8-bit JPEG live frames convert approximately — sample the B/W point from a capture of the same format for a self-consistent preview.)
- Respects Positive mode (captures import as positives, no B/W conversion).

## Testing

- `tests/test_tether_watcher.py` (17 tests): scanner stability/dedupe/pruning/coalescing, extension classification, B/W-point persistence round-trip, and worker decode→emit for unconverted / converted / positive-mode paths.
- **Full suite: 336 passed.**
- Manual smoke (headless): MainWindow construction + parent-chain integrity, full capture lifecycle (enter → capture → select → stop), start/stop restart cycles, and cross-thread `QMetaObject.invokeMethod` dispatch.

## Review

The diff was put through an adversarial multi-agent review; confirmed findings were fixed (seen-set pruning for delete+recreate, no-lost-capture-on-Stop, catalog mtime-cache, `positive_mode` snapshot, folder-unavailable banner clearing, timer lifecycle, `append_image_item` bool return). See `spec/camera-tethering.md §9.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
