### PR TITLE
Neutral dark theme system (UI redesign)

### DIFF
--- a/spec/visual-redesign.md
+++ b/spec/visual-redesign.md
@@ -1,0 +1,320 @@
+# Spec: Visual Redesign — Neutral Dark Theme System
+
+Status: REFINED v1
+Owner: FreeCCR
+Feature branch: `feature/ui-redesign`
+
+## 1. Summary
+
+Give FreeCCR a single, coherent **neutral dark** look suited to color-critical
+work (film-negative conversion + color correction), replacing today's scattered,
+internally-inconsistent per-widget styling. The redesign introduces one
+**theme system** — a central design-token palette, a global Qt stylesheet, a
+Fusion `QPalette`, theme-aware icon tinting, and a small set of Python paint
+constants — installed once at application start. The layout and interaction model
+are unchanged; this is a **full reskin**, not an information-architecture change.
+
+The palette is deliberately **neutral grayscale** (no hue cast) so the UI never
+biases perception of image color — the same rationale Lightroom / Capture One /
+Photoshop use. **Dark-only** for v1 (a light theme is a non-goal but the token
+structure leaves the door open).
+
+Chosen direction (confirmed): neutral dark, full reskin via a theme system,
+dark-only. Anchor swatches: window `#1e1e1e`, panel `#2a2a2a`, text `#e0e0e0`,
+neutral accent `#6e6e6e`.
+
+## 2. Goals / Non-goals
+
+### Goals
+- One **`src/ui/theme.py`** module that is the single source of truth for all UI
+  color, spacing, radius, and type tokens.
+- A global dark theme installed **once** in `src/main.py` (`Fusion` style +
+  `QPalette` + global QSS) so every widget, menu, dialog, scrollbar, and tooltip
+  inherits it — including dialogs created lazily.
+- Refactor the ~30 inline `setStyleSheet` calls so none hardcode literal colors;
+  generic controls are covered by the global QSS, and the few semantic/dynamic
+  styles (channel-tinted labels, color-band swatches, tether states, the dust
+  "Done" accent button) pull their colors from theme tokens.
+- A **paint-constants** layer for the colors QSS cannot reach (curve-editor
+  canvas, the numpy-rendered histogram, and the on-image overlays), so they are
+  centralized and consistent.
+- **Theme-aware toolbar icons**: the pure-black toolbar PNGs are tinted at load
+  so they are visible on the dark theme.
+- The histogram (numpy-rendered) and its QSS container adopt a dark backdrop and
+  stay in sync from one token.
+- Visual consistency verified with the **`qt-testing`** skill (offscreen
+  screenshots of every widget) plus the existing offscreen pytest suite still
+  passing.
+
+### Non-goals
+- **No layout / IA changes** — panel arrangement, control placement, and flows
+  are untouched.
+- **No light theme and no runtime theme toggle** in v1 (structure allows adding
+  one later; not built now).
+- **No new fonts shipped** — keep the system default font family. (The `qt-testing`
+  offscreen platform renders boxes for text because PySide6 ships no fonts; the
+  real app uses the OS font. Screenshot review for *typography* uses the default
+  Windows platform — `init_qt(offscreen=False)`.)
+- **No recoloring of image-overlay semantics** — crop/area/slice/dust/reference
+  /B-W-point markers and cursors keep their current functional colors (tuned for
+  visibility over arbitrary photos); they are only *centralized*, not restyled.
+- No icon redesign / new icon set; existing PNGs are tinted, not replaced.
+
+## 3. Visual design system (tokens)
+
+All values live in `src/ui/theme.py`. Names are stable; widgets reference names,
+never literals. (`*` = changed from a current hardcoded value.)
+
+### 3.1 Surfaces (neutral grays — zero hue)
+| Token | Hex | Use |
+|---|---|---|
+| `WINDOW` | `#1e1e1e` | app background, menu bar |
+| `CANVAS` | `#1a1a1a` * | image viewport behind the photo (`QGraphicsView`) |
+| `PANEL` | `#2a2a2a` | side panels, dialogs, group backgrounds |
+| `SURFACE` | `#333333` * | inputs, combos, line edits, unchecked buttons |
+| `SURFACE_HOVER` | `#3c3c3c` | hover state |
+| `SURFACE_ACTIVE` | `#454545` * | pressed / checked / selected background |
+| `BORDER` | `#3c3c3c` | 1px control borders, separators |
+| `BORDER_STRONG` | `#5a5a5a` | emphasized borders |
+
+### 3.2 Text
+| Token | Hex | Use |
+|---|---|---|
+| `TEXT` | `#e0e0e0` | primary text |
+| `TEXT_MUTED` | `#9a9a9a` * | captions, hints, section labels (was `#888`/`#666`) |
+| `TEXT_DISABLED` | `#6a6a6a` | disabled text |
+| `TEXT_ON_ACCENT` | `#ffffff` | text on a saturated semantic button |
+
+### 3.3 Accent / focus (neutral)
+| Token | Hex | Use |
+|---|---|---|
+| `ACCENT` | `#6e6e6e` | focus ring, active slider handle, checked outline |
+| `SELECTION_BG` | `#454545` | list/thumbnail selection, text selection bg |
+| `SELECTION_TEXT` | `#ffffff` | text over selection |
+
+Selection and focus are **neutral gray on purpose** — no blue/teal highlight, to
+avoid any color cast in a color-critical UI.
+
+### 3.4 Semantic colors (used sparingly; theme-independent)
+| Token | Hex | Use |
+|---|---|---|
+| `CH_R` / `CH_G` / `CH_B` | `#d06666` / `#66aa66` / `#6688d0` | per-channel R/G/B accents — **unifies** the two near-duplicate sets today (curve `#d06666…` vs sliders `#c66…`) |
+| `SUCCESS` | `#3a8f5a` * | dust "Done" / confirm accent (was `#2d7d46`) |
+| `SUCCESS_HOVER` / `SUCCESS_PRESSED` | `#46a368` / `#2f7449` | states |
+| `DANGER` | `#d9534f` | tether dot, "Stop" button |
+| `DANGER_HOVER` / `DANGER_PRESSED` | `#c9302c` / `#ac2925` | states |
+| `BAND_*` | red `#c0392b`, skin `#d8956b`, yellow `#c8b900`, green `#27ae60`, cyan `#17a8b4`, blue `#2f6fd0`, purple `#8e44ad` | color-band swatch fills — **unchanged** (they denote real hue bands) |
+
+### 3.5 Tether banner (re-themed from light → dark amber)
+Today the banner is amber-on-light (`#fff3cd`) and explicitly "for the light
+theme" — it must be redone for dark:
+| Token | Hex |
+|---|---|
+| `WARN_BG` | `#3a2f12` |
+| `WARN_BORDER` | `#5a4a1e` |
+| `WARN_TEXT` | `#e0c060` |
+| `WARN_TEXT_MUTED` | `#b89a48` |
+
+### 3.6 Icons
+| Token | Hex | Use |
+|---|---|---|
+| `ICON` | `#cfcfcf` | tint for monochrome toolbar icons |
+| `ICON_DISABLED` | `#6a6a6a` | disabled toolbar icons |
+
+### 3.7 Spacing / radius / type
+- Spacing scale: `2, 4, 6, 8, 12, 16` (px) — `SPACE_XS…SPACE_XL`.
+- Radius: `RADIUS_SM=3`, `RADIUS_MD=5`, `RADIUS_LG=8`.
+- Type scale (system font, no family change): `FS_CAPTION=11`, `FS_BODY=12`,
+  `FS_CONTROL=13`, `FS_HEADING=14`; weights normal/bold. Matches sizes already in
+  use, just centralized.
+
+### 3.8 Paint constants (non-QSS; see §6)
+- **UI chrome (follows theme):** `CURVE_BG=#232323`, `CURVE_GRID=#3d3d3d`,
+  `CURVE_GRID_MINOR=#333333`, `CURVE_IDENTITY=#5a5a5a`, `CURVE_NODE=#f0f0f0`,
+  `CURVE_NODE_OUTLINE=#222222`, `CURVE_NODE_DISABLED=#777777`,
+  `HIST_BG=(42,42,42)`, `HIST_R/G/B=(230,80,80)/(90,200,90)/(100,140,235)`,
+  `HIST_PEAK=(235,235,235)`.
+- **Image overlays (functional, values preserved):** `OVL_REF_FRAME`,
+  `OVL_SLICE`, `OVL_DIM`, `OVL_CROP_BORDER`, `OVL_HANDLE_FILL`,
+  `OVL_HANDLE_OUTLINE`, `OVL_DUST_STROKE`, `OVL_DUST_CURSOR`, `OVL_BWP_WHITE`,
+  `OVL_BWP_DENSE`, `OVL_AREA_LINE`, `OVL_AREA_FEATHER`, `OVL_COMP_GRID`,
+  `CURSOR_LIGHT`, `CURSOR_DARK` — exact current RGBA values (no visual change).
+
+## 4. Architecture
+
+### 4.1 The theme module — `src/ui/theme.py`
+Pure-PySide6 (imports only `PySide6.QtGui/QtCore`); imports **no** widgets (so no
+import cycle — widgets may freely `from ui.theme import …`). Exposes:
+
+- Token constants (§3) as module-level names / small grouped classes
+  (`class Paint:`, `class Overlay:`).
+- `qcolor(hex_or_rgba) -> QColor` and `c(token)` helpers.
+- `build_palette() -> QPalette` — a full dark Fusion palette (Window, Base,
+  Text, Button, Highlight, ToolTip, Disabled roles…) derived from §3 tokens.
+- `global_qss() -> str` — the central stylesheet (§5), built from tokens via an
+  f-string so there is exactly one place colors are defined.
+- `apply_theme(app, settings=None) -> None` — `app.setStyle("Fusion")`,
+  `app.setPalette(build_palette())`, `app.setStyleSheet(global_qss())`. (`settings`
+  reserved for a future theme pref; v1 always applies dark.)
+- `load_tinted_icon(abs_path, token=ICON) -> QIcon` — load a monochrome PNG, use
+  its alpha as a mask, paint it `token`; returns a `QIcon` with normal+disabled
+  pixmaps (disabled uses `ICON_DISABLED`). Used for the toolbar icons (§7).
+
+### 4.2 Install point — `src/main.py`
+The only correct global hook (audit-confirmed):
+```python
+app = QApplication(sys.argv)            # main.py:59 (unchanged)
+from ui.theme import apply_theme
+apply_theme(app)                        # NEW — before MainWindow() at line 63
+app.setWindowIcon(QIcon(_icon_path))    # unchanged
+window = MainWindow()
+```
+`Fusion` is **required**: the native Windows style ignores `QPalette` for menus,
+scrollbars, and many controls; Fusion honors it fully and is the standard base
+for a cross-platform custom dark theme.
+
+## 5. QSS coverage (control catalog → styled)
+
+`global_qss()` styles every control type the audit found, so nothing is left on
+the default look. Each rule's colors come from §3 tokens.
+
+- `QWidget` base (window bg/text), `QMainWindow`, `QDialog`, `QFrame`
+- `QLabel` (default `TEXT`; muted caption via `[muted="true"]` property or
+  `.caption` class — see §6.3)
+- `QPushButton` (+ `:hover/:pressed/:checked/:disabled`), `QToolButton`,
+  `QToolBar`
+- `QSlider` groove/handle (`ResettableSlider`, `CenteringSlider` inherit)
+- `QComboBox` (+ popup `QAbstractItemView`), `QLineEdit`, `QSpinBox`
+- `QCheckBox`, `QRadioButton` (indicators)
+- `QGroupBox` (title + border), `QListWidget` (item/`:selected`/`:hover`)
+- `QScrollArea`, `QScrollBar:vertical/horizontal` (handle/track)
+- `QProgressBar` (chunk uses `ACCENT`/`SUCCESS`)
+- `QMenuBar`, `QMenu` (item/`:selected`/separator), `QTabWidget`/`QTabBar`
+- `QTextEdit`, `QToolTip`, `QGraphicsView` (canvas bg = `CANVAS`)
+
+`QToolButton` text color is set by palette/QSS (not the current hardcoded
+`red/black/gray`); the toolbar's hardcoded `setStyleSheet` (image_preview.py:617)
+is removed.
+
+## 6. Inline-QSS & paint refactor
+
+### 6.1 Generic inline styles → deleted (covered by global QSS)
+Remove the per-widget `setStyleSheet` calls that only restated generic control
+styling: collapsible toggle (sliders_panel.py:86), export hints
+(export_dialog.py:129/154), dust labels (dust_panel.py:135/157/177/184/223/242),
+sliders captions (sliders_panel.py:295/332/351/471/583). Layout-only separator
+stylesheets (`margin-*`, no color) may stay as-is.
+
+### 6.2 Semantic / dynamic styles → keep, but source colors from tokens
+These stay local (they vary per item or carry meaning) but must inject token
+values instead of literals:
+- **Color-band swatches** (sliders_panel.py:508–525): fills from `BAND_*`,
+  borders from `BORDER`/`ACCENT`.
+- **Curve channel buttons** (curve_editor.py:362): bg `SURFACE`, text
+  `CH_R/G/B`/`TEXT`, checked outline `ACCENT`.
+- **Per-channel slider labels** (sliders_panel.py:480/489/498): `CH_R/G/B`.
+- **Tether banner** (tether_banner.py:21–42): `WARN_*` + `DANGER*`.
+- **Dust "Done" button** (dust_panel.py:231): `SUCCESS*`.
+
+### 6.3 Caption convention
+Replace the repeated `color:#888; font-size:11px` labels with a single mechanism:
+set a dynamic property `caption=true` on those `QLabel`s and style
+`QLabel[caption="true"] { color: TEXT_MUTED; font-size: 11px; }` in global QSS.
+One rule, no per-label stylesheet.
+
+### 6.4 Paint constants (QSS can't reach these)
+- **Curve editor** (`curve_editor.py` `paintEvent`, `_LINE_COLORS`, `_BTN_TINT`):
+  replace `QColor("#2b2b2b"/"#555"/"#3d3d3d"/"#666"/"#222"/"#f0f0f0"/"#777")` and
+  the channel dicts with `Paint.CURVE_*` and `CH_*`. (Already dark — values are
+  close; this just centralizes them.)
+- **Histogram** (`ccr_image.py:591/601-602/613`): numpy backdrop `180 →
+  Paint.HIST_BG`, channel colors `→ Paint.HIST_R/G/B`, peak `→ HIST_PEAK`. The
+  container QSS background (sliders_panel.py:257) is driven by the **same**
+  `HIST_BG` token so they never drift (audit flagged this coupling).
+- **Image overlays** (`image_preview.py` many lines, listed in §8): move every
+  `QColor(...)` literal to `Overlay.*` / `CURSOR_*` constants with **identical
+  values**. De-duplicates the crop (2792–2810) and area (3347–3410) handle pairs
+  that are byte-identical today. **No visual change** — these are tuned for
+  contrast against photos, not the UI theme.
+
+## 7. Icons
+
+The 5 toolbar PNGs (`auto`, `rotate-left`, `rotate-right`, `vertical-mirror`,
+`horizontal-mirror`) are pure-black line art on alpha → invisible on dark. Route
+their loading (image_preview.py:630–667) through `theme.load_tinted_icon(
+resource_path('icons/<name>.png'), ICON)`. `resource_path()` (dev + Nuitka) is
+unchanged. The app/window logo and `.ico/.icns` packaging icons are untouched.
+
+## 8. Integration points
+
+| File | Change |
+|---|---|
+| **add** `src/ui/theme.py` | tokens, `build_palette`, `global_qss`, `apply_theme`, `load_tinted_icon`, `Paint`, `Overlay`. |
+| `src/main.py` (after :59) | `from ui.theme import apply_theme; apply_theme(app)` before `MainWindow()`. |
+| `src/widgets/image_preview.py` | remove toolbar `setStyleSheet` (:617); tint toolbar icons (:630–667); move all overlay/cursor `QColor` literals (:30,54,278,491,1103,1164,2012,2037,2159,2431,2451,2765,2779,2792,2810,3347,3390,3410) to `Overlay.*`; set `QGraphicsView` bg = `CANVAS`. |
+| `src/widgets/curve_editor.py` | `paintEvent` + `_LINE_COLORS` + `_BTN_TINT` → `Paint.CURVE_*`/`CH_*`; channel-button QSS from tokens. |
+| `src/widgets/sliders_panel.py` | drop generic caption stylesheets (use `caption` property); channel labels → `CH_*`; band swatches → `BAND_*`/tokens; histogram container bg → `HIST_BG`. |
+| `src/widgets/dust_panel.py` | drop caption stylesheets; "Done" button → `SUCCESS*`. |
+| `src/widgets/tether_banner.py` | re-theme to `WARN_*` + `DANGER*`; update its "light theme" docstring. |
+| `src/widgets/export_dialog.py` | drop `color:gray` hint stylesheets (caption property). |
+| `src/core/ccr_image.py` | histogram numpy colors → `Paint.HIST_*`. |
+| **add** `tests/test_theme.py` | token/palette/QSS/icon-tint unit tests (§9). |
+
+`thumbnail_list.py` needs no color change (its `QPainter` only composites a
+pixmap); it inherits the global QSS for the list/scrollbar.
+
+## 9. Test plan
+
+### 9.1 Unit (`tests/test_theme.py`, offscreen pytest)
+- `build_palette()` returns a `QPalette` with `Window`/`Base`/`Text` matching the
+  tokens; `apply_theme(app)` sets style name `Fusion` and a non-empty stylesheet.
+- `global_qss()` contains a rule for each control type in §5 and references no
+  raw hex that isn't a token value (guard against re-introducing literals).
+- `load_tinted_icon()` on a black test PNG yields a non-null icon whose pixmap’s
+  opaque pixels equal `ICON` (and disabled pixmap equals `ICON_DISABLED`).
+- Histogram coupling: the QSS container background value equals `HIST_BG`.
+- Overlay constants equal the pre-refactor literals (regression table) — proves
+  "no visual change" for on-image overlays.
+
+### 9.2 Visual (qt-testing skill, default platform for real fonts)
+Capture each widget **before** (current `main`) and **after**, read the PNGs, and
+confirm: dark neutral surfaces, legible text (≥ AA contrast for body text on
+`PANEL`), visible toolbar icons, themed scrollbars/menus, histogram on dark
+backdrop, and that **on-image overlays are unchanged**. Targets: `MainWindow`,
+`SlidersPanel`, `ImagePreview` (incl. toolbar), `CurveEditor`, `ThumbnailList`,
+`DustRemovalPanel`, `ExportSettingsDialog`, `TetherBanner`, menu bar.
+
+### 9.3 Regression
+- `python tests/run_tests.py` (full offscreen suite) stays green.
+- App launches (`python src/main.py`) with no QSS parse warnings.
+
+## 10. Refinement (v1) — resolved decisions, risks
+
+1. **Fusion is mandatory**, not optional — without it the dark palette won't take
+   on native Windows menus/scrollbars. Accepted side effect: Fusion changes
+   control metrics slightly vs. native; acceptable for a deliberate custom look.
+2. **Palette alone is insufficient** — ~30 inline stylesheets override it
+   per-widget, so the inline refactor (§6) is part of the core work, not optional
+   polish. Global QSS + palette + inline cleanup together.
+3. **Chrome vs. overlay split** is the key correctness call: UI-surface paint
+   (curve canvas, histogram) adopts theme tokens; on-image overlays keep their
+   functional RGBA. Mixing these up would either wash out overlays on photos or
+   leave a light histogram. The §9.1 regression table locks overlay values.
+4. **Histogram two-sided coupling** (numpy fill ↔ QSS container) is collapsed to a
+   single `HIST_BG` token referenced from both sites.
+5. **Channel-color unification**: adopt the curve editor's `#d06666/#66aa66/
+   #6688d0` as canonical `CH_*` and retire the near-duplicate `#c66/#6a6/#66c`.
+6. **No literals rule**: after the refactor, a grep for hex colors in
+   `src/widgets` and `src/ui` should return only token definitions / the
+   `theme.py` module (enforced loosely by the §9.1 QSS test).
+7. **Icons tinted, not replaced** — keeps the build/`resource_path` and Nuitka
+   bundling untouched; no new assets.
+8. **Light theme / toggle deferred** — `apply_theme(app, settings)` and the token
+   table make a future light variant a localized change, but it is out of scope.
+
+## 11. Files touched / added (summary)
+- **add**: `src/ui/theme.py`, `tests/test_theme.py`
+- **edit**: `src/main.py`, `src/widgets/image_preview.py`,
+  `src/widgets/curve_editor.py`, `src/widgets/sliders_panel.py`,
+  `src/widgets/dust_panel.py`, `src/widgets/tether_banner.py`,
+  `src/widgets/export_dialog.py`, `src/core/ccr_image.py`

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -14,6 +14,7 @@ from core.ccr_processor import (adjust_image, adjust_image_opencl,
                                 apply_area_layers, apply_crop_to_image,
                                 apply_dust_removal)
 from core import color_management
