### PR TITLE
Rename Exposure slider to Gain

### DIFF
--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -304,7 +304,7 @@ class CCRImage:
                 # the brightest pixels saturate, CLIPPING highlights to white.
                 # rawpy's auto-scale (no_auto_scale left at its default, off) still
                 # maps the sensor white level to full range — a proper, non-clipping
-                # exposure that preserves highlight headroom (raise Exposure to taste).
+                # exposure that preserves highlight headroom (raise Gain to taste).
                 no_auto_bright=True,
                 gamma=(2.222, 4.5),                               # sRGB-ish TRC
                 user_flip=0,

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -15,7 +15,7 @@ import copy
 SYNC_GROUPS = [
     ("profile", "Color Profile (Color / B&W)", ()),
     ("wb", "White Balance / Tint", ("temperature", "tint")),
-    ("tone", "Tone (exposure, brightness, contrast, ...)",
+    ("tone", "Tone (gain, brightness, contrast, ...)",
      ("exposure", "brightness", "highlights", "white_point",
       "shadows", "black_point", "contrast")),
     ("sat", "Saturation", ("saturation", "sub_saturation")),
@@ -275,7 +275,7 @@ class SlidersPanel(QWidget):
         layout.addWidget(scroll_area, 1)  # stretch=1: fills remaining height
 
         self.slider_labels = [
-            "Temperature", "Tint", "Exposure", "Brightness",
+            "Temperature", "Tint", "Gain", "Brightness",
             "Highlights", "White Point", "Shadows", "Black Point", "Contrast", "Saturation",
             "Subtracted Sat"
         ]
@@ -399,7 +399,7 @@ class SlidersPanel(QWidget):
 
         self.temperature_slider_layout = self.create_slider("Temperature")
         self.tint_slider_layout = self.create_slider("Tint")
-        self.exposure_slider_layout = self.create_slider("Exposure")
+        self.exposure_slider_layout = self.create_slider("Gain")
         self.brightness_slider_layout = self.create_slider("Brightness")
         self.highlights_slider_layout = self.create_slider("Highlights")
         self.white_point_slider_layout = self.create_slider("White Point")


### PR DESCRIPTION
## What

Rename the user-facing **"Exposure"** slider to **"Gain"**.

## Why

The control is a highlight-protecting, *tone-aware gain*, not a true exposure (a uniform linear gain). When decreased, it crushes shadow/midtone contrast while sparing highlights, which a user reported as "lost contrast." The behavior is intentional and useful, so this renames the label to set accurate expectations rather than changing the math.

## Scope

- Display strings only: slider label, the decorative `slider_labels` entry, the "Sync to All" group description, and one stale code comment.
- The internal `exposure` adjustment key is **unchanged** — saved settings, Sync-to-All, and serialization are unaffected.
- No processing/math changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
