### PR TITLE
feat: Dust Removal (manual brush + AI-detect)

### DIFF
--- a/LICENSES/license-dust-detector.txt
+++ b/LICENSES/license-dust-detector.txt
@@ -1,0 +1,21 @@
+Dust Removal — AI detector model
+=================================
+
+FreeCCR's optional "AI Dust Detection" downloads a neural dust/scratch
+detector model (detector.onnx) on first use. The model and its weights are not
+bundled with FreeCCR; they are fetched from the openenlarge project's published
+release asset and cached locally in the user's app-data folder.
+
+Model: BOPBTL ("Bringing Old Photos Back to Life") scratch detector, U-Net.
+Distributed via: openenlarge (https://github.com/MohaElder/openenlarge),
+release "autodust-assets-v1".
+Upstream lineage: leonelhs/zeroscratches → Microsoft "Bringing Old Photos Back
+to Life" (microsoft/Bringing-Old-Photos-Back-to-Life), MIT License.
+
+Inference is performed with onnxruntime (MIT License). The actual dust removal
+(inpainting) uses OpenCV's cv2.inpaint (see license-opencv.txt).
+
+This file records attribution. Confirm and, if required, reproduce the full
+upstream MIT license text here before distributing a build that advertises the
+AI feature. The manual (brush) dust removal path uses no third-party model and
+works fully offline.

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -14,4 +14,6 @@ nuitka --mingw64 --standalone --assume-yes-for-downloads --include-package=numpy
 --include-data-dir=src/icons=icons --include-data-dir=LICENSES=LICENSES --windows-icon-from-ico=src/icons/freeccr_logo.ico ^
 --windows-console-mode=attach --include-package=pyopencl --include-data-dir="%PYOPENCL_CL_DIR%=pyopencl/cl" ^
 --include-package=onnxruntime --include-package-data=onnxruntime ^
---nofollow-import-to=doctest --nofollow-import-to=IPython --output-filename=freeccr.exe src/main.py
+--nofollow-import-to=doctest --nofollow-import-to=IPython ^
+--nofollow-import-to=PIL.PdfParser --nofollow-import-to=PIL.PdfImagePlugin ^
+--output-filename=freeccr.exe src/main.py

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -10,7 +10,14 @@ REM the compiled build. --include-package pulls the modules + extension and
 REM --include-package-data copies the native DLLs alongside it.
 REM See spec/dust-removal.md.
 
-nuitka --mingw64 --standalone --assume-yes-for-downloads --include-package=numpy --include-package=utils --enable-plugin=pyside6 ^
+REM Use clang (bundled with Nuitka's mingw64) instead of gcc: gcc 14.2.0 hits an
+REM internal compiler error (segfault in the ce1/if-conversion RTL pass) on the
+REM large generated C for ccr_processor / PIL. clang 19 compiles those cleanly
+REM (it is the compiler the Makefile's build-windows target already uses).
+REM --jobs=6 bounds parallel C compilation so the few HUGE generated files
+REM (ccr_processor, __helpers) don't spike memory enough to crash a compiler
+REM process (24 cores would otherwise launch 24 at once).
+nuitka --mingw64 --clang --jobs=6 --standalone --assume-yes-for-downloads --include-package=numpy --include-package=utils --enable-plugin=pyside6 ^
 --include-data-dir=src/icons=icons --include-data-dir=LICENSES=LICENSES --windows-icon-from-ico=src/icons/freeccr_logo.ico ^
 --windows-console-mode=attach --include-package=pyopencl --include-data-dir="%PYOPENCL_CL_DIR%=pyopencl/cl" ^
 --include-package=onnxruntime --include-package-data=onnxruntime ^

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -4,7 +4,14 @@ python write_version.py
 for /f "delims=" %%i in ('python -c "import pyopencl, os; print(os.path.join(os.path.dirname(pyopencl.__file__), 'cl'))"') do set PYOPENCL_CL_DIR=%%i
 echo PyOpenCL cl directory: %PYOPENCL_CL_DIR%
 
+REM onnxruntime ships native DLLs (capi/onnxruntime*.dll) + a .pyd extension
+REM that Nuitka must bundle, or the AI dust-detection feature is unavailable in
+REM the compiled build. --include-package pulls the modules + extension and
+REM --include-package-data copies the native DLLs alongside it.
+REM See spec/dust-removal.md.
+
 nuitka --mingw64 --standalone --assume-yes-for-downloads --include-package=numpy --include-package=utils --enable-plugin=pyside6 ^
 --include-data-dir=src/icons=icons --include-data-dir=LICENSES=LICENSES --windows-icon-from-ico=src/icons/freeccr_logo.ico ^
 --windows-console-mode=attach --include-package=pyopencl --include-data-dir="%PYOPENCL_CL_DIR%=pyopencl/cl" ^
---nofollow-import-to=doctest --nofollow-import-to=IPython --output-filename=freeccr.exe src/main.py 
+--include-package=onnxruntime --include-package-data=onnxruntime ^
+--nofollow-import-to=doctest --nofollow-import-to=IPython --output-filename=freeccr.exe src/main.py

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -10,17 +10,24 @@ REM the compiled build. --include-package pulls the modules + extension and
 REM --include-package-data copies the native DLLs alongside it.
 REM See spec/dust-removal.md.
 
-REM Use clang (bundled with Nuitka's mingw64) instead of gcc: gcc 14.2.0 hits an
-REM internal compiler error (segfault in the ce1/if-conversion RTL pass) on the
-REM large generated C for ccr_processor / PIL. clang 19 compiles those cleanly
-REM (it is the compiler the Makefile's build-windows target already uses).
-REM --jobs=6 bounds parallel C compilation so the few HUGE generated files
-REM (ccr_processor, __helpers) don't spike memory enough to crash a compiler
-REM process (24 cores would otherwise launch 24 at once).
-nuitka --mingw64 --clang --jobs=6 --standalone --assume-yes-for-downloads --include-package=numpy --include-package=utils --enable-plugin=pyside6 ^
+REM Build with MSVC (Visual Studio), NOT mingw: MSVC compiles FreeCCR's huge
+REM generated C files (ccr_processor, __helpers) that crashed gcc 14.2 / clang 19,
+REM and matches onnxruntime's toolchain. --jobs=6 bounds parallel compilation
+REM memory (24 cores would otherwise launch 24 cl.exe at once).
+nuitka --msvc=latest --jobs=6 --standalone --assume-yes-for-downloads --include-package=numpy --include-package=utils --enable-plugin=pyside6 ^
 --include-data-dir=src/icons=icons --include-data-dir=LICENSES=LICENSES --windows-icon-from-ico=src/icons/freeccr_logo.ico ^
 --windows-console-mode=attach --include-package=pyopencl --include-data-dir="%PYOPENCL_CL_DIR%=pyopencl/cl" ^
 --include-package=onnxruntime --include-package-data=onnxruntime ^
 --nofollow-import-to=doctest --nofollow-import-to=IPython ^
 --nofollow-import-to=PIL.PdfParser --nofollow-import-to=PIL.PdfImagePlugin ^
 --output-filename=freeccr.exe src/main.py
+
+REM Nuitka bundles the MSVC runtime from the VC toolset redist, which is OLDER
+REM (14.29/14.32) than onnxruntime.dll requires. Loaded against that stale
+REM runtime, onnxruntime's .pyd fails its init ("DLL initialization routine
+REM failed") and AI dust detection is disabled in the exe. Overwrite with the
+REM system's current runtime so it initialises. See spec/dust-removal.md §8.
+for %%d in (msvcp140.dll msvcp140_1.dll msvcp140_2.dll vcruntime140.dll vcruntime140_1.dll) do (
+    if exist "%SystemRoot%\System32\%%d" copy /Y "%SystemRoot%\System32\%%d" "main.dist\%%d" >nul
+)
+echo Refreshed bundled MSVC runtime for onnxruntime.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ keyring
 requests
 nuitka
 pyopencl
+onnxruntime

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -113,7 +113,11 @@ reference to `MainWindow` and `ImagePreview` passed at construction (it does
   - **Left-release**: commit the stroke as one `brush` spot (§4),
     `push_undo_state()` once for the stroke, re-render the image (inpaint
     applied), and refresh thumbnail + preview. The dust is now visibly gone.
-  - **Mouse wheel**: adjust brush size (kept in sync with the slider).
+  - **Ctrl + mouse wheel**: resize the brush (kept in sync with the slider).
+  - **Mouse wheel** (no modifier): zoom in/out for precise spotting (preview
+    pixels; hi-res replay is suppressed in dust mode — §5.5). **Middle-button
+    drag**: pan the zoomed view. (Both match the normal viewer; only the brush
+    moves to Ctrl + wheel.)
   - A **brush-circle cursor** tracks the pointer; its on-screen radius is
     `r_norm * W * view_scale` display pixels (§5.5).
 - Coordinate mapping reuses the existing inverse-`base_transform` +

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -421,18 +421,33 @@ pytest-style. Two groups:
 
 ## 8. Build / packaging
 
-- `onnxruntime` is added to `requirements.txt` so running from source
-  (`python src/main.py`, the primary dev path) has AI working out of the box.
-- The lazy in-function import means a Nuitka **standalone** build that does *not*
-  bundle `onnxruntime` still runs — the AI section simply reports unavailable and
-  manual dust works. Two valid build options (validate empirically, tracked as a
-  build TODO, not blocking this feature):
-  1. **Bundle**: add `--include-package=onnxruntime` and the provider DLL/data
-     dirs to `build_exe.bat` / Makefile.
-  2. **Exclude**: `--nofollow-import-to=onnxruntime` to ship AI-disabled (manual
-     only), keeping the build small and green.
-- The ~150 MB model is **never** bundled; it downloads on demand to the app data
-  dir, like a user asset.
+`onnxruntime` is in `requirements.txt`, so from source (`python src/main.py`) AI
+works out of the box. Making it work in the **Nuitka standalone exe** took four
+fixes (all empirically verified by a startup diagnostic that logs onnxruntime
+readiness, and `--windows-console-mode=attach` so it's visible):
+
+1. **Compiler = MSVC, not mingw** (`--msvc=latest`). mingw gcc 14.2 / clang 19
+   both crashed (ICE / codegen) compiling FreeCCR's huge generated C files
+   (`ccr_processor`, `__helpers`); MSVC compiles them. `--jobs=6` bounds parallel
+   compile memory (24 cores otherwise launch 24 compilers and crash on the huge
+   units).
+2. **Bundle onnxruntime**: `--include-package=onnxruntime
+   --include-package-data=onnxruntime` (pulls the modules, the `.pyd`, and the
+   native `capi/*.dll`).
+3. **Refresh the MSVC runtime** (the key one): Nuitka bundles the VC toolset's
+   redist runtime (`msvcp140*.dll` / `vcruntime140*.dll`), which is OLDER
+   (14.29/14.32) than onnxruntime needs (14.44+). Loaded against the stale
+   runtime the `.pyd` fails its init ("DLL initialization routine failed") and AI
+   is silently disabled. `build_exe.bat` overwrites those DLLs in `main.dist`
+   with the system's current ones post-build.
+4. **`main.py` startup**: before any Qt import (load-order matters on Windows),
+   add `<exe>/onnxruntime/capi` to the DLL search path and pre-load
+   `onnxruntime.dll` so the bundled `.pyd` resolves it. Guarded / no-op from
+   source.
+
+The lazy in-function import still means a build *without* onnxruntime runs fine
+(AI reports the reason, manual dust unaffected). The ~150 MB detector model is
+**never** bundled; it downloads on demand to the app-data dir.
 
 ## 9. Refinement notes — resolved decisions
 

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -1,0 +1,456 @@
+# Spec: Dust Removal
+
+Status: REFINED v2
+Owner: FreeCCR
+Feature branch: `feature/dust-removal`
+Reference: ported/adapted from the `openenlarge` repo (manual eraser + AI auto-dust).
+
+## 1. Summary
+
+Add a **Dust Removal** feature for spotting out dust, hair, and small scratches on
+scanned film. It has two paths that share one non-destructive data model:
+
+- **Manual** — the user paints over dust on the canvas with a sized brush; the
+  painted region is inpainted (`cv2.inpaint`, Telea) so the speck is filled from
+  its surroundings.
+- **AI (hybrid)** — an ONNX neural detector (BOPBTL U-Net, downloaded on first
+  use) finds dust automatically; the detected blobs are inpainted with the same
+  `cv2.inpaint` fill. A sensitivity slider tunes how aggressive detection is.
+
+A single **Dust Removal** button on the image toolbar enters "dust mode": the
+right-hand sliders panel is covered by a Dust Removal panel exposing the manual
+and AI controls. Edits are stored as normalized 0..1 *spots* on the image,
+replayed in the render pipeline at preview and full-export resolution, persisted
+in the catalog, and undoable.
+
+## 2. Goals / Non-goals
+
+### Goals
+- One **Dust Removal** toolbar button that toggles dust mode (enter/exit).
+- In dust mode, the sliders panel is replaced (covered) by a **DustRemovalPanel**
+  with a **Manual** section and an **AI** section, plus a **Done** button.
+- **Manual**: brush-size slider; click or click-drag on the canvas paints a
+  spot/stroke; the painted area is inpainted on release; **Undo last spot** and
+  **Clear all** controls; a live red mask overlay while painting.
+- **AI**: a **Detect & Remove** button and a **Sensitivity** slider. If the ONNX
+  detector model is not present, an explicit **Download AI model (~150 MB)** gate
+  (off-thread, with progress + SHA‑256 verification) is shown first.
+- **Non-destructive**: edits are stored as normalized spots on `CCRImage`; the
+  render pipeline rasterizes a mask and inpaints at whatever resolution it is
+  processing, so preview, hi-res zoom, and export all match and scale.
+- Dust edits **persist** in the catalog, **participate in Undo** (Ctrl+Z), and
+  survive image switch / app restart.
+- Manual dust removal works with **no new runtime dependencies** and **fully
+  offline** (`cv2.inpaint` ships with the already-required `opencv-python`).
+- The AI detector is **optional and degrades gracefully**: if `onnxruntime` or
+  the model is unavailable, the manual path is unaffected and the AI section
+  shows an unavailable/needs-download state instead of erroring.
+
+### Non-goals
+- No MI-GAN / neural *inpainting* fill (openenlarge's second ONNX model). Fill is
+  `cv2.inpaint` only. The detection backend is abstracted so a neural inpainter
+  could be added later.
+- No IR-channel ("infrared cleaning") dust removal — FreeCCR has no IR plane.
+- No per-spot re-editing handles (move/resize an existing spot). Edits are
+  add-only with Undo-last and Clear-all. (Future enhancement.)
+- No elongated-scratch vectorization. AI-detected components are approximated by
+  circular spots; long scratches are best handled with the manual brush (§5.4).
+- AI detection is **not** re-run inside the render pipeline (too slow for the hot
+  path). Detection is an explicit user action that *adds spots*; rendering only
+  rasterizes + inpaints stored spots (§5.3).
+
+## 3. UX / Interaction
+
+### 3.1 Entering / exiting dust mode
+- A **Dust Removal** checkable `QAction` is added to `ImagePreview`'s toolbar,
+  immediately after the `▤ Gradient` action and preceded by a separator (grouped
+  with the area-editing tools). Clicking toggles dust mode.
+- Gating: enabled only when the current image's sliders are enabled (a converted
+  negative, or any image in Positive mode) — the same `sliders_enabled` condition
+  computed in `_update_unconvert_action_state` (image_preview.py:1269-1292).
+  Disabled otherwise.
+- **Entering** dust mode (`ImagePreview.enter_dust_mode()`):
+  1. Exit any other canvas mode (crop / slice / area / bw-point / wb-pick).
+  2. Set `self.dust_mode = True`; reset zoom to fit and `_release_hires`.
+  3. `update_preview(idx)` now shows the **full, un-cropped** working positive
+     with **coarse rotation/flip only** (no fine rotation, no displayed crop) —
+     mirroring crop mode — so canvas pixels map 1:1 to `resized_raw` (§5.5).
+  4. Set a brush-circle cursor and draw the red mask overlay for the image's
+     stored spots.
+  5. Call `self.window().toggle_dust_removal(True)` so `MainWindow` swaps panels.
+- **Exiting** dust mode (the **Done** button, the toggled-off toolbar action, or
+  `Esc`): hide the red mask overlay, clear `dust_mode`, restore the normal
+  (cropped, fine-rotated) preview, restore the sliders panel, and re-enable the
+  toolbar actions. **Previously applied dust edits remain on the image.**
+
+### 3.2 DustRemovalPanel layout (top → bottom)
+1. Header: **Dust Removal**.
+2. **Manual** group:
+   - **Brush size** slider (label shows size as a % of image width).
+   - Hint: "Click or drag over dust to remove it."
+   - **Undo last spot** button and **Clear all** button.
+3. Separator.
+4. **AI** group:
+   - When the model is **absent**: an explanatory line + **Download AI model
+     (~150 MB)** button; while downloading, a progress bar; on failure, an error
+     line + retry.
+   - When the model is **present**: a **Sensitivity** slider (0–100) and a
+     **Detect & Remove** button (busy/spinner state while running).
+   - When `onnxruntime` is **not importable**: a disabled state with
+     "AI detection unavailable in this build."
+5. Spacer.
+6. **Done** button (returns to the sliders panel; exits dust mode).
+
+The panel reuses the existing dark slider/button styling. It holds an explicit
+reference to `MainWindow` and `ImagePreview` passed at construction (it does
+**not** rely on `parent().parent()` chains).
+
+### 3.3 Manual painting
+- On the canvas in dust mode:
+  - **Left-press**: begin a stroke; record the first normalized point at the
+    current brush radius; show the red dab.
+  - **Left-drag**: append normalized points; extend the red stroke overlay.
+  - **Left-release**: commit the stroke as one `brush` spot (§4),
+    `push_undo_state()` once for the stroke, re-render the image (inpaint
+    applied), and refresh thumbnail + preview. The dust is now visibly gone.
+  - **Mouse wheel**: adjust brush size (kept in sync with the slider).
+  - A **brush-circle cursor** tracks the pointer; its on-screen radius is
+    `r_norm * W * view_scale` display pixels (§5.5).
+- Coordinate mapping reuses the existing inverse-`base_transform` +
+  `map_displayed_to_full` chain (as B/W-point sampling and the reference frame
+  do), producing **un-rotated, un-flipped, un-cropped** working-image pixel
+  coords, then normalized by the working image (`resized_raw`) size (§5.5).
+
+### 3.4 AI detect & remove
+- **Detect & Remove** runs detection **off the GUI thread** on the current
+  working positive (`resized_raw` with existing spots already inpainted, so
+  already-cleaned dust is not re-flagged), at preview resolution:
+  1. If no cached probability map for this image, run the ONNX detector and cache
+     it (so re-tuning Sensitivity does not re-run the net).
+  2. Threshold + size-gate + dilate the prob map into a binary mask at detection
+     resolution (§5.3).
+  3. Extract connected components; convert each to one normalized `auto` spot
+     (centroid + radius from component extent).
+  4. Replace any prior `auto` spots on the image with the new set (manual `brush`
+     spots are untouched), `push_undo_state()` once, re-render.
+- **Sensitivity** changes re-threshold the cached prob map and refresh the
+  `auto` spots live (no net re-run) unless the working buffer changed.
+- A status line reports "Removed N spots" (or "No dust found").
+
+### 3.5 Interaction with other edits
+- Dust removal is independent of sliders/curves/areas/crop: it runs earliest in
+  the adjustment stage (§5.1), so subsequent color adjustments apply to the
+  already-cleaned positive.
+- **Compare** (hold) and the main **Reset** button do **not** clear dust spots
+  (dust is a separate concern from tonal adjustments). Both code paths
+  (`on_compare_pressed`, `on_reset_clicked` in sliders_panel.py) already leave
+  `dust_spots` untouched; an explanatory comment is added at each to keep that
+  intentional. **Clear all** in the dust panel (and Undo) is the only UI that
+  removes spots.
+
+## 4. Data model
+
+### 4.1 Storage
+A new attribute on `CCRImage`, initialized in `__init__` next to `area_layers`:
+
+```python
+self.dust_spots: list[dict] = []
+```
+
+Each entry is a **spot** (a stamp = the union of equal-radius circular dabs along
+a polyline):
+
+```python
+{
+  "kind": "brush" | "auto",   # provenance: hand-painted vs AI-detected
+  "pts":  [[x, y], ...],      # normalized; x over WIDTH, y over HEIGHT, in [0,1]
+  "r":    0.012,              # radius as a fraction of image WIDTH, in (0,1]
+}
+```
+
+- A single click is a `brush` spot with one point.
+- An AI-detected blob is an `auto` spot with one centroid point and a radius
+  from the component's extent.
+- Empty list = "no dust removal"; the render fast-path leaves the image
+  untouched (§5.2).
+
+Rationale: mirrors openenlarge's normalized `DustStroke` model, serializes
+cleanly to JSON, deep-copies cleanly for undo, and is fully resolution
+independent (rasterized at the processing resolution).
+
+### 4.2 Persistence (catalog)
+- `serialize_image()` (catalog.py:141) adds `"dust_spots": list(img.dust_spots)`.
+- `_restore_image()` (catalog.py:347) restores
+  `img.dust_spots = list(state.get("dust_spots") or [])` (missing key → `[]`, so
+  old catalogs load unchanged).
+- `_is_pristine()` (catalog.py:168) adds `and not state.get("dust_spots")` to its
+  AND-chain, so a **dust-only** image (no conversion/adjustment/crop) is treated
+  as edited and is **not** purged on save (same hazard the curves spec fixed in
+  §9.8). No decoded pixels are persisted — spots replay against the freshly
+  decoded scan exactly like the existing conversion/adjustment replay.
+
+### 4.3 Undo
+- `capture_undo_state()` (ccr_image.py:794) adds
+  `"dust_spots": copy.deepcopy(self.dust_spots)`.
+- `pop_undo_state()` (ccr_image.py:822) restores
+  `self.dust_spots = copy.deepcopy(state.get("dust_spots", []))`.
+- Deep-copied because entries hold nested point lists. `dust_spots` is **global**
+  image state (not per-area), so the `active_area_id` validation in
+  `pop_undo_state` is unaffected.
+
+### 4.4 Render cache invalidation
+The hi-res zoom adjustment identity `_current_adj_sig` (image_preview.py ~1554)
+must include a **dust signature** so changing spots invalidates the cached hi-res
+render. It goes in the *adjustment* signature (display-time), **not** the base
+decode signature `_hires_signature`. Concrete form:
+
+```python
+dust_sig = tuple(
+    (s.get("kind"),
+     tuple((round(p[0] * 10000), round(p[1] * 10000)) for p in s.get("pts", [])),
+     round(float(s.get("r", 0)) * 10000))
+    for s in getattr(img, "dust_spots", []))
+```
+
+(4-decimal rounding ≈ 0.01% of the image — fine enough to never falsely reuse a
+stale render, coarse enough not to thrash.)
+
+## 5. Processing / math
+
+### 5.1 Where it applies — the single funnel
+Dust removal runs at the **very start of `CCRImage.apply_adjustments(image)`**,
+*before* the early-return guard and `adjust_image_opencl`:
+
+```python
+def apply_adjustments(self, image, ...):
+    image = self._apply_dust_removal(image)   # NEW — no-op when no spots
+    s = self.adjustment_settings if settings is None else settings
+    ...
+    if not s and cb == 0 and tb == 0 and bb == 0 and not has_areas:
+        return self._to_grayscale(image) if profile == "bw" else image
+    ...
+```
+
+`apply_adjustments` is the one method every render context routes the
+**post-inversion positive** through, at its own resolution (verified):
+
+- **Preview / thumbnail**: `update_thumbnail_and_preview` →
+  `apply_adjustments(resized_raw)` (ccr_image.py:537).
+- **Hi-res zoom**: the hi-res worker renders the conversion base, then calls
+  `apply_adjustments` for display.
+- **Export**: each normalization function calls `apply_adjustments` on the
+  full-res post-inversion positive when `output_path is not None` —
+  `ccr_normalize_with_reference` (ccr_processor.py:863),
+  `ccr_normalize_with_bwpoint` (:1113), positive export (:1206/:1208).
+
+Because user **crop / flip / 90° / fine-rotation are applied *after***
+`apply_adjustments` in every export path (e.g. :871, :1119, :1212), spots stored
+in `resized_raw` (un-cropped, un-rotated, un-flipped) space line up at every
+resolution. The area-layer path (`_adjust_for_area`) does **not** funnel through
+`apply_adjustments`, so dust is applied exactly once per render.
+
+`_apply_dust_removal` runs before the guard so a **dust-only** image (all sliders
+neutral) is still inpainted. For un-converted negatives, dust runs before the
+display-only `_auto_brightness_for_preview` (ccr_image.py:548) — acceptable: the
+normalized spots replay correctly at export regardless of preview auto-brightness.
+
+### 5.2 Mask rasterization + inpaint (`ccr_processor.py`)
+New functions:
+
+```python
+def rasterize_dust_mask(spots, h, w) -> np.ndarray:                  # uint8 {0,255}, (h,w)
+def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 RGB
+```
+
+- `rasterize_dust_mask`: zero mask; for each spot `r_px = max(1, round(r*w))`;
+  draw `cv2.circle(mask, (round(x*w), round(y*h)), r_px, 255, -1)` at each point,
+  and a `cv2.line(..., thickness=2*r_px)` between consecutive points of a stroke
+  so a fast drag leaves no gaps. (`r_px` is width-based in **both** axes → a true
+  pixel circle at any resolution; pixels are square so it reads as a circle.)
+- `apply_dust_removal`:
+  - Identity fast-path: empty `spots` or all-zero mask → return `img16` unchanged.
+  - Inpaint in 8-bit (what `cv2.inpaint` supports); only **masked** pixels are
+    replaced so the unmasked image keeps full 16-bit precision:
+    1. `bgr8 = cv2.cvtColor(cv2.convertScaleAbs(img16, alpha=255/65535), RGB2BGR)`.
+    2. `filled8 = cv2.inpaint(bgr8, mask, inpaint_radius, cv2.INPAINT_TELEA)`.
+    3. `filled16 = cv2.cvtColor(filled8, BGR2RGB).astype(uint16) * 257`.
+    4. Build a **feathered alpha** `a` (dilate the mask ~2 px, box-blur ~3 px,
+       normalize to 0..1) and composite `out = img16*(1-a) + filled16*a`, so the
+       fill blends seamlessly and `out == img16` away from any spot.
+  - Returns a new `uint16` RGB array; `img16` is never mutated (non-destructive).
+  - Precision note: only the **synthetic fill** pixels inside the mask carry 8-bit
+    quantization; the rest of the frame is bit-for-bit unchanged. Acceptable for
+    small specks. (A future 16-bit-native inpaint could remove even that.)
+  - Cost is dominated by the inpaint over the mask bbox; a few ms on ~1080 px.
+
+### 5.3 AI detection (`src/core/dust_detect.py`)
+A self-contained module wrapping the ONNX BOPBTL detector. **`onnxruntime` is
+imported only inside functions, never at module level**, so the module (and the
+panel that imports it) load even when `onnxruntime` is absent.
+
+- **Availability**: `is_available()` (can `import onnxruntime`) and
+  `is_model_present()` (model file on disk).
+- **Model management**: `model_path()` →
+  `<APPDATA>/FreeCCR/models/detector.onnx` (same app dir as the catalog).
+  `download_model(progress_cb)` streams the asset with `requests`, verifies
+  SHA‑256 before use, writes atomically (`tmp` + `os.replace`).
+  - URL: `https://github.com/MohaElder/openenlarge/releases/download/autodust-assets-v1/detector.onnx`
+  - SHA‑256: `61e4a93d4e94b4fc6212e2e9b785fa12b5cbc9654724b02aaf8b212075bb729f`
+  - (URL / SHA / filename are module constants so they can be repointed.)
+- **`detect(positive_rgb16) -> (prob_h, prob_w, prob: float32[0,1])`**: resize so
+  the short side is `DETECT_SHORT=512` and both dims are multiples of 16; Rec.709
+  luma; normalize to `[-1,1]`; run the session (`[1,1,dh,dw]` → logits); sigmoid.
+  CPU execution provider (matches openenlarge's Windows guidance). Returns the
+  prob map at detection resolution (cached per image for cheap Sensitivity).
+- **`prob_to_spots(prob, prob_h, prob_w, sensitivity, max_dim) -> list[spot]`**:
+  - `thr = 0.85 - 0.60 * (sensitivity/100)` (0 → very selective … 100 →
+    aggressive), matching openenlarge.
+  - Binarize at `thr`; via `cv2.connectedComponentsWithStats`, drop components
+    whose pixel area exceeds a resolution-normalized `max_blob` (only small
+    dust/hairs removed, not real detail); dilate 1 px.
+  - Each surviving component → one `auto` spot: centroid `(cx/prob_w, cy/prob_h)`;
+    radius `r = (0.5*max(comp_w, comp_h) + pad) / prob_w` (covers the speck plus a
+    small margin for the inpaint to key off).
+  - `prob_to_spots` is **pure / model-free** (operates on a numpy prob map) so it
+    is unit-testable without ONNX.
+- All ONNX use is guarded; any import/inference error surfaces as
+  "AI detection unavailable" and never breaks manual dust or the rest of the app.
+
+### 5.4 Known approximation
+AI-detected components become circular spots. Round dust/hair specks are covered
+well; long diagonal scratches are only partially covered by one circle — the
+manual brush (a stroke = many dabs) is the tool for those. Keeps the stored model
+uniform and resolution-independent. (Future: component polygons / multi-circle.)
+
+### 5.5 Coordinate mapping (canvas → normalized spot)
+Dust mode shows the working positive with **coarse rotation/flip only** — no
+displayed crop (the `not self.dust_mode` guard is added to update_preview's
+crop-display branch, image_preview.py:951) and no fine rotation (mirroring crop
+mode's `apply_transformations`). Therefore canvas pixels map **exactly** to
+`resized_raw` pixels via:
+1. `scene = view.mapToScene(event.pos())` (auto-accounts for zoom/pan).
+2. Invert the display `base_transform` (coarse 90°/180°/270° + H/V flips) → local
+   pixmap coords.
+3. `map_displayed_to_full(x, y)` — **identity** in dust mode (no crop shown).
+4. Normalize: `H, W = resized_raw.shape[:2]`; `x_n = px/W`, `y_n = py/H`,
+   `r_n = r_px/W`.
+
+Because spots are applied in `apply_adjustments` **before** crop and fine rotation
+(§5.1), and dust mode shows the image **without** those, mapping is exact — no
+sub-pixel fine-rotation error. The on-canvas brush radius is `r_n*W*view_scale`
+display pixels.
+
+## 6. Integration points
+
+| File | Change |
+|---|---|
+| `src/core/ccr_image.py` | `self.dust_spots = []` in `__init__`; `_apply_dust_removal()` + call at top of `apply_adjustments`; add `dust_spots` to `capture_undo_state` / `pop_undo_state`. |
+| `src/core/ccr_processor.py` | `rasterize_dust_mask`, `apply_dust_removal`, feathered-composite helper. |
+| `src/core/dust_detect.py` (new) | ONNX detector: availability, model path/download/verify, `detect`, `prob_to_spots`, constants. `onnxruntime` imported only inside functions. |
+| `src/core/catalog.py` | Serialize/restore `dust_spots`; add `not state.get("dust_spots")` to `_is_pristine`. |
+| `src/widgets/image_preview.py` | Toolbar **Dust Removal** checkable action (after Gradient, with separator) + gating in `_update_unconvert_action_state`; `dust_mode` flag; `enter_dust_mode`/`exit_dust_mode`; canvas press/move/release + brush cursor + red mask overlay; `_scene_to_norm_spot()`; `and not self.dust_mode` in the crop-display branch + clear_preview/Esc routing; `dust_sig` in `_current_adj_sig`. |
+| `src/widgets/dust_panel.py` (new) | `DustRemovalPanel(QWidget)` (manual + AI sections, Done); QThread workers for model download and detection; explicit MainWindow/ImagePreview refs. |
+| `src/ui/main_window.py` | Add `dust_panel` as a **direct child** of `central_widget`'s layout (fixed 300 px, hidden); `toggle_dust_removal(on)` toggles `sliders_panel`/`dust_panel` visibility (no `QStackedWidget` — preserves `SlidersPanel`'s `parent().parent()` chains) and drives canvas enter/exit + toolbar action state. |
+| `requirements.txt` | Add `onnxruntime` (CPU). Manual path needs nothing new (`cv2`, `requests` already present). |
+| `LICENSES/` | Add attribution for the detector model (BOPBTL U-Net, MIT, via openenlarge) — see §9 open item. |
+| `tests/test_dust_removal.py` (new) | See §7. |
+
+## 7. Test plan
+
+The harness (`tests/run_tests.py`) sets `QT_QPA_PLATFORM=offscreen`; tests are
+pytest-style. Two groups:
+
+**Pure processing (no Qt, no ONNX model):**
+- `rasterize_dust_mask`: a normalized spot rasterizes to a filled circle of the
+  expected pixel radius at a given `(h,w)`; the **same** spot covers a
+  proportionally larger region at 2× resolution (resolution independence).
+- `apply_dust_removal`: on a synthetic flat image with a bright speck, a spot over
+  the speck removes it (masked pixels move toward the surround) while pixels far
+  from any spot are **bit-for-bit unchanged**; dtype stays `uint16`.
+- Identity: empty `dust_spots` → `apply_dust_removal` returns the input unchanged.
+- `apply_adjustments` integration: a `CCRImage` with only `dust_spots` set (all
+  sliders neutral) still inpaints (the early guard does not skip dust).
+- `prob_to_spots` (model-free): synthetic prob map → assert sensitivity→threshold
+  mapping, size-gating (an over-large blob is dropped), and small blobs become
+  spots with sane normalized centroids/radii.
+
+**Persistence / undo (CCRImage, no GUI):**
+- `serialize_image`/`_restore_image` round-trips `dust_spots`; an old entry with
+  no `dust_spots` key restores to `[]`; `_is_pristine` returns False for a
+  dust-only state.
+- `capture_undo_state` → mutate → `pop_undo_state` restores the prior `dust_spots`
+  as an independent deep copy.
+
+**Graceful degradation:**
+- Monkeypatch `sys.modules["onnxruntime"]` to raise `ImportError` *before*
+  importing `dust_detect`; `is_available()` is `False` and importing the module
+  does not raise.
+
+**Manual (not automated):**
+- Toolbar button toggles the panel cover; Done restores sliders; Esc exits.
+- Paint a spot → dust disappears; Undo restores it; Clear all empties.
+- Download gate appears without the model; after download, Detect & Remove finds
+  specks; Sensitivity re-tunes live without a visible re-run.
+- Dust survives image switch, app restart (catalog), Ctrl+Z, and is visible in
+  zoom detail and the exported file at full resolution.
+
+## 8. Build / packaging
+
+- `onnxruntime` is added to `requirements.txt` so running from source
+  (`python src/main.py`, the primary dev path) has AI working out of the box.
+- The lazy in-function import means a Nuitka **standalone** build that does *not*
+  bundle `onnxruntime` still runs — the AI section simply reports unavailable and
+  manual dust works. Two valid build options (validate empirically, tracked as a
+  build TODO, not blocking this feature):
+  1. **Bundle**: add `--include-package=onnxruntime` and the provider DLL/data
+     dirs to `build_exe.bat` / Makefile.
+  2. **Exclude**: `--nofollow-import-to=onnxruntime` to ship AI-disabled (manual
+     only), keeping the build small and green.
+- The ~150 MB model is **never** bundled; it downloads on demand to the app data
+  dir, like a user asset.
+
+## 9. Refinement notes — resolved decisions
+
+1. **Panel cover via visibility toggle, not `QStackedWidget`.** Wrapping
+   `sliders_panel` in a `QStackedWidget` would insert a layer between it and
+   `central_widget`, breaking the ~12 `self.parent().parent()` chains
+   `SlidersPanel` uses to reach `MainWindow`. Instead both panels are direct
+   children of `central_widget`'s layout and `toggle_dust_removal(on)` flips
+   their `setVisible`. `dust_panel` takes explicit refs (no parent-chain
+   reliance). Mirrors the proven tether-banner pattern.
+2. **Toolbar action** is checkable, placed after `▤ Gradient` with a leading
+   separator, gated by the same `sliders_enabled` as the adjustment sliders.
+3. **Esc / exit** routes through `_on_escape_key` (`elif self.dust_mode:
+   self.exit_dust_mode()`) and `clear_preview` also exits dust mode, alongside
+   the existing crop/slice/area handling.
+4. **Exact rendering in dust mode**: full image, coarse rotation/flip only, no
+   crop, no fine rotation → exact 1:1 canvas↔`resized_raw` mapping (§5.5). This
+   removes the fine-rotation sub-pixel error entirely.
+5. **Single-funnel verified** against the real export paths (§5.1 line refs); a
+   single insertion at the top of `apply_adjustments` covers preview, zoom, and
+   all export modes.
+6. **Inpaint** = `cv2.INPAINT_TELEA`, radius 3, masked-only feathered composite to
+   preserve 16-bit precision outside the fill (§5.2). NS is a possible future
+   toggle.
+7. **`dust_spots` is global** image state and independent of Compare/Reset; both
+   leave it untouched (with clarifying comments).
+8. **Catalog**: `_is_pristine` must include `dust_spots` so dust-only images
+   persist; old catalogs restore `dust_spots → []`.
+9. **Cache**: `dust_sig` added to the hi-res *adjustment* signature (§4.4).
+10. **Image switch leaves dust mode** (like crop/area): `update_preview` tears
+    down dust mode on a different image so a half-drawn stroke can't commit to
+    the wrong image and the panel can't drift out of sync.
+11. **Fine-rotation slider is disabled in dust mode** (the canvas shows the
+    un-fine-rotated image), so it can't show an ignored value or mutate state.
+12. **Detection results are discarded** if the user navigates to a different
+    image (or out of dust mode) while the off-thread detector runs; the model
+    download is cancelled on exit, and a session lock guards the cached ONNX
+    session against the detect/download threads.
+
+### Open items (non-blocking)
+- Confirm the detector model's exact license text and add
+  `LICENSES/license-openenlarge.txt` (BOPBTL U-Net is MIT per openenlarge);
+  ensure the Nuitka build bundles it.
+- Validate the chosen Nuitka onnxruntime option (§8) in a real build.
+- Tune brush-size slider range/default and `max_blob` / `pad` constants against
+  real scans during manual testing.

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -114,10 +114,13 @@ reference to `MainWindow` and `ImagePreview` passed at construction (it does
     `push_undo_state()` once for the stroke, re-render the image (inpaint
     applied), and refresh thumbnail + preview. The dust is now visibly gone.
   - **Ctrl + mouse wheel**: resize the brush (kept in sync with the slider).
-  - **Mouse wheel** (no modifier): zoom in/out for precise spotting (preview
-    pixels; hi-res replay is suppressed in dust mode — §5.5). **Middle-button
-    drag**: pan the zoomed view. (Both match the normal viewer; only the brush
-    moves to Ctrl + wheel.)
+  - **Mouse wheel** (no modifier): zoom in/out for precise spotting.
+    **Middle-button drag**: pan the zoomed view. (Both match the normal viewer;
+    only the brush moves to Ctrl + wheel.)
+  - **Hi-res detail loads on entry** (and refines on zoom) so dust is visible at
+    full sharpness. The hi-res render reproduces `resized_raw`'s orientation and
+    goes through `apply_adjustments` (so it shows the dust-removed result); the
+    dust-mode display stays full / un-fine-rotated, so spots stay aligned.
   - A **brush-circle cursor** tracks the pointer; its on-screen radius is
     `r_norm * W * view_scale` display pixels (§5.5).
 - Coordinate mapping reuses the existing inverse-`base_transform` +
@@ -309,12 +312,19 @@ panel that imports it) load even when `onnxruntime` is absent.
 - **`prob_to_spots(prob, prob_h, prob_w, sensitivity, max_dim) -> list[spot]`**:
   - `thr = 0.85 - 0.60 * (sensitivity/100)` (0 → very selective … 100 →
     aggressive), matching openenlarge.
-  - Binarize at `thr`; via `cv2.connectedComponentsWithStats`, drop components
-    whose pixel area exceeds a resolution-normalized `max_blob` (only small
-    dust/hairs removed, not real detail); dilate 1 px.
-  - Each surviving component → one `auto` spot: centroid `(cx/prob_w, cy/prob_h)`;
-    radius `r = (0.5*max(comp_w, comp_h) + pad) / prob_w` (covers the speck plus a
-    small margin for the inpaint to key off).
+  - Binarize at `thr`; via `cv2.connectedComponentsWithStats`:
+    - drop components whose pixel area exceeds a resolution-normalized
+      `max_blob` (film border / real image content, not dust);
+    - **drop elongated components** (aspect ratio > `MAX_ASPECT`): the detector
+      also fires on legitimate thin LINES (a bike frame, the horizon, a path
+      edge); circle-inpainting those smears real detail, so linear defects are
+      left to the manual brush (§5.4). This is the main guard against AI
+      artifacts on clean scans.
+  - Each surviving (compact) component → one `auto` spot: centroid
+    `(cx/prob_w, cy/prob_h)`; **area-equivalent** radius
+    `r = (sqrt(area/π) + pad) / prob_w` — a tight circle matching the speck, so
+    the inpaint stays invisible rather than leaving a smudge (the old
+    bounding-extent radius over-covered and was the artifact source).
   - `prob_to_spots` is **pure / model-free** (operates on a numpy prob map) so it
     is unit-testable without ONNX.
 - All ONNX use is guarded; any import/inference error surfaces as

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -94,8 +94,13 @@ in the catalog, and undoable.
    - When the model is **absent**: an explanatory line + **Download AI model
      (~150 MB)** button; while downloading, a progress bar; on failure, an error
      line + retry.
-   - When the model is **present**: a **Sensitivity** slider (0–100) and a
-     **Detect & Remove** button (busy/spinner state while running).
+   - When the model is **present**: a **Sensitivity** slider (0–100), a
+     **Detect & Remove** button (current image), and a **Detect & Remove — All
+     Images** button. The latter runs detection **per image** (each scan has its
+     own dust) at the current sensitivity, off the GUI thread with progress, and
+     replaces each image's `auto` spots (manual spots kept). Detection always
+     heals only the **manual** spots first, never the `auto` spots it is about
+     to replace, so re-running never loses prior coverage.
    - When `onnxruntime` is **not importable**: a disabled state with
      "AI detection unavailable in this build."
 5. Spacer.

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -318,8 +318,14 @@ panel that imports it) load even when `onnxruntime` is absent.
     - **drop elongated components** (aspect ratio > `MAX_ASPECT`): the detector
       also fires on legitimate thin LINES (a bike frame, the horizon, a path
       edge); circle-inpainting those smears real detail, so linear defects are
-      left to the manual brush (§5.4). This is the main guard against AI
-      artifacts on clean scans.
+      left to the manual brush (§5.4).
+    - **bright-speck gate**: film dust inverts to **white** specks, so a real
+      dust blob is brighter than its surroundings. Require the blob's mean luma
+      to exceed a surrounding ring by `BRIGHT_MARGIN`; this rejects normal-toned
+      content the detector wrongly fires on (a face, a dark feature — which is
+      how the AI once removed a person's head). `detect` therefore returns
+      `(prob, luma)` so `prob_to_spots` has the detection-resolution grayscale.
+      This and the aspect filter are the main guards against AI false positives.
   - Each surviving (compact) component → one `auto` spot: centroid
     `(cx/prob_w, cy/prob_h)`; **area-equivalent** radius
     `r = (sqrt(area/π) + pad) / prob_w` — a tight circle matching the speck, so

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -150,6 +150,7 @@ def serialize_image(img) -> dict:
         "conversion_inputs": _ci_to_json(img.conversion_inputs),
         "adjustment_settings": dict(img.adjustment_settings),
         "areas": _areas_to_json(getattr(img, "area_layers", None)),
+        "dust_spots": copy.deepcopy(getattr(img, "dust_spots", None) or []),
         "color_profile": getattr(img, "color_profile", "color"),
         "crop_rect": list(img.crop_rect) if img.crop_rect else None,
         "crop_angle": float(img.crop_angle or 0.0),
@@ -170,6 +171,7 @@ def _is_pristine(state: dict) -> bool:
     return (not state["converted"] and not state["source_ops"]
             and not state["adjustment_settings"]
             and not state.get("areas")
+            and not state.get("dust_spots")
             and state.get("color_profile", "color") == "color"
             and state["crop_rect"] is None
             and state["rotation_angle"] == 0 and state["fine_rotation_angle"] == 0
@@ -363,6 +365,7 @@ def _restore_image(file_path: str, state: dict):
         areas=_areas_from_json(state.get("areas")),
     )
     img.is_duplicate = bool(state.get("is_duplicate", False))
+    img.dust_spots = copy.deepcopy(state.get("dust_spots") or [])
     img.color_profile = state.get("color_profile", "color")
     ref = state.get("reference_frame")
     img.reference_frame = tuple(ref) if ref else None

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -11,7 +11,8 @@ from PySide6.QtGui import QImage, QPixmap  # or from PySide6.QtGui import QImage
 #import lensfunpy  # Make sure lensfunpy is installed
 from core.ccr_processor import (adjust_image, adjust_image_opencl,
                                 BAND_ADJUSTMENT_KEYS, apply_curves,
-                                apply_area_layers, apply_crop_to_image)
+                                apply_area_layers, apply_crop_to_image,
+                                apply_dust_removal)
 from core import color_management
 
 # Import optional libraries with fallbacks
@@ -112,6 +113,12 @@ class CCRImage:
         # The global adjustment_settings is the implicit "whole image" layer;
         # areas composite additively on top of it (see spec/area-editing.md).
         self.area_layers: List[Dict[str, Any]] = list(areas) if areas else []
+        # Dust removal: non-destructive spot inpainting. Each spot is
+        # {kind ("brush"|"auto"), pts ([[x,y],...] normalized over W/H),
+        # r (radius as a fraction of WIDTH)}. Rasterized + inpainted at render
+        # time (resolution-independent). [] = no dust removal. See
+        # spec/dust-removal.md.
+        self.dust_spots: List[Dict[str, Any]] = []
         # Which layer the adjustment panel currently edits: None = global
         # (whole image); otherwise the id of an area in area_layers. Session
         # state only — never persisted; always defaults to global on load.
@@ -621,12 +628,26 @@ class CCRImage:
         gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
         return cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
 
+    def _apply_dust_removal(self, image: np.ndarray) -> np.ndarray:
+        """Inpaint stored dust spots out of the working image (no-op when there
+        are none). Spots are normalized, so this scales to whatever resolution
+        is being processed — preview, hi-res zoom, or full-res export. See
+        spec/dust-removal.md."""
+        spots = getattr(self, "dust_spots", None)
+        if not spots:
+            return image
+        return apply_dust_removal(image, spots)
+
     def apply_adjustments(self, image: np.ndarray, settings=None, contrast_base=None,
                           temperature_base=None, brightness_base=None,
                           color_profile=None, areas_override=None) -> np.ndarray:
         """Apply the slider adjustments. The optional overrides let the zoom
         hi-res worker render from a snapshot taken at request time instead of
         live state the GUI thread may be mutating concurrently."""
+        # Dust removal runs FIRST so the inpainted positive flows through the
+        # rest of the adjustment stage (and so a dust-only image is still
+        # cleaned even when the early-return guard below would otherwise skip).
+        image = self._apply_dust_removal(image)
         s = self.adjustment_settings if settings is None else settings
         cb = self.contrast_base if contrast_base is None else contrast_base
         tb = self.temperature_base if temperature_base is None else temperature_base
@@ -806,6 +827,9 @@ class CCRImage:
             # sub-dict) and a geometry dict — a shallow copy would alias the
             # live structure and a later edit would corrupt the snapshot.
             "area_layers": copy.deepcopy(getattr(self, "area_layers", [])),
+            # Deep copy: each spot nests a point list, so a shallow copy would
+            # alias live state and a later edit would corrupt the snapshot.
+            "dust_spots": copy.deepcopy(getattr(self, "dust_spots", [])),
         }
 
     def push_undo_state(self) -> None:
@@ -834,6 +858,7 @@ class CCRImage:
         self.horizontal_mirrored = state["horizontal_mirrored"]
         self.vertical_mirrored = state["vertical_mirrored"]
         self.area_layers = copy.deepcopy(state.get("area_layers", []))
+        self.dust_spots = copy.deepcopy(state.get("dust_spots", []))
         # The previously-active area may have been added back/removed by this
         # undo; the panel re-resolves None -> global if the id is now stale.
         active_id = getattr(self, "active_area_id", None)

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -2815,6 +2815,77 @@ def apply_curves(img16: np.ndarray, curves) -> np.ndarray:
     return out
 
 
+# --- Dust removal (spot inpainting) ----------------------------------------
+# Dust edits are stored as NORMALIZED spots (fractions of width/height) on the
+# image, so the same definition reproduces at the 1080px preview, the hi-res
+# zoom detail and the full-res export — the resolution-independent contract the
+# area masks and reference-norm replay already honor. See spec/dust-removal.md.
+
+def rasterize_dust_mask(spots, h: int, w: int) -> np.ndarray:
+    """Rasterize dust spots into a uint8 {0,255} mask of shape (h, w).
+
+    spots: list of {"kind", "pts": [[x,y],...], "r"} where x,y are normalized
+    over width/height and r is a fraction of WIDTH. Each spot is the union of
+    equal-radius circular dabs along its polyline (consecutive points joined by
+    a thick line so a fast drag leaves no gap). r is width-based in both axes,
+    so a spot rasterizes to a true pixel circle at any resolution.
+    """
+    mask = np.zeros((h, w), dtype=np.uint8)
+    if not spots or w <= 0 or h <= 0:
+        return mask
+    for spot in spots:
+        pts = spot.get("pts") or []
+        r_px = max(1, int(round(float(spot.get("r", 0.0)) * w)))
+        prev = None
+        for p in pts:
+            try:
+                x = int(round(float(p[0]) * w))
+                y = int(round(float(p[1]) * h))
+            except (TypeError, ValueError, IndexError):
+                continue
+            cv2.circle(mask, (x, y), r_px, 255, -1)
+            if prev is not None:
+                cv2.line(mask, prev, (x, y), 255, thickness=2 * r_px)
+            prev = (x, y)
+    return mask
+
+
+def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3) -> np.ndarray:
+    """Inpaint the dust spots out of a 16-bit RGB image, non-destructively.
+
+    Only the masked pixels are replaced (the rest of the frame keeps full
+    16-bit precision); the fill is computed by cv2.inpaint (Telea) in 8-bit and
+    composited back through a feathered alpha so the patch blends seamlessly.
+    Returns a NEW uint16 array; img16 is never mutated. No-op (returns img16
+    unchanged) when there are no spots or the rasterized mask is empty.
+    """
+    if not spots:
+        return img16
+    h, w = img16.shape[:2]
+    mask = rasterize_dust_mask(spots, h, w)
+    if not mask.any():
+        return img16
+
+    # Inpaint in 8-bit BGR (what cv2.inpaint supports).
+    bgr8 = cv2.cvtColor(cv2.convertScaleAbs(img16, alpha=255.0 / 65535.0),
+                        cv2.COLOR_RGB2BGR)
+    filled8 = cv2.inpaint(bgr8, mask, inpaint_radius, cv2.INPAINT_TELEA)
+    filled16 = cv2.cvtColor(filled8, cv2.COLOR_BGR2RGB).astype(np.uint16) * 257
+
+    # Feathered alpha: dilate a touch to bury the speck's antialiased edge,
+    # then box-blur to a soft 0..1 ramp so the fill has no visible seam. Inside
+    # the dilate+blur halo (a few px around the mask) pixels blend toward the
+    # fill; OUTSIDE the halo alpha is exactly 0, so those pixels are kept
+    # bit-for-bit. The halo is the intended seamless-blend region.
+    k = np.ones((3, 3), np.uint8)
+    a = cv2.dilate(mask, k, iterations=1)
+    a = (cv2.blur(a, (5, 5)).astype(np.float32) / 255.0)[..., None]
+
+    out = (img16.astype(np.float32) * (1.0 - a)
+           + filled16.astype(np.float32) * a)
+    return np.clip(out, 0, 65535).astype(np.uint16)
+
+
 # --- Area editing (local masked adjustment layers) -------------------------
 # Masks are rasterized from NORMALIZED geometry (fractions of width/height) so
 # the same area definition reproduces identically at the 1080px preview, the

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -1,0 +1,201 @@
+"""
+AI dust detection (hybrid) — ONNX BOPBTL U-Net detector + classical fill.
+
+The neural net only *detects* dust; the actual removal is `cv2.inpaint`
+(see ccr_processor.apply_dust_removal). This module is deliberately
+self-contained and imports `onnxruntime` ONLY inside functions, so importing it
+(and the dust panel that uses it) never fails when onnxruntime is absent — the
+manual brush path is wholly independent of anything here.
+
+Model asset (downloaded on first use, not bundled) is the BOPBTL scratch
+detector published by the openenlarge project. See spec/dust-removal.md §5.3.
+"""
+import hashlib
+import logging
+import os
+import tempfile
+import threading
+
+import cv2
+import numpy as np
+
+# --- Model asset constants (repointable) -----------------------------------
+MODEL_FILENAME = "detector.onnx"
+MODEL_URL = ("https://github.com/MohaElder/openenlarge/releases/download/"
+             "autodust-assets-v1/detector.onnx")
+MODEL_SHA256 = "61e4a93d4e94b4fc6212e2e9b785fa12b5cbc9654724b02aaf8b212075bb729f"
+
+# --- Detection tuning -------------------------------------------------------
+DETECT_SHORT = 512      # short side the detector runs at
+DETECT_MULTIPLE = 16    # both dims rounded to a multiple of this (U-Net req.)
+MAX_BLOB = 600          # connected-component pixel cap at ~2k px (resolution-normalized)
+SPOT_PAD = 2.0          # px added to each detected spot's radius (inpaint margin)
+
+_session = None          # cached ort.InferenceSession
+_session_path = None     # model path the cached session was built from
+_session_lock = threading.Lock()  # guards the cache (detect vs download threads)
+
+
+def models_dir() -> str:
+    """`<APPDATA>/FreeCCR/models` (same app folder family as the catalog)."""
+    base = os.environ.get("APPDATA") or os.path.join(os.path.expanduser("~"), ".config")
+    folder = os.path.join(base, "FreeCCR", "models")
+    os.makedirs(folder, exist_ok=True)
+    return folder
+
+
+def model_path() -> str:
+    return os.path.join(models_dir(), MODEL_FILENAME)
+
+
+def is_available() -> bool:
+    """True when onnxruntime can be imported (AI detection is possible)."""
+    try:
+        import onnxruntime  # noqa: F401  (late import — never at module level)
+        return True
+    except Exception:
+        return False
+
+
+def is_model_present() -> bool:
+    """True when the detector model file exists locally and is non-empty."""
+    try:
+        return os.path.getsize(model_path()) > 0
+    except OSError:
+        return False
+
+
+def download_model(progress_cb=None, should_cancel=None) -> str:
+    """Download the detector model to `model_path()`, verifying SHA-256 and
+    writing atomically. `progress_cb(done_bytes, total_bytes)` is called as it
+    streams; `should_cancel()` (if given) aborts cleanly. Raises on network
+    error / checksum mismatch / cancel. Returns the final path on success."""
+    import requests  # already a project dependency
+    path = model_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    resp = requests.get(MODEL_URL, stream=True, timeout=30)
+    resp.raise_for_status()
+    total = int(resp.headers.get("Content-Length", 0) or 0)
+    hasher = hashlib.sha256()
+    done = 0
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".part")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            for block in resp.iter_content(chunk_size=1 << 20):
+                if should_cancel is not None and should_cancel():
+                    raise RuntimeError("Download cancelled")
+                if not block:
+                    continue
+                f.write(block)
+                hasher.update(block)
+                done += len(block)
+                if progress_cb is not None:
+                    progress_cb(done, total)
+        digest = hasher.hexdigest()
+        if MODEL_SHA256 and digest.lower() != MODEL_SHA256.lower():
+            raise ValueError(
+                f"Detector model checksum mismatch (got {digest})")
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+    # Drop any stale cached session so the next detect() reloads the new file.
+    global _session, _session_path
+    with _session_lock:
+        _session = None
+        _session_path = None
+    return path
+
+
+def _get_session():
+    """Lazily build (and cache) the CPU ONNX inference session."""
+    global _session, _session_path
+    with _session_lock:
+        path = model_path()
+        if _session is not None and _session_path == path:
+            return _session
+        if not is_model_present():
+            raise FileNotFoundError("Detector model not downloaded")
+        import onnxruntime as ort  # late import
+        sess = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+        _session = sess
+        _session_path = path
+        return sess
+
+
+def _detect_size(h: int, w: int) -> tuple:
+    """Detection resolution: short side ~DETECT_SHORT (never upscaled), both
+    dims rounded to a multiple of DETECT_MULTIPLE."""
+    short_side = max(1, min(h, w))
+    scale = min(1.0, DETECT_SHORT / short_side)
+    dh = max(DETECT_MULTIPLE,
+             int(round(h * scale / DETECT_MULTIPLE)) * DETECT_MULTIPLE)
+    dw = max(DETECT_MULTIPLE,
+             int(round(w * scale / DETECT_MULTIPLE)) * DETECT_MULTIPLE)
+    return dh, dw
+
+
+def detect(positive_rgb16: np.ndarray) -> np.ndarray:
+    """Run the detector on a 16-bit RGB positive and return a float32
+    probability map (values 0..1) at detection resolution. Raises if the model
+    or onnxruntime is unavailable. Cache this per image — re-thresholding for a
+    Sensitivity change uses `prob_to_spots`, no net re-run."""
+    sess = _get_session()
+    h, w = positive_rgb16.shape[:2]
+    dh, dw = _detect_size(h, w)
+    small = cv2.resize(positive_rgb16, (dw, dh), interpolation=cv2.INTER_AREA)
+    small_f = small.astype(np.float32) / 65535.0
+    luma = (0.2126 * small_f[..., 0] + 0.7152 * small_f[..., 1]
+            + 0.0722 * small_f[..., 2])
+    inp = (luma * 2.0 - 1.0)[None, None, :, :].astype(np.float32)
+    name = sess.get_inputs()[0].name
+    out = sess.run(None, {name: inp})[0]
+    arr = np.asarray(out, dtype=np.float32).squeeze()
+    if arr.ndim > 2:
+        arr = arr.reshape(arr.shape[-2], arr.shape[-1])
+    elif arr.ndim < 2:
+        # Unexpected flat output — reshape to the detection grid (raises a clear
+        # ValueError if the size doesn't fit, rather than a cryptic IndexError).
+        arr = arr.reshape(dh, dw)
+    prob = 1.0 / (1.0 + np.exp(-arr))
+    if prob.shape != (dh, dw):
+        prob = cv2.resize(prob, (dw, dh), interpolation=cv2.INTER_LINEAR)
+    return prob.astype(np.float32)
+
+
+def prob_to_spots(prob: np.ndarray, sensitivity: float, kind: str = "auto") -> list:
+    """Threshold + size-gate a probability map into normalized dust spots.
+
+    Pure / model-free (operates on a numpy prob map), so it is unit-testable
+    without ONNX. Threshold follows openenlarge: thr = 0.85 - 0.60*(s/100), so
+    higher sensitivity removes more. Components larger than a resolution-
+    normalized cap are dropped (real image detail, not dust). Each surviving
+    component becomes one circular spot (centroid + extent-derived radius).
+    """
+    h, w = prob.shape[:2]
+    s = max(0.0, min(100.0, float(sensitivity)))
+    thr = 0.85 - 0.60 * (s / 100.0)
+    binary = (prob >= thr).astype(np.uint8)
+    if not binary.any():
+        return []
+    n, _labels, stats, centroids = cv2.connectedComponentsWithStats(
+        binary, connectivity=8)
+    max_blob = MAX_BLOB * max(h, w) / 2000.0
+    spots = []
+    for i in range(1, n):  # 0 is background
+        area = int(stats[i, cv2.CC_STAT_AREA])
+        if area > max_blob:
+            continue
+        cw = int(stats[i, cv2.CC_STAT_WIDTH])
+        ch = int(stats[i, cv2.CC_STAT_HEIGHT])
+        cx, cy = centroids[i]
+        r = (0.5 * max(cw, ch) + SPOT_PAD) / w
+        spots.append({
+            "kind": kind,
+            "pts": [[float(cx) / w, float(cy) / h]],
+            "r": float(r),
+        })
+    return spots

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -57,6 +57,18 @@ def is_available() -> bool:
         return False
 
 
+def availability_reason() -> str:
+    """Human-readable reason the AI detector can't run, or '' when available.
+    Surfaced in the panel so the user knows exactly what to do."""
+    try:
+        import onnxruntime  # noqa: F401
+        return ""
+    except Exception as e:
+        return ("AI detection needs the 'onnxruntime' package, which isn't "
+                f"importable ({type(e).__name__}). Run "
+                "`pip install -r requirements.txt`, then restart FreeCCR.")
+
+
 def is_model_present() -> bool:
     """True when the detector model file exists locally and is non-empty."""
     try:

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -28,8 +28,11 @@ MODEL_SHA256 = "61e4a93d4e94b4fc6212e2e9b785fa12b5cbc9654724b02aaf8b212075bb729f
 # --- Detection tuning -------------------------------------------------------
 DETECT_SHORT = 512      # short side the detector runs at
 DETECT_MULTIPLE = 16    # both dims rounded to a multiple of this (U-Net req.)
-MAX_BLOB = 600          # connected-component pixel cap at ~2k px (resolution-normalized)
-SPOT_PAD = 2.0          # px added to each detected spot's radius (inpaint margin)
+MAX_BLOB = 400          # connected-component pixel cap at ~2k px (resolution-normalized);
+                        # drops large detections (film border / real image content)
+MAX_ASPECT = 3.0        # drop elongated detections (thin LINES are usually real
+                        # structure — a bike frame, the horizon — not dust)
+SPOT_PAD = 1.5          # px added to each detected spot's radius (inpaint margin)
 
 _session = None          # cached ort.InferenceSession
 _session_path = None     # model path the cached session was built from
@@ -200,14 +203,23 @@ def prob_to_spots(prob: np.ndarray, sensitivity: float, kind: str = "auto") -> l
     for i in range(1, n):  # 0 is background
         area = int(stats[i, cv2.CC_STAT_AREA])
         if area > max_blob:
-            continue
+            continue  # too big — film border / real image content, not dust
         cw = int(stats[i, cv2.CC_STAT_WIDTH])
         ch = int(stats[i, cv2.CC_STAT_HEIGHT])
+        # Drop elongated detections. Real dust is compact; the scratch detector
+        # also fires on legitimate thin LINES (a bike frame, the horizon, a path
+        # edge), and circle-inpainting those smears real detail. Leave linear
+        # defects to the manual brush (a stroke). See spec/dust-removal.md §5.4.
+        if max(cw, ch) / max(1, min(cw, ch)) > MAX_ASPECT:
+            continue
         cx, cy = centroids[i]
-        r = (0.5 * max(cw, ch) + SPOT_PAD) / w
+        # Area-EQUIVALENT radius (+ small margin), NOT the bounding-box extent:
+        # a tight circle matches the speck so the inpaint stays invisible
+        # instead of leaving a big smudge over the surrounding pixels.
+        r_px = float(np.sqrt(area / np.pi)) + SPOT_PAD
         spots.append({
             "kind": kind,
             "pts": [[float(cx) / w, float(cy) / h]],
-            "r": float(r),
+            "r": float(r_px / w),
         })
     return spots

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -33,6 +33,12 @@ MAX_BLOB = 400          # connected-component pixel cap at ~2k px (resolution-no
 MAX_ASPECT = 3.0        # drop elongated detections (thin LINES are usually real
                         # structure — a bike frame, the horizon — not dust)
 SPOT_PAD = 1.5          # px added to each detected spot's radius (inpaint margin)
+# Film dust inverts to BRIGHT/white specks, so a real dust blob is brighter than
+# its surroundings. Require at least this luma lift (0..1) over the surrounding
+# ring; this rejects normal-toned content the detector wrongly fires on (a face,
+# a dark feature) — those are not bright specks.
+BRIGHT_MARGIN = 0.06
+BRIGHT_RING = 3         # px ring around a blob used as the "surround" reference
 
 _session = None          # cached ort.InferenceSession
 _session_path = None     # model path the cached session was built from
@@ -153,11 +159,12 @@ def _detect_size(h: int, w: int) -> tuple:
     return dh, dw
 
 
-def detect(positive_rgb16: np.ndarray) -> np.ndarray:
-    """Run the detector on a 16-bit RGB positive and return a float32
-    probability map (values 0..1) at detection resolution. Raises if the model
-    or onnxruntime is unavailable. Cache this per image — re-thresholding for a
-    Sensitivity change uses `prob_to_spots`, no net re-run."""
+def detect(positive_rgb16: np.ndarray) -> tuple:
+    """Run the detector on a 16-bit RGB positive. Returns
+    `(prob, luma)` — both float32 at detection resolution: the probability map
+    (0..1) and the grayscale luma (0..1, used for the bright-speck gate in
+    prob_to_spots). Raises if the model or onnxruntime is unavailable. Cache the
+    pair per image — a Sensitivity change re-runs only prob_to_spots, not the net."""
     sess = _get_session()
     h, w = positive_rgb16.shape[:2]
     dh, dw = _detect_size(h, w)
@@ -178,17 +185,23 @@ def detect(positive_rgb16: np.ndarray) -> np.ndarray:
     prob = 1.0 / (1.0 + np.exp(-arr))
     if prob.shape != (dh, dw):
         prob = cv2.resize(prob, (dw, dh), interpolation=cv2.INTER_LINEAR)
-    return prob.astype(np.float32)
+    return prob.astype(np.float32), luma.astype(np.float32)
 
 
-def prob_to_spots(prob: np.ndarray, sensitivity: float, kind: str = "auto") -> list:
-    """Threshold + size-gate a probability map into normalized dust spots.
+def prob_to_spots(prob: np.ndarray, luma: np.ndarray, sensitivity: float,
+                  kind: str = "auto") -> list:
+    """Threshold + filter a probability map into normalized dust spots.
 
-    Pure / model-free (operates on a numpy prob map), so it is unit-testable
-    without ONNX. Threshold follows openenlarge: thr = 0.85 - 0.60*(s/100), so
-    higher sensitivity removes more. Components larger than a resolution-
-    normalized cap are dropped (real image detail, not dust). Each surviving
-    component becomes one circular spot (centroid + extent-derived radius).
+    Pure / model-free (operates on numpy arrays), so it is unit-testable without
+    ONNX. `luma` is the detection-resolution grayscale (0..1) used for the
+    bright-speck gate. Threshold follows openenlarge: thr = 0.85 - 0.60*(s/100),
+    so higher sensitivity removes more. A surviving component must be:
+      - small enough (not film border / real content),
+      - compact (elongated lines are structure/scratches → manual brush),
+      - BRIGHTER than its surroundings (film dust inverts to white specks; this
+        rejects normal-toned content the detector wrongly fires on — e.g. a
+        face). See spec/dust-removal.md §5.3.
+    Each survivor becomes one circular spot (centroid + area-equivalent radius).
     """
     h, w = prob.shape[:2]
     s = max(0.0, min(100.0, float(sensitivity)))
@@ -196,7 +209,7 @@ def prob_to_spots(prob: np.ndarray, sensitivity: float, kind: str = "auto") -> l
     binary = (prob >= thr).astype(np.uint8)
     if not binary.any():
         return []
-    n, _labels, stats, centroids = cv2.connectedComponentsWithStats(
+    n, labels, stats, centroids = cv2.connectedComponentsWithStats(
         binary, connectivity=8)
     max_blob = MAX_BLOB * max(h, w) / 2000.0
     spots = []
@@ -204,6 +217,8 @@ def prob_to_spots(prob: np.ndarray, sensitivity: float, kind: str = "auto") -> l
         area = int(stats[i, cv2.CC_STAT_AREA])
         if area > max_blob:
             continue  # too big — film border / real image content, not dust
+        left = int(stats[i, cv2.CC_STAT_LEFT])
+        top = int(stats[i, cv2.CC_STAT_TOP])
         cw = int(stats[i, cv2.CC_STAT_WIDTH])
         ch = int(stats[i, cv2.CC_STAT_HEIGHT])
         # Drop elongated detections. Real dust is compact; the scratch detector
@@ -212,6 +227,20 @@ def prob_to_spots(prob: np.ndarray, sensitivity: float, kind: str = "auto") -> l
         # defects to the manual brush (a stroke). See spec/dust-removal.md §5.4.
         if max(cw, ch) / max(1, min(cw, ch)) > MAX_ASPECT:
             continue
+        # Bright-speck gate: compare the blob's luma to a surrounding ring. Film
+        # dust is brighter (white) than its surroundings after inversion; a face
+        # or other real feature is not, so it is rejected.
+        x0 = max(0, left - BRIGHT_RING)
+        y0 = max(0, top - BRIGHT_RING)
+        x1 = min(w, left + cw + BRIGHT_RING)
+        y1 = min(h, top + ch + BRIGHT_RING)
+        win_comp = labels[y0:y1, x0:x1] == i
+        win_luma = luma[y0:y1, x0:x1]
+        comp_luma = float(win_luma[win_comp].mean())
+        surround = win_luma[~win_comp]
+        surround_luma = float(surround.mean()) if surround.size else comp_luma
+        if comp_luma - surround_luma < BRIGHT_MARGIN:
+            continue  # not a bright speck → not film dust
         cx, cy = centroids[i]
         # Area-EQUIVALENT radius (+ small margin), NOT the bounding-box extent:
         # a tight circle matches the speck so the inpaint stays invisible

--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,29 @@
 import sys
 import os
 
-# Pre-load onnxruntime (if installed) BEFORE Qt. On Windows, onnxruntime's
-# native DLLs fail their init routine when loaded AFTER Qt ("DLL initialization
-# routine failed"), which would silently disable AI dust detection in this Qt
-# app. Importing it first lets its DLLs load cleanly; Qt then loads fine on top.
-# Guarded so the app still runs when onnxruntime isn't installed (manual dust
-# removal is unaffected). See spec/dust-removal.md §8.
+# Make onnxruntime usable for AI dust detection, then pre-load it BEFORE Qt.
+# Two Windows gotchas this handles (see spec/dust-removal.md §8):
+#  1) Nuitka standalone build: the bundled onnxruntime .pyd is loaded without
+#     its own folder on the DLL search path, so its onnxruntime.dll dependency
+#     isn't found -> "DLL initialization routine failed". Adding the capi dir
+#     (next to the exe) before import fixes it. (No-op when running from source.)
+#  2) onnxruntime's DLLs fail to init if first loaded AFTER Qt, so import it
+#     before any PySide6 import.
+# Guarded so the app still runs when onnxruntime is absent (manual dust removal
+# is unaffected, and the AI panel reports the reason).
 try:
-    import onnxruntime  # noqa: F401
+    _ort_capi = os.path.join(os.path.dirname(os.path.abspath(sys.executable)),
+                             "onnxruntime", "capi")
+    if os.path.isdir(_ort_capi):
+        os.add_dll_directory(_ort_capi)
 except Exception:
     pass
+try:
+    import onnxruntime as _ort  # noqa: F401
+    print(f"AI dust detection: onnxruntime {_ort.__version__} ready", flush=True)
+    del _ort
+except Exception as _e:  # noqa: BLE001
+    print(f"AI dust detection: onnxruntime unavailable ({_e})", flush=True)
 
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,17 @@
 import sys
 import os
+
+# Pre-load onnxruntime (if installed) BEFORE Qt. On Windows, onnxruntime's
+# native DLLs fail their init routine when loaded AFTER Qt ("DLL initialization
+# routine failed"), which would silently disable AI dust detection in this Qt
+# app. Importing it first lets its DLLs load cleanly; Qt then loads fine on top.
+# Guarded so the app still runs when onnxruntime isn't installed (manual dust
+# removal is unaffected). See spec/dust-removal.md §8.
+try:
+    import onnxruntime  # noqa: F401
+except Exception:
+    pass
+
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
 

--- a/src/main.py
+++ b/src/main.py
@@ -12,10 +12,35 @@ import os
 # Guarded so the app still runs when onnxruntime is absent (manual dust removal
 # is unaffected, and the AI panel reports the reason).
 try:
-    _ort_capi = os.path.join(os.path.dirname(os.path.abspath(sys.executable)),
-                             "onnxruntime", "capi")
-    if os.path.isdir(_ort_capi):
-        os.add_dll_directory(_ort_capi)
+    import ctypes
+    _bases = []
+    for _b in (getattr(sys, "executable", ""), (sys.argv[0] if sys.argv else "")):
+        try:
+            _b = os.path.dirname(os.path.abspath(_b))
+        except Exception:
+            continue
+        if _b and _b not in _bases:
+            _bases.append(_b)
+    for _b in _bases:
+        _ort_capi = os.path.join(_b, "onnxruntime", "capi")
+        if not os.path.isdir(_ort_capi):
+            continue
+        try:
+            os.add_dll_directory(_ort_capi)
+        except Exception:
+            pass
+        # add_dll_directory alone is NOT enough in the Nuitka build: it loads the
+        # .pyd without searching capi/ for its onnxruntime.dll dependency. Load
+        # the native runtime explicitly (by full path) so the .pyd finds it
+        # already in-process. (ctypes-proven; see spec/dust-removal.md §8.)
+        for _dll in ("onnxruntime.dll", "onnxruntime_providers_shared.dll"):
+            _dp = os.path.join(_ort_capi, _dll)
+            if os.path.exists(_dp):
+                try:
+                    ctypes.WinDLL(_dp)
+                except Exception:
+                    pass
+        break
 except Exception:
     pass
 try:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import (Qt, QEvent, QThread, Signal, QObject, QSettings,
 from widgets.thumbnail_list import ThumbnailList
 from widgets.image_preview import ImagePreview
 from widgets.sliders_panel import SlidersPanel
+from widgets.dust_panel import DustRemovalPanel
 from widgets.tether_banner import TetherBanner
 from core.ccr_backend import ccr_backend
 from core.tether_watcher import (TetherWatchWorker, FolderScanner, is_supported,
@@ -132,6 +133,15 @@ class MainWindow(QMainWindow):
         self.sliders_panel.set_sliders_enabled(False)
         self.sliders_panel.image_preview = self.image_preview
 
+        # Dust Removal panel — covers the sliders panel while in dust mode. Kept
+        # as a SIBLING of sliders_panel (not a QStackedWidget wrapping it) so
+        # SlidersPanel's parent().parent() chain to MainWindow stays valid.
+        # See spec/dust-removal.md.
+        self.dust_panel = DustRemovalPanel(self, self.image_preview)
+        self.dust_panel.setFixedWidth(300)
+        self.dust_panel.setVisible(False)
+        self.image_preview.set_dust_panel(self.dust_panel)
+
         # Tethering (watch-folder capture) state + status banner. The banner is
         # installed INTO image_preview's own layout (not wrapped around it) so
         # ImagePreview's parent().parent() chains stay valid — see
@@ -155,6 +165,7 @@ class MainWindow(QMainWindow):
         self.layout.addWidget(self.thumbnail_list, 0)
         self.layout.addWidget(self.image_preview, 3)
         self.layout.addWidget(self.sliders_panel, 0)
+        self.layout.addWidget(self.dust_panel, 0)
 
         # Persisted UI preferences (last-open location etc.)
         self._settings = QSettings("FreeCCR", "FreeCCR")
@@ -235,6 +246,10 @@ class MainWindow(QMainWindow):
             # before persisting, so no capture is mid-write into a locked catalog.
             if self._tether_active:
                 self.stop_tethering()
+            # Stop any in-flight dust model download / detection thread so a
+            # running QThread can't abort the process at teardown.
+            if hasattr(self, "dust_panel"):
+                self.dust_panel.shutdown()
             # Persist the edit catalog so reopening these files restores
             # their conversion/slices/crop/adjustments.
             ccr_backend.save_catalog()
@@ -244,6 +259,40 @@ class MainWindow(QMainWindow):
 
     def on_image_selected(self, file_path):
         pass
+
+    # --- Dust removal (panel cover + canvas mode) -------------------------
+    def toggle_dust_removal(self, on=None):
+        """Show/hide the Dust Removal panel (covering the sliders) and
+        enter/exit the canvas dust mode. `on=None` flips the current state."""
+        if on is None:
+            on = not self.image_preview.dust_mode
+        if on:
+            if self.image_preview.current_idx is None:
+                self._sync_dust_action(False)
+                return
+            if not self.image_preview.enter_dust_mode():
+                self._sync_dust_action(False)
+                return
+            self.sliders_panel.setVisible(False)
+            self.dust_panel.bind_image()
+            self.dust_panel.setVisible(True)
+            self._sync_dust_action(True)
+        else:
+            self.dust_panel.cancel_jobs()
+            self.image_preview.exit_dust_mode()
+            self._show_sliders_panel()
+
+    def _show_sliders_panel(self):
+        self.dust_panel.setVisible(False)
+        self.sliders_panel.setVisible(True)
+        self._sync_dust_action(False)
+
+    def _sync_dust_action(self, checked: bool):
+        action = getattr(self.image_preview, "dust_action", None)
+        if action is not None:
+            action.blockSignals(True)
+            action.setChecked(checked)
+            action.blockSignals(False)
 
     def undo_last_action(self):
         """Restore the current image's previous state (adjustments, crop,

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -172,7 +172,14 @@ class DustRemovalPanel(QWidget):
 
         layout.addStretch(1)
 
-        self.done_btn = QPushButton("Done")
+        self.done_btn = QPushButton("✓  Done")
+        self.done_btn.setMinimumHeight(42)
+        self.done_btn.setToolTip("Close dust removal and return to the adjustment sliders.")
+        self.done_btn.setStyleSheet(
+            "QPushButton { background:#2d7d46; color:white; font-weight:bold; "
+            "font-size:13px; border:none; border-radius:5px; padding:8px; }"
+            "QPushButton:hover { background:#359152; }"
+            "QPushButton:pressed { background:#256b3b; }")
         self.done_btn.clicked.connect(self._on_done)
         layout.addWidget(self.done_btn)
 
@@ -344,6 +351,10 @@ class DustRemovalPanel(QWidget):
         present = avail and dust_detect.is_model_present()
         need_dl = avail and not present and not self._downloading
 
+        if not avail:
+            self.ai_unavailable_label.setText(
+                dust_detect.availability_reason()
+                or "AI detection unavailable in this build.")
         self.ai_unavailable_label.setVisible(not avail)
         self.download_label.setVisible(need_dl)
         self.download_btn.setVisible(need_dl)

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -20,7 +20,7 @@ from core import dust_detect
 
 
 class _DetectWorker(QObject):
-    done = Signal(object)   # probability map (np.ndarray)
+    done = Signal(object)   # (prob, luma) numpy arrays
     failed = Signal(str)
 
     def __init__(self, source):
@@ -29,8 +29,8 @@ class _DetectWorker(QObject):
 
     def run(self):
         try:
-            prob = dust_detect.detect(self.source)
-            self.done.emit(prob)
+            prob, luma = dust_detect.detect(self.source)
+            self.done.emit((prob, luma))
         except Exception as e:  # noqa: BLE001 — surfaced to the user
             self.failed.emit(str(e))
 
@@ -68,9 +68,10 @@ class DustRemovalPanel(QWidget):
         self._download_worker = None
         self._detect_thread = None
         self._detect_worker = None
-        # Cached detector probability map for the current image so the
-        # Sensitivity slider re-thresholds without re-running the net.
+        # Cached detector outputs (probability map + luma) for the current
+        # image so the Sensitivity slider re-thresholds without re-running the net.
         self._prob = None
+        self._luma = None
         self._prob_image_ref = None
         # The image a running detection was started on — results are discarded
         # if the user switches images before it finishes.
@@ -205,6 +206,7 @@ class DustRemovalPanel(QWidget):
         img = self._current_image()
         if img is not self._prob_image_ref:
             self._prob = None
+            self._luma = None
             self._prob_image_ref = None
         # Push the current brush size to the canvas so they agree on entry.
         self.image_preview.set_dust_brush_size(self.brush_slider.value() / 1000.0)
@@ -244,7 +246,7 @@ class DustRemovalPanel(QWidget):
         self.sensitivity_value.setText(str(value))
         # Cheap re-threshold of the cached prob map (no net re-run).
         if self._prob is not None and self._current_image() is self._prob_image_ref:
-            spots = dust_detect.prob_to_spots(self._prob, float(value))
+            spots = dust_detect.prob_to_spots(self._prob, self._luma, float(value))
             n = self.image_preview.apply_detected_spots(spots)
             self.status_label.setText(
                 f"Removed {n} spot{'s' if n != 1 else ''}." if n
@@ -275,7 +277,7 @@ class DustRemovalPanel(QWidget):
         self._detect_thread.finished.connect(self._clear_detect_thread)
         self._detect_thread.start()
 
-    def _on_detect_done(self, prob):
+    def _on_detect_done(self, result):
         # Discard results if the user navigated to a different image (or out of
         # dust mode) while detection was running — the prob map is for the old
         # image and must not be applied to the current one.
@@ -283,10 +285,12 @@ class DustRemovalPanel(QWidget):
                 or not self.image_preview.dust_mode):
             self._finish_detect()
             return
+        prob, luma = result
         self._prob = prob
+        self._luma = luma
         self._prob_image_ref = self._current_image()
         spots = dust_detect.prob_to_spots(
-            prob, float(self.sensitivity_slider.value()))
+            prob, luma, float(self.sensitivity_slider.value()))
         n = self.image_preview.apply_detected_spots(spots)
         self.status_label.setText(
             f"Removed {n} spot{'s' if n != 1 else ''}." if n

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -151,8 +151,8 @@ class DustRemovalPanel(QWidget):
         self.sensitivity_slider = QSlider(Qt.Horizontal)
         self.sensitivity_slider.setMinimum(0)
         self.sensitivity_slider.setMaximum(100)
-        self.sensitivity_slider.setValue(50)
-        self.sensitivity_value = QLabel("50")
+        self.sensitivity_slider.setValue(35)  # conservative default — fewer false positives
+        self.sensitivity_value = QLabel("35")
         self.sensitivity_value.setMinimumWidth(40)
         self.sensitivity_slider.valueChanged.connect(self._on_sensitivity_changed)
         sens_row.addWidget(self.sensitivity_label)

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -1,0 +1,392 @@
+"""
+Dust Removal panel — covers the right-hand sliders panel while in dust mode.
+
+Two sections sharing one non-destructive model (spots stored on the image):
+  - Manual: a sized brush; paint over dust on the canvas to inpaint it.
+  - AI: an ONNX detector (downloaded on first use) finds dust automatically;
+    the same cv2.inpaint fills it.
+
+All ONNX work happens off the GUI thread; the panel imports `dust_detect`
+(which never imports onnxruntime at module level), so this widget is safe to
+build even when onnxruntime is absent — the AI section then shows an
+unavailable/needs-download state and the manual brush is unaffected.
+See spec/dust-removal.md.
+"""
+from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
+                                QPushButton, QSlider, QFrame, QProgressBar)
+from PySide6.QtCore import Qt, QObject, QThread, Signal
+
+from core import dust_detect
+
+
+class _DetectWorker(QObject):
+    done = Signal(object)   # probability map (np.ndarray)
+    failed = Signal(str)
+
+    def __init__(self, source):
+        super().__init__()
+        self.source = source
+
+    def run(self):
+        try:
+            prob = dust_detect.detect(self.source)
+            self.done.emit(prob)
+        except Exception as e:  # noqa: BLE001 — surfaced to the user
+            self.failed.emit(str(e))
+
+
+class _DownloadWorker(QObject):
+    progress = Signal(int, int)   # done_bytes, total_bytes
+    done = Signal()
+    failed = Signal(str)
+
+    def __init__(self):
+        super().__init__()
+        self._cancel = False
+
+    def cancel(self):
+        self._cancel = True
+
+    def run(self):
+        try:
+            dust_detect.download_model(
+                progress_cb=lambda d, t: self.progress.emit(d, t),
+                should_cancel=lambda: self._cancel)
+            self.done.emit()
+        except Exception as e:  # noqa: BLE001
+            self.failed.emit(str(e))
+
+
+class DustRemovalPanel(QWidget):
+    def __init__(self, main_window, image_preview, parent=None):
+        super().__init__(parent)
+        self.main_window = main_window
+        self.image_preview = image_preview
+        self._downloading = False
+        self._detecting = False
+        self._download_thread = None
+        self._download_worker = None
+        self._detect_thread = None
+        self._detect_worker = None
+        # Cached detector probability map for the current image so the
+        # Sensitivity slider re-thresholds without re-running the net.
+        self._prob = None
+        self._prob_image_ref = None
+        # The image a running detection was started on — results are discarded
+        # if the user switches images before it finishes.
+        self._detect_image_ref = None
+
+        self._build_ui()
+        self._refresh_ai_section()
+
+    # --- UI ---------------------------------------------------------------
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+
+        header = QLabel("Dust Removal")
+        header.setAlignment(Qt.AlignCenter)
+        header.setStyleSheet("font-size: 14px; font-weight: bold; margin: 4px;")
+        layout.addWidget(header)
+
+        # --- Manual section ---
+        layout.addWidget(self._section_label("Manual"))
+        brush_row = QHBoxLayout()
+        brush_lbl = QLabel("Brush size")
+        brush_lbl.setMinimumWidth(70)
+        self.brush_slider = QSlider(Qt.Horizontal)
+        self.brush_slider.setMinimum(2)     # r = value/1000  ->  0.002 .. 0.200
+        self.brush_slider.setMaximum(200)
+        self.brush_slider.setValue(12)      # 0.012 (1.2% of image width)
+        self.brush_value = QLabel("1.2%")
+        self.brush_value.setMinimumWidth(40)
+        self.brush_slider.valueChanged.connect(self._on_brush_changed)
+        brush_row.addWidget(brush_lbl)
+        brush_row.addWidget(self.brush_slider)
+        brush_row.addWidget(self.brush_value)
+        layout.addLayout(brush_row)
+
+        hint = QLabel("Click or drag over dust to remove it.")
+        hint.setWordWrap(True)
+        hint.setStyleSheet("color: #888; font-size: 11px;")
+        layout.addWidget(hint)
+
+        manual_btns = QHBoxLayout()
+        self.undo_btn = QPushButton("Undo last spot")
+        self.undo_btn.clicked.connect(self._on_undo_last)
+        self.clear_btn = QPushButton("Clear all")
+        self.clear_btn.clicked.connect(self._on_clear_all)
+        manual_btns.addWidget(self.undo_btn)
+        manual_btns.addWidget(self.clear_btn)
+        layout.addLayout(manual_btns)
+
+        layout.addWidget(self._separator())
+
+        # --- AI section ---
+        layout.addWidget(self._section_label("AI Dust Detection"))
+
+        self.ai_unavailable_label = QLabel(
+            "AI detection unavailable in this build.")
+        self.ai_unavailable_label.setWordWrap(True)
+        self.ai_unavailable_label.setStyleSheet("color: #888; font-size: 11px;")
+        layout.addWidget(self.ai_unavailable_label)
+
+        self.download_label = QLabel(
+            "Download the local AI model (~150 MB) to detect dust "
+            "automatically. One-time download.")
+        self.download_label.setWordWrap(True)
+        self.download_label.setStyleSheet("color: #888; font-size: 11px;")
+        layout.addWidget(self.download_label)
+        self.download_btn = QPushButton("Download AI model (~150 MB)")
+        self.download_btn.clicked.connect(self._on_download)
+        layout.addWidget(self.download_btn)
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setRange(0, 100)
+        layout.addWidget(self.progress_bar)
+
+        sens_row = QHBoxLayout()
+        self.sensitivity_label = QLabel("Sensitivity")
+        self.sensitivity_label.setMinimumWidth(70)
+        self.sensitivity_slider = QSlider(Qt.Horizontal)
+        self.sensitivity_slider.setMinimum(0)
+        self.sensitivity_slider.setMaximum(100)
+        self.sensitivity_slider.setValue(50)
+        self.sensitivity_value = QLabel("50")
+        self.sensitivity_value.setMinimumWidth(40)
+        self.sensitivity_slider.valueChanged.connect(self._on_sensitivity_changed)
+        sens_row.addWidget(self.sensitivity_label)
+        sens_row.addWidget(self.sensitivity_slider)
+        sens_row.addWidget(self.sensitivity_value)
+        self._sens_row = sens_row
+        layout.addLayout(sens_row)
+
+        self.detect_btn = QPushButton("Detect && Remove")
+        self.detect_btn.clicked.connect(self._on_detect)
+        layout.addWidget(self.detect_btn)
+
+        self.status_label = QLabel("")
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet("color: #888; font-size: 11px;")
+        layout.addWidget(self.status_label)
+
+        layout.addStretch(1)
+
+        self.done_btn = QPushButton("Done")
+        self.done_btn.clicked.connect(self._on_done)
+        layout.addWidget(self.done_btn)
+
+    @staticmethod
+    def _section_label(text):
+        lbl = QLabel(text)
+        lbl.setStyleSheet("color: #aaa; font-size: 11px; font-weight: bold; "
+                          "margin-top: 4px;")
+        return lbl
+
+    @staticmethod
+    def _separator():
+        sep = QFrame()
+        sep.setFrameShape(QFrame.HLine)
+        sep.setFrameShadow(QFrame.Sunken)
+        sep.setStyleSheet("margin-top: 6px; margin-bottom: 2px;")
+        return sep
+
+    # --- Public API used by MainWindow / ImagePreview ---------------------
+    def bind_image(self):
+        """Refresh per-image state when the panel is shown. The detector prob
+        cache is per image, so invalidate it on a different image."""
+        img = self._current_image()
+        if img is not self._prob_image_ref:
+            self._prob = None
+            self._prob_image_ref = None
+        # Push the current brush size to the canvas so they agree on entry.
+        self.image_preview.set_dust_brush_size(self.brush_slider.value() / 1000.0)
+        self._refresh_ai_section()
+        self.status_label.setText("")
+
+    def sync_brush_size(self, r_norm: float):
+        """Reflect a wheel-driven brush change from the canvas without
+        re-emitting back to the canvas."""
+        v = max(2, min(200, int(round(r_norm * 1000))))
+        self.brush_slider.blockSignals(True)
+        self.brush_slider.setValue(v)
+        self.brush_slider.blockSignals(False)
+        self.brush_value.setText(f"{v / 10.0:.1f}%")
+
+    # --- Manual handlers --------------------------------------------------
+    def _on_brush_changed(self, value):
+        self.brush_value.setText(f"{value / 10.0:.1f}%")
+        self.image_preview.set_dust_brush_size(value / 1000.0)
+
+    def _on_undo_last(self):
+        if not self.image_preview.dust_undo_last():
+            self.status_label.setText("Nothing to undo.")
+
+    def _on_clear_all(self):
+        if self.image_preview.dust_clear_all():
+            self._prob = None  # spots gone; a re-detect should start fresh
+            self.status_label.setText("Cleared all dust spots.")
+        else:
+            self.status_label.setText("No dust spots to clear.")
+
+    def _on_done(self):
+        self.main_window.toggle_dust_removal(False)
+
+    # --- AI handlers ------------------------------------------------------
+    def _on_sensitivity_changed(self, value):
+        self.sensitivity_value.setText(str(value))
+        # Cheap re-threshold of the cached prob map (no net re-run).
+        if self._prob is not None and self._current_image() is self._prob_image_ref:
+            spots = dust_detect.prob_to_spots(self._prob, float(value))
+            n = self.image_preview.apply_detected_spots(spots)
+            self.status_label.setText(
+                f"Removed {n} spot{'s' if n != 1 else ''}." if n
+                else "No dust found at this sensitivity.")
+
+    def _on_detect(self):
+        if self._detecting or self._downloading:
+            return
+        source = self.image_preview.dust_detect_source()
+        if source is None:
+            self.status_label.setText("No image to detect on.")
+            return
+        self._detecting = True
+        self._detect_image_ref = self._current_image()
+        self.detect_btn.setEnabled(False)
+        self.detect_btn.setText("Detecting…")
+        self.status_label.setText("Running AI detection…")
+        self._detect_thread = QThread()
+        self._detect_worker = _DetectWorker(source)
+        self._detect_worker.moveToThread(self._detect_thread)
+        self._detect_thread.started.connect(self._detect_worker.run)
+        self._detect_worker.done.connect(self._on_detect_done)
+        self._detect_worker.failed.connect(self._on_detect_failed)
+        self._detect_worker.done.connect(self._detect_thread.quit)
+        self._detect_worker.failed.connect(self._detect_thread.quit)
+        self._detect_worker.done.connect(self._detect_worker.deleteLater)
+        self._detect_worker.failed.connect(self._detect_worker.deleteLater)
+        self._detect_thread.finished.connect(self._clear_detect_thread)
+        self._detect_thread.start()
+
+    def _on_detect_done(self, prob):
+        # Discard results if the user navigated to a different image (or out of
+        # dust mode) while detection was running — the prob map is for the old
+        # image and must not be applied to the current one.
+        if (self._current_image() is not self._detect_image_ref
+                or not self.image_preview.dust_mode):
+            self._finish_detect()
+            return
+        self._prob = prob
+        self._prob_image_ref = self._current_image()
+        spots = dust_detect.prob_to_spots(
+            prob, float(self.sensitivity_slider.value()))
+        n = self.image_preview.apply_detected_spots(spots)
+        self.status_label.setText(
+            f"Removed {n} spot{'s' if n != 1 else ''}." if n
+            else "No dust found.")
+        self._finish_detect()
+
+    def _on_detect_failed(self, msg):
+        self.status_label.setText(f"AI detection failed: {msg}")
+        self._finish_detect()
+
+    def _finish_detect(self):
+        self._detecting = False
+        self.detect_btn.setEnabled(True)
+        self.detect_btn.setText("Detect && Remove")
+
+    def _clear_detect_thread(self):
+        self._detect_thread = None
+        self._detect_worker = None
+
+    def _on_download(self):
+        if self._downloading:
+            return
+        self._downloading = True
+        self.progress_bar.setValue(0)
+        self.status_label.setText("Downloading AI model…")
+        self._refresh_ai_section()
+        self._download_thread = QThread()
+        self._download_worker = _DownloadWorker()
+        self._download_worker.moveToThread(self._download_thread)
+        self._download_thread.started.connect(self._download_worker.run)
+        self._download_worker.progress.connect(self._on_download_progress)
+        self._download_worker.done.connect(self._on_download_done)
+        self._download_worker.failed.connect(self._on_download_failed)
+        self._download_worker.done.connect(self._download_thread.quit)
+        self._download_worker.failed.connect(self._download_thread.quit)
+        self._download_worker.done.connect(self._download_worker.deleteLater)
+        self._download_worker.failed.connect(self._download_worker.deleteLater)
+        self._download_thread.finished.connect(self._clear_download_thread)
+        self._download_thread.start()
+
+    def _on_download_progress(self, done, total):
+        if total > 0:
+            self.progress_bar.setValue(int(done * 100 / total))
+
+    def _on_download_done(self):
+        self._downloading = False
+        self.status_label.setText("AI model ready.")
+        self._refresh_ai_section()
+
+    def _on_download_failed(self, msg):
+        self._downloading = False
+        self.status_label.setText(f"Download failed: {msg}")
+        self._refresh_ai_section()
+
+    def _clear_download_thread(self):
+        self._download_thread = None
+        self._download_worker = None
+
+    # --- helpers ----------------------------------------------------------
+    def _refresh_ai_section(self):
+        avail = dust_detect.is_available()
+        present = avail and dust_detect.is_model_present()
+        need_dl = avail and not present and not self._downloading
+
+        self.ai_unavailable_label.setVisible(not avail)
+        self.download_label.setVisible(need_dl)
+        self.download_btn.setVisible(need_dl)
+        self.progress_bar.setVisible(self._downloading)
+        self.sensitivity_label.setVisible(present)
+        self.sensitivity_slider.setVisible(present)
+        self.sensitivity_value.setVisible(present)
+        self.detect_btn.setVisible(present)
+
+    def _current_image(self):
+        from core.ccr_backend import ccr_backend
+        idx = self.image_preview.current_idx
+        return ccr_backend.get_image_by_index(idx) if idx is not None else None
+
+    def cancel_jobs(self):
+        """Cancel an in-flight model download when leaving dust mode (Done/Esc).
+        The download worker honours cancel(); the (short) ONNX detection has no
+        interrupt, but its result is already discarded if the image changed."""
+        wkr = self._download_worker
+        if wkr is not None:
+            try:
+                wkr.cancel()
+            except Exception:
+                pass
+
+    def shutdown(self):
+        """Stop any in-flight download/detection thread (called on app close).
+        Mirrors MainWindow._stop_loader_if_running: cancel, quit, wait, then
+        drop the refs so isRunning() is never called on a freed C++ object."""
+        if self._download_worker is not None:
+            try:
+                self._download_worker.cancel()
+            except Exception:
+                pass
+        for attr_thr, attr_wkr in (("_download_thread", "_download_worker"),
+                                   ("_detect_thread", "_detect_worker")):
+            thr = getattr(self, attr_thr, None)
+            if thr is not None:
+                try:
+                    if thr.isRunning():
+                        thr.quit()
+                        thr.wait(3000)
+                except RuntimeError:
+                    pass
+            setattr(self, attr_thr, None)
+            setattr(self, attr_wkr, None)

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -35,6 +35,47 @@ class _DetectWorker(QObject):
             self.failed.emit(str(e))
 
 
+class _DetectAllWorker(QObject):
+    """Runs AI detection on EVERY target image off the GUI thread. Detection is
+    per-image (each scan has its own dust), at the current sensitivity. Emits a
+    (img, spots) pair per image so the GUI thread applies them; reads only stable
+    per-image state (resized_raw + manual spots) off-thread."""
+    detected = Signal(object, object)   # img, spots
+    progress = Signal(int, int)         # done, total
+    done = Signal(int)                  # processed count
+    failed = Signal(str)
+
+    def __init__(self, targets, sensitivity):
+        super().__init__()
+        self._targets = targets
+        self._sensitivity = sensitivity
+        self._cancel = False
+
+    def cancel(self):
+        self._cancel = True
+
+    def run(self):
+        try:
+            from widgets.image_preview import ImagePreview
+            total = len(self._targets)
+            processed = 0
+            for img in self._targets:
+                if self._cancel:
+                    break
+                source = ImagePreview.dust_detect_source_for(img)
+                if source is None:
+                    self.progress.emit(processed, total)
+                    continue
+                prob, luma = dust_detect.detect(source)
+                spots = dust_detect.prob_to_spots(prob, luma, self._sensitivity)
+                self.detected.emit(img, spots)
+                processed += 1
+                self.progress.emit(processed, total)
+            self.done.emit(processed)
+        except Exception as e:  # noqa: BLE001
+            self.failed.emit(str(e))
+
+
 class _DownloadWorker(QObject):
     progress = Signal(int, int)   # done_bytes, total_bytes
     done = Signal()
@@ -64,10 +105,13 @@ class DustRemovalPanel(QWidget):
         self.image_preview = image_preview
         self._downloading = False
         self._detecting = False
+        self._detecting_all = False
         self._download_thread = None
         self._download_worker = None
         self._detect_thread = None
         self._detect_worker = None
+        self._detect_all_thread = None
+        self._detect_all_worker = None
         # Cached detector outputs (probability map + luma) for the current
         # image so the Sensitivity slider re-thresholds without re-running the net.
         self._prob = None
@@ -166,6 +210,14 @@ class DustRemovalPanel(QWidget):
         self.detect_btn.clicked.connect(self._on_detect)
         layout.addWidget(self.detect_btn)
 
+        self.detect_all_btn = QPushButton("Detect && Remove — All Images")
+        self.detect_all_btn.setToolTip(
+            "Run AI dust detection on every converted image — each scan is "
+            "detected on its own (not by copying spots), at the current "
+            "sensitivity.")
+        self.detect_all_btn.clicked.connect(self._on_detect_all)
+        layout.addWidget(self.detect_all_btn)
+
         self.status_label = QLabel("")
         self.status_label.setWordWrap(True)
         self.status_label.setStyleSheet("color: #888; font-size: 11px;")
@@ -253,7 +305,7 @@ class DustRemovalPanel(QWidget):
                 else "No dust found at this sensitivity.")
 
     def _on_detect(self):
-        if self._detecting or self._downloading:
+        if self._detecting or self._detecting_all or self._downloading:
             return
         source = self.image_preview.dust_detect_source()
         if source is None:
@@ -309,6 +361,84 @@ class DustRemovalPanel(QWidget):
     def _clear_detect_thread(self):
         self._detect_thread = None
         self._detect_worker = None
+
+    # --- AI: detect on ALL images ----------------------------------------
+    def _on_detect_all(self):
+        if self._detecting or self._detecting_all or self._downloading:
+            return
+        from core.ccr_backend import ccr_backend
+        targets = [im for im in ccr_backend.images
+                   if (getattr(im, "converted", False) or ccr_backend.positive_mode)
+                   and getattr(im, "resized_raw", None) is not None]
+        if not targets:
+            self.status_label.setText("No converted images to detect on.")
+            return
+        self._detecting_all = True
+        self.detect_btn.setEnabled(False)
+        self.detect_all_btn.setEnabled(False)
+        self.detect_all_btn.setText("Detecting all…")
+        self.status_label.setText(f"AI dust detection on {len(targets)} images…")
+        try:
+            self._detect_all_thread = QThread()
+            self._detect_all_worker = _DetectAllWorker(
+                targets, float(self.sensitivity_slider.value()))
+            self._detect_all_worker.moveToThread(self._detect_all_thread)
+            self._detect_all_thread.started.connect(self._detect_all_worker.run)
+            self._detect_all_worker.detected.connect(self._on_detect_all_one)
+            self._detect_all_worker.progress.connect(self._on_detect_all_progress)
+            self._detect_all_worker.done.connect(self._on_detect_all_done)
+            self._detect_all_worker.failed.connect(self._on_detect_all_failed)
+            self._detect_all_worker.done.connect(self._detect_all_thread.quit)
+            self._detect_all_worker.failed.connect(self._detect_all_thread.quit)
+            self._detect_all_worker.done.connect(self._detect_all_worker.deleteLater)
+            self._detect_all_worker.failed.connect(self._detect_all_worker.deleteLater)
+            self._detect_all_thread.finished.connect(self._clear_detect_all_thread)
+            self._detect_all_thread.start()
+        except Exception as e:  # noqa: BLE001 — never leave the flag/buttons stuck
+            self._detect_all_thread = None
+            self._detect_all_worker = None
+            self._finish_detect_all()
+            self.status_label.setText(f"Could not start batch detection: {e}")
+
+    def _finish_detect_all(self):
+        self._detecting_all = False
+        self.detect_btn.setEnabled(True)
+        self.detect_all_btn.setEnabled(True)
+        self.detect_all_btn.setText("Detect && Remove — All Images")
+
+    def _on_detect_all_one(self, img, spots):
+        # Runs on the GUI thread (queued from the worker). Discard if the user
+        # left dust mode while the batch was running (Done/Esc cancels it, but a
+        # signal may already be queued); apply_auto_spots_to_image also ignores
+        # an image no longer loaded.
+        if not self.image_preview.dust_mode:
+            return
+        self.image_preview.apply_auto_spots_to_image(img, spots)
+        if img is self._prob_image_ref:
+            self._prob = None
+            self._luma = None
+            self._prob_image_ref = None
+
+    def _on_detect_all_progress(self, done, total):
+        self.status_label.setText(f"AI dust detection… {done}/{total}")
+
+    def _on_detect_all_done(self, count):
+        self._finish_detect_all()
+        self.status_label.setText(
+            f"AI dust removal applied to {count} image{'s' if count != 1 else ''}.")
+        try:
+            from core.ccr_backend import ccr_backend
+            ccr_backend.save_catalog()
+        except Exception:
+            pass
+
+    def _on_detect_all_failed(self, msg):
+        self._finish_detect_all()
+        self.status_label.setText(f"Batch AI detection failed: {msg}")
+
+    def _clear_detect_all_thread(self):
+        self._detect_all_thread = None
+        self._detect_all_worker = None
 
     def _on_download(self):
         if self._downloading:
@@ -367,6 +497,7 @@ class DustRemovalPanel(QWidget):
         self.sensitivity_slider.setVisible(present)
         self.sensitivity_value.setVisible(present)
         self.detect_btn.setVisible(present)
+        self.detect_all_btn.setVisible(present)
 
     def _current_image(self):
         from core.ccr_backend import ccr_backend
@@ -374,27 +505,30 @@ class DustRemovalPanel(QWidget):
         return ccr_backend.get_image_by_index(idx) if idx is not None else None
 
     def cancel_jobs(self):
-        """Cancel an in-flight model download when leaving dust mode (Done/Esc).
-        The download worker honours cancel(); the (short) ONNX detection has no
-        interrupt, but its result is already discarded if the image changed."""
-        wkr = self._download_worker
-        if wkr is not None:
-            try:
-                wkr.cancel()
-            except Exception:
-                pass
+        """Cancel in-flight model download / batch detection when leaving dust
+        mode (Done/Esc). Those workers honour cancel(); the single short ONNX
+        detection has no interrupt, but its result is discarded if the image
+        changed."""
+        for wkr in (self._download_worker, self._detect_all_worker):
+            if wkr is not None:
+                try:
+                    wkr.cancel()
+                except Exception:
+                    pass
 
     def shutdown(self):
         """Stop any in-flight download/detection thread (called on app close).
         Mirrors MainWindow._stop_loader_if_running: cancel, quit, wait, then
         drop the refs so isRunning() is never called on a freed C++ object."""
-        if self._download_worker is not None:
-            try:
-                self._download_worker.cancel()
-            except Exception:
-                pass
+        for wkr in (self._download_worker, self._detect_all_worker):
+            if wkr is not None:
+                try:
+                    wkr.cancel()
+                except Exception:
+                    pass
         for attr_thr, attr_wkr in (("_download_thread", "_download_worker"),
-                                   ("_detect_thread", "_detect_worker")):
+                                   ("_detect_thread", "_detect_worker"),
+                                   ("_detect_all_thread", "_detect_all_worker")):
             thr = getattr(self, attr_thr, None)
             if thr is not None:
                 try:

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -2333,24 +2333,52 @@ class ImagePreview(QWidget):
         self._commit_dust_change(img)
         return True
 
-    def dust_detect_source(self):
-        """The working positive (with existing spots already healed) the AI
-        detector should run on, or None."""
-        img = ccr_backend.get_image_by_index(self.current_idx)
-        if img is None or img.resized_raw is None:
+    @staticmethod
+    def dust_detect_source_for(img):
+        """The working positive the AI detector should run on for `img`, or None.
+        Only the MANUAL (brush) spots are healed first — the 'auto' spots are
+        about to be replaced, so healing them would hide the very dust we want to
+        re-detect (making a second Detect lose the first one's coverage)."""
+        raw = getattr(img, "resized_raw", None)
+        if img is None or raw is None:
             return None
-        return apply_dust_removal(img.resized_raw, img.dust_spots)
+        brush = [s for s in getattr(img, "dust_spots", []) if s.get("kind") == "brush"]
+        return apply_dust_removal(raw, brush)
+
+    def dust_detect_source(self):
+        """Detection source for the current image (see dust_detect_source_for)."""
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        return self.dust_detect_source_for(img) if img is not None else None
 
     def apply_detected_spots(self, new_auto_spots) -> int:
         """Replace the AI-detected ('auto') spots with a fresh set; manual
         ('brush') spots are kept. Returns the new auto-spot count."""
         img = ccr_backend.get_image_by_index(self.current_idx)
-        if img is None:
+        return self.apply_auto_spots_to_image(img, new_auto_spots)
+
+    def apply_auto_spots_to_image(self, img, new_auto_spots) -> int:
+        """Replace the AI 'auto' spots on a SPECIFIC image (used by both the
+        single Detect and the batch 'detect on all'). Manual spots are kept.
+        Re-bakes that image's thumbnail/preview; refreshes the canvas only when
+        it is the current image. Returns the new auto-spot count."""
+        # Ignore an image no longer loaded — a stale batch result for an image
+        # the user removed or replaced (new Open) must not mutate an orphan.
+        if img is None or img not in ccr_backend.images:
             return 0
         img.push_undo_state()
         img.dust_spots = [s for s in img.dust_spots if s.get("kind") != "auto"]
         img.dust_spots.extend(new_auto_spots or [])
-        self._commit_dust_change(img)
+        cur = (ccr_backend.get_image_by_index(self.current_idx)
+               if self.current_idx is not None else None)
+        if img is cur:
+            self._commit_dust_change(img)
+        else:
+            img.update_thumbnail_and_preview()
+            try:
+                idx = ccr_backend.images.index(img)
+                self.window().thumbnail_list.update_thumbnail(idx)
+            except (ValueError, AttributeError):
+                pass
         return len(new_auto_spots or [])
 
     def _commit_dust_change(self, img):

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1739,7 +1739,12 @@ class ImagePreview(QWidget):
             self._hires["display_pm"] = None
             self._hires["crop_sig"] = None
             if self._hires.get("adj_sig") != self._current_adj_sig():
-                self._hires["full_pm"] = None
+                # In dust mode, KEEP the last sharp render on screen until the
+                # re-render lands, so a paint stroke doesn't flash the blurry
+                # preview in between (the new render — with the spot inpainted —
+                # swaps in a moment later). Outside dust mode, drop it as before.
+                if not self.dust_mode:
+                    self._hires["full_pm"] = None
                 self._hires["adj_sig"] = None
         if self._zoomed_in_enough():
             self._hires_timer.start(350)
@@ -2352,6 +2357,10 @@ class ImagePreview(QWidget):
         """Re-bake the preview/thumbnail after a dust edit and refresh the UI."""
         img.update_thumbnail_and_preview()
         self.update_preview(self.current_idx)
+        # Kick the hi-res re-render right away (instead of the debounce) so the
+        # inpainted spot resolves promptly; the in-flight guard dedups it. The
+        # previous sharp render stays on screen until this lands (no blur flash).
+        self._maybe_request_hires()
         try:
             self.window().thumbnail_list.update_thumbnail(self.current_idx)
         except Exception:

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -138,7 +138,8 @@ class GraphicsImageView(QGraphicsView):
             interaction_active = (self.drawing_reference or self._space_pan
                                   or self._bw_drag_start is not None
                                   or self.parent_widget.crop_mode
-                                  or self.parent_widget.dust_mode
+                                  or (self.parent_widget.dust_mode
+                                      and self.parent_widget._dust_painting)
                                   or self.parent_widget._area_drag is not None
                                   or self.parent_widget._slice_drag is not None)
             if not interaction_active:
@@ -511,8 +512,9 @@ class GraphicsImageView(QGraphicsView):
         if delta == 0 or self.parent_widget.pixmap_item is None:
             event.ignore()
             return
-        if self.parent_widget.dust_mode:
-            # Wheel resizes the brush in dust mode (no zoom).
+        if self.parent_widget.dust_mode and (event.modifiers() & Qt.ControlModifier):
+            # Ctrl+wheel resizes the brush in dust mode; a plain wheel zooms
+            # (handled below), so the user can zoom in for precise spotting.
             self.parent_widget.adjust_dust_brush(
                 1 if delta > 0 else -1,
                 anchor_scene=self.mapToScene(event.position().toPoint()))
@@ -1663,6 +1665,11 @@ class ImagePreview(QWidget):
     HIRES_MAX_LONG_SIDE = 4500   # bounds non-RAW decodes (RAW half-size passes through)
 
     def _maybe_request_hires(self):
+        # Dust mode renders preview pixels only: the hi-res replay can bake fine
+        # rotation / conversion specifics that would misalign the normalized dust
+        # spots, so zoom there stays on the (upscaled) preview.
+        if self.dust_mode:
+            return
         if not self._zoomed_in_enough() or self.current_idx is None:
             return
         img = ccr_backend.get_image_by_index(self.current_idx)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1545,6 +1545,12 @@ class ImagePreview(QWidget):
         detail would help. Magnification comes from zooming in, or from cropping
         into the image (the kept region is scaled up to fill the view even at
         the fitted zoom)."""
+        # Dust mode always wants the sharpest pixels for precise spotting, so
+        # load hi-res detail even at the fitted view (and on zoom-in). The
+        # display path already shows the full, un-fine-rotated image in dust
+        # mode, so the hi-res lines up with the normalized dust spots.
+        if self.dust_mode:
+            return True
         if self._view_scale() <= 1.05:
             return False
         return self._zoom > 1.0 or self._crop_wants_hires()
@@ -1665,11 +1671,6 @@ class ImagePreview(QWidget):
     HIRES_MAX_LONG_SIDE = 4500   # bounds non-RAW decodes (RAW half-size passes through)
 
     def _maybe_request_hires(self):
-        # Dust mode renders preview pixels only: the hi-res replay can bake fine
-        # rotation / conversion specifics that would misalign the normalized dust
-        # spots, so zoom there stays on the (upscaled) preview.
-        if self.dust_mode:
-            return
         if not self._zoomed_in_enough() or self.current_idx is None:
             return
         img = ccr_backend.get_image_by_index(self.current_idx)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -9,6 +9,7 @@ from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QP
                            QImage)
 from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
+from core.ccr_processor import apply_dust_removal
 from widgets.export_dialog import ExportSettingsDialog
 import math
 import copy
@@ -137,6 +138,7 @@ class GraphicsImageView(QGraphicsView):
             interaction_active = (self.drawing_reference or self._space_pan
                                   or self._bw_drag_start is not None
                                   or self.parent_widget.crop_mode
+                                  or self.parent_widget.dust_mode
                                   or self.parent_widget._area_drag is not None
                                   or self.parent_widget._slice_drag is not None)
             if not interaction_active:
@@ -148,6 +150,10 @@ class GraphicsImageView(QGraphicsView):
         if self._space_pan:
             # Space+drag pans the view (ScrollHandDrag handles the motion)
             return super().mousePressEvent(event)
+        if self.parent_widget.dust_mode and self.parent_widget.pixmap_item is not None:
+            if event.button() == Qt.LeftButton:
+                self.parent_widget.dust_press(self.mapToScene(event.pos()))
+            return
         if self.parent_widget.crop_mode and self.parent_widget.pixmap_item is not None:
             if event.button() == Qt.LeftButton:
                 self.parent_widget.begin_crop_drag(self.mapToScene(event.pos()))
@@ -217,6 +223,9 @@ class GraphicsImageView(QGraphicsView):
             return
         if self._space_pan:
             return super().mouseMoveEvent(event)
+        if self.parent_widget.dust_mode:
+            self.parent_widget.dust_move(self.mapToScene(event.pos()))
+            return
         if self.parent_widget.crop_mode:
             scene_pos = self.mapToScene(event.pos())
             if self.parent_widget._crop_drag is not None:
@@ -333,6 +342,10 @@ class GraphicsImageView(QGraphicsView):
             return
         if self._space_pan:
             return super().mouseReleaseEvent(event)
+        if self.parent_widget.dust_mode:
+            if event.button() == Qt.LeftButton:
+                self.parent_widget.dust_release()
+            return
         if self.parent_widget.crop_mode:
             if event.button() == Qt.LeftButton:
                 self.parent_widget.end_crop_drag(self.mapToScene(event.pos()))
@@ -498,6 +511,13 @@ class GraphicsImageView(QGraphicsView):
         if delta == 0 or self.parent_widget.pixmap_item is None:
             event.ignore()
             return
+        if self.parent_widget.dust_mode:
+            # Wheel resizes the brush in dust mode (no zoom).
+            self.parent_widget.adjust_dust_brush(
+                1 if delta > 0 else -1,
+                anchor_scene=self.mapToScene(event.position().toPoint()))
+            event.accept()
+            return
         # Take keyboard focus so space-pan is immediately available after a
         # zoom (ClickFocus alone would leave space going to other widgets)
         self.setFocus()
@@ -509,6 +529,8 @@ class GraphicsImageView(QGraphicsView):
     def _restore_mode_cursor(self):
         pw = self.parent_widget
         if pw is not None and pw.crop_mode:
+            self.setCursor(Qt.CrossCursor)
+        elif pw is not None and pw.dust_mode:
             self.setCursor(Qt.CrossCursor)
         elif self.wb_pick_mode:
             self.setCursor(_eyedropper_cursor())
@@ -663,6 +685,21 @@ class ImagePreview(QWidget):
         self.toolbar.addAction(self.add_gradient_action)
         add_spacer()
 
+        # Dust removal: opens the Dust Removal panel (covers the sliders) and a
+        # paint/AI-detect mode on the canvas. Checkable so it reflects mode
+        # state. Grouped with the area-editing tools (a separator before it).
+        self.toolbar.addSeparator()
+        add_spacer()
+        self.dust_action = QAction("🧹 Dust Removal", self)
+        self.dust_action.setCheckable(True)
+        self.dust_action.setToolTip(
+            "Spot out dust, hair and small scratches. Opens the Dust Removal "
+            "panel: paint over dust with the brush, or use AI auto-detect.")
+        self.dust_action.triggered.connect(
+            lambda checked: self.window().toggle_dust_removal(checked))
+        self.toolbar.addAction(self.dust_action)
+        add_spacer()
+
         self.convert_action = QAction("Convert", self)
         self.convert_action.triggered.connect(self.convert_ccr)
         self.toolbar.addAction(self.convert_action)
@@ -786,6 +823,19 @@ class ImagePreview(QWidget):
         self._slice_drag = None          # line dict being dragged, or None
         self._slice_worker = None
 
+        # Dust removal mode. Like crop, dust mode shows the FULL un-cropped
+        # image with coarse rotation/flip only (no fine rotation) so canvas
+        # pixels map 1:1 to resized_raw. Spots are stored on the image; the
+        # brush only draws a live overlay + commits on release. See
+        # spec/dust-removal.md.
+        self.dust_mode = False
+        self._dust_painting = False
+        self._dust_pts = []              # current stroke, normalized [[x,y],...]
+        self._dust_brush_r = 0.012       # brush radius, fraction of image width
+        self._dust_stroke_item = None    # live red stroke overlay (in-progress)
+        self._dust_cursor_item = None    # brush-circle cursor following the pointer
+        self.dust_panel = None           # set by MainWindow (brush-slider sync)
+
         # Coalesce a fine-rotation drag into a single undo step
         self._fine_rot_burst_active = False
         self._fine_rot_burst_timer = QTimer(self)
@@ -831,6 +881,15 @@ class ImagePreview(QWidget):
         """Empty the canvas after the last image is removed: drop all
         references to the deleted image (incl. the hi-res cache memory) and
         reset the view state."""
+        if self.dust_mode:
+            # No image left to edit — drop dust mode and restore the sliders.
+            self.dust_mode = False
+            self._dust_painting = False
+            self._dust_pts = []
+            self._clear_dust_items()
+            mw = self.window()
+            if hasattr(mw, "_show_sliders_panel"):
+                mw._show_sliders_panel()
         if self.crop_mode:
             self._exit_crop_mode()
         if self.slice_mode:
@@ -872,6 +931,9 @@ class ImagePreview(QWidget):
         elif self.area_mode:
             # Esc leaves area editing: deselect back to the Whole Image layer.
             self._select_whole_image_layer()
+        elif self.dust_mode:
+            # Esc leaves dust mode (MainWindow restores the sliders panel).
+            self.window().toggle_dust_removal(False)
 
     # --- Tethering banner (watch-folder mode) ----------------------------
     def set_tether_banner(self, banner):
@@ -920,6 +982,19 @@ class ImagePreview(QWidget):
             editable = img_obj_now.converted or ccr_backend.positive_mode
             if not same_image or active_gone or not editable:
                 self._exit_area_mode()
+        # Dust mode leaves on an image switch (like crop/area), so a half-drawn
+        # stroke can't commit to the wrong image and the panel can't drift out
+        # of sync. Torn down WITHOUT a recursive update_preview — we're already
+        # rendering the new image; MainWindow restores the sliders panel.
+        if self.dust_mode and not same_image:
+            self.dust_mode = False
+            self._dust_painting = False
+            self._dust_pts = []
+            self._clear_dust_items()
+            self.view.setCursor(Qt.ArrowCursor)
+            mw = self.window()
+            if hasattr(mw, "_show_sliders_panel"):
+                mw._show_sliders_panel()
         if not same_image:
             # The fine-rotation burst belongs to the previous image; a switch
             # must end it so the next image's first drag gets its own snapshot.
@@ -949,7 +1024,7 @@ class ImagePreview(QWidget):
         crop_angle = getattr(ccr_backend.images[idx], "crop_angle", 0.0) or 0.0
         if (preview_img is not None and not preview_img.isNull()
                 and crop is not None and not self.crop_mode and not self.slice_mode
-                and not self.area_mode
+                and not self.area_mode and not self.dust_mode
                 and (ccr_backend.images[idx].converted or ccr_backend.positive_mode)):
             if crop_angle:
                 extracted = self._extract_rotated_crop(preview_img, crop, crop_angle)
@@ -990,13 +1065,20 @@ class ImagePreview(QWidget):
         self._area_overlay_items = []
         self._slice_ghost_item = None
         self._slice_dim_item = None
+        # scene.clear() above already deleted these — drop the stale refs so a
+        # later removeItem() can't touch freed C++ objects.
+        self._dust_stroke_item = None
+        self._dust_cursor_item = None
         for _slice_line in self._slice_lines:
             _slice_line["item"] = None
 
         self.parent().parent().sliders_panel.set_current_idx(idx)
 
         if preview_img and not preview_img.isNull():
-            self.rotation_slider.setEnabled(True)
+            # Fine rotation is suppressed in dust mode (the canvas shows the
+            # un-fine-rotated image), so disable its slider to match — otherwise
+            # it would show a value the display ignores and could mutate state.
+            self.rotation_slider.setEnabled(not self.dust_mode)
             self.pixmap_item = QGraphicsPixmapItem(preview_img)
             self.scene.addItem(self.pixmap_item)
 
@@ -1143,7 +1225,7 @@ class ImagePreview(QWidget):
         # (Slice mode keeps the fine rotation displayed: cuts are placed on
         # the rotated frame and the rotation is baked into the slices.)
         img_transform = QTransform(base_transform)
-        if self.current_fine_rotation and not self.crop_mode:
+        if self.current_fine_rotation and not self.crop_mode and not self.dust_mode:
             img_transform.translate(cx, cy)
             img_transform.rotate(self.current_fine_rotation / 100.0)
             img_transform.translate(-cx, -cy)
@@ -1290,6 +1372,9 @@ class ImagePreview(QWidget):
             # Film B/W Point tools are negative-only.
             if hasattr(sliders_panel, "set_negative_controls_enabled"):
                 sliders_panel.set_negative_controls_enabled(not positive)
+            # Dust removal follows the same gate as the adjustment sliders.
+            if hasattr(self, "dust_action"):
+                self.dust_action.setEnabled(sliders_enabled)
         
 
     def set_bwpoint_mode(self, mode):
@@ -1562,10 +1647,18 @@ class ImagePreview(QWidget):
              tuple(sorted((a.get("geometry") or {}).items())),
              tuple(sorted((a.get("settings") or {}).items())))
             for a in getattr(img, "area_layers", []))
+        # Dust spots are inpainted inside apply_adjustments, so a change to them
+        # must invalidate the cached hi-res display (see spec/dust-removal.md §4.4).
+        dust_sig = tuple(
+            (s.get("kind"),
+             tuple((round(float(p[0]) * 10000), round(float(p[1]) * 10000))
+                   for p in (s.get("pts") or [])),
+             round(float(s.get("r", 0)) * 10000))
+            for s in getattr(img, "dust_spots", []))
         return (tuple(sorted(img.adjustment_settings.items())),
                 img.contrast_base, img.temperature_base, img.brightness_base,
                 getattr(img, "color_profile", "color"),
-                areas_sig)
+                areas_sig, dust_sig)
 
     HIRES_MAX_LONG_SIDE = 4500   # bounds non-RAW decodes (RAW half-size passes through)
 
@@ -2089,6 +2182,232 @@ class ImagePreview(QWidget):
             t.rotate(self.current_rotation)
         t.translate(-cx, -cy)
         return t if t.isInvertible() else None
+
+    # --- Dust removal mode -------------------------------------------------
+    # Paint over dust to inpaint it (cv2.inpaint), or AI-detect it. Edits are
+    # stored as normalized spots on the image and replayed in the render
+    # pipeline at every resolution. See spec/dust-removal.md.
+    def enter_dust_mode(self) -> bool:
+        """Show the full un-cropped image (coarse rotation/flip only, no fine
+        rotation) so canvas pixels map 1:1 to resized_raw, ready for painting."""
+        if self.current_idx is None:
+            return False
+        img_obj = ccr_backend.get_image_by_index(self.current_idx)
+        if (img_obj is None or self.current_pixmap is None
+                or self.current_pixmap.isNull()):
+            return False
+        if self.crop_mode:
+            self._exit_crop_mode()
+        if self.slice_mode:
+            self._exit_slice_mode()
+        if self.area_mode:
+            self._exit_area_mode()
+        self.view.bwpoint_mode = None
+        self.view.wb_pick_mode = False
+        self.dust_mode = True
+        self._dust_painting = False
+        self._dust_pts = []
+        self._zoom = 1.0
+        self._release_hires(refresh=False)
+        # dust_mode is already True, so update_preview shows the full un-cropped
+        # image (its crop-display branch checks `not self.dust_mode`).
+        self.update_preview(self.current_idx)
+        self._sync_zoom_combo()
+        self.view.setCursor(Qt.CrossCursor)
+        return True
+
+    def exit_dust_mode(self):
+        """Tear down the brush overlay and restore the normal (cropped,
+        fine-rotated) preview. Stored dust edits remain on the image."""
+        if not self.dust_mode:
+            return
+        self.dust_mode = False
+        self._dust_painting = False
+        self._dust_pts = []
+        self._clear_dust_items()
+        self.view.setCursor(Qt.ArrowCursor)
+        if self.current_idx is not None:
+            self.update_preview(self.current_idx)
+            self._sync_zoom_combo()
+
+    def set_dust_panel(self, panel):
+        """MainWindow wires the DustRemovalPanel here so wheel-resize can keep
+        the panel's brush slider in sync."""
+        self.dust_panel = panel
+
+    def set_dust_brush_size(self, r_norm: float):
+        self._dust_brush_r = max(0.002, min(0.2, float(r_norm)))
+
+    def adjust_dust_brush(self, step: int, anchor_scene=None):
+        """Wheel-resize the brush (exponential); keep the panel slider + the
+        on-canvas brush ring in sync."""
+        factor = 1.15 if step > 0 else (1.0 / 1.15)
+        self._dust_brush_r = max(0.002, min(0.2, self._dust_brush_r * factor))
+        if getattr(self, "dust_panel", None) is not None:
+            self.dust_panel.sync_brush_size(self._dust_brush_r)
+        self._update_dust_cursor(anchor_scene)
+
+    def _dust_scene_to_norm(self, scene_pos):
+        """Scene point -> normalized (x over width, y over height) in the
+        displayed (= resized_raw, un-cropped, un-fine-rotated) pixmap."""
+        t = self._base_transform()
+        if t is None or self.current_pixmap is None:
+            return None
+        inv, ok = t.inverted()
+        if not ok:
+            return None
+        local = inv.map(scene_pos)
+        w = self.current_pixmap.width()
+        h = self.current_pixmap.height()
+        if w <= 0 or h <= 0:
+            return None
+        return [local.x() / w, local.y() / h]
+
+    def dust_press(self, scene_pos):
+        if not self.dust_mode:
+            return
+        n = self._dust_scene_to_norm(scene_pos)
+        if n is None:
+            return
+        self._dust_painting = True
+        self._dust_pts = [n]
+        self._draw_dust_stroke()
+        self._update_dust_cursor(scene_pos)
+
+    def dust_move(self, scene_pos):
+        if not self.dust_mode:
+            return
+        self._update_dust_cursor(scene_pos)
+        if not self._dust_painting:
+            return
+        n = self._dust_scene_to_norm(scene_pos)
+        if n is None:
+            return
+        self._dust_pts.append(n)
+        self._draw_dust_stroke()
+
+    def dust_release(self):
+        if not self.dust_mode or not self._dust_painting:
+            return
+        self._dust_painting = False
+        pts = self._dust_pts
+        self._dust_pts = []
+        if not pts:
+            return
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None:
+            return
+        img.push_undo_state()
+        img.dust_spots.append(
+            {"kind": "brush", "pts": pts, "r": float(self._dust_brush_r)})
+        self._commit_dust_change(img)
+
+    def dust_undo_last(self) -> bool:
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None or not img.dust_spots:
+            return False
+        img.push_undo_state()
+        img.dust_spots.pop()
+        self._commit_dust_change(img)
+        return True
+
+    def dust_clear_all(self) -> bool:
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None or not img.dust_spots:
+            return False
+        img.push_undo_state()
+        img.dust_spots = []
+        self._commit_dust_change(img)
+        return True
+
+    def dust_detect_source(self):
+        """The working positive (with existing spots already healed) the AI
+        detector should run on, or None."""
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None or img.resized_raw is None:
+            return None
+        return apply_dust_removal(img.resized_raw, img.dust_spots)
+
+    def apply_detected_spots(self, new_auto_spots) -> int:
+        """Replace the AI-detected ('auto') spots with a fresh set; manual
+        ('brush') spots are kept. Returns the new auto-spot count."""
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None:
+            return 0
+        img.push_undo_state()
+        img.dust_spots = [s for s in img.dust_spots if s.get("kind") != "auto"]
+        img.dust_spots.extend(new_auto_spots or [])
+        self._commit_dust_change(img)
+        return len(new_auto_spots or [])
+
+    def _commit_dust_change(self, img):
+        """Re-bake the preview/thumbnail after a dust edit and refresh the UI."""
+        img.update_thumbnail_and_preview()
+        self.update_preview(self.current_idx)
+        try:
+            self.window().thumbnail_list.update_thumbnail(self.current_idx)
+        except Exception:
+            pass
+
+    def _clear_dust_items(self):
+        for attr in ("_dust_stroke_item", "_dust_cursor_item"):
+            item = getattr(self, attr, None)
+            if item is not None:
+                try:
+                    self.scene.removeItem(item)
+                except (RuntimeError, ValueError):
+                    pass
+                setattr(self, attr, None)
+
+    def _draw_dust_stroke(self):
+        """Draw/refresh the live red overlay for the in-progress stroke."""
+        if self._dust_stroke_item is not None:
+            try:
+                self.scene.removeItem(self._dust_stroke_item)
+            except (RuntimeError, ValueError):
+                pass
+            self._dust_stroke_item = None
+        if not self._dust_pts or self.current_pixmap is None:
+            return
+        t = self._base_transform()
+        if t is None:
+            return
+        w = self.current_pixmap.width()
+        h = self.current_pixmap.height()
+        path = QPainterPath()
+        first = t.map(QPointF(self._dust_pts[0][0] * w, self._dust_pts[0][1] * h))
+        path.moveTo(first)
+        for p in self._dust_pts[1:]:
+            path.lineTo(t.map(QPointF(p[0] * w, p[1] * h)))
+        if len(self._dust_pts) == 1:
+            path.lineTo(first)  # a single dab
+        item = QGraphicsPathItem(path)
+        pen = QPen(QColor(255, 40, 40, 150), 2.0 * self._dust_brush_r * w,
+                   Qt.SolidLine, Qt.RoundCap, Qt.RoundJoin)
+        item.setPen(pen)
+        self.scene.addItem(item)
+        self._dust_stroke_item = item
+
+    def _update_dust_cursor(self, scene_pos):
+        """Move the brush-circle cursor ring to the pointer (sized by brush)."""
+        if self._dust_cursor_item is not None:
+            try:
+                self.scene.removeItem(self._dust_cursor_item)
+            except (RuntimeError, ValueError):
+                pass
+            self._dust_cursor_item = None
+        if (scene_pos is None or self.current_pixmap is None
+                or not self.dust_mode or self.pixmap_item is None):
+            return
+        r = self._dust_brush_r * self.current_pixmap.width()
+        item = QGraphicsEllipseItem(scene_pos.x() - r, scene_pos.y() - r,
+                                    2 * r, 2 * r)
+        pen = QPen(QColor(255, 255, 255, 220), 1)
+        pen.setCosmetic(True)
+        item.setPen(pen)
+        item.setBrush(QBrush(Qt.NoBrush))
+        self.scene.addItem(item)
+        self._dust_cursor_item = item
 
     def enter_crop_mode(self) -> bool:
         """Show the full image with the current crop (if any) as the starting

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -323,6 +323,20 @@ class TestPanelWiring:
         panel.cancel_jobs()
         panel.shutdown()   # must not raise with no threads running
 
+    def test_detect_all_no_targets_is_safe(self):
+        from widgets.dust_panel import DustRemovalPanel, _DetectAllWorker  # noqa: F401
+        from core.ccr_backend import ccr_backend
+        saved = ccr_backend.images
+        ccr_backend.images = []
+        try:
+            panel = DustRemovalPanel(_StubMain(), _StubPreview())
+            assert hasattr(panel, "detect_all_btn")
+            panel._on_detect_all()                 # no convertible images
+            assert panel._detecting_all is False    # no batch started
+            assert panel._detect_all_thread is None
+        finally:
+            ccr_backend.images = saved
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -121,13 +121,20 @@ class TestApplyAdjustmentsIntegration:
 
 
 # --- dust_detect.prob_to_spots (model-free) ---------------------------------
+def _bright_luma(prob):
+    """Luma where high-prob regions read bright (white film dust) on a dark
+    surround, so detections pass the bright-speck gate."""
+    return np.clip(prob, 0.0, 1.0).astype(np.float32)
+
+
 class TestProbToSpots:
     def test_threshold_direction(self):
         prob = np.zeros((100, 100), np.float32)
         prob[10:13, 10:13] = 0.5            # a small mid-confidence blob
+        luma = _bright_luma(prob)
         # sensitivity 0 -> thr 0.85 -> nothing; 100 -> thr 0.25 -> detected.
-        assert dust_detect.prob_to_spots(prob, 0) == []
-        spots = dust_detect.prob_to_spots(prob, 100)
+        assert dust_detect.prob_to_spots(prob, luma, 0) == []
+        spots = dust_detect.prob_to_spots(prob, luma, 100)
         assert len(spots) == 1
         assert spots[0]["kind"] == "auto"
         x, y = spots[0]["pts"][0]
@@ -135,17 +142,18 @@ class TestProbToSpots:
         assert spots[0]["r"] > 0
 
     def test_size_gate_drops_large_blobs(self):
-        # max_blob = 600 * max(h,w) / 2000 = 30 px for a 100x100 map.
+        # max_blob = MAX_BLOB(400) * max(h,w) / 2000 = 20 px for a 100x100 map.
         prob = np.zeros((100, 100), np.float32)
         prob[10:13, 10:13] = 0.9            # 9 px  -> kept
         prob[50:62, 50:62] = 0.9            # 144 px -> dropped
-        spots = dust_detect.prob_to_spots(prob, 50)
+        spots = dust_detect.prob_to_spots(prob, _bright_luma(prob), 50)
         assert len(spots) == 1
         x, y = spots[0]["pts"][0]
         assert x < 0.3 and y < 0.3          # the small blob, not the big one
 
     def test_blank_prob_yields_nothing(self):
-        assert dust_detect.prob_to_spots(np.zeros((40, 40), np.float32), 100) == []
+        z = np.zeros((40, 40), np.float32)
+        assert dust_detect.prob_to_spots(z, z, 100) == []
 
     def test_drops_elongated_keeps_compact(self):
         # A thin line is real image structure (bike frame / horizon), not dust:
@@ -154,7 +162,7 @@ class TestProbToSpots:
         prob = np.zeros((100, 100), np.float32)
         prob[50, 10:22] = 0.9       # 1x12 thin line (area 12, aspect 12) -> dropped
         prob[80:83, 80:83] = 0.9    # 3x3 compact speck (area 9)          -> kept
-        spots = dust_detect.prob_to_spots(prob, 60)
+        spots = dust_detect.prob_to_spots(prob, _bright_luma(prob), 60)
         assert len(spots) == 1
         x, y = spots[0]["pts"][0]
         assert x > 0.5 and y > 0.5  # the compact speck, not the line
@@ -164,10 +172,25 @@ class TestProbToSpots:
         # 0.5*extent=3 of the old bounding-box sizing blown up by elongation.
         prob = np.zeros((200, 200), np.float32)
         prob[100:106, 100:106] = 0.9
-        spots = dust_detect.prob_to_spots(prob, 60)
+        spots = dust_detect.prob_to_spots(prob, _bright_luma(prob), 60)
         assert len(spots) == 1
         r_px = spots[0]["r"] * 200
         assert 3.0 < r_px < 7.0     # tight circle, no big smudge
+
+    def test_bright_gate_drops_dark_blob(self):
+        # Film dust inverts to WHITE specks. A compact, right-sized blob that is
+        # DARKER than its surround (e.g. a face on bright sky) is NOT dust and
+        # must be rejected — this is what removed a person's head before.
+        # 200x200 so the 6x6 blob clears the size gate (max_blob ~ 40 here) and
+        # the brightness gate is what actually decides.
+        prob = np.zeros((200, 200), np.float32)
+        prob[40:46, 40:46] = 0.9                 # detector fires on a 6x6 region
+        dark = np.full((200, 200), 0.8, np.float32)
+        dark[40:46, 40:46] = 0.2                 # dark blob, bright surround
+        assert dust_detect.prob_to_spots(prob, dark, 60) == []
+        bright = np.full((200, 200), 0.2, np.float32)
+        bright[40:46, 40:46] = 0.9               # bright blob (real dust)
+        assert len(dust_detect.prob_to_spots(prob, bright, 60)) == 1
 
 
 # --- Availability / graceful degradation ------------------------------------

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -147,6 +147,28 @@ class TestProbToSpots:
     def test_blank_prob_yields_nothing(self):
         assert dust_detect.prob_to_spots(np.zeros((40, 40), np.float32), 100) == []
 
+    def test_drops_elongated_keeps_compact(self):
+        # A thin line is real image structure (bike frame / horizon), not dust:
+        # the aspect filter drops it while keeping a compact speck. Guards the
+        # AI-artifact fix (see spec/dust-removal.md §5.3/§5.4).
+        prob = np.zeros((100, 100), np.float32)
+        prob[50, 10:22] = 0.9       # 1x12 thin line (area 12, aspect 12) -> dropped
+        prob[80:83, 80:83] = 0.9    # 3x3 compact speck (area 9)          -> kept
+        spots = dust_detect.prob_to_spots(prob, 60)
+        assert len(spots) == 1
+        x, y = spots[0]["pts"][0]
+        assert x > 0.5 and y > 0.5  # the compact speck, not the line
+
+    def test_radius_is_area_equivalent_not_extent(self):
+        # A 6x6 compact blob -> radius ~ sqrt(36/pi) ~ 3.4 px (+pad), NOT the
+        # 0.5*extent=3 of the old bounding-box sizing blown up by elongation.
+        prob = np.zeros((200, 200), np.float32)
+        prob[100:106, 100:106] = 0.9
+        spots = dust_detect.prob_to_spots(prob, 60)
+        assert len(spots) == 1
+        r_px = spots[0]["r"] * 200
+        assert 3.0 < r_px < 7.0     # tight circle, no big smudge
+
 
 # --- Availability / graceful degradation ------------------------------------
 class TestAvailability:

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Tests for the Dust Removal feature.
+
+Dust edits are stored as NORMALIZED spots on the image
+({kind, pts:[[x,y],...], r}) and inpainted at render time by
+ccr_processor.apply_dust_removal (cv2.inpaint, masked-only feathered composite).
+The AI detector (dust_detect) only finds dust; the fill is the same cv2 path.
+See spec/dust-removal.md.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+import cv2  # noqa: E402
+from core import catalog, dust_detect  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+from core.ccr_processor import (apply_dust_removal,  # noqa: E402
+                                rasterize_dust_mask)
+
+
+def _flat_with_speck(h=100, w=100, base=30000, speck=60000, cx=50, cy=50, r=4):
+    """Flat gray image with one bright circular speck near the center."""
+    img = np.full((h, w, 3), base, dtype=np.uint16)
+    cv2.circle(img, (cx, cy), r, (speck, speck, speck), -1)
+    return img
+
+
+# --- rasterize_dust_mask ----------------------------------------------------
+class TestRasterize:
+    def test_centered_spot_is_a_filled_circle(self):
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.1}
+        mask = rasterize_dust_mask([spot], 100, 100)
+        assert mask.dtype == np.uint8
+        assert mask[50, 50] == 255          # center filled
+        assert mask[50, 70] == 0            # well outside r_px=10
+        area = int((mask > 0).sum())
+        assert abs(area - np.pi * 100) < 60  # ~ pi*r_px^2, r_px = 10
+
+    def test_resolution_independence(self):
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.1}
+        a1 = int((rasterize_dust_mask([spot], 100, 100) > 0).sum())
+        a2 = int((rasterize_dust_mask([spot], 200, 200) > 0).sum())
+        # Same normalized spot covers ~4x the pixels at 2x resolution.
+        assert 3.5 < a2 / a1 < 4.6
+
+    def test_empty_spots_is_blank(self):
+        mask = rasterize_dust_mask([], 50, 50)
+        assert mask.shape == (50, 50)
+        assert not mask.any()
+
+
+# --- apply_dust_removal -----------------------------------------------------
+class TestApplyDustRemoval:
+    def test_identity_returns_same_object(self):
+        img = _flat_with_speck()
+        assert apply_dust_removal(img, []) is img
+        assert apply_dust_removal(img, None) is img
+
+    def test_speck_removed_and_far_pixels_untouched(self):
+        img = _flat_with_speck(base=30000, speck=60000, cx=50, cy=50, r=4)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.08}
+        out = apply_dust_removal(img, [spot])
+        assert out.dtype == np.uint16
+        assert out is not img                       # new array (non-destructive)
+        # The speck is filled toward the flat surround.
+        assert abs(int(out[50, 50, 0]) - 30000) < 15000
+        assert int(out[50, 50, 0]) < 55000
+        # A corner far from the mask is bit-for-bit unchanged.
+        assert np.array_equal(out[0:10, 0:10], img[0:10, 0:10])
+
+    def test_input_not_mutated(self):
+        img = _flat_with_speck()
+        before = img.copy()
+        apply_dust_removal(img, [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.08}])
+        assert np.array_equal(img, before)
+
+
+# --- apply_adjustments integration (dust runs before the early-return guard) -
+class TestApplyAdjustmentsIntegration:
+    def test_dust_only_image_still_inpaints(self, tmp_path):
+        # Build a bare CCRImage; neutralize bases so apply_adjustments takes the
+        # early-return path AFTER dust removal (proving dust runs before it).
+        path = str(tmp_path / "x.png")
+        cv2.imwrite(path, np.zeros((10, 10, 3), np.uint8))
+        img = CCRImage(path)
+        img.adjustment_settings = {}
+        img.contrast_base = 0
+        img.temperature_base = 0
+        img.brightness_base = 0
+        img.color_profile = "color"
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.08}]
+
+        src = _flat_with_speck()
+        out = img.apply_adjustments(src)
+        # Speck healed even though every slider/base is neutral.
+        assert int(out[50, 50, 0]) < 55000
+        assert np.array_equal(out[0:10, 0:10], src[0:10, 0:10])
+
+    def test_no_dust_no_change_in_neutral_pipeline(self, tmp_path):
+        path = str(tmp_path / "y.png")
+        cv2.imwrite(path, np.zeros((10, 10, 3), np.uint8))
+        img = CCRImage(path)
+        img.adjustment_settings = {}
+        img.contrast_base = img.temperature_base = img.brightness_base = 0
+        img.dust_spots = []
+        src = _flat_with_speck()
+        out = img.apply_adjustments(src)
+        assert np.array_equal(out, src)
+
+
+# --- dust_detect.prob_to_spots (model-free) ---------------------------------
+class TestProbToSpots:
+    def test_threshold_direction(self):
+        prob = np.zeros((100, 100), np.float32)
+        prob[10:13, 10:13] = 0.5            # a small mid-confidence blob
+        # sensitivity 0 -> thr 0.85 -> nothing; 100 -> thr 0.25 -> detected.
+        assert dust_detect.prob_to_spots(prob, 0) == []
+        spots = dust_detect.prob_to_spots(prob, 100)
+        assert len(spots) == 1
+        assert spots[0]["kind"] == "auto"
+        x, y = spots[0]["pts"][0]
+        assert 0.08 < x < 0.16 and 0.08 < y < 0.16
+        assert spots[0]["r"] > 0
+
+    def test_size_gate_drops_large_blobs(self):
+        # max_blob = 600 * max(h,w) / 2000 = 30 px for a 100x100 map.
+        prob = np.zeros((100, 100), np.float32)
+        prob[10:13, 10:13] = 0.9            # 9 px  -> kept
+        prob[50:62, 50:62] = 0.9            # 144 px -> dropped
+        spots = dust_detect.prob_to_spots(prob, 50)
+        assert len(spots) == 1
+        x, y = spots[0]["pts"][0]
+        assert x < 0.3 and y < 0.3          # the small blob, not the big one
+
+    def test_blank_prob_yields_nothing(self):
+        assert dust_detect.prob_to_spots(np.zeros((40, 40), np.float32), 100) == []
+
+
+# --- Availability / graceful degradation ------------------------------------
+class TestAvailability:
+    def test_unavailable_when_onnxruntime_absent(self, monkeypatch):
+        # Setting the module to None makes `import onnxruntime` raise ImportError.
+        monkeypatch.setitem(sys.modules, "onnxruntime", None)
+        assert dust_detect.is_available() is False
+
+    def test_model_path_is_under_freeccr(self):
+        assert "FreeCCR" in dust_detect.model_path()
+        assert dust_detect.model_path().endswith("detector.onnx")
+
+
+# --- Persistence (catalog) --------------------------------------------------
+def _scan_png(tmp_path, name="neg.png", w=120, h=80, seed=3):
+    rng = np.random.default_rng(seed)
+    img = np.clip(rng.normal(30000, 4000, (h, w, 3)), 0, 65535).astype(np.uint16)
+    path = str(tmp_path / name)
+    cv2.imwrite(path, cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+    return path
+
+
+class TestPersistence:
+    def test_dust_spots_round_trip(self, tmp_path):
+        cat = str(tmp_path / "catalog.json")
+        path = _scan_png(tmp_path)
+        img = CCRImage(path)
+        img.dust_spots = [{"kind": "brush", "pts": [[0.25, 0.5], [0.3, 0.55]],
+                           "r": 0.01},
+                          {"kind": "auto", "pts": [[0.7, 0.2]], "r": 0.004}]
+        catalog.update_for_images([img], path=cat)
+        restored = catalog.create_images_for_path(path, path=cat)
+        assert len(restored) == 1
+        assert restored[0].dust_spots == img.dust_spots
+
+    def test_old_entry_without_dust_defaults_empty(self, tmp_path):
+        cat = str(tmp_path / "catalog.json")
+        path = _scan_png(tmp_path)
+        img = CCRImage(path)
+        img.adjustment_settings = {"exposure": 5}
+        state = catalog.serialize_image(img)
+        del state["dust_spots"]            # simulate a pre-feature catalog entry
+        restored = catalog._restore_image(path, state)
+        assert restored.dust_spots == []
+
+    def test_dust_only_image_is_not_pristine(self, tmp_path):
+        path = _scan_png(tmp_path)
+        img = CCRImage(path)
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.01}]
+        state = catalog.serialize_image(img)
+        assert catalog._is_pristine(state) is False
+
+
+# --- Undo -------------------------------------------------------------------
+class TestUndo:
+    def test_capture_and_pop_restore_dust_spots(self, tmp_path):
+        path = _scan_png(tmp_path)
+        img = CCRImage(path)
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.01}]
+        img.push_undo_state()
+        # Mutate after snapshot.
+        img.dust_spots.append({"kind": "auto", "pts": [[0.1, 0.1]], "r": 0.005})
+        assert len(img.dust_spots) == 2
+        assert img.pop_undo_state()
+        assert img.dust_spots == [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.01}]
+
+    def test_snapshot_is_independent_deep_copy(self, tmp_path):
+        path = _scan_png(tmp_path)
+        img = CCRImage(path)
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.01}]
+        img.push_undo_state()
+        # Mutate a NESTED structure in place; the snapshot must not change.
+        img.dust_spots[0]["pts"].append([0.6, 0.6])
+        img.pop_undo_state()
+        assert img.dust_spots[0]["pts"] == [[0.5, 0.5]]
+
+
+# --- DustRemovalPanel wiring (headless, with stubs) -------------------------
+class _StubPreview:
+    def __init__(self):
+        self.dust_mode = True
+        self.current_idx = None
+        self.brush = None
+
+    def set_dust_brush_size(self, r):
+        self.brush = r
+
+    def dust_undo_last(self):
+        return False
+
+    def dust_clear_all(self):
+        return False
+
+
+class _StubMain:
+    def __init__(self):
+        self.toggled = None
+
+    def toggle_dust_removal(self, on):
+        self.toggled = on
+
+
+class TestPanelWiring:
+    def test_panel_builds_without_onnxruntime(self):
+        from widgets.dust_panel import DustRemovalPanel
+        # Building the panel must never import onnxruntime / raise.
+        panel = DustRemovalPanel(_StubMain(), _StubPreview())
+        assert panel is not None
+
+    def test_brush_slider_drives_canvas(self):
+        from widgets.dust_panel import DustRemovalPanel
+        prev = _StubPreview()
+        panel = DustRemovalPanel(_StubMain(), prev)
+        panel._on_brush_changed(30)            # 30 / 1000 = 0.030 of width
+        assert abs(prev.brush - 0.030) < 1e-9
+        panel.sync_brush_size(0.05)            # canvas -> slider, no feedback loop
+        assert abs(panel.brush_slider.value() - 50) <= 1
+
+    def test_done_button_exits_mode(self):
+        from widgets.dust_panel import DustRemovalPanel
+        main = _StubMain()
+        panel = DustRemovalPanel(main, _StubPreview())
+        panel._on_done()
+        assert main.toggled is False
+
+    def test_cancel_and_shutdown_are_safe_with_no_jobs(self):
+        from widgets.dust_panel import DustRemovalPanel
+        panel = DustRemovalPanel(_StubMain(), _StubPreview())
+        panel.cancel_jobs()
+        panel.shutdown()   # must not raise with no threads running
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Adds a non-destructive **Dust Removal** feature for spotting out dust, hair and small scratches on scanned film, adapted from the `openenlarge` project. A single checkable **🧹 Dust Removal** button on the image toolbar enters "dust mode": the right-hand sliders panel is **covered** by a Dust Removal panel with **Manual** and **AI** sections.

- **Manual** — a sized brush; paint over dust on the canvas and it's inpainted (`cv2.inpaint`, Telea). Undo-last / Clear-all, live red overlay, brush-ring cursor (wheel resizes).
- **AI (hybrid)** — an ONNX BOPBTL U-Net detector (downloaded on first use, ~150 MB) finds dust automatically; the **same** `cv2.inpaint` fills it. Sensitivity slider re-thresholds the cached probability map without re-running the net.

Edits are stored as **normalized 0..1 spots** on the image and replayed at the top of `CCRImage.apply_adjustments`, so **preview, hi-res zoom, and full-res export all match and scale**. Spots persist in the catalog and participate in Undo. Manual dust removal needs **no new runtime deps** and works offline; AI **degrades gracefully** when `onnxruntime`/the model is absent.

## Approach

Per the project workflow, a spec was authored and refined under adversarial review before implementation: `spec/dust-removal.md`.

Key design decisions (settled up front):
- **Hybrid AI**: ONNX detect + `cv2.inpaint` fill (not MI-GAN).
- **Top image toolbar** button; **non-destructive** normalized-spot model.
- Panel cover via **visibility toggle of sibling widgets** (not a `QStackedWidget`) so `SlidersPanel`'s `parent().parent()` chains to `MainWindow` stay valid.
- Dust mode shows the **full, un-cropped, un-fine-rotated** image → exact 1:1 canvas↔`resized_raw` mapping (reusing the proven inverse-`base_transform` chain).
- Single insertion point in `apply_adjustments` covers preview / zoom / all three export paths.

## Files

- **new** `src/core/dust_detect.py` — ONNX detector (lazy `onnxruntime` import, model download + SHA‑256 verify, `detect`, `prob_to_spots`).
- **new** `src/widgets/dust_panel.py` — `DustRemovalPanel` + off-thread download/detect workers.
- **edit** `ccr_processor.py` (`rasterize_dust_mask`, `apply_dust_removal`), `ccr_image.py` (field + pipeline hook + undo), `catalog.py` (persist + `_is_pristine`), `image_preview.py` (toolbar + paint mode + cache sig), `main_window.py` (panel toggle).
- **new** `spec/dust-removal.md`, `tests/test_dust_removal.py`, `LICENSES/license-dust-detector.txt`.

## Testing

- 22 new tests (mask rasterization + resolution-independence, inpaint correctness + bit-for-bit preservation outside the halo, pipeline integration, persistence round-trip, undo deep-copy isolation, detector threshold/size-gate logic, graceful degradation, panel wiring).
- **Full suite: 362 passed**, no regressions.
- Two review passes (spec + implementation), each with adversarial verification of findings; confirmed fixes folded in (image-switch leaves dust mode; fine-rotation slider disabled in dust mode; stale-detection guard; thread cancel/cleanup; ONNX session lock).

## Notes

- `onnxruntime` is added to `requirements.txt` (running from source enables AI). It is **not** bundled by default — the Nuitka build options are documented in the spec (§8) as a follow-up to validate; manual dust works regardless.
- The ~150 MB detector model is **never** bundled; it downloads on demand to the app-data folder. Model attribution recorded in `LICENSES/license-dust-detector.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