+from ui import theme
 
 # Import optional libraries with fallbacks
 try:
@@ -588,7 +589,8 @@ class CCRImage:
         hist_height = 150
         hist_width = 256
         alpha = 0.33  # transparency for histogram curves
-        hist_img_f = np.full((hist_height, hist_width, 3), 180.0, dtype=np.float32)
+        hist_img_f = np.full((hist_height, hist_width, 3),
+                             float(theme.Paint.HIST_BG[0]), dtype=np.float32)
 
         # Find the global max value across all channels for adaptive scaling
         max_val = max([hist[c].mean() for c in hist]) * 6
@@ -599,7 +601,8 @@ class CCRImage:
         # RGB order: hist_img is rendered via QImage Format_RGB888, not cv2.imshow,
         # so colors must be RGB — (255,0,0) draws the R-data curve in red.
         for channel, color in zip(('r', 'g', 'b'),
-                                  ((255, 0, 0), (0, 255, 0), (0, 0, 255))):
+                                  (theme.Paint.HIST_R, theme.Paint.HIST_G,
+                                   theme.Paint.HIST_B)):
             h_scaled = np.clip((hist[channel] / scale) * (hist_height - 1),
                                0, hist_height - 1)
             col_tops = hist_height - h_scaled.astype(np.int32)  # (256,)
@@ -610,7 +613,7 @@ class CCRImage:
 
         hist_img = hist_img_f.astype(np.uint8)
         # Where all three channels overlap, set to white
-        hist_img[masks[0] & masks[1] & masks[2]] = (235, 235, 235)
+        hist_img[masks[0] & masks[1] & masks[2]] = theme.Paint.HIST_PEAK
         hist_img = np.ascontiguousarray(hist_img)
 
         self.histogram_image = QPixmap.fromImage(self.generate_qimage_from_np_array_8(hist_img))

--- a/src/main.py
+++ b/src/main.py
@@ -57,8 +57,9 @@ def main():
     from ui.main_window import MainWindow
 
     app = QApplication(sys.argv)
-    from ui.theme import apply_theme, apply_windows_dark_titlebar
+    from ui.theme import apply_theme, apply_windows_dark_titlebar, install_dark_titlebar_filter
     apply_theme(app)  # neutral dark theme (Fusion + palette + global QSS)
+    install_dark_titlebar_filter(app)  # dark title bars for dialogs / message boxes
     _icon_path = os.path.join(os.path.dirname(__file__), 'icons', 'freeccr_logo.png')
     app.setWindowIcon(QIcon(_icon_path))
     print("Starting FreeCCR...")

--- a/src/main.py
+++ b/src/main.py
@@ -57,7 +57,7 @@ def main():
     from ui.main_window import MainWindow
 
     app = QApplication(sys.argv)
-    from ui.theme import apply_theme
+    from ui.theme import apply_theme, apply_windows_dark_titlebar
     apply_theme(app)  # neutral dark theme (Fusion + palette + global QSS)
     _icon_path = os.path.join(os.path.dirname(__file__), 'icons', 'freeccr_logo.png')
     app.setWindowIcon(QIcon(_icon_path))
@@ -65,6 +65,7 @@ def main():
     window = MainWindow()
     print("MainWindow created, setting up UI...")
 
+    apply_windows_dark_titlebar(window)  # dark native title bar (Win10/11)
     window.show()
     sys.exit(app.exec())
 

--- a/src/main.py
+++ b/src/main.py
@@ -57,6 +57,8 @@ def main():
     from ui.main_window import MainWindow
 
     app = QApplication(sys.argv)
+    from ui.theme import apply_theme
+    apply_theme(app)  # neutral dark theme (Fusion + palette + global QSS)
     _icon_path = os.path.join(os.path.dirname(__file__), 'icons', 'freeccr_logo.png')
     app.setWindowIcon(QIcon(_icon_path))
     print("Starting FreeCCR...")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -24,6 +24,7 @@ import webbrowser
 from utils.unicode_path_utils import normalize_unicode_path, validate_unicode_path
 from utils.update_check import (fetch_latest_release, parse_version,
                                 should_offer_update, REPO_URL)
+from ui import theme
 
 class UpdateCheckWorker(QObject):
     """Fetches the latest GitHub release off the GUI thread.
@@ -59,10 +60,9 @@ class UpdateAvailableDialog(QDialog):
     def __init__(self, parent, release, current_version):
         super().__init__(parent)
         self.setWindowTitle("Update Available")
-        self.setMinimumWidth(460)
+        self.setMinimumWidth(theme.DIALOG_W_MD)
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(24, 20, 24, 20)
-        layout.setSpacing(18)
+        theme.apply_panel_spacing(layout, margin=theme.SPACE_XL, spacing=theme.GAP_SECTION)
         message = QLabel(
             f"A new version of FreeCCR is available: "
             f"<b>{html.escape(release['tag'])}</b><br>"
@@ -70,13 +70,13 @@ class UpdateAvailableDialog(QDialog):
         message.setWordWrap(True)
         layout.addWidget(message)
         buttons = QHBoxLayout()
-        buttons.setSpacing(10)
+        buttons.setSpacing(theme.GAP_BTN)
         update_btn = QPushButton("Update")
         update_btn.setDefault(True)
         remind_btn = QPushButton("Remind Me Later")
         skip_btn = QPushButton("Skip This Version")
         for btn in (update_btn, remind_btn, skip_btn):
-            btn.setMinimumHeight(30)
+            btn.setMinimumHeight(theme.CONTROL_H)
         update_btn.clicked.connect(lambda: self.done(self.UPDATE))
         remind_btn.clicked.connect(lambda: self.done(self.REMIND))
         skip_btn.clicked.connect(lambda: self.done(self.SKIP))
@@ -121,6 +121,8 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(self.central_widget)
 
         self.layout = QHBoxLayout(self.central_widget)
+        self.layout.setSpacing(theme.GAP_PANEL)
+        self.layout.setContentsMargins(0, 0, 0, 0)
 
         self.thumbnail_list = ThumbnailList(self.on_image_selected)
         self.thumbnail_list.setFixedWidth(216)
@@ -478,7 +480,9 @@ class MainWindow(QMainWindow):
     def show_licenses_dialog(self):
         dialog = QDialog(self)
         dialog.setWindowTitle("Third-Party Licenses")
+        dialog.setMinimumWidth(theme.DIALOG_W_MD)
         layout = QVBoxLayout(dialog)
+        theme.apply_panel_spacing(layout)
 
         text_edit = QTextEdit(dialog)
         text_edit.setReadOnly(True)
@@ -981,8 +985,9 @@ class ActivationDialog(QDialog):
     def __init__(self, parent=None, allow_deactivate=False):
         super().__init__(parent)
         self.setWindowTitle("Activate FreeCCR")
-        self.setMinimumWidth(350)
+        self.setMinimumWidth(theme.DIALOG_W_MD)
         layout = QVBoxLayout(self)
+        theme.apply_panel_spacing(layout)
         self.allow_deactivate = allow_deactivate
 
         layout.addWidget(QLabel("Please activate your software to continue."))

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -315,6 +315,70 @@ def load_tinted_icon(abs_path: str, color: str = ICON,
     return icon
 
 
+_BTN_ROLE_QSS = {
+    # Primary = the weighty commit on a surface. NEUTRAL elevation (no hue) so it
+    # leads without adding colour to a colour-critical UI.
+    "primary": (
+        "QPushButton { background-color: %(s_active)s; color: %(text)s;"
+        " border: 1px solid %(border_strong)s; border-radius: %(r)dpx;"
+        " padding: 5px 12px; font-weight: bold; }"
+        " QPushButton:hover { background-color: %(p_hover)s; }"
+        " QPushButton:pressed { background-color: %(border)s; }"
+        " QPushButton:disabled { background-color: %(surface)s; color: %(disabled)s;"
+        " border-color: %(border)s; }"
+    ),
+    # Danger = irreversible data loss. The only saturated colour in normal UI;
+    # restrained at rest (red text + border), fills red on hover.
+    "danger": (
+        "QPushButton { background-color: %(surface)s; color: %(danger)s;"
+        " border: 1px solid %(danger)s; border-radius: %(r)dpx; padding: 4px 12px; }"
+        " QPushButton:hover { background-color: %(danger)s; color: #ffffff; }"
+        " QPushButton:pressed { background-color: %(danger_pressed)s; color: #ffffff; }"
+        " QPushButton:disabled { background-color: %(surface)s; color: %(disabled)s;"
+        " border-color: %(border)s; }"
+    ),
+    # Glyph-only danger (e.g. a ✕ remove): no rest emphasis, red glyph, fills on hover.
+    "danger_glyph": (
+        "QPushButton { background-color: transparent; color: %(danger)s;"
+        " border: 1px solid %(border)s; border-radius: %(r)dpx; padding: 4px 8px; }"
+        " QPushButton:hover { background-color: %(danger)s; color: #ffffff;"
+        " border-color: %(danger)s; }"
+        " QPushButton:pressed { background-color: %(danger_pressed)s; color: #ffffff; }"
+        " QPushButton:disabled { color: %(disabled)s; border-color: %(border)s; }"
+    ),
+}
+
+
+def style_button(btn, role, *, default=False, glyph_only=False) -> None:
+    """Give a QPushButton a semantic role so colour carries meaning, not decoration:
+
+    - ``"primary"`` — the surface's weighty commit (neutral elevation, bold):
+      Convert Current, Sync, Export, Done.
+    - ``"danger"``  — irreversible data loss (red): Reset, Reset Curve, Clear all.
+      Pass ``glyph_only=True`` for a glyph button like a ✕ remove.
+    - ``"secondary"`` / ``None`` — the default neutral button (clears any role).
+
+    ``default=True`` also makes it the dialog's default button (focus ring). Plain
+    QPushButtons honour their own stylesheet over the global rule, so the role
+    reliably takes effect.
+    """
+    role = (role or "").lower()
+    vals = {
+        "r": RADIUS_SM, "surface": SURFACE, "s_active": SURFACE_ACTIVE,
+        "p_hover": "#505050", "border": BORDER, "border_strong": BORDER_STRONG,
+        "text": TEXT, "disabled": TEXT_DISABLED,
+        "danger": DANGER, "danger_pressed": DANGER_PRESSED,
+    }
+    if role == "primary":
+        btn.setStyleSheet(_BTN_ROLE_QSS["primary"] % vals)
+    elif role == "danger":
+        btn.setStyleSheet(_BTN_ROLE_QSS["danger_glyph" if glyph_only else "danger"] % vals)
+    else:
+        btn.setStyleSheet("")
+    if default:
+        btn.setDefault(True)
+
+
 def apply_theme(app, settings=None) -> None:
     """Install the global dark theme on the QApplication.
 

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -10,8 +10,9 @@ See ``spec/visual-redesign.md`` for the design rationale and token table.
 
 import sys
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QObject, QEvent
 from PySide6.QtGui import QColor, QPalette, QIcon, QPixmap, QPainter
+from PySide6.QtWidgets import QWidget
 
 # --------------------------------------------------------------------------- #
 # 3.1 Surfaces (neutral grays — zero hue)
@@ -350,3 +351,42 @@ def apply_windows_dark_titlebar(widget) -> bool:
         return True
     except Exception:
         return False
+
+
+class _DarkTitleBarFilter(QObject):
+    """App-level filter that darkens each top-level window's title bar on show.
+
+    Covers dialogs created on demand (message boxes, the export / loading / about
+    dialogs) without touching every call site. Windows-only; inert elsewhere.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._seen = set()
+
+    def eventFilter(self, obj, event):
+        if (event.type() == QEvent.Type.Show
+                and isinstance(obj, QWidget) and obj.isWindow()):
+            key = id(obj)
+            if key not in self._seen:
+                self._seen.add(key)
+                apply_windows_dark_titlebar(obj)
+        return False
+
+
+_dark_titlebar_filter = None
+
+
+def install_dark_titlebar_filter(app) -> None:
+    """Install an app-wide filter so every top-level window (dialogs, message
+    boxes) gets a dark native title bar when shown.
+
+    No-op off Windows or if already installed. Call once after ``apply_theme()``
+    from the app entry point (kept out of ``apply_theme`` so the test suite,
+    which themes a shared QApplication, isn't given a persistent filter).
+    """
+    global _dark_titlebar_filter
+    if sys.platform != "win32" or _dark_titlebar_filter is not None:
+        return
+    _dark_titlebar_filter = _DarkTitleBarFilter(app)
+    app.installEventFilter(_dark_titlebar_filter)

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -8,6 +8,8 @@ image color). Installed once at app start via ``apply_theme(app)`` (see
 See ``spec/visual-redesign.md`` for the design rationale and token table.
 """
 
+import sys
+
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QPalette, QIcon, QPixmap, QPainter
 
@@ -319,3 +321,32 @@ def apply_theme(app, settings=None) -> None:
     app.setStyle("Fusion")
     app.setPalette(build_palette())
     app.setStyleSheet(global_qss())
+
+
+def apply_windows_dark_titlebar(widget) -> bool:
+    """Make a top-level window's native title bar dark on Windows 10/11.
+
+    Qt's palette/QSS don't reach the OS-drawn title bar (the non-client area), so
+    it stays light against the dark theme. This sets the DWM immersive-dark-mode
+    attribute on the window's HWND. Apply it to each top-level window (main window,
+    custom dialogs) before showing it. No-op off Windows or if unsupported.
+    Returns True if the attribute call was made.
+    """
+    if sys.platform != "win32":
+        return False
+    try:
+        import ctypes
+
+        # winId() forces creation of the native window handle.
+        hwnd = int(widget.winId())
+        if not hwnd:
+            return False
+        value = ctypes.c_int(1)
+        size = ctypes.sizeof(value)
+        # DWMWA_USE_IMMERSIVE_DARK_MODE = 20 (Win10 20H1+/Win11); 19 on older builds.
+        dwm = ctypes.windll.dwmapi
+        if dwm.DwmSetWindowAttribute(hwnd, 20, ctypes.byref(value), size) != 0:
+            dwm.DwmSetWindowAttribute(hwnd, 19, ctypes.byref(value), size)
+        return True
+    except Exception:
+        return False

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -70,6 +70,24 @@ SPACE_XS, SPACE_SM, SPACE_MD, SPACE_LG, SPACE_XL = 2, 4, 6, 8, 12
 RADIUS_SM, RADIUS_MD, RADIUS_LG = 3, 5, 8
 FS_CAPTION, FS_BODY, FS_CONTROL, FS_HEADING = 11, 12, 13, 14
 
+# 3.7b Layout rhythm — the spacing "design language". Use these intent-named gaps
+# in Python layout code (setSpacing / setContentsMargins / addSpacing) so spacing
+# is consistent, never an ad-hoc literal.
+GAP_TIGHT = SPACE_XS      # 2  — within one control row (label | control | value)
+GAP_ROW = SPACE_SM        # 4  — between rows inside a group (intra-group rhythm)
+GAP_BTN = SPACE_LG        # 8  — between sibling buttons in a button row (canonical)
+GAP_PANEL = SPACE_LG      # 8  — panel/dialog content margin; inter-column gutter
+GAP_SECTION = SPACE_XL    # 12 — between functional groups (usually with a separator)
+
+# Standard control geometry (one scale instead of a 22/24/28/30/42 zoo).
+CONTROL_H = 28            # sliders, combos, labels, normal & secondary buttons, tabs
+CONTROL_H_LG = 36         # weighty primary commits (Done, Export)
+GLYPH_W = 28             # square glyph buttons (✕ remove / clear) — one width
+LABEL_COL_W = 90          # right-aligned label gutter — fits the longest label ("Subtracted Sat")
+VALUE_COL_W = 40          # left-aligned value gutter in a 3-column row
+DIALOG_W_SM = 280         # progress / simple dialogs
+DIALOG_W_MD = 440         # forms (export, update, sync)
+
 
 class Paint:
     """3.8 UI-chrome paint constants (non-QSS; follow the dark theme)."""
@@ -377,6 +395,37 @@ def style_button(btn, role, *, default=False, glyph_only=False) -> None:
         btn.setStyleSheet("")
     if default:
         btn.setDefault(True)
+
+
+def apply_panel_spacing(layout, *, margin=GAP_PANEL, spacing=GAP_ROW):
+    """Conform a panel/dialog layout to the standard rhythm in one call."""
+    layout.setContentsMargins(margin, margin, margin, margin)
+    layout.setSpacing(spacing)
+    return layout
+
+
+def apply_button_row(layout, *, spacing=GAP_BTN):
+    """Conform a horizontal button row: canonical button gap, no extra margins."""
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(spacing)
+    return layout
+
+
+def section_separator():
+    """The one canonical horizontal rule between functional regions."""
+    from PySide6.QtWidgets import QFrame
+    sep = QFrame()
+    sep.setFrameShape(QFrame.HLine)
+    sep.setFrameShadow(QFrame.Sunken)
+    sep.setStyleSheet(
+        f"color: {BORDER}; margin-top: {SPACE_LG}px; margin-bottom: {SPACE_SM}px;")
+    return sep
+
+
+def section_header_qss():
+    """QSS for a group-anchor section header (bold caption, full-strength text)."""
+    return (f"color: {TEXT}; font-size: {FS_CAPTION}px; font-weight: bold; "
+            f"letter-spacing: 0.5px; margin-bottom: {SPACE_XS}px;")
 
 
 def apply_theme(app, settings=None) -> None:

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -1,0 +1,321 @@
+"""FreeCCR UI theme — single source of truth for color, spacing, radius, type.
+
+Neutral dark, color-critical (no hue cast so the UI never biases perception of
+image color). Installed once at app start via ``apply_theme(app)`` (see
+``src/main.py``). Pure PySide6 — imports no FreeCCR widgets, so any widget may
+``from ui.theme import ...`` without an import cycle.
+
+See ``spec/visual-redesign.md`` for the design rationale and token table.
+"""
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QPalette, QIcon, QPixmap, QPainter
+
+# --------------------------------------------------------------------------- #
+# 3.1 Surfaces (neutral grays — zero hue)
+# --------------------------------------------------------------------------- #
+WINDOW = "#1e1e1e"          # app background, menu bar
+CANVAS = "#1a1a1a"          # image viewport behind the photo (QGraphicsView)
+PANEL = "#2a2a2a"           # side panels, dialogs, group backgrounds
+SURFACE = "#333333"         # inputs, combos, line edits, unchecked buttons
+SURFACE_HOVER = "#3c3c3c"   # hover state
+SURFACE_ACTIVE = "#454545"  # pressed / checked / selected background
+BORDER = "#3c3c3c"          # 1px control borders, separators
+BORDER_STRONG = "#5a5a5a"   # emphasized borders
+
+# 3.2 Text
+TEXT = "#e0e0e0"
+TEXT_MUTED = "#9a9a9a"
+TEXT_DISABLED = "#6a6a6a"
+TEXT_ON_ACCENT = "#ffffff"
+
+# 3.3 Accent / focus (neutral — no colored highlight)
+ACCENT = "#6e6e6e"
+SELECTION_BG = "#454545"
+SELECTION_TEXT = "#ffffff"
+
+# 3.4 Semantic colors (used sparingly; theme-independent)
+CH_R = "#d06666"
+CH_G = "#66aa66"
+CH_B = "#6688d0"
+SUCCESS = "#3a8f5a"
+SUCCESS_HOVER = "#46a368"
+SUCCESS_PRESSED = "#2f7449"
+DANGER = "#d9534f"
+DANGER_HOVER = "#c9302c"
+DANGER_PRESSED = "#ac2925"
+BAND_COLORS = {
+    "red": "#c0392b", "skin": "#d8956b", "yellow": "#c8b900",
+    "green": "#27ae60", "cyan": "#17a8b4", "blue": "#2f6fd0", "purple": "#8e44ad",
+}
+
+# 3.5 Tether banner (dark amber — was light-themed)
+WARN_BG = "#3a2f12"
+WARN_BORDER = "#5a4a1e"
+WARN_TEXT = "#e0c060"
+WARN_TEXT_MUTED = "#b89a48"
+
+# 3.6 Icons
+ICON = "#cfcfcf"
+ICON_DISABLED = "#6a6a6a"
+
+# 3.7 Spacing / radius / type
+SPACE_XS, SPACE_SM, SPACE_MD, SPACE_LG, SPACE_XL = 2, 4, 6, 8, 12
+RADIUS_SM, RADIUS_MD, RADIUS_LG = 3, 5, 8
+FS_CAPTION, FS_BODY, FS_CONTROL, FS_HEADING = 11, 12, 13, 14
+
+
+class Paint:
+    """3.8 UI-chrome paint constants (non-QSS; follow the dark theme)."""
+    CURVE_BG = "#232323"
+    CURVE_GRID = "#3d3d3d"
+    CURVE_GRID_MINOR = "#333333"
+    CURVE_IDENTITY = "#5a5a5a"
+    CURVE_NODE = "#f0f0f0"
+    CURVE_NODE_OUTLINE = "#222222"
+    CURVE_NODE_DISABLED = "#777777"
+    # Histogram (numpy-rendered) — kept as RGB tuples to match ccr_image.py.
+    HIST_BG = (42, 42, 42)            # == PANEL #2a2a2a (keep container in sync)
+    HIST_R = (230, 80, 80)
+    HIST_G = (90, 200, 90)
+    HIST_B = (100, 140, 235)
+    HIST_PEAK = (235, 235, 235)
+
+
+class Overlay:
+    """3.8 On-image overlay constants (functional; values preserved verbatim).
+
+    These sit over arbitrary photos and are tuned for contrast against image
+    content, NOT the UI theme — do not re-tint to match the dark surfaces.
+    """
+    CURSOR_LIGHT = (255, 255, 255)
+    CURSOR_DARK = (25, 25, 25)
+    BWP_WHITE = (0, 100, 255, 140)
+    BWP_DENSE = (255, 140, 0, 140)
+    COMP_GRID = (0, 80, 0, 80)
+    REF_FRAME = (255, 0, 0, 180)
+    REF_FRAME_DRAG = (255, 0, 0, 120)
+    SLICE = (0, 200, 255)            # alpha applied at call site (150 ghost / 235)
+    DIM = (0, 0, 0, 80)
+    DIM_CROP = (0, 0, 0, 110)
+    BLACK_FILL = (0, 0, 0)
+    DUST_STROKE = (255, 40, 40, 150)
+    DUST_CURSOR = (255, 255, 255, 220)
+    CROP_BORDER = (255, 255, 255, 220)
+    HANDLE_FILL = (255, 255, 255, 235)
+    HANDLE_OUTLINE = (30, 30, 30, 230)
+    AREA_LINE = (255, 255, 255, 220)
+    AREA_FEATHER = (255, 255, 255, 120)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def qcolor(v) -> QColor:
+    """Coerce a hex string, (r,g,b[,a]) tuple, or QColor into a QColor."""
+    if isinstance(v, QColor):
+        return v
+    if isinstance(v, (tuple, list)):
+        return QColor(*v)
+    return QColor(v)
+
+
+def build_palette() -> QPalette:
+    """A full dark Fusion palette derived from the tokens above."""
+    pal = QPalette()
+    pal.setColor(QPalette.Window, qcolor(WINDOW))
+    pal.setColor(QPalette.WindowText, qcolor(TEXT))
+    pal.setColor(QPalette.Base, qcolor(SURFACE))
+    pal.setColor(QPalette.AlternateBase, qcolor(PANEL))
+    pal.setColor(QPalette.ToolTipBase, qcolor(PANEL))
+    pal.setColor(QPalette.ToolTipText, qcolor(TEXT))
+    pal.setColor(QPalette.Text, qcolor(TEXT))
+    pal.setColor(QPalette.Button, qcolor(SURFACE))
+    pal.setColor(QPalette.ButtonText, qcolor(TEXT))
+    pal.setColor(QPalette.BrightText, qcolor("#ffffff"))
+    pal.setColor(QPalette.Highlight, qcolor(SELECTION_BG))
+    pal.setColor(QPalette.HighlightedText, qcolor(SELECTION_TEXT))
+    pal.setColor(QPalette.Link, qcolor("#9ab0c0"))
+    try:
+        pal.setColor(QPalette.PlaceholderText, qcolor(TEXT_MUTED))
+    except AttributeError:
+        pass  # older Qt without PlaceholderText role
+    for role in (QPalette.WindowText, QPalette.Text, QPalette.ButtonText):
+        pal.setColor(QPalette.Disabled, role, qcolor(TEXT_DISABLED))
+    pal.setColor(QPalette.Disabled, QPalette.Highlight, qcolor(SURFACE_ACTIVE))
+    pal.setColor(QPalette.Disabled, QPalette.HighlightedText, qcolor(TEXT_DISABLED))
+    return pal
+
+
+# QSS uses { } literally, so format with %(name)s (QSS has no literal '%').
+_QSS_TEMPLATE = """
+QToolTip {
+    color: %(text)s; background-color: %(panel)s;
+    border: 1px solid %(border)s; padding: 3px 6px;
+}
+
+QPushButton {
+    background-color: %(surface)s; color: %(text)s;
+    border: 1px solid %(border)s; border-radius: %(r_sm)dpx;
+    padding: 4px 10px;
+}
+QPushButton:hover { background-color: %(surface_hover)s; }
+QPushButton:pressed, QPushButton:checked { background-color: %(surface_active)s; }
+QPushButton:disabled { color: %(text_disabled)s; border-color: %(border)s; }
+
+QToolBar { background-color: %(window)s; border: none; spacing: 2px; padding: 2px; }
+QToolButton {
+    background-color: transparent; color: %(text)s;
+    border: none; border-radius: %(r_sm)dpx; padding: 3px;
+}
+QToolButton:hover { background-color: %(surface_hover)s; }
+QToolButton:pressed, QToolButton:checked { background-color: %(surface_active)s; }
+QToolButton:disabled { color: %(text_disabled)s; }
+
+QComboBox {
+    background-color: %(surface)s; color: %(text)s;
+    border: 1px solid %(border)s; border-radius: %(r_sm)dpx; padding: 2px 6px;
+}
+QComboBox:hover { border-color: %(border_strong)s; }
+QComboBox::drop-down { border: none; width: 18px; }
+QComboBox QAbstractItemView {
+    background-color: %(panel)s; color: %(text)s;
+    border: 1px solid %(border)s;
+    selection-background-color: %(selection_bg)s;
+    selection-color: %(selection_text)s;
+}
+
+QLineEdit, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {
+    background-color: %(surface)s; color: %(text)s;
+    border: 1px solid %(border)s; border-radius: %(r_sm)dpx; padding: 2px 4px;
+    selection-background-color: %(selection_bg)s;
+    selection-color: %(selection_text)s;
+}
+QLineEdit:focus, QSpinBox:focus, QTextEdit:focus { border-color: %(accent)s; }
+
+QGroupBox {
+    border: 1px solid %(border)s; border-radius: %(r_md)dpx;
+    margin-top: 8px; padding-top: 4px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin; left: 8px; padding: 0 4px;
+    color: %(text_muted)s;
+}
+
+QListWidget, QListView, QTreeView {
+    background-color: %(panel)s; color: %(text)s;
+    border: 1px solid %(border)s; border-radius: %(r_sm)dpx;
+}
+QListWidget::item:hover, QListView::item:hover { background-color: %(surface_hover)s; }
+QListWidget::item:selected, QListView::item:selected {
+    background-color: %(selection_bg)s; color: %(selection_text)s;
+}
+
+QScrollArea { border: none; background: transparent; }
+QScrollBar:vertical { background-color: %(window)s; width: 12px; margin: 0; }
+QScrollBar::handle:vertical {
+    background-color: %(surface_active)s; min-height: 24px;
+    border-radius: 6px; margin: 2px;
+}
+QScrollBar::handle:vertical:hover { background-color: %(border_strong)s; }
+QScrollBar:horizontal { background-color: %(window)s; height: 12px; margin: 0; }
+QScrollBar::handle:horizontal {
+    background-color: %(surface_active)s; min-width: 24px;
+    border-radius: 6px; margin: 2px;
+}
+QScrollBar::handle:horizontal:hover { background-color: %(border_strong)s; }
+QScrollBar::add-line, QScrollBar::sub-line { width: 0; height: 0; }
+QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
+
+QProgressBar {
+    background-color: %(surface)s; color: %(text)s;
+    border: 1px solid %(border)s; border-radius: %(r_sm)dpx;
+    text-align: center;
+}
+QProgressBar::chunk { background-color: %(accent)s; border-radius: %(r_sm)dpx; }
+
+QSlider::groove:horizontal {
+    height: 4px; background-color: %(surface)s; border-radius: 2px;
+}
+QSlider::sub-page:horizontal { background-color: %(border_strong)s; border-radius: 2px; }
+QSlider::handle:horizontal {
+    background-color: %(text_muted)s; width: 12px; height: 12px;
+    margin: -5px 0; border-radius: 6px;
+}
+QSlider::handle:horizontal:hover { background-color: %(text)s; }
+
+QMenuBar { background-color: %(window)s; color: %(text)s; }
+QMenuBar::item { background: transparent; padding: 4px 8px; }
+QMenuBar::item:selected { background-color: %(surface_hover)s; }
+QMenu { background-color: %(panel)s; color: %(text)s; border: 1px solid %(border)s; }
+QMenu::item { padding: 4px 22px; }
+QMenu::item:selected { background-color: %(selection_bg)s; color: %(selection_text)s; }
+QMenu::item:disabled { color: %(text_disabled)s; }
+QMenu::separator { height: 1px; background-color: %(border)s; margin: 4px 10px; }
+
+QCheckBox, QRadioButton { color: %(text)s; spacing: 6px; }
+QCheckBox:disabled, QRadioButton:disabled { color: %(text_disabled)s; }
+
+QTabWidget::pane { border: 1px solid %(border)s; }
+QTabBar::tab {
+    background-color: %(surface)s; color: %(text_muted)s;
+    padding: 4px 10px; border: 1px solid %(border)s; border-bottom: none;
+}
+QTabBar::tab:selected { background-color: %(panel)s; color: %(text)s; }
+
+QGraphicsView { background-color: %(canvas)s; border: none; }
+
+QLabel[caption="true"] { color: %(text_muted)s; font-size: %(fs_caption)dpx; }
+"""
+
+
+def global_qss() -> str:
+    """The central stylesheet, built from the tokens above (one source of truth)."""
+    return _QSS_TEMPLATE % {
+        "window": WINDOW, "canvas": CANVAS, "panel": PANEL, "surface": SURFACE,
+        "surface_hover": SURFACE_HOVER, "surface_active": SURFACE_ACTIVE,
+        "border": BORDER, "border_strong": BORDER_STRONG,
+        "text": TEXT, "text_muted": TEXT_MUTED, "text_disabled": TEXT_DISABLED,
+        "accent": ACCENT, "selection_bg": SELECTION_BG, "selection_text": SELECTION_TEXT,
+        "r_sm": RADIUS_SM, "r_md": RADIUS_MD, "fs_caption": FS_CAPTION,
+    }
+
+
+def load_tinted_icon(abs_path: str, color: str = ICON,
+                     disabled_color: str = ICON_DISABLED) -> QIcon:
+    """Load a monochrome PNG and recolor it using its alpha as a mask.
+
+    The toolbar icons are pure-black line art on transparency (invisible on a
+    dark theme); this paints them ``color`` (and a dimmer ``disabled_color`` for
+    the disabled state) so they read on dark surfaces.
+    """
+    base = QPixmap(abs_path)
+    if base.isNull():
+        return QIcon(abs_path)
+
+    def _tint(pm: QPixmap, col: str) -> QPixmap:
+        out = QPixmap(pm.size())
+        out.fill(Qt.transparent)
+        p = QPainter(out)
+        p.drawPixmap(0, 0, pm)
+        p.setCompositionMode(QPainter.CompositionMode_SourceIn)
+        p.fillRect(out.rect(), qcolor(col))
+        p.end()
+        return out
+
+    icon = QIcon()
+    icon.addPixmap(_tint(base, color), QIcon.Normal)
+    icon.addPixmap(_tint(base, disabled_color), QIcon.Disabled)
+    return icon
+
+
+def apply_theme(app, settings=None) -> None:
+    """Install the global dark theme on the QApplication.
+
+    Fusion is required: the native Windows/macOS style ignores QPalette for many
+    controls; Fusion honors it fully. Call once, before building the main window.
+    ``settings`` is reserved for a future theme preference; v1 always applies dark.
+    """
+    app.setStyle("Fusion")
+    app.setPalette(build_palette())
+    app.setStyleSheet(global_qss())

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -8,10 +8,12 @@ image color). Installed once at app start via ``apply_theme(app)`` (see
 See ``spec/visual-redesign.md`` for the design rationale and token table.
 """
 
+import os
 import sys
+import tempfile
 
 from PySide6.QtCore import Qt, QObject, QEvent
-from PySide6.QtGui import QColor, QPalette, QIcon, QPixmap, QPainter
+from PySide6.QtGui import QColor, QPalette, QIcon, QPixmap, QPainter, QPen
 from PySide6.QtWidgets import QWidget
 
 # --------------------------------------------------------------------------- #
@@ -201,7 +203,7 @@ QComboBox {
     border: 1px solid %(border)s; border-radius: %(r_sm)dpx; padding: 2px 6px;
 }
 QComboBox:hover { border-color: %(border_strong)s; }
-QComboBox::drop-down { border: none; width: 18px; }
+QComboBox::drop-down { border: none; width: 22px; }
 QComboBox QAbstractItemView {
     background-color: %(panel)s; color: %(text)s;
     border: 1px solid %(border)s;
@@ -293,9 +295,13 @@ QLabel[caption="true"] { color: %(text_muted)s; font-size: %(fs_caption)dpx; }
 """
 
 
-def global_qss() -> str:
-    """The central stylesheet, built from the tokens above (one source of truth)."""
-    return _QSS_TEMPLATE % {
+def global_qss(chevron_path=None) -> str:
+    """The central stylesheet, built from the tokens above (one source of truth).
+
+    ``chevron_path`` (from :func:`_ensure_chevron_icon`) adds the combo dropdown
+    arrow; omitted (e.g. in tests) the base combo styling still applies.
+    """
+    qss = _QSS_TEMPLATE % {
         "window": WINDOW, "canvas": CANVAS, "panel": PANEL, "surface": SURFACE,
         "surface_hover": SURFACE_HOVER, "surface_active": SURFACE_ACTIVE,
         "border": BORDER, "border_strong": BORDER_STRONG,
@@ -303,6 +309,11 @@ def global_qss() -> str:
         "accent": ACCENT, "selection_bg": SELECTION_BG, "selection_text": SELECTION_TEXT,
         "r_sm": RADIUS_SM, "r_md": RADIUS_MD, "fs_caption": FS_CAPTION,
     }
+    if chevron_path:
+        cp = str(chevron_path).replace("\\", "/")
+        qss += (f"\nQComboBox::down-arrow {{ image: url({cp});"
+                f" width: 12px; height: 12px; margin-right: 6px; }}\n")
+    return qss
 
 
 def load_tinted_icon(abs_path: str, color: str = ICON,
@@ -412,14 +423,44 @@ def apply_button_row(layout, *, spacing=GAP_BTN):
 
 
 def section_separator():
-    """The one canonical horizontal rule between functional regions."""
+    """The one canonical horizontal rule between functional regions — a 1px line
+    with section spacing above/below. A plain HLine coloured via ``color:`` is
+    invisible on the dark theme, so the line is painted via ``background-color``.
+    """
     from PySide6.QtWidgets import QFrame
     sep = QFrame()
-    sep.setFrameShape(QFrame.HLine)
-    sep.setFrameShadow(QFrame.Sunken)
     sep.setStyleSheet(
-        f"color: {BORDER}; margin-top: {SPACE_LG}px; margin-bottom: {SPACE_SM}px;")
+        f"QFrame {{ background-color: {BORDER_STRONG}; min-height: 1px; max-height: 1px;"
+        f" margin-top: {SPACE_LG}px; margin-bottom: {SPACE_SM}px; }}")
     return sep
+
+
+_CHEVRON_PATH = None
+
+
+def _ensure_chevron_icon() -> str:
+    """Generate the combo dropdown chevron PNG once; return its path for QSS
+    ``image: url(...)``. Requires a running QApplication (uses QPixmap/QPainter).
+
+    Qt suppresses the native combo arrow once the combo is stylesheet-styled and
+    the QSS border-triangle trick renders as a blocky shape, so we paint a clean
+    chevron and reference it as the down-arrow image.
+    """
+    global _CHEVRON_PATH
+    if _CHEVRON_PATH and os.path.exists(_CHEVRON_PATH):
+        return _CHEVRON_PATH
+    path = os.path.join(tempfile.gettempdir(), "freeccr_chevron_down.png")
+    pm = QPixmap(12, 12)
+    pm.fill(Qt.transparent)
+    p = QPainter(pm)
+    p.setRenderHint(QPainter.Antialiasing)
+    p.setPen(QPen(qcolor(TEXT_MUTED), 1.6))
+    p.drawLine(3, 4, 6, 8)   # ╲
+    p.drawLine(6, 8, 9, 4)   # ╱  → a downward chevron ˅
+    p.end()
+    pm.save(path)
+    _CHEVRON_PATH = path
+    return path
 
 
 def section_header_qss():
@@ -437,7 +478,7 @@ def apply_theme(app, settings=None) -> None:
     """
     app.setStyle("Fusion")
     app.setPalette(build_palette())
-    app.setStyleSheet(global_qss())
+    app.setStyleSheet(global_qss(_ensure_chevron_icon()))
 
 
 def apply_windows_dark_titlebar(widget) -> bool:

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -41,6 +41,9 @@ SELECTION_TEXT = "#ffffff"
 CH_R = "#d06666"
 CH_G = "#66aa66"
 CH_B = "#6688d0"
+# Slider track gradients (groove) — map the axis to its colour meaning.
+TEMP_GRADIENT = ("#3d7fd1", "#e6c34d")   # Temperature: cool blue (low) -> warm amber (high)
+TINT_GRADIENT = ("#5cb85c", "#c264c2")   # Tint: green (low) -> magenta (high)
 SUCCESS = "#3a8f5a"
 SUCCESS_HOVER = "#46a368"
 SUCCESS_PRESSED = "#2f7449"

--- a/src/widgets/curve_editor.py
+++ b/src/widgets/curve_editor.py
@@ -352,22 +352,22 @@ class CurveEditor(QWidget):
         super().__init__(parent)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(4)
+        layout.setSpacing(theme.GAP_ROW)
 
         # Channel selector buttons (mutually exclusive, checkable)
         btn_row = QHBoxLayout()
-        btn_row.setSpacing(4)
+        btn_row.setSpacing(theme.GAP_BTN)
         self._channel_buttons = {}
         for ch, label in self._CHANNEL_LABELS:
             btn = QPushButton(label)
             btn.setCheckable(True)
-            btn.setFixedHeight(22)
+            btn.setFixedHeight(theme.CONTROL_H)
             btn.setStyleSheet(
                 f"QPushButton {{ background: {theme.SURFACE}; border: 1px solid {theme.BORDER}; "
-                f"border-radius: 3px; color: {self._BTN_TINT[ch]}; font-size: 11px; }}"
+                f"border-radius: {theme.RADIUS_SM}px; color: {self._BTN_TINT[ch]}; font-size: 11px; }}"
                 f"QPushButton:checked {{ background: {theme.SURFACE_ACTIVE}; border: 2px solid {theme.ACCENT}; }}")
             btn.clicked.connect(lambda _=False, c=ch: self._on_channel(c))
-            btn_row.addWidget(btn)
+            btn_row.addWidget(btn, 1)
             self._channel_buttons[ch] = btn
         layout.addLayout(btn_row)
 
@@ -379,6 +379,7 @@ class CurveEditor(QWidget):
         self.reset_button = QPushButton("Reset Curve")
         self.reset_button.clicked.connect(self.canvas.reset)
         theme.style_button(self.reset_button, "danger")  # discards the curve
+        self.reset_button.setFixedHeight(theme.CONTROL_H)
         layout.addWidget(self.reset_button)
 
         self._channel_buttons["rgb"].setChecked(True)

--- a/src/widgets/curve_editor.py
+++ b/src/widgets/curve_editor.py
@@ -378,6 +378,7 @@ class CurveEditor(QWidget):
 
         self.reset_button = QPushButton("Reset Curve")
         self.reset_button.clicked.connect(self.canvas.reset)
+        theme.style_button(self.reset_button, "danger")  # discards the curve
         layout.addWidget(self.reset_button)
 
         self._channel_buttons["rgb"].setChecked(True)

--- a/src/widgets/curve_editor.py
+++ b/src/widgets/curve_editor.py
@@ -12,6 +12,8 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPushButton
 from PySide6.QtCore import Qt, Signal, QPointF, QRectF
 from PySide6.QtGui import QPainter, QPen, QBrush, QColor, QPainterPath
 
+from ui import theme
+
 # Mirror ccr_processor's channel set / identity so the two agree by construction.
 CURVE_CHANNELS = ("rgb", "r", "g", "b")
 
@@ -84,9 +86,9 @@ class CurveCanvas(QWidget):
 
     _LINE_COLORS = {
         "rgb": QColor("#e8e8e8"),
-        "r": QColor("#d06666"),
-        "g": QColor("#66aa66"),
-        "b": QColor("#6688d0"),
+        "r": QColor(theme.CH_R),
+        "g": QColor(theme.CH_G),
+        "b": QColor(theme.CH_B),
     }
 
     def __init__(self, parent=None):
@@ -292,12 +294,12 @@ class CurveCanvas(QWidget):
         r = self._plot_rect()
 
         # Background
-        p.fillRect(self.rect(), QColor("#2b2b2b"))
-        p.setPen(QPen(QColor("#555"), 1))
+        p.fillRect(self.rect(), QColor(theme.Paint.CURVE_BG))
+        p.setPen(QPen(QColor(theme.BORDER_STRONG), 1))
         p.drawRect(r)
 
         # Grid (4x4)
-        p.setPen(QPen(QColor("#3d3d3d"), 1))
+        p.setPen(QPen(QColor(theme.Paint.CURVE_GRID), 1))
         for k in range(1, 4):
             gx = r.left() + r.width() * k / 4.0
             gy = r.top() + r.height() * k / 4.0
@@ -305,7 +307,7 @@ class CurveCanvas(QWidget):
             p.drawLine(QPointF(r.left(), gy), QPointF(r.right(), gy))
 
         # Identity diagonal reference
-        p.setPen(QPen(QColor("#666"), 1, Qt.DashLine))
+        p.setPen(QPen(QColor(theme.Paint.CURVE_IDENTITY), 1, Qt.DashLine))
         p.drawLine(self._to_widget(0, 0), self._to_widget(255, 255))
 
         pts = self._points[self._channel]
@@ -323,13 +325,14 @@ class CurveCanvas(QWidget):
             path.lineTo(self._to_widget(qx, min(255.0, max(0.0, qy))))
         line_color = self._LINE_COLORS.get(self._channel, QColor("#e8e8e8"))
         if not self._enabled:
-            line_color = QColor("#555")
+            line_color = QColor(theme.Paint.CURVE_NODE_DISABLED)
         p.setPen(QPen(line_color, 2))
         p.drawPath(path)
 
         # Control points
-        p.setPen(QPen(QColor("#222"), 1))
-        p.setBrush(QBrush(QColor("#f0f0f0") if self._enabled else QColor("#777")))
+        p.setPen(QPen(QColor(theme.Paint.CURVE_NODE_OUTLINE), 1))
+        p.setBrush(QBrush(QColor(theme.Paint.CURVE_NODE) if self._enabled
+                          else QColor(theme.Paint.CURVE_NODE_DISABLED)))
         for x, y in pts:
             w = self._to_widget(x, y)
             p.drawEllipse(w, self.POINT_RADIUS, self.POINT_RADIUS)
@@ -343,7 +346,7 @@ class CurveEditor(QWidget):
     editFinished = Signal()
 
     _CHANNEL_LABELS = (("rgb", "All"), ("r", "R"), ("g", "G"), ("b", "B"))
-    _BTN_TINT = {"rgb": "#bbbbbb", "r": "#d06666", "g": "#66aa66", "b": "#6688d0"}
+    _BTN_TINT = {"rgb": theme.TEXT_MUTED, "r": theme.CH_R, "g": theme.CH_G, "b": theme.CH_B}
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -360,9 +363,9 @@ class CurveEditor(QWidget):
             btn.setCheckable(True)
             btn.setFixedHeight(22)
             btn.setStyleSheet(
-                "QPushButton { background: #3a3a3a; border: 1px solid #222; "
+                f"QPushButton {{ background: {theme.SURFACE}; border: 1px solid {theme.BORDER}; "
                 f"border-radius: 3px; color: {self._BTN_TINT[ch]}; font-size: 11px; }}"
-                "QPushButton:checked { background: #555; border: 2px solid #eee; }")
+                f"QPushButton:checked {{ background: {theme.SURFACE_ACTIVE}; border: 2px solid {theme.ACCENT}; }}")
             btn.clicked.connect(lambda _=False, c=ch: self._on_channel(c))
             btn_row.addWidget(btn)
             self._channel_buttons[ch] = btn

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -129,8 +129,7 @@ class DustRemovalPanel(QWidget):
     # --- UI ---------------------------------------------------------------
     def _build_ui(self):
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(6)
+        theme.apply_panel_spacing(layout)
 
         header = QLabel("Dust Removal")
         header.setAlignment(Qt.AlignCenter)
@@ -140,14 +139,16 @@ class DustRemovalPanel(QWidget):
         # --- Manual section ---
         layout.addWidget(self._section_label("Manual"))
         brush_row = QHBoxLayout()
+        brush_row.setSpacing(theme.GAP_TIGHT)
         brush_lbl = QLabel("Brush size")
-        brush_lbl.setMinimumWidth(70)
+        brush_lbl.setFixedWidth(theme.LABEL_COL_W)
         self.brush_slider = QSlider(Qt.Horizontal)
         self.brush_slider.setMinimum(2)     # r = value/1000  ->  0.002 .. 0.200
         self.brush_slider.setMaximum(200)
         self.brush_slider.setValue(12)      # 0.012 (1.2% of image width)
+        self.brush_slider.setFixedHeight(theme.CONTROL_H)
         self.brush_value = QLabel("1.2%")
-        self.brush_value.setMinimumWidth(40)
+        self.brush_value.setFixedWidth(theme.VALUE_COL_W)
         self.brush_slider.valueChanged.connect(self._on_brush_changed)
         brush_row.addWidget(brush_lbl)
         brush_row.addWidget(self.brush_slider)
@@ -160,13 +161,13 @@ class DustRemovalPanel(QWidget):
         layout.addWidget(hint)
 
         manual_btns = QHBoxLayout()
+        theme.apply_button_row(manual_btns)
         self.undo_btn = QPushButton("Undo last spot")
         self.undo_btn.clicked.connect(self._on_undo_last)
         self.clear_btn = QPushButton("Clear all")
         self.clear_btn.clicked.connect(self._on_clear_all)
         theme.style_button(self.clear_btn, "danger")  # removes all spots
         manual_btns.addWidget(self.undo_btn)
-        manual_btns.addSpacing(8)
         manual_btns.addWidget(self.clear_btn)
         layout.addLayout(manual_btns)
 
@@ -188,6 +189,7 @@ class DustRemovalPanel(QWidget):
         self.download_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         layout.addWidget(self.download_label)
         self.download_btn = QPushButton("Download AI model (~150 MB)")
+        self.download_btn.setFixedHeight(theme.CONTROL_H)
         self.download_btn.clicked.connect(self._on_download)
         layout.addWidget(self.download_btn)
         self.progress_bar = QProgressBar()
@@ -195,14 +197,16 @@ class DustRemovalPanel(QWidget):
         layout.addWidget(self.progress_bar)
 
         sens_row = QHBoxLayout()
+        sens_row.setSpacing(theme.GAP_TIGHT)
         self.sensitivity_label = QLabel("Sensitivity")
-        self.sensitivity_label.setMinimumWidth(70)
+        self.sensitivity_label.setFixedWidth(theme.LABEL_COL_W)
         self.sensitivity_slider = QSlider(Qt.Horizontal)
         self.sensitivity_slider.setMinimum(0)
         self.sensitivity_slider.setMaximum(100)
         self.sensitivity_slider.setValue(35)  # conservative default — fewer false positives
+        self.sensitivity_slider.setFixedHeight(theme.CONTROL_H)
         self.sensitivity_value = QLabel("35")
-        self.sensitivity_value.setMinimumWidth(40)
+        self.sensitivity_value.setFixedWidth(theme.VALUE_COL_W)
         self.sensitivity_slider.valueChanged.connect(self._on_sensitivity_changed)
         sens_row.addWidget(self.sensitivity_label)
         sens_row.addWidget(self.sensitivity_slider)
@@ -211,10 +215,12 @@ class DustRemovalPanel(QWidget):
         layout.addLayout(sens_row)
 
         self.detect_btn = QPushButton("Detect && Remove")
+        self.detect_btn.setFixedHeight(theme.CONTROL_H)
         self.detect_btn.clicked.connect(self._on_detect)
         layout.addWidget(self.detect_btn)
 
         self.detect_all_btn = QPushButton("Detect && Remove — All Images")
+        self.detect_all_btn.setFixedHeight(theme.CONTROL_H)
         self.detect_all_btn.setToolTip(
             "Run AI dust detection on every converted image — each scan is "
             "detected on its own (not by copying spots), at the current "
@@ -230,7 +236,7 @@ class DustRemovalPanel(QWidget):
         layout.addStretch(1)
 
         self.done_btn = QPushButton("✓  Done")
-        self.done_btn.setMinimumHeight(42)
+        self.done_btn.setMinimumHeight(theme.CONTROL_H_LG)
         self.done_btn.setToolTip("Close dust removal and return to the adjustment sliders.")
         # The panel's commit action → neutral primary (no success-green chrome).
         theme.style_button(self.done_btn, "primary")
@@ -240,17 +246,12 @@ class DustRemovalPanel(QWidget):
     @staticmethod
     def _section_label(text):
         lbl = QLabel(text)
-        lbl.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px; font-weight: bold; "
-                          "margin-top: 4px;")
+        lbl.setStyleSheet(theme.section_header_qss())
         return lbl
 
     @staticmethod
     def _separator():
-        sep = QFrame()
-        sep.setFrameShape(QFrame.HLine)
-        sep.setFrameShadow(QFrame.Sunken)
-        sep.setStyleSheet("margin-top: 6px; margin-bottom: 2px;")
-        return sep
+        return theme.section_separator()
 
     # --- Public API used by MainWindow / ImagePreview ---------------------
     def bind_image(self):

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -13,7 +13,8 @@ unavailable/needs-download state and the manual brush is unaffected.
 See spec/dust-removal.md.
 """
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
-                                QPushButton, QSlider, QFrame, QProgressBar)
+                                QPushButton, QSlider, QFrame, QProgressBar,
+                                QMessageBox)
 from PySide6.QtCore import Qt, QObject, QThread, Signal
 
 from core import dust_detect
@@ -163,7 +164,9 @@ class DustRemovalPanel(QWidget):
         self.undo_btn.clicked.connect(self._on_undo_last)
         self.clear_btn = QPushButton("Clear all")
         self.clear_btn.clicked.connect(self._on_clear_all)
+        theme.style_button(self.clear_btn, "danger")  # removes all spots
         manual_btns.addWidget(self.undo_btn)
+        manual_btns.addSpacing(8)
         manual_btns.addWidget(self.clear_btn)
         layout.addLayout(manual_btns)
 
@@ -229,11 +232,8 @@ class DustRemovalPanel(QWidget):
         self.done_btn = QPushButton("✓  Done")
         self.done_btn.setMinimumHeight(42)
         self.done_btn.setToolTip("Close dust removal and return to the adjustment sliders.")
-        self.done_btn.setStyleSheet(
-            f"QPushButton {{ background:{theme.SUCCESS}; color:white; font-weight:bold; "
-            f"font-size:13px; border:none; border-radius:5px; padding:8px; }}"
-            f"QPushButton:hover {{ background:{theme.SUCCESS_HOVER}; }}"
-            f"QPushButton:pressed {{ background:{theme.SUCCESS_PRESSED}; }}")
+        # The panel's commit action → neutral primary (no success-green chrome).
+        theme.style_button(self.done_btn, "primary")
         self.done_btn.clicked.connect(self._on_done)
         layout.addWidget(self.done_btn)
 
@@ -285,6 +285,17 @@ class DustRemovalPanel(QWidget):
             self.status_label.setText("Nothing to undo.")
 
     def _on_clear_all(self):
+        from core.ccr_backend import ccr_backend
+        img = ccr_backend.get_image_by_index(self.image_preview.current_idx)
+        n = len(getattr(img, "dust_spots", []) or []) if img is not None else 0
+        if n == 0:
+            self.status_label.setText("No dust spots to clear.")
+            return
+        if QMessageBox.question(
+                self, "Clear All Dust Spots",
+                f"Remove all {n} dust spot{'s' if n != 1 else ''} from this image?",
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.No) != QMessageBox.Yes:
+            return
         if self.image_preview.dust_clear_all():
             self._prob = None  # spots gone; a re-detect should start fresh
             self.status_label.setText("Cleared all dust spots.")
@@ -373,6 +384,13 @@ class DustRemovalPanel(QWidget):
                    and getattr(im, "resized_raw", None) is not None]
         if not targets:
             self.status_label.setText("No converted images to detect on.")
+            return
+        n = len(targets)
+        if QMessageBox.question(
+                self, "Detect on All Images",
+                f"Run AI dust detection on all {n} image{'s' if n != 1 else ''}? "
+                "This may take a while.",
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.No) != QMessageBox.Yes:
             return
         self._detecting_all = True
         self.detect_btn.setEnabled(False)

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
 from PySide6.QtCore import Qt, QObject, QThread, Signal
 
 from core import dust_detect
+from ui import theme
 
 
 class _DetectWorker(QObject):
@@ -154,7 +155,7 @@ class DustRemovalPanel(QWidget):
 
         hint = QLabel("Click or drag over dust to remove it.")
         hint.setWordWrap(True)
-        hint.setStyleSheet("color: #888; font-size: 11px;")
+        hint.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         layout.addWidget(hint)
 
         manual_btns = QHBoxLayout()
@@ -174,14 +175,14 @@ class DustRemovalPanel(QWidget):
         self.ai_unavailable_label = QLabel(
             "AI detection unavailable in this build.")
         self.ai_unavailable_label.setWordWrap(True)
-        self.ai_unavailable_label.setStyleSheet("color: #888; font-size: 11px;")
+        self.ai_unavailable_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         layout.addWidget(self.ai_unavailable_label)
 
         self.download_label = QLabel(
             "Download the local AI model (~150 MB) to detect dust "
             "automatically. One-time download.")
         self.download_label.setWordWrap(True)
-        self.download_label.setStyleSheet("color: #888; font-size: 11px;")
+        self.download_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         layout.addWidget(self.download_label)
         self.download_btn = QPushButton("Download AI model (~150 MB)")
         self.download_btn.clicked.connect(self._on_download)
@@ -220,7 +221,7 @@ class DustRemovalPanel(QWidget):
 
         self.status_label = QLabel("")
         self.status_label.setWordWrap(True)
-        self.status_label.setStyleSheet("color: #888; font-size: 11px;")
+        self.status_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         layout.addWidget(self.status_label)
 
         layout.addStretch(1)
@@ -229,17 +230,17 @@ class DustRemovalPanel(QWidget):
         self.done_btn.setMinimumHeight(42)
         self.done_btn.setToolTip("Close dust removal and return to the adjustment sliders.")
         self.done_btn.setStyleSheet(
-            "QPushButton { background:#2d7d46; color:white; font-weight:bold; "
-            "font-size:13px; border:none; border-radius:5px; padding:8px; }"
-            "QPushButton:hover { background:#359152; }"
-            "QPushButton:pressed { background:#256b3b; }")
+            f"QPushButton {{ background:{theme.SUCCESS}; color:white; font-weight:bold; "
+            f"font-size:13px; border:none; border-radius:5px; padding:8px; }}"
+            f"QPushButton:hover {{ background:{theme.SUCCESS_HOVER}; }}"
+            f"QPushButton:pressed {{ background:{theme.SUCCESS_PRESSED}; }}")
         self.done_btn.clicked.connect(self._on_done)
         layout.addWidget(self.done_btn)
 
     @staticmethod
     def _section_label(text):
         lbl = QLabel(text)
-        lbl.setStyleSheet("color: #aaa; font-size: 11px; font-weight: bold; "
+        lbl.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px; font-weight: bold; "
                           "margin-top: 4px;")
         return lbl
 

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 
 from core.ccr_backend import ccr_backend
 from core import export_estimator
+from ui import theme
 from utils.export_naming import build_export_names, build_filename, resolve_conflicts
 from utils.unicode_path_utils import normalize_unicode_path, validate_unicode_path
 
@@ -126,7 +127,7 @@ class ExportSettingsDialog(QDialog):
         fields_layout.addWidget(self.filename_edit, 1)
         naming_layout.addLayout(fields_layout)
         hint = QLabel("Macros: {name} = original filename, {date}, {time}, {seq}")
-        hint.setStyleSheet("color: gray;")
+        hint.setStyleSheet(f"color: {theme.TEXT_MUTED};")
         naming_layout.addWidget(hint)
         self.example_label = QLabel("")
         naming_layout.addWidget(self.example_label)
@@ -151,7 +152,7 @@ class ExportSettingsDialog(QDialog):
         form.addRow("Color space:", self.colorspace_combo)
         self.colorspace_hint = QLabel(
             "8-bit ProPhoto JPEG can band — prefer 16-bit TIFF for wide gamut.")
-        self.colorspace_hint.setStyleSheet("color: gray;")
+        self.colorspace_hint.setStyleSheet(f"color: {theme.TEXT_MUTED};")
         self.colorspace_hint.setWordWrap(True)
         form.addRow("", self.colorspace_hint)
 

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -46,7 +46,7 @@ class ExportSettingsDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Export")
         self.setModal(True)
-        self.setMinimumWidth(440)
+        self.setMinimumWidth(theme.DIALOG_W_MD)
         theme.apply_windows_dark_titlebar(self)  # dark native title bar (Win10/11)
 
         self.plan: Optional[ExportPlan] = None
@@ -83,6 +83,7 @@ class ExportSettingsDialog(QDialog):
 
     def _build_ui(self):
         layout = QVBoxLayout(self)
+        theme.apply_panel_spacing(layout, margin=theme.SPACE_XL, spacing=theme.GAP_SECTION)
 
         # Scope
         scope_group = QGroupBox("Export scope")
@@ -110,6 +111,7 @@ class ExportSettingsDialog(QDialog):
 
         # Destination
         dest_layout = QHBoxLayout()
+        dest_layout.setSpacing(theme.GAP_BTN)
         dest_layout.addWidget(QLabel("Destination:"))
         self.dest_edit = QLineEdit()
         self.dest_edit.textChanged.connect(self._on_dest_changed)
@@ -137,6 +139,8 @@ class ExportSettingsDialog(QDialog):
 
         # Format / quality / estimate / resize / conflicts
         form = QFormLayout()
+        form.setHorizontalSpacing(theme.GAP_BTN)
+        form.setVerticalSpacing(theme.GAP_ROW)
         self.format_combo = QComboBox()
         self.format_combo.addItem("TIFF 16-bit (lossless)", "tiff")
         self.format_combo.addItem("JPEG", "jpeg")
@@ -158,11 +162,12 @@ class ExportSettingsDialog(QDialog):
         form.addRow("", self.colorspace_hint)
 
         quality_layout = QHBoxLayout()
+        quality_layout.setSpacing(theme.GAP_BTN)
         self.quality_slider = QSlider(Qt.Horizontal)
         self.quality_slider.setRange(1, 100)
         self.quality_slider.setValue(92)
         self.quality_value_label = QLabel("92")
-        self.quality_value_label.setMinimumWidth(28)
+        self.quality_value_label.setMinimumWidth(theme.VALUE_COL_W)
         quality_layout.addWidget(self.quality_slider, 1)
         quality_layout.addWidget(self.quality_value_label)
         self.quality_slider.valueChanged.connect(self._on_quality_changed)
@@ -192,11 +197,15 @@ class ExportSettingsDialog(QDialog):
         layout.addWidget(self.open_folder_checkbox)
 
         # Buttons
+        layout.addWidget(theme.section_separator())
         button_layout = QHBoxLayout()
+        button_layout.setSpacing(theme.GAP_BTN)
         button_layout.addStretch(1)
         self.export_button = QPushButton("Export")
+        self.export_button.setFixedHeight(theme.CONTROL_H_LG)
         self.export_button.clicked.connect(self._on_export_clicked)
         cancel_button = QPushButton("Cancel")
+        cancel_button.setFixedHeight(theme.CONTROL_H)
         cancel_button.clicked.connect(self.reject)
         # Export is the deliberate commit → primary + dialog default; Cancel recedes.
         theme.style_button(self.export_button, "primary", default=True)

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -47,6 +47,7 @@ class ExportSettingsDialog(QDialog):
         self.setWindowTitle("Export")
         self.setModal(True)
         self.setMinimumWidth(440)
+        theme.apply_windows_dark_titlebar(self)  # dark native title bar (Win10/11)
 
         self.plan: Optional[ExportPlan] = None
         self._current_idx = current_idx

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -195,12 +195,14 @@ class ExportSettingsDialog(QDialog):
         button_layout = QHBoxLayout()
         button_layout.addStretch(1)
         self.export_button = QPushButton("Export")
-        self.export_button.setDefault(True)
         self.export_button.clicked.connect(self._on_export_clicked)
         cancel_button = QPushButton("Cancel")
         cancel_button.clicked.connect(self.reject)
-        button_layout.addWidget(self.export_button)
+        # Export is the deliberate commit → primary + dialog default; Cancel recedes.
+        theme.style_button(self.export_button, "primary", default=True)
+        theme.style_button(cancel_button, "secondary")
         button_layout.addWidget(cancel_button)
+        button_layout.addWidget(self.export_button)
         layout.addLayout(button_layout)
 
         # Debounced size estimation

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -610,7 +610,9 @@ class ImagePreview(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.layout = QVBoxLayout()
-        self.layout.setContentsMargins(40, 0, 40, 0)
+        # Canvas fills its column; the gap to neighbours comes from the main
+        # frame's inter-column gutter (was a 40px margin → an oversized gap).
+        self.layout.setContentsMargins(0, 0, 0, 0)
 
         # Toolbar
         self.toolbar = QToolBar()

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -11,6 +11,7 @@ from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, Q
 from core.ccr_backend import ccr_backend
 from core.ccr_processor import apply_dust_removal
 from widgets.export_dialog import ExportSettingsDialog
+from ui import theme
 import math
 import copy
 import sys
@@ -614,12 +615,6 @@ class ImagePreview(QWidget):
         # Toolbar
         self.toolbar = QToolBar()
         self.toolbar.setIconSize(QSize(24, 24))
-        self.toolbar.setStyleSheet("""
-    QToolButton { color: red; }
-    QToolButton:enabled { color: black; }
-    QToolButton:!hover { color: black; }
-    QToolButton:disabled { color: gray; }
-""")
 
         def add_spacer(width=5):
             spacer = QWidget()
@@ -627,7 +622,7 @@ class ImagePreview(QWidget):
             spacer.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
             self.toolbar.addWidget(spacer)
 
-        auto_icon = QIcon(resource_path("icons/auto.png"))
+        auto_icon = theme.load_tinted_icon(resource_path("icons/auto.png"))
         if auto_icon.isNull():
             auto_icon = QIcon.fromTheme("view-refresh")
         self.auto_frame_action = QAction(auto_icon, "Auto Frame", self)
@@ -635,7 +630,7 @@ class ImagePreview(QWidget):
         self.toolbar.addAction(self.auto_frame_action)
         add_spacer()
 
-        rotate_left_icon = QIcon(resource_path("icons/rotate-left-icon-size_512.png"))
+        rotate_left_icon = theme.load_tinted_icon(resource_path("icons/rotate-left-icon-size_512.png"))
         if rotate_left_icon.isNull():
             rotate_left_icon = QIcon.fromTheme("view-refresh")
         rotate_left_action = QAction(rotate_left_icon, "Rotate Left", self)
@@ -643,7 +638,7 @@ class ImagePreview(QWidget):
         self.toolbar.addAction(rotate_left_action)
         add_spacer()
 
-        rotate_right_icon = QIcon(resource_path("icons/rotate-right-icon-size_512.png"))
+        rotate_right_icon = theme.load_tinted_icon(resource_path("icons/rotate-right-icon-size_512.png"))
         if rotate_right_icon.isNull():
             rotate_right_icon = QIcon.fromTheme("view-refresh")
         rotate_right_action = QAction(rotate_right_icon, "Rotate Right", self)
@@ -651,7 +646,7 @@ class ImagePreview(QWidget):
         self.toolbar.addAction(rotate_right_action)
         add_spacer()
 
-        mirror_v_icon = QIcon(resource_path("icons/vertical-mirror-icon.png"))
+        mirror_v_icon = theme.load_tinted_icon(resource_path("icons/vertical-mirror-icon.png"))
         if mirror_v_icon.isNull():
             mirror_v_icon = QIcon.fromTheme("view-refresh")
         mirror_v_action = QAction(mirror_v_icon, "Mirror Vertical", self)
@@ -659,7 +654,7 @@ class ImagePreview(QWidget):
         self.toolbar.addAction(mirror_v_action)
         add_spacer()
 
-        mirror_h_icon = QIcon(resource_path("icons/horizontal-mirror-icon.png"))
+        mirror_h_icon = theme.load_tinted_icon(resource_path("icons/horizontal-mirror-icon.png"))
         if mirror_h_icon.isNull():
             mirror_h_icon = QIcon.fromTheme("view-refresh")
         mirror_h_action = QAction(mirror_h_icon, "Mirror Horizontal", self)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -705,6 +705,13 @@ class ImagePreview(QWidget):
         self.unconvert_action = QAction("Un-convert", self)
         self.unconvert_action.triggered.connect(self.unconvert_ccr)
         self.toolbar.addAction(self.unconvert_action)
+        # Destructive revert → red text when enabled, muted when disabled.
+        _unconv_btn = self.toolbar.widgetForAction(self.unconvert_action)
+        if _unconv_btn is not None:
+            _unconv_btn.setStyleSheet(
+                f"QToolButton {{ color: {theme.DANGER}; }}"
+                f"QToolButton:hover {{ color: {theme.DANGER_HOVER}; }}"
+                f"QToolButton:disabled {{ color: {theme.TEXT_DISABLED}; }}")
         add_spacer()
 
         self.export_action = QAction("Export…", self)

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -401,10 +401,12 @@ class SlidersPanel(QWidget):
         self.bwp_mode_label = QLabel("")
         self.bwp_mode_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         scroll_layout.addWidget(self.bwp_mode_label)
-        self.convert_current_bwp_btn = QPushButton("Convert Current (B/W Point)")
-        scroll_layout.addWidget(self.convert_current_bwp_btn)
-        self.convert_all_bwp_btn = QPushButton("Convert All (B/W Point)")
-        scroll_layout.addWidget(self.convert_all_bwp_btn)
+        self.convert_current_bwp_btn = QPushButton("Convert Current")
+        self.convert_all_bwp_btn = QPushButton("Convert All")
+        convert_row = QHBoxLayout()
+        convert_row.addWidget(self.convert_current_bwp_btn)
+        convert_row.addWidget(self.convert_all_bwp_btn)
+        scroll_layout.addLayout(convert_row)
 
         # Separator between B/W Point tools and the adjustment sliders
         separator = QFrame()
@@ -1444,7 +1446,7 @@ class SlidersPanel(QWidget):
         self._update_bwp_mode_label()
         if bp_set and wp_set:
             self.set_temporary_hint(
-                f"{label} sampled! Both points set — click <b>Convert All (B/W Point)</b>.", duration=5000)
+                f"{label} sampled! Both points set — click <b>Convert All</b>.", duration=5000)
         elif bp_set:
             # Black point alone is enough — default slope fills in for the white.
             self.set_temporary_hint(

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -52,23 +52,36 @@ class SyncSettingsDialog(QDialog):
             layout.addWidget(checkbox)
             self._checkboxes[gid] = checkbox
 
+        # Selection helpers — pushed to opposite ends with checkbox glyphs so they
+        # no longer read as one identical pair.
         select_row = QHBoxLayout()
-        select_all_btn = QPushButton("Select All")
-        deselect_all_btn = QPushButton("Deselect All")
+        select_all_btn = QPushButton("☑  Select All")
+        deselect_all_btn = QPushButton("☐  Deselect All")
+        theme.style_button(select_all_btn, "secondary")
+        theme.style_button(deselect_all_btn, "secondary")
         select_all_btn.clicked.connect(lambda: self._set_all(True))
         deselect_all_btn.clicked.connect(lambda: self._set_all(False))
         select_row.addWidget(select_all_btn)
+        select_row.addStretch(1)
         select_row.addWidget(deselect_all_btn)
         layout.addLayout(select_row)
 
+        # Separator: "choose what to sync" (above) vs "commit" (below).
+        sep = QFrame()
+        sep.setFrameShape(QFrame.HLine)
+        sep.setStyleSheet(f"color: {theme.BORDER}; margin-top: 8px; margin-bottom: 4px;")
+        layout.addWidget(sep)
+
         button_row = QHBoxLayout()
         sync_btn = QPushButton("Sync")
-        sync_btn.setDefault(True)
         cancel_btn = QPushButton("Cancel")
+        theme.style_button(sync_btn, "primary", default=True)
+        theme.style_button(cancel_btn, "secondary")
         sync_btn.clicked.connect(self.accept)
         cancel_btn.clicked.connect(self.reject)
-        button_row.addWidget(sync_btn)
+        button_row.addStretch(1)
         button_row.addWidget(cancel_btn)
+        button_row.addWidget(sync_btn)
         layout.addLayout(button_row)
 
     def _set_all(self, checked: bool):
@@ -392,9 +405,11 @@ class SlidersPanel(QWidget):
         self.clear_white_point_btn.setFixedWidth(28)
         self.clear_white_point_btn.setToolTip(
             "Clear the white point — use the calibrated default slope instead")
+        theme.style_button(self.clear_white_point_btn, "danger", glyph_only=True)
         self.black_point_btn = QPushButton("Set Black Point")
         bwp_row.addWidget(self.black_point_btn)
         bwp_row.addWidget(self.white_point_btn)
+        bwp_row.addSpacing(4)
         bwp_row.addWidget(self.clear_white_point_btn)
         scroll_layout.addLayout(bwp_row)
         # Shows which slope source the next conversion will use.
@@ -403,6 +418,9 @@ class SlidersPanel(QWidget):
         scroll_layout.addWidget(self.bwp_mode_label)
         self.convert_current_bwp_btn = QPushButton("Convert Current")
         self.convert_all_bwp_btn = QPushButton("Convert All")
+        # Convert Current is the section's primary (core single-image action);
+        # Convert All stays neutral and gets a count confirmation instead.
+        theme.style_button(self.convert_current_bwp_btn, "primary")
         convert_row = QHBoxLayout()
         convert_row.addWidget(self.convert_current_bwp_btn)
         convert_row.addWidget(self.convert_all_bwp_btn)
@@ -481,7 +499,10 @@ class SlidersPanel(QWidget):
         buttons_layout = QHBoxLayout()
         self.reset_button = QPushButton("Reset")
         self.compare_button = QPushButton("Compare")
+        # Reset discards all adjustments → danger. Gap so it isn't one block with Compare.
+        theme.style_button(self.reset_button, "danger")
         buttons_layout.addWidget(self.reset_button)
+        buttons_layout.addSpacing(8)
         buttons_layout.addWidget(self.compare_button)
         scroll_layout.addLayout(buttons_layout)
 
@@ -1499,6 +1520,15 @@ class SlidersPanel(QWidget):
             QMessageBox.warning(self, "Black Point Missing",
                 "Please set a Black Point (film base) before converting. A White "
                 "Point is optional — without it the calibrated default slope is used.")
+            return
+        n = len(ccr_backend.images)
+        if n == 0:
+            return
+        if QMessageBox.question(
+                self, "Convert All Images",
+                f"Convert all {n} image{'s' if n != 1 else ''} with the current "
+                "black/white point? Any existing conversions will be replaced.",
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.No) != QMessageBox.Yes:
             return
         dialog = BWPointConvertDialog(self)
         worker = BWPointConvertWorker()

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -319,7 +319,12 @@ class SlidersPanel(QWidget):
         self.histogram_label.setStyleSheet(
             f"background-color: rgb({theme.Paint.HIST_BG[0]},{theme.Paint.HIST_BG[1]},{theme.Paint.HIST_BG[2]}); border: none; border-radius: 12px;"
         )
-        layout.addWidget(self.histogram_label)
+        # Inset to match the content below so it isn't flush against the panel's
+        # right border (the scroll area below keeps its scrollbar at the edge).
+        hist_row = QHBoxLayout()
+        hist_row.setContentsMargins(theme.GAP_PANEL, theme.GAP_PANEL, theme.GAP_PANEL, 0)
+        hist_row.addWidget(self.histogram_label)
+        layout.addLayout(hist_row)
 
         # --- Scrollable middle section ---
         scroll_content = QWidget()

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -7,6 +7,7 @@ from PySide6.QtGui import QPixmap, QKeySequence, QShortcut
 from core.ccr_backend import ccr_backend
 from core.ccr_processor import COLOR_BANDS, BAND_PARAMS, BAND_ADJUSTMENT_KEYS
 from widgets.curve_editor import CurveEditor
+from ui import theme
 import copy
 
 # Setting groups offered by the "Sync to All" dialog. The adjustment-key
@@ -85,9 +86,9 @@ class CollapsibleSection(QWidget):
         self._toggle_btn.setChecked(False)
         self._toggle_btn.setStyleSheet(
             "QPushButton { text-align: left; padding: 4px 6px; "
-            "background: #3a3a3a; border: none; border-radius: 4px; "
-            "color: #ccc; font-size: 11px; }"
-            "QPushButton:checked { background: #505050; }"
+            f"background: {theme.SURFACE}; border: none; border-radius: 4px; "
+            f"color: {theme.TEXT}; font-size: 11px; }}"
+            f"QPushButton:checked {{ background: {theme.SURFACE_ACTIVE}; }}"
         )
         self._toggle_btn.clicked.connect(self._on_toggle)
 
@@ -255,7 +256,7 @@ class SlidersPanel(QWidget):
         self.histogram_label.setFrameShape(QFrame.NoFrame)
         self.histogram_label.setText("")
         self.histogram_label.setStyleSheet(
-            "background-color: rgb(180,180,180); border: none; border-radius: 12px;"
+            f"background-color: rgb({theme.Paint.HIST_BG[0]},{theme.Paint.HIST_BG[1]},{theme.Paint.HIST_BG[2]}); border: none; border-radius: 12px;"
         )
         layout.addWidget(self.histogram_label)
 
@@ -292,7 +293,7 @@ class SlidersPanel(QWidget):
         layers_vbox.setContentsMargins(0, 0, 0, 0)
         layers_vbox.setSpacing(2)
         layers_title = QLabel("Layers")
-        layers_title.setStyleSheet("color: #888; font-size: 11px;")
+        layers_title.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         layers_title.setAlignment(Qt.AlignCenter)
         layers_vbox.addWidget(layers_title)
         self._layers_list_vbox = QVBoxLayout()   # dynamic rows, rebuilt per image
@@ -329,7 +330,7 @@ class SlidersPanel(QWidget):
         # --- 10 existing sliders (sliders[0]–[9]) ---
         # --- Film B/W Point section — at the top, right below the histogram ---
         bwp_label = QLabel("Film B/W Point")
-        bwp_label.setStyleSheet("color: #888; font-size: 11px; margin-bottom: 2px;")
+        bwp_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px; margin-bottom: 2px;")
         bwp_label.setAlignment(Qt.AlignCenter)
         scroll_layout.addWidget(bwp_label)
 
@@ -348,7 +349,7 @@ class SlidersPanel(QWidget):
         scroll_layout.addLayout(bwp_row)
         # Shows which slope source the next conversion will use.
         self.bwp_mode_label = QLabel("")
-        self.bwp_mode_label.setStyleSheet("color: #888; font-size: 11px;")
+        self.bwp_mode_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         scroll_layout.addWidget(self.bwp_mode_label)
         self.convert_current_bwp_btn = QPushButton("Convert Current (B/W Point)")
         scroll_layout.addWidget(self.convert_current_bwp_btn)
@@ -468,7 +469,7 @@ class SlidersPanel(QWidget):
         # section's display position above.
         # Master group
         master_label = QLabel("Master")
-        master_label.setStyleSheet("color: #888; font-size: 11px; margin-top: 4px;")
+        master_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px; margin-top: 4px;")
         master_label.setAlignment(Qt.AlignCenter)
         self.od_section.add_widget(master_label)
         self.od_section.add_layout(self.create_slider("Input Gain"))
@@ -477,7 +478,7 @@ class SlidersPanel(QWidget):
 
         # R channel group
         r_label = QLabel("R Channel")
-        r_label.setStyleSheet("color: #c66; font-size: 11px; margin-top: 4px;")
+        r_label.setStyleSheet(f"color: {theme.CH_R}; font-size: 11px; margin-top: 4px;")
         r_label.setAlignment(Qt.AlignCenter)
         self.od_section.add_widget(r_label)
         self.od_section.add_layout(self.create_slider("R Shift"))
@@ -486,7 +487,7 @@ class SlidersPanel(QWidget):
 
         # G channel group
         g_label = QLabel("G Channel")
-        g_label.setStyleSheet("color: #6a6; font-size: 11px; margin-top: 4px;")
+        g_label.setStyleSheet(f"color: {theme.CH_G}; font-size: 11px; margin-top: 4px;")
         g_label.setAlignment(Qt.AlignCenter)
         self.od_section.add_widget(g_label)
         self.od_section.add_layout(self.create_slider("G Shift"))
@@ -495,7 +496,7 @@ class SlidersPanel(QWidget):
 
         # B channel group
         b_label = QLabel("B Channel")
-        b_label.setStyleSheet("color: #66c; font-size: 11px; margin-top: 4px;")
+        b_label.setStyleSheet(f"color: {theme.CH_B}; font-size: 11px; margin-top: 4px;")
         b_label.setAlignment(Qt.AlignCenter)
         self.od_section.add_widget(b_label)
         self.od_section.add_layout(self.create_slider("B Shift"))
@@ -505,11 +506,7 @@ class SlidersPanel(QWidget):
         # --- Populate Subtractive Saturations (per-color bands) ---
         # A swatch button per color selects which band's sliders are shown;
         # all 24 sliders exist (and feed adjustment_settings) regardless.
-        band_swatch_colors = {
-            "red": "#c0392b", "skin": "#d8956b", "yellow": "#c8b900",
-            "green": "#27ae60", "cyan": "#17a8b4", "blue": "#2f6fd0",
-            "purple": "#8e44ad",
-        }
+        band_swatch_colors = theme.BAND_COLORS
         self._band_buttons = {}
         self._band_pages = {}
         band_btn_row = QHBoxLayout()
@@ -521,8 +518,8 @@ class SlidersPanel(QWidget):
             btn.setToolTip(color.capitalize())
             btn.setStyleSheet(
                 f"QPushButton {{ background: {band_swatch_colors[color]}; "
-                "border: 1px solid #222; border-radius: 3px; }"
-                "QPushButton:checked { border: 2px solid #eee; }")
+                f"border: 1px solid {theme.BORDER}; border-radius: 3px; }}"
+                f"QPushButton:checked {{ border: 2px solid {theme.ACCENT}; }}")
             btn.clicked.connect(lambda _=False, c=color: self._show_band_page(c))
             band_btn_row.addWidget(btn)
             self._band_buttons[color] = btn
@@ -580,7 +577,7 @@ class SlidersPanel(QWidget):
         # --- Hint label — fixed at bottom, outside scroll area ---
         self.hint_label = QLabel()
         self.hint_label.setWordWrap(True)
-        self.hint_label.setStyleSheet("color: #666; font-size: 12px; margin-top: 8px;")
+        self.hint_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 12px; margin-top: 8px;")
         self.hint_label.setText("")
         layout.addWidget(self.hint_label)
 

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -41,8 +41,9 @@ class SyncSettingsDialog(QDialog):
     def __init__(self, parent=None, selection=None):
         super().__init__(parent)
         self.setWindowTitle("Sync to All")
-        self.setMinimumWidth(280)
+        self.setMinimumWidth(theme.DIALOG_W_SM)
         layout = QVBoxLayout(self)
+        theme.apply_panel_spacing(layout)
         layout.addWidget(QLabel("Sync these settings to all images:"))
 
         self._checkboxes = {}
@@ -54,7 +55,7 @@ class SyncSettingsDialog(QDialog):
 
         # Selection helpers — pushed to opposite ends with checkbox glyphs so they
         # no longer read as one identical pair.
-        select_row = QHBoxLayout()
+        select_row = theme.apply_button_row(QHBoxLayout())
         select_all_btn = QPushButton("☑  Select All")
         deselect_all_btn = QPushButton("☐  Deselect All")
         theme.style_button(select_all_btn, "secondary")
@@ -67,12 +68,9 @@ class SyncSettingsDialog(QDialog):
         layout.addLayout(select_row)
 
         # Separator: "choose what to sync" (above) vs "commit" (below).
-        sep = QFrame()
-        sep.setFrameShape(QFrame.HLine)
-        sep.setStyleSheet(f"color: {theme.BORDER}; margin-top: 8px; margin-bottom: 4px;")
-        layout.addWidget(sep)
+        layout.addWidget(theme.section_separator())
 
-        button_row = QHBoxLayout()
+        button_row = theme.apply_button_row(QHBoxLayout())
         sync_btn = QPushButton("Sync")
         cancel_btn = QPushButton("Cancel")
         theme.style_button(sync_btn, "primary", default=True)
@@ -100,8 +98,8 @@ class CollapsibleSection(QWidget):
         self._toggle_btn.setChecked(False)
         self._toggle_btn.setStyleSheet(
             "QPushButton { text-align: left; padding: 4px 6px; "
-            f"background: {theme.SURFACE}; border: none; border-radius: 4px; "
-            f"color: {theme.TEXT}; font-size: 11px; }}"
+            f"background: {theme.SURFACE}; border: none; border-radius: {theme.RADIUS_SM}px; "
+            f"color: {theme.TEXT}; font-size: 11px; font-weight: bold; }}"
             f"QPushButton:checked {{ background: {theme.SURFACE_ACTIVE}; }}"
         )
         self._toggle_btn.clicked.connect(self._on_toggle)
@@ -109,13 +107,13 @@ class CollapsibleSection(QWidget):
         self._content = QWidget()
         self._content_layout = QVBoxLayout()
         self._content_layout.setContentsMargins(0, 0, 0, 0)
-        self._content_layout.setSpacing(2)
+        self._content_layout.setSpacing(theme.GAP_ROW)
         self._content.setLayout(self._content_layout)
         self._content.setVisible(False)
 
         outer = QVBoxLayout()
-        outer.setContentsMargins(0, 4, 0, 0)
-        outer.setSpacing(2)
+        outer.setContentsMargins(0, theme.GAP_SECTION, 0, 0)
+        outer.setSpacing(theme.GAP_ROW)
         outer.addWidget(self._toggle_btn)
         outer.addWidget(self._content)
         self.setLayout(outer)
@@ -310,7 +308,7 @@ class SlidersPanel(QWidget):
         # Outer layout: histogram (fixed) + scroll area (stretchy) + hint (fixed)
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(4)
+        layout.setSpacing(theme.GAP_ROW)
 
         # --- Histogram — fixed at top, outside scroll area ---
         self.histogram_label = QLabel()
@@ -327,8 +325,7 @@ class SlidersPanel(QWidget):
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout()
         scroll_layout.setAlignment(Qt.AlignTop)
-        scroll_layout.setContentsMargins(4, 4, 4, 4)
-        scroll_layout.setSpacing(2)
+        theme.apply_panel_spacing(scroll_layout)
         scroll_content.setLayout(scroll_layout)
 
         scroll_area = QScrollArea()
@@ -356,8 +353,8 @@ class SlidersPanel(QWidget):
         layers_vbox.setContentsMargins(0, 0, 0, 0)
         layers_vbox.setSpacing(2)
         layers_title = QLabel("Layers")
-        layers_title.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
-        layers_title.setAlignment(Qt.AlignCenter)
+        layers_title.setStyleSheet(theme.section_header_qss())
+        layers_title.setAlignment(Qt.AlignLeft)
         layers_vbox.addWidget(layers_title)
         self._layers_list_vbox = QVBoxLayout()   # dynamic rows, rebuilt per image
         self._layers_list_vbox.setSpacing(2)
@@ -366,16 +363,17 @@ class SlidersPanel(QWidget):
         self.feather_row = QWidget()
         feather_layout = QHBoxLayout(self.feather_row)
         feather_layout.setContentsMargins(0, 0, 0, 0)
+        feather_layout.setSpacing(theme.GAP_TIGHT)
         feather_label = QLabel("Feather")
-        feather_label.setMinimumWidth(70)
+        feather_label.setFixedWidth(theme.LABEL_COL_W)
         feather_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         self.feather_slider = ResettableSlider(Qt.Horizontal)
         self.feather_slider.setMinimum(0)
         self.feather_slider.setMaximum(100)
         self.feather_slider.setValue(25)
-        self.feather_slider.setFixedHeight(30)
+        self.feather_slider.setFixedHeight(theme.CONTROL_H)
         self.feather_value_label = QLabel("25")
-        self.feather_value_label.setMinimumWidth(40)
+        self.feather_value_label.setFixedWidth(theme.VALUE_COL_W)
         self.feather_slider.valueChanged.connect(self._on_feather_changed)
         feather_layout.addWidget(feather_label)
         feather_layout.addWidget(self.feather_slider)
@@ -384,32 +382,30 @@ class SlidersPanel(QWidget):
         self.feather_row.setVisible(False)
         self._layer_buttons = {}
         scroll_layout.addWidget(self.layers_container)
-        layers_sep = QFrame()
-        layers_sep.setFrameShape(QFrame.HLine)
-        layers_sep.setFrameShadow(QFrame.Sunken)
-        layers_sep.setStyleSheet("margin-top: 4px; margin-bottom: 4px;")
-        scroll_layout.addWidget(layers_sep)
+        scroll_layout.addWidget(theme.section_separator())
 
         # --- 10 existing sliders (sliders[0]–[9]) ---
         # --- Film B/W Point section — at the top, right below the histogram ---
         bwp_label = QLabel("Film B/W Point")
-        bwp_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px; margin-bottom: 2px;")
-        bwp_label.setAlignment(Qt.AlignCenter)
+        bwp_label.setStyleSheet(theme.section_header_qss())
+        bwp_label.setAlignment(Qt.AlignLeft)
         scroll_layout.addWidget(bwp_label)
 
-        bwp_row = QHBoxLayout()
+        bwp_row = theme.apply_button_row(QHBoxLayout())
         self.white_point_btn = QPushButton("Set White Point")
         # Small "clear" button: drops the white point so conversion uses the
         # calibrated default slope (black point only).
         self.clear_white_point_btn = QPushButton("✕")
-        self.clear_white_point_btn.setFixedWidth(28)
+        self.clear_white_point_btn.setFixedWidth(theme.GLYPH_W)
+        self.clear_white_point_btn.setFixedHeight(theme.CONTROL_H)
         self.clear_white_point_btn.setToolTip(
             "Clear the white point — use the calibrated default slope instead")
         theme.style_button(self.clear_white_point_btn, "danger", glyph_only=True)
         self.black_point_btn = QPushButton("Set Black Point")
+        self.black_point_btn.setFixedHeight(theme.CONTROL_H)
+        self.white_point_btn.setFixedHeight(theme.CONTROL_H)
         bwp_row.addWidget(self.black_point_btn)
         bwp_row.addWidget(self.white_point_btn)
-        bwp_row.addSpacing(4)
         bwp_row.addWidget(self.clear_white_point_btn)
         scroll_layout.addLayout(bwp_row)
         # Shows which slope source the next conversion will use.
@@ -421,22 +417,19 @@ class SlidersPanel(QWidget):
         # Convert Current is the section's primary (core single-image action);
         # Convert All stays neutral and gets a count confirmation instead.
         theme.style_button(self.convert_current_bwp_btn, "primary")
-        convert_row = QHBoxLayout()
+        self.convert_current_bwp_btn.setFixedHeight(theme.CONTROL_H)
+        self.convert_all_bwp_btn.setFixedHeight(theme.CONTROL_H)
+        convert_row = theme.apply_button_row(QHBoxLayout())
         convert_row.addWidget(self.convert_current_bwp_btn)
         convert_row.addWidget(self.convert_all_bwp_btn)
         scroll_layout.addLayout(convert_row)
 
         # Separator between B/W Point tools and the adjustment sliders
-        separator = QFrame()
-        separator.setFrameShape(QFrame.HLine)
-        separator.setFrameShadow(QFrame.Sunken)
-        separator.setStyleSheet("margin-top: 8px; margin-bottom: 4px;")
-        scroll_layout.addWidget(separator)
+        scroll_layout.addWidget(theme.section_separator())
 
         # Auto white balance: pick a neutral point with an eyedropper.
         # Enabled only for converted images (same gating as the sliders).
         self.wb_picker_btn = QPushButton("Auto WB Picker")
-        self.wb_picker_btn.setFixedWidth(140)
         self.wb_picker_btn.setToolTip(
             "Click, then pick a neutral gray/white point on the image "
             "to auto-set Temperature and Tint.")
@@ -456,11 +449,13 @@ class SlidersPanel(QWidget):
             "left/right edge for a horizontal cut; click to place a line, "
             "drag to adjust, right-click to delete, Enter to slice, "
             "Esc to cancel.")
-        wb_crop_row = QHBoxLayout()
-        wb_crop_row.addWidget(self.wb_picker_btn)
-        wb_crop_row.addWidget(self.crop_btn)
-        wb_crop_row.addWidget(self.slice_btn)
-        wb_crop_row.addStretch()
+        self.wb_picker_btn.setFixedHeight(theme.CONTROL_H)
+        self.crop_btn.setFixedHeight(theme.CONTROL_H)
+        self.slice_btn.setFixedHeight(theme.CONTROL_H)
+        wb_crop_row = theme.apply_button_row(QHBoxLayout())
+        wb_crop_row.addWidget(self.wb_picker_btn, 1)
+        wb_crop_row.addWidget(self.crop_btn, 1)
+        wb_crop_row.addWidget(self.slice_btn, 1)
         scroll_layout.addLayout(wb_crop_row)
 
         # Color Profile dropdown — sits right above Temperature. "Color" keeps
@@ -496,18 +491,20 @@ class SlidersPanel(QWidget):
         scroll_layout.addLayout(self.sub_saturation_slider_layout)
 
         # --- Reset / Compare / Sync buttons ---
-        buttons_layout = QHBoxLayout()
+        buttons_layout = theme.apply_button_row(QHBoxLayout())
         self.reset_button = QPushButton("Reset")
         self.compare_button = QPushButton("Compare")
         # Reset discards all adjustments → danger. Gap so it isn't one block with Compare.
         theme.style_button(self.reset_button, "danger")
+        self.reset_button.setFixedHeight(theme.CONTROL_H)
+        self.compare_button.setFixedHeight(theme.CONTROL_H)
         buttons_layout.addWidget(self.reset_button)
-        buttons_layout.addSpacing(8)
         buttons_layout.addWidget(self.compare_button)
         scroll_layout.addLayout(buttons_layout)
 
         sync_layout = QHBoxLayout()
         self.sync_to_all_button = QPushButton("Sync to All")
+        self.sync_to_all_button.setFixedHeight(theme.CONTROL_H)
         sync_layout.addWidget(self.sync_to_all_button)
         scroll_layout.addLayout(sync_layout)
 
@@ -520,11 +517,7 @@ class SlidersPanel(QWidget):
         # content layout, so create_slider() append order is independent of where
         # the section sits in scroll_layout.
         def _section_separator():
-            sep = QFrame()
-            sep.setFrameShape(QFrame.HLine)
-            sep.setFrameShadow(QFrame.Sunken)
-            sep.setStyleSheet("margin-top: 8px; margin-bottom: 4px;")
-            return sep
+            return theme.section_separator()
 
         scroll_layout.addWidget(_section_separator())
         self.curves_section = CollapsibleSection("Curves")
@@ -585,7 +578,7 @@ class SlidersPanel(QWidget):
         self._band_buttons = {}
         self._band_pages = {}
         band_btn_row = QHBoxLayout()
-        band_btn_row.setSpacing(4)
+        band_btn_row.setSpacing(theme.GAP_BTN)
         for color in COLOR_BANDS:
             btn = QPushButton()
             btn.setCheckable(True)
@@ -699,16 +692,16 @@ class SlidersPanel(QWidget):
         slider.setValue(default_value)
         slider.setOrientation(Qt.Horizontal)
         slider.setTickInterval(10)
-        slider.setFixedHeight(30)
+        slider.setFixedHeight(theme.CONTROL_H)
 
         label = QLabel(label_text)
-        label.setMinimumWidth(70)
+        label.setFixedWidth(theme.LABEL_COL_W)
         label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        label.setFixedHeight(30)
+        label.setFixedHeight(theme.CONTROL_H)
         label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
 
         value_label = QLabel(str(slider.value()))
-        value_label.setMinimumWidth(40)
+        value_label.setFixedWidth(theme.VALUE_COL_W)
         value_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         # Directly call on_slider_changed without debounce
@@ -719,6 +712,8 @@ class SlidersPanel(QWidget):
         slider.valueChanged.connect(handle_slider_change)
 
         slider_layout = QHBoxLayout()
+        slider_layout.setContentsMargins(0, 0, 0, 0)
+        slider_layout.setSpacing(theme.GAP_TIGHT)
         slider_layout.addWidget(label, alignment=Qt.AlignVCenter)
         slider_layout.addWidget(slider, alignment=Qt.AlignVCenter)
         slider_layout.addWidget(value_label, alignment=Qt.AlignVCenter)
@@ -732,17 +727,18 @@ class SlidersPanel(QWidget):
         """Build the 'Color Profile' label + dropdown row (Color / Black &
         White). Laid out like a slider row so it lines up with Temperature."""
         label = QLabel("Color Profile")
-        label.setMinimumWidth(70)
+        label.setFixedWidth(theme.LABEL_COL_W)
         label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        label.setFixedHeight(30)
+        label.setFixedHeight(theme.CONTROL_H)
         label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
 
         self.color_profile_combo = QComboBox()
         self.color_profile_combo.addItems(["Color", "Black & White"])
-        self.color_profile_combo.setFixedHeight(28)
+        self.color_profile_combo.setFixedHeight(theme.CONTROL_H)
         self.color_profile_combo.currentIndexChanged.connect(self.on_color_profile_changed)
 
         row = QHBoxLayout()
+        row.setSpacing(theme.GAP_TIGHT)
         row.addWidget(label, alignment=Qt.AlignVCenter)
         row.addWidget(self.color_profile_combo, alignment=Qt.AlignVCenter)
         return row
@@ -945,7 +941,7 @@ class SlidersPanel(QWidget):
             glyph = "○" if kind == "circle" else "▤"
             aid = a.get("id")
             row = QHBoxLayout()
-            row.setSpacing(3)
+            row.setSpacing(theme.GAP_BTN)
             chk = QCheckBox()
             chk.setChecked(bool(a.get("enabled", True)))
             chk.setToolTip("Enable / disable this area")
@@ -955,7 +951,7 @@ class SlidersPanel(QWidget):
             sel.setChecked(active == aid)
             sel.clicked.connect(lambda _=False, _id=aid: self._select_layer(_id))
             rem = QPushButton("✕")
-            rem.setFixedWidth(24)
+            rem.setFixedWidth(theme.GLYPH_W)
             rem.setToolTip("Remove this area")
             rem.clicked.connect(lambda _=False, _id=aid: self._on_remove_area(_id))
             row.addWidget(chk)
@@ -1665,7 +1661,7 @@ class BWPointConvertDialog(QDialog):
         self.setModal(True)
         self.setWindowFlags(Qt.Dialog | Qt.CustomizeWindowHint | Qt.WindowTitleHint)
         self.setWindowModality(Qt.ApplicationModal)
-        self.setMinimumWidth(260)
+        self.setMinimumWidth(theme.DIALOG_W_SM)
 
         self.label = QLabel("Applying B/W point conversion", self)
         self.label.setAlignment(Qt.AlignCenter)
@@ -1677,6 +1673,7 @@ class BWPointConvertDialog(QDialog):
         self.stop_button.clicked.connect(self._on_stop)
 
         layout = QVBoxLayout()
+        theme.apply_panel_spacing(layout)
         layout.addWidget(self.label)
         layout.addWidget(self.progress_label)
         layout.addWidget(self.stop_button)

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -2,8 +2,9 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QSlider, QLabel, QHBoxLayou
                                 QSizePolicy, QStyleOptionSlider, QFrame, QStyle,
                                 QPushButton, QDialog, QMessageBox, QScrollArea,
                                 QCheckBox, QComboBox)
-from PySide6.QtCore import Qt, QTimer, QThread, Signal
-from PySide6.QtGui import QPixmap, QKeySequence, QShortcut
+from PySide6.QtCore import Qt, QTimer, QThread, Signal, QRectF
+from PySide6.QtGui import (QPixmap, QKeySequence, QShortcut, QPainter, QColor,
+                           QLinearGradient, QPen)
 from core.ccr_backend import ccr_backend
 from core.ccr_processor import COLOR_BANDS, BAND_PARAMS, BAND_ADJUSTMENT_KEYS
 from widgets.curve_editor import CurveEditor
@@ -178,6 +179,55 @@ class ResettableSlider(QSlider):
         elif delta < 0:
             self.setValue(self.value() - 1)
         event.accept()
+
+
+class GradientSlider(ResettableSlider):
+    """A horizontal slider whose groove is a left->right colour gradient
+    (Temperature blue->amber, Tint green->magenta) so the axis reads at a glance.
+
+    The groove + knob are painted directly rather than via QSS: a global
+    ``QSlider`` stylesheet rule, matching this widget through subclassing, would
+    otherwise outrank any per-widget / #id groove rule (a Qt cascade quirk), so
+    QSS gradients never take here. Custom painting sidesteps that entirely.
+    """
+
+    GROOVE_H = 6
+    KNOB_D = 14
+
+    def __init__(self, stops, orientation=Qt.Horizontal, parent=None):
+        super().__init__(orientation, parent)
+        self._lo = QColor(stops[0])
+        self._hi = QColor(stops[1])
+
+    def paintEvent(self, event):
+        opt = QStyleOptionSlider()
+        self.initStyleOption(opt)
+        groove = self.style().subControlRect(
+            QStyle.CC_Slider, opt, QStyle.SC_SliderGroove, self)
+        handle = self.style().subControlRect(
+            QStyle.CC_Slider, opt, QStyle.SC_SliderHandle, self)
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        # Gradient groove bar, vertically centred.
+        gy = self.height() / 2 - self.GROOVE_H / 2
+        bar = QRectF(groove.x(), gy, groove.width(), self.GROOVE_H)
+        grad = QLinearGradient(bar.left(), 0.0, bar.right(), 0.0)
+        grad.setColorAt(0.0, self._lo)
+        grad.setColorAt(1.0, self._hi)
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(grad)
+        painter.drawRoundedRect(bar, 3, 3)
+
+        # Light, outlined knob at the handle position.
+        knob = QRectF(0, 0, self.KNOB_D, self.KNOB_D)
+        knob.moveCenter(QRectF(handle).center())
+        painter.setBrush(QColor(theme.Paint.CURVE_NODE))
+        painter.setPen(QPen(QColor(theme.Paint.CURVE_NODE_OUTLINE), 1))
+        painter.drawEllipse(knob)
+        painter.end()
+
 
 class SlidersPanel(QWidget):
     # Order must match the create_slider() call order exactly — the two
@@ -398,8 +448,10 @@ class SlidersPanel(QWidget):
         # luminance channel (preview and export). Per-image, like the sliders.
         self.color_profile_row = self._create_color_profile_row()
 
-        self.temperature_slider_layout = self.create_slider("Temperature")
-        self.tint_slider_layout = self.create_slider("Tint")
+        self.temperature_slider_layout = self.create_slider(
+            "Temperature", gradient=theme.TEMP_GRADIENT)
+        self.tint_slider_layout = self.create_slider(
+            "Tint", gradient=theme.TINT_GRADIENT)
         self.exposure_slider_layout = self.create_slider("Gain")
         self.brightness_slider_layout = self.create_slider("Brightness")
         self.highlights_slider_layout = self.create_slider("Highlights")
@@ -612,8 +664,13 @@ class SlidersPanel(QWidget):
             self.histogram_label.setText("")
 
     def create_slider(self, label_text, min_value=-100, max_value=100,
-                      default_value=0):
-        slider = ResettableSlider(Qt.Horizontal)
+                      default_value=0, gradient=None):
+        # `gradient` (a (left, right) colour pair) gives a custom-painted
+        # gradient groove — e.g. Temperature blue->amber, Tint green->magenta.
+        if gradient is not None:
+            slider = GradientSlider(gradient, Qt.Horizontal)
+        else:
+            slider = ResettableSlider(Qt.Horizontal)
         slider.setMinimum(min_value)
         slider.setMaximum(max_value)
         slider.setValue(default_value)

--- a/src/widgets/tether_banner.py
+++ b/src/widgets/tether_banner.py
@@ -3,11 +3,13 @@
 Inserted into ImagePreview's own internal layout (see spec §9.1.5) — NOT wrapped
 around image_preview, which would break its parent().parent() chains.
 
-Styled to fit FreeCCR's default (light) theme: a soft amber "active session"
+Styled to fit FreeCCR's neutral dark theme: a muted warning "active session"
 strip with a red recording dot and a clearly-visible Stop button.
 """
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QPushButton
+
+from ui import theme
 
 
 class TetherBanner(QWidget):
@@ -19,27 +21,28 @@ class TetherBanner(QWidget):
         # Scope the background to the banner itself (objectName selector) so the
         # child labels/button keep their own styling.
         self.setStyleSheet(
-            "#TetherBanner { background-color: #fff3cd; "
-            "border-bottom: 1px solid #e6cf87; }")
+            f"#TetherBanner {{ background-color: {theme.WARN_BG}; "
+            f"border-bottom: 1px solid {theme.WARN_BORDER}; }}")
         layout = QHBoxLayout(self)
         layout.setContentsMargins(12, 5, 12, 5)
         layout.setSpacing(8)
 
         self._dot = QLabel("●")  # ●
         self._dot.setStyleSheet(
-            "color: #d9534f; font-size: 13px; background: transparent;")
+            f"color: {theme.DANGER}; font-size: 13px; background: transparent;")
         self._status = QLabel("")
         self._status.setStyleSheet(
-            "color: #5c4a00; font-weight: bold; background: transparent;")
+            f"color: {theme.WARN_TEXT}; font-weight: bold; background: transparent;")
         self._note = QLabel("")
-        self._note.setStyleSheet("color: #9a6a00; background: transparent;")
+        self._note.setStyleSheet(
+            f"color: {theme.WARN_TEXT_MUTED}; background: transparent;")
         self._stop = QPushButton("Stop")
         self._stop.setFixedHeight(24)
         self._stop.setStyleSheet(
-            "QPushButton { background-color: #d9534f; color: white; border: none; "
-            "border-radius: 4px; padding: 2px 14px; }"
-            "QPushButton:hover { background-color: #c9302c; }"
-            "QPushButton:pressed { background-color: #ac2925; }")
+            f"QPushButton {{ background-color: {theme.DANGER}; color: white; border: none; "
+            f"border-radius: 4px; padding: 2px 14px; }}"
+            f"QPushButton:hover {{ background-color: {theme.DANGER_HOVER}; }}"
+            f"QPushButton:pressed {{ background-color: {theme.DANGER_PRESSED}; }}")
         self._stop.clicked.connect(self.stopRequested)
 
         layout.addWidget(self._dot)

--- a/src/widgets/tether_banner.py
+++ b/src/widgets/tether_banner.py
@@ -24,8 +24,8 @@ class TetherBanner(QWidget):
             f"#TetherBanner {{ background-color: {theme.WARN_BG}; "
             f"border-bottom: 1px solid {theme.WARN_BORDER}; }}")
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(12, 5, 12, 5)
-        layout.setSpacing(8)
+        layout.setContentsMargins(theme.SPACE_XL, theme.GAP_ROW, theme.SPACE_XL, theme.GAP_ROW)
+        layout.setSpacing(theme.GAP_BTN)
 
         self._dot = QLabel("●")  # ●
         self._dot.setStyleSheet(
@@ -37,10 +37,10 @@ class TetherBanner(QWidget):
         self._note.setStyleSheet(
             f"color: {theme.WARN_TEXT_MUTED}; background: transparent;")
         self._stop = QPushButton("Stop")
-        self._stop.setFixedHeight(24)
+        self._stop.setFixedHeight(theme.CONTROL_H)
         self._stop.setStyleSheet(
             f"QPushButton {{ background-color: {theme.DANGER}; color: white; border: none; "
-            f"border-radius: 4px; padding: 2px 14px; }}"
+            f"border-radius: {theme.RADIUS_SM}px; padding: 2px 14px; }}"
             f"QPushButton:hover {{ background-color: {theme.DANGER_HOVER}; }}"
             f"QPushButton:pressed {{ background-color: {theme.DANGER_PRESSED}; }}")
         self._stop.clicked.connect(self.stopRequested)

--- a/src/widgets/thumbnail_list.py
+++ b/src/widgets/thumbnail_list.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 from io import BytesIO
 from core.ccr_backend import ccr_backend  # <-- Add this import
+from ui import theme
 
 class LoadingDialog(QDialog):
     def __init__(self, parent=None, cancel_callback=None):
@@ -25,9 +26,11 @@ class LoadingDialog(QDialog):
         # Add Cancel button
         self.cancel_button = QPushButton("Cancel")
         self.cancel_button.setFixedWidth(100)
+        self.cancel_button.setFixedHeight(theme.CONTROL_H)
         self.cancel_button.clicked.connect(self.on_cancel)
         self.cancel_callback = cancel_callback
         btn_layout = QVBoxLayout()
+        btn_layout.setSpacing(theme.GAP_ROW)
         btn_layout.addWidget(self.cancel_button, alignment=Qt.AlignCenter)
         layout.addLayout(btn_layout)
 
@@ -88,6 +91,7 @@ class ThumbnailList(QWidget):
 
     def init_ui(self):
         self.layout = QVBoxLayout()
+        theme.apply_panel_spacing(self.layout)
 
         # Positive mode toggle — sits above the thumbnails. When checked, RAWs
         # decode as normal sRGB positives and the film-negative tools are

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,99 @@
+"""Tests for the neutral-dark theme system (src/ui/theme.py).
+
+See spec/visual-redesign.md §9.1. Runs headless (offscreen Qt platform).
+"""
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+from PySide6.QtGui import QPalette, QPixmap, QColor  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from ui import theme  # noqa: E402
+
+
+def test_apply_theme_applies_palette_and_stylesheet():
+    from PySide6.QtWidgets import QStyleFactory
+    theme.apply_theme(_app)
+    # Qt wraps the base style in QStyleSheetStyle once a stylesheet is set, so
+    # style().objectName() is unreliable; assert the observable effects instead.
+    assert _app.styleSheet().strip(), "global stylesheet should be applied"
+    assert _app.palette().color(QPalette.Window).name() == theme.WINDOW
+    assert "Fusion" in QStyleFactory.keys(), "Fusion base style must be available"
+
+
+def test_palette_matches_tokens():
+    pal = theme.build_palette()
+    assert pal.color(QPalette.Window).name() == theme.WINDOW
+    assert pal.color(QPalette.WindowText).name() == theme.TEXT
+    assert pal.color(QPalette.Base).name() == theme.SURFACE
+    assert pal.color(QPalette.Highlight).name() == theme.SELECTION_BG
+    assert pal.color(QPalette.HighlightedText).name() == theme.SELECTION_TEXT
+    # disabled text is dimmed
+    assert pal.color(QPalette.Disabled, QPalette.Text).name() == theme.TEXT_DISABLED
+
+
+def test_global_qss_covers_every_control_type():
+    qss = theme.global_qss()
+    for selector in (
+        "QPushButton", "QToolButton", "QToolBar", "QComboBox", "QLineEdit",
+        "QGroupBox", "QListWidget", "QScrollBar", "QProgressBar", "QSlider",
+        "QMenuBar", "QMenu", "QTabBar", "QGraphicsView", "QToolTip",
+        'QLabel[caption="true"]',
+    ):
+        assert selector in qss, f"global QSS missing a rule for {selector}"
+
+
+def test_load_tinted_icon_recolors_to_icon_token(tmp_path):
+    # An opaque black source -> every opaque pixel becomes ICON after tinting.
+    src = QPixmap(8, 8)
+    src.fill(QColor(0, 0, 0, 255))
+    png = tmp_path / "black.png"
+    assert src.save(str(png))
+
+    icon = theme.load_tinted_icon(str(png))
+    assert not icon.isNull()
+
+    img = icon.pixmap(8, 8).toImage()
+    col = img.pixelColor(4, 4)
+    assert (col.red(), col.green(), col.blue()) == (0xCF, 0xCF, 0xCF)
+
+
+def test_histogram_backdrop_is_dark_and_coupled():
+    # Numpy backdrop and the QSS container must share one dark value (spec §6.4).
+    assert theme.Paint.HIST_BG == (42, 42, 42)
+    assert theme.Paint.HIST_PEAK == (235, 235, 235)
+
+
+def test_overlay_constants_unchanged_regression():
+    # On-image overlays must keep their functional RGBA (spec §9.1 / §10.3):
+    # centralized, NOT restyled. Locks "no visual change" for overlays.
+    o = theme.Overlay
+    assert o.REF_FRAME == (255, 0, 0, 180)
+    assert o.REF_FRAME_DRAG == (255, 0, 0, 120)
+    assert o.SLICE == (0, 200, 255)
+    assert o.DIM == (0, 0, 0, 80)
+    assert o.DIM_CROP == (0, 0, 0, 110)
+    assert o.DUST_STROKE == (255, 40, 40, 150)
+    assert o.DUST_CURSOR == (255, 255, 255, 220)
+    assert o.CROP_BORDER == (255, 255, 255, 220)
+    assert o.HANDLE_FILL == (255, 255, 255, 235)
+    assert o.HANDLE_OUTLINE == (30, 30, 30, 230)
+    assert o.AREA_LINE == (255, 255, 255, 220)
+    assert o.AREA_FEATHER == (255, 255, 255, 120)
+    assert o.BWP_WHITE == (0, 100, 255, 140)
+    assert o.BWP_DENSE == (255, 140, 0, 140)
+    assert o.COMP_GRID == (0, 80, 0, 80)
+    assert o.CURSOR_LIGHT == (255, 255, 255)
+    assert o.CURSOR_DARK == (25, 25, 25)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Gives FreeCCR a single, coherent **neutral-dark** look suited to color-critical work (film-negative conversion + color correction), replacing the previous scattered, inconsistent per-widget styling. The palette is deliberately neutral grayscale (no hue cast) so the UI never biases perception of image color — the same rationale Lightroom / Capture One / Photoshop use. **Dark-only** for v1.

Layout and interaction are unchanged — this is a full reskin via a theme system, not an IA change.

Spec: `spec/visual-redesign.md`.

## What changed

- **New `src/ui/theme.py`** — single source of truth: design tokens (surfaces/text/accent/semantic + `Paint`/`Overlay` constants), `build_palette()` (dark Fusion `QPalette`), `global_qss()` covering every control type, and `load_tinted_icon()`. Installed once in `main.py` via `apply_theme(app)`.
  - **Fusion is required**: the native Windows style ignores `QPalette`; Fusion honors it fully.
- **Widget refactor** — the ~30 inline `setStyleSheet` color literals and the histogram/curve paint colors now reference theme tokens:
  - **Toolbar icons tinted** (auto/rotate/mirror) so the black line-art is visible on dark.
  - **Tether banner** re-themed from light amber to dark.
  - **Histogram** backdrop darkened (numpy render + QSS container kept in sync via one token).
  - Channel R/G/B labels, color-band swatches, and the dust "Done" button sourced from tokens.
- **UI chrome vs. on-image overlays** are split deliberately: curve canvas/histogram follow the dark theme; crop/dust/slice/reference overlays keep their bright functional colors (tuned for contrast over photos) and are unchanged — locked by a regression test.

## Testing

- `tests/test_theme.py` — **6/6 pass** (palette matches tokens, global QSS covers every control type, icon tinting recolors correctly, overlay constants unchanged regression).
- Changed-widget tests (curves, dust, crop overlay) pass; `test_export.py` passes 8/8 in isolation.
- **No new regressions**: the suite's pre-existing failures (`exposure_base` `AttributeError` from the earlier Exposure→Gain rename) and an intermittent native heap-corruption/GC crash in the OpenCL path both reproduce on a pristine baseline with these changes stashed. Worth a separate ticket.

## Verification

Before/after rendered offscreen with the `qt-testing` skill (real fonts). The app goes from the light native Windows look to a coherent neutral-dark UI across menus, toolbar, sliders, dialogs, scrollbars, and the image canvas.

## Follow-ups (optional, out of scope here)

- Centralize the remaining `image_preview.py` overlay `QColor` literals onto the `Overlay` class (no visual change; constants + regression test already in place).
- Fix the pre-existing `exposure_base` test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
