### PR TITLE
feat: IT8 camera ICC maker + B/W-point/Gain/DNG changes on main

### DIFF
--- a/spec/it8-camera-profile.md
+++ b/spec/it8-camera-profile.md
@@ -439,3 +439,48 @@ Manual:
    are not lost when the active profile changes.
 6. **Both IT8.7/1 and IT8.7/2 accepted** (identical layout); chart type shown for
    confirmation only.
+
+## 11. Refinement (v2) — CxF references, mirroring, non-classic grids
+
+Driven by a real user target (LaserSoft **ISO 12641-2 "advanced"** transmissive
+film target, 864 patches, batch reference in **CxF**).
+
+### 11.1 CxF reference files (`parse_cxf_reference`)
+- `parse_reference(path)` dispatches by content: XML / `.cxf` → CxF, else CGATS.
+- CxF3 (ISO 17972) is XML. The parser is **namespace-tolerant** (default *or*
+  `cc:` namespace — strip to local names) and **spelling-tolerant**: LaserSoft
+  uses British `Colour*` (e.g. `ColourValues`, `ColourCIELab`, `ColourIEXYZ`,
+  `ColourSpecification`); X-Rite uses American `Color*`. Values are matched by
+  **child structure** (`L/A/B` ⇒ Lab, `X/Y/Z` ⇒ XYZ), not by tag name, so the
+  spelling variance is irrelevant.
+- Each value's `Colo[u]rSpecification` IDREF resolves against
+  `ColorSpecificationCollection`; the D50/2° value is preferred. XYZ are Y≈100.
+- Patch id = `Object/@Name`. `ObjectType` substrate/colorant/trick/measurements
+  are skipped.
+
+### 11.2 Mirrored capture
+A back-lit film target shot through its base is left-right **mirrored**. The
+locator gains a **"Mirrored capture"** checkbox that `np.fliplr`s the working
+image (display + sampling); patch geometry then maps normally. Distinct from
+**Flip 180°** (rotation), which a mirror cannot be corrected by.
+
+### 11.3 Non-classic (plain-grid) targets — block mode
+Targets that aren't the classic 12×22-colour-block-plus-GS-strip layout (e.g.
+the ISO 12641-2 advanced grid, a regular 12×72 with grays as in-grid rows) use
+**block mode**: a regular `rows × cols` grid the user delimits by the **top-left
+and bottom-right patch ids** of the block in frame (e.g. `A49`/`L72` for one
+photographed panel). `parse_block` derives the row letters + column numbers;
+`block_sample_points` lays the grid on the 4-corner quad. The dialog selects
+block vs classic by whether the reference has a `GS0` patch.
+
+### 11.4 ID-agnostic, auto-neutral fit
+`fit_camera_matrix` no longer assumes the classic id set or a `GS0` white patch.
+It fits over whatever ids are sampled-and-in-reference, and `_pick_wb_id`
+auto-selects the **lightest low-chroma (near-neutral) patch** from the reference
+— working for the classic GS strip *and* in-grid grays. Sampling-window size
+scales to the grid density (`ncols`/`nrows`).
+
+### 11.5 Validated on real data
+The full path (CxF parse → un-mirror → 12×24 block A49–L72 → auto-neutral fit)
+on the user's LaserSoft shot yields **avg ΔE2000 ≈ 1.8** (232 of 288 patches;
+dark patches clipped at the low end were rejected).

--- a/spec/it8-camera-profile.md
+++ b/spec/it8-camera-profile.md
@@ -1,0 +1,441 @@
+# Spec: Create Camera ICC Profile from an IT8 Target
+
+Status: REFINED v1
+Owner: FreeCCR
+Feature branch: `feature/it8-camera-profile`
+
+## 1. Summary
+
+Add a File-menu feature that builds a **camera input ICC profile** from a
+photograph of an **IT8 calibration target** shot under the user's capture light.
+The user photographs a printed IT8 chart (a grid of patches with factory-measured
+colours), supplies the matching batch reference file, locates the patch grid in
+the shot, and the app fits a camera-RGB→XYZ colour transform and writes a valid
+ICC profile. The profile plugs directly into FreeCCR's **existing global Input
+ICC Profile** system (`File ▸ Set Input ICC Profile…`), so once built it is
+applied to every decoded scan before negative conversion/adjustments.
+
+The whole feature is **self-contained in pure numpy + OpenCV** (both already
+dependencies). It reuses the in-process ICC writer
+(`color_management.build_matrix_shaper_icc`) and the `InputProfile` apply path
+that already exist — **no ArgyllCMS, lcms, Pillow, scipy, or colour-science**
+dependency is added.
+
+### Why this fits FreeCCR exactly
+- The default (negative) decode path produces **raw-linear sensor RGB**
+  (`rawpy` `output_color=raw`, `gamma=(1,1)`, no white balance, white-level
+  scaled to 16-bit) — see `ccr_image.py:307`/`read_image`. That is precisely the
+  *device RGB* an input ICC profile maps from.
+- A camera profile fit as a **3×3 matrix (linear device RGB → XYZ D50) + identity
+  tone curve** is exactly a **matrix-shaper** ICC profile — the only kind the app
+  builds (`build_matrix_shaper_icc`) and the only kind `InputProfile` accepts.
+- The created profile is therefore round-trippable: we synthesise it, and the
+  app's own `InputProfile.from_bytes` parses and applies it with no new plumbing.
+
+## 2. Goals / Non-goals
+
+### Goals
+- A File-menu item **"Create Camera Profile from IT8…"** that opens a guided
+  multi-step dialog (wizard).
+- Parse an IT8 **CGATS.17** reference file (Wolf Faust `.it8`/`.txt` and
+  equivalents), reading columns dynamically from the `DATA_FORMAT` block.
+- Decode the IT8 target shot to **raw-linear device RGB**, identically to the
+  negative pipeline and **independent of** the global Positive-mode toggle and of
+  any currently-set input profile.
+- A **patch locator**: the user drags 4 corner handles onto the colour grid; the
+  app overlays all 288 sample points (264 colour + 24 grayscale) via a perspective
+  homography and samples each patch robustly (central window, trimmed mean, clip
+  rejection).
+- Fit a **3×3 camera matrix** (least squares, neutral-axis pinned to D50) and
+  write a valid matrix-shaper ICC profile via the existing builder.
+- Report **fit quality** (mean / median / max ΔE2000) with a pass/warn indicator
+  and a per-patch list.
+- **Save** the `.icc` to a per-user profiles folder, and optionally **apply it
+  now** as the global input profile (reusing `ccr_backend.set_input_icc`).
+- Unit tests for the parser, grid geometry, matrix fit (synthetic round-trip),
+  ΔE math, and ICC build→reparse.
+
+### Non-goals
+- **No ArgyllCMS / external binaries.** No `scanin`/`colprof`, no per-platform
+  bundles, no AGPL entanglement.
+- **No cLUT / polynomial / root-polynomial profiles.** A matrix-shaper ICC can
+  only store a 3×3 + per-channel curves, so higher-order fits are out of scope
+  (noted in §5.6). 3×3 is the correct, well-behaved camera model here.
+- **No automatic chart detection / fiducial recognition.** Manual 4-corner
+  placement is the robust, industry-standard choice for hand-held camera shots.
+- **No dual-illuminant profiles** (that is a DCP feature; a single ICC is valid
+  only under the light it was shot — surfaced as guidance, not engineered around).
+- **No application of the camera profile in Positive mode.** The input ICC is, by
+  existing design (`read_image` skips it when `positive_decode`), a tool for the
+  raw-linear negative path. Positive mode already colour-manages via `rawpy`
+  `output_color=sRGB`. Out of scope to change.
+- **No spectral / measurement-instrument path** (we consume a reference file; we
+  do not measure the chart).
+- No bundled reference files — the user must supply the file matching their
+  chart's batch (we link them to the source in the UI text).
+
+## 3. Background (researched)
+
+### 3.1 What IT8 is
+An IT8 target (ISO 12641) is a printed chart of colour patches whose CIE values
+were spectrophotometrically measured at the factory. **IT8.7/1** is transmissive
+(film/slide); **IT8.7/2** is reflective (paper). The patch *layout is identical*
+between them; only the substrate differs. The feature accepts either (the chart
+type is read from the reference file but does not change the math). Common source:
+Wolf Faust (coloraid.de / colorreference.de), which ships a **free reference file
+per production batch**.
+
+### 3.2 Chart geometry
+- **Colour grid:** 12 rows `A`–`L` (top→bottom) × 22 columns `1`–`22`
+  (left→right) = **264 patches**. Patch IDs concatenate row+col: `A1`…`A22`,
+  `B1`… `L22`. Iteration order: column fastest, row slowest.
+- **Grayscale strip:** **24 steps `GS0`…`GS23`** in one horizontal row **below
+  row L**, `GS0` (lightest / Dmin) at left → `GS23` (darkest / Dmax) at right. The
+  strip uses the same horizontal pitch as the colour columns but has 24 cells and
+  begins flush at the chart's left margin, so it is **slightly wider and offset**
+  from the 22-column block — it must be modelled as its own 1×24 row, not as
+  "22 + 2".
+- ArgyllCMS's `it8.cht` gives proportionally exact extents (active frame
+  615.5 × 409 units; colour block x∈[26.625, 590.375], y∈[26.625, 334.125]; gray
+  strip x∈[0, 615], y∈[358.75, 410]; `BOX_SHRINK 3.5` ⇒ sample ~73% central). We
+  use these ratios to place the grayscale row relative to the colour block.
+
+### 3.3 Reference file (CGATS.17) format
+Plain ASCII. Structure:
+- **Line 1**: chart-type token, e.g. `IT8.7/1` or `IT8.7/2`.
+- **Preamble**: `KEYWORD "value"` lines — `ORIGINATOR`, `DESCRIPTOR`,
+  `MANUFACTURER`, `SERIAL "E111007 Batch Average Data"` (batch id),
+  `NUMBER_OF_FIELDS n`, `NUMBER_OF_SETS 288`. `#` starts a comment. A
+  `KEYWORD "NAME"` line registers a custom column name.
+- **`BEGIN_DATA_FORMAT` … `END_DATA_FORMAT`**: one whitespace-separated line of
+  column names, e.g.
+  `SAMPLE_ID XYZ_X XYZ_Y XYZ_Z LAB_L LAB_A LAB_B …`. **Field set varies by
+  batch** (17 vs 18 fields seen). The only reliably-present columns are
+  `SAMPLE_ID`, `XYZ_X/Y/Z`, and `LAB_L/A/B`.
+- **`BEGIN_DATA` … `END_DATA`**: one row per patch, tokens positional against the
+  format line, keyed by `SAMPLE_ID`. XYZ are D50 / 2° tristimulus scaled to white
+  ≈ Y=100. Lab is CIE L\*a\*b\* against D50.
+A parser **must** read columns from the `DATA_FORMAT` block (never hard-code
+positions), tolerate CRLF/BOM/comments/blank lines/quoted-or-unquoted values, and
+validate row/field counts.
+
+### 3.4 The fitting model (researched, reduced to our container)
+For raw-linear device RGB the well-behaved camera model is:
+**identity TRC + a single 3×3 matrix `M` (device-linear RGB → XYZ D50), least
+squares, neutral-axis pinned so equal RGB → D50 white.** Because the reference is
+already D50, `M`'s columns are directly the ICC `rXYZ`/`gXYZ`/`bXYZ` colorants
+(no Bradford adaptation needed). Good 3×3 camera profiles land **avg ΔE2000 ≈
+1–3, max ≈ 5–8**; avg < 2 is good, avg < 1 is rarely reachable without
+cLUT/polynomial fits (out of scope).
+
+### 3.5 Capture conditions (surfaced as in-app guidance)
+A camera profile bakes in the light's spectrum and is valid only under that light.
+Guidance to show the user (Step 1 of the wizard and a "?" help): broad-spectrum
+daylight/strobe (not tungsten/fluorescent); even 45° lighting, no glare/specular
+hotspots, no vignetting; chart flat and fronto-parallel; fill the centre of the
+frame; expose so the brightest neutral (GS0) is bright but **not clipped** in any
+channel; **shoot RAW** (the profiling decode uses raw-linear: no WB, linear gamma,
+no camera matrix — the same device space the negative pipeline relies on).
+
+## 4. Data model & files
+
+### 4.1 New module `src/core/it8_profile.py` (pure logic, no Qt)
+Public surface:
+```python
+# --- reference file ---
+class IT8Reference:
+    chart_type: str            # 'IT8.7/1' | 'IT8.7/2' | '' (unknown)
+    batch: str                 # SERIAL value, for display/confirmation
+    descriptor: str
+    fields: list[str]          # column names from DATA_FORMAT
+    patches: dict[str, dict]   # 'A1' -> {'XYZ_X':..,'XYZ_Y':..,'XYZ_Z':..,'LAB_L':..}
+    def xyz(self, sample_id) -> np.ndarray | None      # (3,) D50, Y≈100 scale
+    def lab(self, sample_id) -> np.ndarray | None      # (3,) from LAB_* or derived
+def parse_it8_reference(path: str) -> IT8Reference     # raises IT8ReferenceError
+
+# --- patch grid geometry ---
+COLOR_IDS:  list[str]    # ['A1',...,'A22','B1',...,'L22'] (264, col-fastest)
+GRAY_IDS:   list[str]    # ['GS0',...,'GS23'] (24)
+ALL_IDS = COLOR_IDS + GRAY_IDS
+def grid_sample_points(quad, gray_offset=DEFAULT_GRAY) -> dict[str, (x, y)]
+    # quad = 4 corners (TL,TR,BR,BL) of the COLOR block in array coords.
+    # Returns array-space sample centres for all 288 ids via a homography;
+    # gray row placed from §3.2 ratios (gray_offset tunes its vertical position).
+
+# --- sampling ---
+def sample_patches(img_u16, points, frac=0.5) -> dict[str, PatchSample]
+    # PatchSample: rgb (3,) float in [0,65535], valid: bool (clip test), n_pix:int
+    # central-window trimmed mean per channel; valid=False if >2% pixels clipped.
+
+# --- fit ---
+class CameraFit:
+    matrix: np.ndarray         # (3,3) device-norm RGB[0,1] -> XYZ D50 (white≈1)
+    avg_de: float; med_de: float; max_de: float
+    per_patch: list[(id, dE2000)]
+    used_ids: list[str]; dropped_ids: list[str]
+def fit_camera_matrix(samples, ref, *, weight='1/Y', wb_id='GS0') -> CameraFit
+
+# --- icc ---
+def build_camera_icc(fit, desc, illuminant_note) -> bytes
+    # identity TRC + matrix colorants via color_management.build_matrix_shaper_icc
+```
+`IT8ReferenceError` is a new exception (mirrors `UnsupportedICCError`'s role) so
+the dialog can show a friendly message on a malformed/empty file.
+
+### 4.2 New widget `src/widgets/it8_profile_dialog.py` (Qt UI)
+- `IT8ProfileDialog(QDialog)` — a `QStackedWidget` of pages with Back/Next/Cancel,
+  matching the app's existing dialog styling (cf. `export_dialog.py`,
+  `UpdateAvailableDialog`).
+- `IT8PatchLocator(QWidget)` — displays the (gamma-stretched for visibility)
+  decoded target, 4 draggable colour-block corner handles, a live overlay of all
+  288 sample dots, a **Flip 180°** button, and a **gray-strip vertical** nudge
+  slider for batch variation. Works in the *sampling array's* coordinate space
+  (a display↔array scale is applied for painting).
+
+### 4.3 Edits
+- `src/ui/main_window.py` — add the File-menu action + handler
+  `create_camera_profile_from_it8()`.
+- `src/core/ccr_image.py` — extend `read_image` with two optional, default-noop
+  params so the profiling decode is exact and isolated (see §6.1):
+  `read_image(..., positive_override: Optional[bool] = None,
+   apply_input_icc: bool = True)`.
+
+### 4.4 Profile storage
+Saved `.icc` files live in a per-user folder next to the catalog:
+`<appdata>/camera_profiles/<name>.icc` (folder created on demand). "Apply now"
+copies into the existing input-profile slot via `ccr_backend.set_input_icc(path)`
+(which already copies to its own persistent working copy and activates it). The
+two storages are independent by design (a saved camera profile survives changing
+the active input profile).
+
+## 5. Processing / math (in `it8_profile.py`)
+
+### 5.1 Decode the target (device RGB)
+Use `read_image(preview=True, max_long_side=SAMPLE_MAX, positive_override=False,
+apply_input_icc=False)` (see §6.1) so the target is decoded **raw-linear, no input
+ICC, regardless of Positive mode**. `SAMPLE_MAX = 2048` bounds memory while
+leaving ample pixels per patch (~80px/patch ⇒ ~1.5k px in each central window);
+the half-size (preview) RAW decode is plenty at that cap and matches the runtime
+preview's device space. `decode_target` constructs the `CCRImage` via `__new__`
+(setting only `source_ops`) to skip the heavyweight `__init__` (which would do a
+redundant 1080px decode + lens correction + thumbnail).
+
+### 5.2 Patch grid geometry (`grid_sample_points`)
+- Build a perspective homography `H` mapping the unit square corners
+  `(0,0),(1,0),(1,1),(0,1)` → the user's 4 colour-block corners `(TL,TR,BR,BL)`
+  (via `cv2.getPerspectiveTransform`).
+- **Colour patch centres** in unit space: column `c∈0..21` → `u=(c+0.5)/22`;
+  row `r∈0..11` → `v=(r+0.5)/12`. Map `(u,v)` through `H`.
+- **Gray strip** in the *same* unit space, from §3.2 ratios relative to the colour
+  block (block width 563.75, height 307.5, origin (26.625,26.625) in cht units):
+  `u_g(k) = ((k+0.5)*25.625 - 26.625)/563.75` for `k∈0..23`;
+  `v_g = (384.375 - 26.625)/307.5 + gray_offset ≈ 1.163 + gray_offset`.
+  These land outside `[0,1]`; the homography extrapolates correctly because the
+  chart is planar. `gray_offset` (slider, default 0) nudges the strip vertically
+  to absorb manufacturer variation.
+- Orientation: handles are placed TL→TR→BR→BL; **Flip 180°** reverses the corner
+  list (and the dot overlay updates), covering an upside-down placement. A
+  validation hint checks that sampled `GS0` is lighter than `GS23` and warns if
+  not.
+
+### 5.3 Sampling (`sample_patches`)
+For each id's centre `(x,y)`, take a window of `frac × local-cell-size` (default
+`frac=0.5`; ~central 50%), `clip` to image bounds, compute a **per-channel
+trimmed mean** (drop the 10th/90th percentile tails) over the window. Mark
+`valid=False` when >2% of window pixels are clipped (≤0.5% or ≥99.5% of full
+scale) in any channel — those patches are excluded from the fit. Local cell size
+is derived from neighbouring mapped centres so the window scales with perspective.
+
+### 5.4 Matrix fit (`fit_camera_matrix`)
+Inputs: `samples` (device RGB per id) and `ref` (XYZ per id). Steps:
+1. Keep ids present in **both** sample set and reference and with `valid=True`.
+   Normalise device RGB `d = rgb/65535 ∈ [0,1]`; reference `X = XYZ/100`
+   (so GS0 white ≈ Y 0.83, D50 white = 1.0).
+2. **White-balance** on the lightest valid neutral (`wb_id='GS0'`, fallback to the
+   highest-L valid `GS*`): `gains = mean(d_wb_patch) / d_wb_patch` (per channel);
+   `d_wb = d * gains` (now the neutral is equal-RGB).
+3. **Weighted least squares** (weight `w_i = 1/max(Y_i, ε)` to stop bright patches
+   dominating): with `sw=√w`, solve
+   `A, *_ = np.linalg.lstsq(d_wb*sw[:,None], X*sw[:,None], rcond=None)`;
+   `M_wb = A.T` (so `XYZ = M_wb @ d_wb`).
+4. **Neutral pin to D50**: `M_pin = M_wb @ diag(D50_XYZ / (M_wb @ [1,1,1]))` so
+   equal-RGB (post-WB) maps exactly to D50 chromaticity (`D50_XYZ` reuses
+   `color_management.D50_XYZ`). This is the "well-behaved" constraint.
+5. **Fold WB back in** so the stored matrix consumes *un*-white-balanced device
+   RGB: `M = M_pin @ diag(gains)`. (A neutral scene, after the camera's own
+   imbalance, still maps neutral because the profile applies `gains` then `M_pin`
+   internally — algebraically `M·d = M_pin·(gains·d)`.)
+6. `fit.matrix = M`. Columns of `M` are the D50 colorants for the ICC.
+
+### 5.5 Quality (ΔE2000)
+Predicted Lab per patch: `xyz_to_lab((M @ d)·100)`; reference Lab from the
+file's `LAB_*` columns (or `xyz_to_lab(XYZ_ref)` if absent). Compute **CIEDE2000**
+(`kL=kC=kH=1`, Sharma formulation, pure numpy) and **ΔE76** for cross-check;
+report mean/median/95th/max over the *used* patches, plus the per-patch list
+(sorted worst-first) for the results page. `xyz_to_lab` uses D50 white
+`[96.422,100,82.521]`, `ε=216/24389`, `κ=24389/27`.
+
+Indicator thresholds: **good** avg ΔE2000 < 2.0, **ok** < 4.0, **warn** ≥ 4.0 or
+max > 12 (suggest re-checking corner placement / clipping / lighting).
+
+### 5.6 Why 3×3 + identity TRC (and not more)
+An ICC matrix-shaper stores only a 3×3 colorant matrix + per-channel TRCs. 3×4
+(offset), polynomial, and root-polynomial fits are not representable in that
+container (they would require a cLUT `mAB`/`A2B` profile, which neither our writer
+nor `InputProfile` supports). Raw-linear input ⇒ TRC is identity (gamma 1.0). So
+the model is fixed: **identity TRC + 3×3**. Residual black level is handled by
+`rawpy`'s black subtraction at decode (optionally refine by subtracting the GS23
+sample before the fit to keep the model a pure 3×3 with no offset term).
+
+### 5.7 ICC synthesis (`build_camera_icc`)
+Call `color_management.build_matrix_shaper_icc(desc, r_xyz, g_xyz, b_xyz,
+trc_para=(1.0,1.0,0.0,1.0,0.0), wtpt=D50_XYZ, copyright_text=…)` where
+`r_xyz,g_xyz,b_xyz = M[:,0], M[:,1], M[:,2]`. The TRC params `(g=1,a=1,b=0,c=1,
+d=0)` evaluate to the identity (`_eval_para` func 3 ⇒ `y=x` for `x≥0`). `desc`
+encodes the user's profile name + illuminant note (e.g.
+`"FreeCCR Camera — Daylight (2026-06-17)"`). The bytes are a valid ICC v2.4
+matrix-shaper profile that `InputProfile.from_bytes` parses without
+`UnsupportedICCError` (verified by a unit test).
+
+## 6. Integration points
+
+### 6.1 `read_image` isolation params (`ccr_image.py`)
+Add two optional params, both defaulting to current behaviour:
+```python
+def read_image(self, file_path, preview=True, max_long_side=None,
+               positive_override=None, apply_input_icc=True):
+    ...
+    positive_mode = (self._positive_mode_active() if positive_override is None
+                     else positive_override)
+    ...
+    # every place that currently calls self._apply_input_icc(x):
+    return x if not apply_input_icc else self._apply_input_icc(x)
+    # (and the positive-decode short-circuits use the resolved positive_mode)
+```
+Rationale: the profiling decode needs the **negative raw-linear device space with
+no ICC**, irrespective of the live Positive toggle or active profile — and must
+not mutate global state (avoids races with any background decode). This is a
+minimal, backward-compatible change; all existing callers pass nothing and behave
+identically. Unit-test that `positive_override=False, apply_input_icc=False`
+yields the raw-linear array even when an input profile is active and Positive mode
+is on.
+
+### 6.2 File menu (`main_window.py:create_menu`)
+After the Input-ICC actions (≈line 304), add:
+```python
+file_menu.addSeparator()
+it8_action = file_menu.addAction("Create Camera Profile from IT8…")
+it8_action.triggered.connect(self.create_camera_profile_from_it8)
+```
+Handler `create_camera_profile_from_it8()`:
+- Construct `IT8ProfileDialog(self)`. If the currently-selected image looks like a
+  plausible target the dialog offers it as the default Step-1 source (the user can
+  also browse to any file).
+- On accept with "apply now": call the existing
+  `set_input_icc`/persist/`_reprocess_after_input_icc_change` flow
+  (`main_window.set_input_icc_profile` factored to accept a path), then
+  `_refresh_input_icc_menu()`. Otherwise just confirm the save path via a hint.
+
+### 6.3 Reuse, not reinvent
+- ICC bytes ⇒ `color_management.build_matrix_shaper_icc` (existing).
+- Apply/persist ⇒ `ccr_backend.set_input_icc` + the existing reprocess machinery
+  (existing; our file is a valid matrix-shaper, so it just works).
+- Unicode paths ⇒ `normalize_unicode_path`/`validate_unicode_path` on both the
+  target shot and the reference/output paths (existing utils).
+- D50 constants / `xyz`↔`lab` adjacency ⇒ reuse `color_management.D50_XYZ` (add a
+  small `xyz_to_lab`/ΔE helper in `it8_profile.py`; keep `color_management`
+  focused on ICC I/O).
+
+## 7. UX / wizard flow (`IT8ProfileDialog`)
+
+**Step 1 — Target shot.** Pick the IT8 photo (default: current image; "Browse…"
+for any file). Show capture-conditions guidance and a **RAW recommended** note
+(warn, don't block, if a non-RAW file is chosen — the device space must match the
+user's scan workflow). Decode per §5.1 on Next; show a gamma-stretched preview.
+
+**Step 2 — Reference file.** Browse to the batch CGATS `.it8`/`.txt`. Parse and
+show chart type, **batch/SERIAL**, patch count, and a "matches your chart's
+printed batch number?" reminder + a link to the source. Block Next on a parse
+error (friendly `IT8ReferenceError` message).
+
+**Step 3 — Locate patches.** `IT8PatchLocator`: drag the 4 colour-grid corners;
+live 288-dot overlay; **Flip 180°**; gray-strip vertical nudge. A small live
+read-out shows "valid patches: N/288" and warns if GS0 darker than GS23. Sample
+on Next.
+
+**Step 4 — Build & review.** Fit (§5.4–5.5). Show avg/median/max ΔE2000 with the
+pass/ok/warn chip, a worst-first per-patch list, and the count of dropped
+(clipped/missing) patches. Fields: **Profile name** and **Illuminant** (free text
+or a small combo: Daylight/Strobe/Tungsten/Other) folded into the ICC description.
+A **Back** to re-place corners if quality is poor.
+
+**Step 5 — Save / apply.** Save the `.icc` (default folder §4.4, default name
+`Camera <illuminant> <date>`). Checkbox **"Set as input profile now"** (default
+on). Finish writes the file and (if checked) activates it via the existing input-
+ICC flow, then a confirmation hint.
+
+## 8. Test plan
+
+Unit (`tests/test_it8_profile.py`):
+- **Parser**: small CGATS fixtures for both the 18-field (XYZ+Lab+density) and
+  17-field (XYZ+Lab+STDEV_LAB) layouts; assert chart type, batch, dynamic column
+  mapping, 288 patches keyed by id, XYZ/Lab values; tolerate CRLF, BOM, comments,
+  quoted values; `IT8ReferenceError` on a truncated/empty file and on
+  field/row-count mismatch.
+- **Geometry**: a unit-square quad maps colour centres to expected positions; a
+  known perspective quad round-trips; gray-strip ids land below row L with the 24-
+  cell pitch; `Flip 180°` reverses ids correctly.
+- **Sampling**: a synthesised chart image (flat patches at known RGB) sampled
+  through an identity quad recovers each patch RGB; clipped patches flagged
+  `valid=False`; trimmed mean rejects injected outliers.
+- **Fit (synthetic round-trip — key test)**: choose a known `M_true`, generate
+  device RGB for all 288 patches from the reference XYZ via `M_true⁻¹`, run
+  `fit_camera_matrix`; assert recovered matrix ≈ `M_true` and **avg ΔE2000 ≈ 0**;
+  neutral pin holds (equal RGB → a\*,b\* ≈ 0); clipped/missing patches excluded.
+- **ΔE**: `xyz_to_lab` and `delta_e_2000` validated against published reference
+  pairs (Sharma test data) within tolerance; ΔE76 cross-check.
+- **ICC build→reparse**: `build_camera_icc` bytes parse via
+  `InputProfile.from_bytes` with no `UnsupportedICCError`; `InputProfile.apply`
+  on a synthetic neutral patch yields a near-neutral sRGB result; profile header is
+  RGB/`acsp`/v2.4 matrix-shaper.
+- **`read_image` isolation**: `positive_override=False, apply_input_icc=False`
+  returns raw-linear even with Positive mode on and an active input profile;
+  defaults unchanged (regression).
+
+Manual:
+- Full wizard on a real IT8 shot + matching batch file end-to-end; corner drag +
+  flip + gray nudge; quality chip reacts to mis-placement; save; "apply now"
+  reprocesses loaded images; profile re-loads on app restart (existing input-ICC
+  persistence); reject a LUT/CMYK file chosen by mistake as a *reference* (clear
+  error, not a crash).
+
+## 9. Risks & mitigations
+- **Wrong batch reference** (most common real failure) → show SERIAL/batch and a
+  prominent "must match your chart" reminder; we cannot detect a wrong-but-valid
+  file, so we surface ΔE (a wrong batch inflates it).
+- **Clipped / under-exposed target** → clip rejection drops bad patches; warn when
+  the lightest neutral is clipped or many patches dropped.
+- **Manufacturer geometry variation** → gray-strip nudge + Flip; corners are
+  user-placed so the colour block is always exact; the gray strip is the only
+  derived geometry and is adjustable.
+- **Non-RAW target / mismatched device space** → warn that RAW raw-linear is the
+  matching device space for FreeCCR's pipeline; ΔE will reveal gross mismatch.
+- **Positive-mode confusion** → the profile applies in the negative/raw-linear
+  path only (existing design); documented as a non-goal, not silently inert.
+
+## 10. Refinement (v1) — resolved decisions
+1. **No ArgyllCMS.** Pure-numpy fit + existing in-process ICC writer. Decisive
+   factors: AGPL licensing, per-platform binaries, install bloat, subprocess +
+   Unicode-path fragility — all avoided, and the app already produces/consumes the
+   exact profile class needed.
+2. **Device space = raw-linear via `read_image`** (single source of truth), made
+   exact and isolated by the two new optional params (no global-state mutation).
+3. **Gray strip = derived geometry + nudge**, not a second mandatory quad — fewer
+   handles, robust because only one block's corners are user-critical.
+4. **Neutral-pin to D50** included (well-behaved profile) over a marginally lower
+   raw ΔE from an unconstrained matrix.
+5. **Single global input profile** reused as the apply target (matches the
+   existing one-profile design); saved camera profiles are kept separately so they
+   are not lost when the active profile changes.
+6. **Both IT8.7/1 and IT8.7/2 accepted** (identical layout); chart type shown for
+   confirmation only.

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -56,6 +56,12 @@ class CCRBackend:
         that produced at least one image (a sliced file yields several)."""
         self.images.clear()
         self.file_paths = file_paths
+        # A fresh batch is a new roll: drop any B/W point sampled from the
+        # previous roll so its film base / dense-area density can't carry over
+        # (different stocks differ). Only the in-memory fields are cleared — the
+        # QSettings copy is intact and still restores at next app start.
+        self.black_point_bgr = None
+        self.white_point_bgr = None
         # Preserved removal states belong to the previous batch (the open
         # flows save the catalog before loading a new one)
         self._catalog_preserved = {}
@@ -1339,6 +1345,11 @@ class CCRBackend:
         calibrated default slope (black point only). See
         spec/optional-white-point-default-slope.md."""
         self.white_point_bgr = None
+
+    def clear_black_point(self):
+        """Drop the sampled black point (film base). With no black point the
+        B/W-point section needs a fresh Set Black Point before converting."""
+        self.black_point_bgr = None
 
     def set_black_point(self, bgr_tuple):
         self.black_point_bgr = bgr_tuple

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -318,13 +318,22 @@ class CCRImage:
             four_color_rgb=False,     # Standard 3-color processing
         )
 
-    def read_image(self, file_path: str, preview = True, max_long_side: Optional[int] = None) -> Optional[np.ndarray]:
+    def read_image(self, file_path: str, preview = True, max_long_side: Optional[int] = None,
+                   positive_override: Optional[bool] = None, apply_input_icc: bool = True) -> Optional[np.ndarray]:
         """
         Read an image file. preview=True decodes RAW at half size.
         max_long_side, when given, downsizes to that size INSIDE the reader —
         for RAW this happens before white-level scaling (both steps are
         linear, so the order only changes values by <=3 LSB, and scaling at
         preview size instead of decode size saves ~100 ms per image).
+
+        positive_override / apply_input_icc let a caller pin the decode space
+        without mutating global state (used by the IT8 camera-profiling decode,
+        see spec/it8-camera-profile.md §6.1): positive_override=False forces the
+        raw-linear negative decode regardless of the live Positive-mode toggle,
+        and apply_input_icc=False skips burning in the active input ICC profile —
+        together they yield the bare device RGB an input profile is fitted on.
+        Both default to current behaviour, so existing callers are unaffected.
         """
         # Ensure file path is properly encoded for Unicode support
         file_path = os.path.normpath(file_path)
@@ -336,8 +345,10 @@ class CCRImage:
 
         # Read the global Positive-mode flag once per call so every branch of
         # this decode (RAW vs non-RAW, white-level, input ICC) uses one
-        # consistent value (spec/positive-mode.md §3 "read once").
-        positive_mode = self._positive_mode_active()
+        # consistent value (spec/positive-mode.md §3 "read once"). A caller may
+        # override it (e.g. force the raw-linear decode for IT8 profiling).
+        positive_mode = (self._positive_mode_active() if positive_override is None
+                         else bool(positive_override))
 
         if ext in [".cr3", ".cr2", ".nef", ".arw", ".dng", ".rw2", ".orf", ".raf", ".srw", ".pef", ".3fr"]:
             try:
@@ -428,8 +439,11 @@ class CCRImage:
                 # Burn in the global input ICC (if any) on the decoded scan,
                 # before negative conversion / adjustments. Skipped in positive
                 # mode (the decode is already a ready sRGB positive — the input
-                # ICC is a negative-scanning tool).
-                return rgb if positive_decode else self._apply_input_icc(rgb)
+                # ICC is a negative-scanning tool) and when the caller opted out
+                # (apply_input_icc=False, e.g. IT8 profiling wants bare device RGB).
+                if positive_decode or not apply_input_icc:
+                    return rgb
+                return self._apply_input_icc(rgb)
             except Exception as e:
                 logging.exception(f"Failed to read RAW image: {file_path}")
                 return None
@@ -516,8 +530,11 @@ class CCRImage:
             if max_long_side:
                 img = self.resize_image_to_max_pixel(img, max_long_side)
             # Burn in the global input ICC (if any) before conversion/adjustments.
-            # Skipped in positive mode (treat the file as a ready sRGB positive).
-            return img if positive_mode else self._apply_input_icc(img)
+            # Skipped in positive mode (treat the file as a ready sRGB positive)
+            # and when the caller opted out (apply_input_icc=False).
+            if positive_mode or not apply_input_icc:
+                return img
+            return self._apply_input_icc(img)
         
     def update_thumbnail_and_preview(self, thumbnail_size: int = 156, preview_size: int = 1080) -> None:
         """

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -266,6 +266,11 @@ class CCRImage:
         identically (resolution-independent point operation)."""
         if arr is None:
             return arr
+        # DNG carries its own embedded camera profile (rawpy honours it on
+        # decode), so burning in an external input ICC on top would
+        # double-correct the colour — skip it for .dng sources only.
+        if os.path.splitext(self.file_path)[1].lower() == ".dng":
+            return arr
         profile = color_management.get_active_input_profile()
         if profile is None:
             return arr

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -200,35 +200,14 @@ def _initialize_opencl():
                 }
             }
 
-            // Exposure (Adobe-like, tone-aware to preserve highlights)
+            // Gain — IDENTICAL to Channel Levels "Master Gain" (ch_master_gain):
+            // uniform linear gain out = in / (1 - v/300), hard-clipped to [0,1].
             if (exposure != 0.0f) {
-                // Calculate luminance for tone-aware exposure mapping
-                float img_norm_r = r / 65535.0f;
-                float img_norm_g = g / 65535.0f;
-                float img_norm_b = b / 65535.0f;
-                float luminance = img_norm_r * 0.299f + img_norm_g * 0.587f + img_norm_b * 0.114f;
-                
-                // Create smooth, continuous tone-aware exposure curve
-                float transition_midpoint = 0.80f;   // Where the curve inflection point is (80% luminance)
-                float transition_width = 0.15f;      // Controls smoothness of transition
-                float min_strength = 0.03f;          // Minimum exposure effect in pure highlights (3%)
-                float max_strength = 1.0f;           // Maximum exposure effect in shadows/midtones
-                
-                // Smooth sigmoid-like curve for continuous transition
-                float exposure_curve = min_strength + (max_strength - min_strength) * (
-                    1.0f / (1.0f + exp((luminance - transition_midpoint) / transition_width))
-                );
-                
-                // Apply tone-aware exposure
-                float exposure_scale = exposure * 2.0f / 100.0f;
-                float exposure_factor = pow(2.0f, exposure_scale);  // Base exposure factor in stops (±2 EV)
-                
-                // Create per-pixel exposure factors
-                float pixel_exposure_factor = 1.0f + (exposure_factor - 1.0f) * exposure_curve;
-                
-                r *= pixel_exposure_factor;
-                g *= pixel_exposure_factor;
-                b *= pixel_exposure_factor;
+                float gm = clamp(exposure, -100.0f, 100.0f) / 300.0f;
+                float wv = 1.0f - gm;
+                r = clamp((r / 65535.0f) / wv, 0.0f, 1.0f) * 65535.0f;
+                g = clamp((g / 65535.0f) / wv, 0.0f, 1.0f) * 65535.0f;
+                b = clamp((b / 65535.0f) / wv, 0.0f, 1.0f) * 65535.0f;
             }
             
             // Brightness (Adobe-like: lift lower midtones, preserve highlights)
@@ -2267,36 +2246,13 @@ def adjust_image(
             img[..., 0] *= r_scale  # R  
             img[..., 2] *= b_scale  # B
 
-    # Exposure (Adobe-like, tone-aware to preserve highlights)
+    # Gain — IDENTICAL to Channel Levels "Master Gain" (ch_master_gain): a uniform
+    # linear gain out = in / (1 - v/300), hard-clipped to [0,1]. Same /300 mapping
+    # so moving "Gain" tracks Master Gain 1:1 (v=100 -> 1.5x, v=-100 -> 0.75x).
     if exposure != 0.0:
-        # Calculate luminance for tone-aware exposure mapping
-        img_norm = img / 65535.0
-        luminance = np.dot(img_norm[..., :3], [0.299, 0.587, 0.114])
-        
-        # Create smooth, continuous tone-aware exposure curve
-        # Full effect in shadows/midtones, smoothly reduced effect in highlights
-        # Using a smooth sigmoid-like transition instead of sharp cutoff
-        transition_midpoint = 0.80   # Where the curve inflection point is (80% luminance)
-        transition_width = 0.15      # Controls smoothness of transition
-        min_strength = 0.03          # Minimum exposure effect in pure highlights (15%)
-        max_strength = 1.0           # Maximum exposure effect in shadows/midtones
-        
-        # Smooth sigmoid-like curve for continuous transition
-        # Formula: strength = min + (max-min) * (1 / (1 + exp((lum - mid) / width)))
-        exposure_curve = min_strength + (max_strength - min_strength) * (
-            1.0 / (1.0 + np.exp((luminance - transition_midpoint) / transition_width))
-        )
-        
-        # Expand curve to match image dimensions
-        exposure_curve = np.expand_dims(exposure_curve, axis=-1)
-        
-        # Apply tone-aware exposure
-        exposure_factor = 2 ** exposure_scale  # Base exposure factor in stops
-        
-        # Create per-pixel exposure factors
-        pixel_exposure_factors = 1.0 + (exposure_factor - 1.0) * exposure_curve
-        
-        img *= pixel_exposure_factors
+        gm = np.clip(exposure, -100.0, 100.0) / 300.0   # match ch_master_gain
+        white_val = 1.0 - gm                            # black_val is 0
+        img = np.clip(img / 65535.0 / white_val, 0.0, 1.0) * 65535.0
     
     # Brightness
     if brightness != 0.0:

--- a/src/core/it8_profile.py
+++ b/src/core/it8_profile.py
@@ -16,6 +16,9 @@ matrix-shaper profile (and FreeCCR's InputProfile apply path) can represent.
 """
 from __future__ import annotations
 
+import os
+import re
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
@@ -260,6 +263,135 @@ def parse_it8_reference(path: str) -> IT8Reference:
 
 
 # --------------------------------------------------------------------------- #
+# 1b. CxF (Color Exchange Format) reference files — XML, ISO 17972.
+# --------------------------------------------------------------------------- #
+
+def _strip_ns(root) -> None:
+    """Rewrite every tag/attribute to its local name (drop the namespace).
+    CxF producers vary between a default and a 'cc:' namespace; some (LaserSoft)
+    also use British spelling (Colour*). Local-name matching tolerates all."""
+    for el in root.iter():
+        el.tag = el.tag.rpartition('}')[2]
+        if el.attrib:
+            el.attrib = {k.rpartition('}')[2]: v for k, v in el.attrib.items()}
+
+
+def _cxf_spec_ref(el) -> Optional[str]:
+    """The Colo[u]rSpecification IDREF attribute of a colour-value element."""
+    for k, v in el.attrib.items():
+        if k.endswith("Specification"):
+            return v
+    return None
+
+
+def _cxf_triplet(obj, children: Tuple[str, str, str], specs: dict):
+    """Among an Object's descendants, find the element that has exactly the
+    given direct child tags (e.g. L/A/B or X/Y/Z) — matched by child structure,
+    so ColorCIELab vs ColourCIELab vs ColourIEXYZ spelling doesn't matter — and
+    return its 3 floats, preferring a value under a D50/2° ColorSpecification."""
+    best, best_score = None, -1
+    for el in obj.iter():
+        vals = []
+        for ct in children:
+            sub = el.find(ct)
+            if sub is None or sub.text is None:
+                vals = None
+                break
+            try:
+                vals.append(float(sub.text.strip()))
+            except ValueError:
+                vals = None
+                break
+        if not vals or len(vals) != 3:
+            continue
+        ill, obs = specs.get(_cxf_spec_ref(el), ("", ""))
+        score = (2 if ill.upper() == "D50" else 0) + (1 if obs.startswith("2") else 0)
+        if score > best_score:
+            best, best_score = vals, score
+    return best
+
+
+_CXF_SKIP_TYPES = {"substrate", "colorant", "trick", "measurements", "device"}
+
+
+def parse_cxf_reference(path: str) -> IT8Reference:
+    """Parse a CxF3 (ISO 17972) reference file. Namespace- and spelling-tolerant
+    (default or cc: namespace; American 'Color' or British 'Colour'). Reads each
+    patch's D50/2° CIEXYZ (and/or CIELab). Raises IT8ReferenceError on a file
+    that isn't parseable CxF or has no usable patches."""
+    try:
+        with open(path, "rb") as f:
+            root = ET.fromstring(f.read())     # bytes → honours XML encoding/BOM
+    except ET.ParseError as e:
+        raise IT8ReferenceError(f"Not a valid CxF/XML file: {e}")
+    _strip_ns(root)
+    if not root.tag.endswith("CxF"):
+        raise IT8ReferenceError("XML root is not <CxF> — not a CxF colour file.")
+
+    ref = IT8Reference()
+    fi = root.find("FileInformation")
+    if fi is not None:
+        for tag in fi.findall("Tag"):
+            nm = (tag.get("Name") or "").lower()
+            if nm == "serial":
+                ref.batch = tag.get("Value") or ""
+            elif nm.endswith("targettype"):
+                ref.chart_type = tag.get("Value") or ""
+        ref.descriptor = fi.findtext("Description") or ""
+        ref.originator = fi.findtext("Creator") or ""
+
+    # spec Id -> (illuminant, observer), for D50/2° selection.
+    specs: Dict[str, Tuple[str, str]] = {}
+    for cs in root.iter():
+        if cs.tag.endswith("Specification") and cs.get("Id") is not None:
+            ill = obs = ""
+            for sub in cs.iter():
+                if sub.tag == "Illuminant" and sub.text:
+                    ill = sub.text.strip()
+                elif sub.tag == "Observer" and sub.text:
+                    obs = sub.text.strip()
+            specs[cs.get("Id")] = (ill, obs)
+
+    for obj in root.iter("Object"):
+        otype = (obj.get("ObjectType") or "").lower()
+        if otype in _CXF_SKIP_TYPES:
+            continue
+        name = obj.get("Name") or obj.get("Id")
+        if not name:
+            continue
+        rec: Dict[str, float] = {}
+        xyz = _cxf_triplet(obj, ("X", "Y", "Z"), specs)
+        if xyz is not None:
+            rec["XYZ_X"], rec["XYZ_Y"], rec["XYZ_Z"] = xyz
+        lab = _cxf_triplet(obj, ("L", "A", "B"), specs)
+        if lab is not None:
+            rec["LAB_L"], rec["LAB_A"], rec["LAB_B"] = lab
+        if rec:
+            ref.patches[_normalize_sample_id(name)] = rec
+
+    ref.fields = ["SAMPLE_ID", "XYZ_X", "XYZ_Y", "XYZ_Z", "LAB_L", "LAB_A", "LAB_B"]
+    if not ref.patches:
+        raise IT8ReferenceError(
+            "No usable patches found in the CxF file (no D50 CIEXYZ/CIELab "
+            "values were parsed).")
+    return ref
+
+
+def parse_reference(path: str) -> IT8Reference:
+    """Parse an IT8 reference file, dispatching by content: CxF (XML) vs CGATS
+    (text). This is the entry point the UI should call."""
+    ext = os.path.splitext(path)[1].lower()
+    try:
+        with open(path, "rb") as f:
+            head = f.read(256).lstrip()
+    except OSError as e:
+        raise IT8ReferenceError(f"Could not read the reference file:\n{e}")
+    if ext == ".cxf" or head[:1] == b"<":
+        return parse_cxf_reference(path)
+    return parse_it8_reference(path)
+
+
+# --------------------------------------------------------------------------- #
 # 2. Target decode (raw-linear device RGB, no input ICC).
 # --------------------------------------------------------------------------- #
 
@@ -341,6 +473,36 @@ def grid_sample_points(quad, gray_offset: float = DEFAULT_GRAY_OFFSET
     return {i: (float(x), float(y)) for i, (x, y) in zip(ALL_IDS, pts)}
 
 
+def parse_block(tl_id: str, br_id: str):
+    """Row letters + column numbers for a rectangular patch block from its
+    top-left and bottom-right ids, e.g. ('A49','L72') -> (['A'..'L'],[49..72]).
+    Used for non-classic targets (e.g. the ISO 12641-2 advanced grid) that are a
+    plain rows×cols grid with no separate gray strip."""
+    def split(s):
+        m = re.match(r'^\s*([A-Za-z])(\d+)\s*$', s or "")
+        if not m:
+            raise ValueError(f"Patch id must be a letter + number (e.g. A49), got {s!r}")
+        return m.group(1).upper(), int(m.group(2))
+    (r0, c0), (r1, c1) = split(tl_id), split(br_id)
+    rows = [chr(x) for x in range(min(ord(r0), ord(r1)), max(ord(r0), ord(r1)) + 1)]
+    cols = list(range(min(c0, c1), max(c0, c1) + 1))
+    return rows, cols
+
+
+def block_sample_points(quad, rows, cols) -> Dict[str, Tuple[float, float]]:
+    """Sample centres (array coords) for a regular len(rows)×len(cols) grid laid
+    on the 4-corner quad (TL,TR,BR,BL). IDs are '<row><col>' (e.g. 'A49')."""
+    H = _homography(np.asarray(quad, dtype=np.float64))
+    nr, nc = len(rows), len(cols)
+    uv, ids = [], []
+    for ri, r in enumerate(rows):
+        for ci, c in enumerate(cols):
+            uv.append(((ci + 0.5) / nc, (ri + 0.5) / nr))
+            ids.append(f"{r}{c}")
+    pts = _apply_h(H, np.asarray(uv, dtype=np.float64))
+    return {i: (float(x), float(y)) for i, (x, y) in zip(ids, pts)}
+
+
 # --------------------------------------------------------------------------- #
 # 4. Patch sampling (robust central window, clip rejection).
 # --------------------------------------------------------------------------- #
@@ -352,26 +514,29 @@ class PatchSample:
     n_pix: int
 
 
-def _quad_cell_halfsize(quad: np.ndarray, frac: float) -> Tuple[float, float]:
-    """Half-window (px) for sampling, derived from the colour block's mean cell
-    size so the window scales with the chart's size in the frame."""
+def _quad_cell_halfsize(quad: np.ndarray, frac: float,
+                        ncols: int = 22, nrows: int = 12) -> Tuple[float, float]:
+    """Half-window (px) for sampling, derived from the block's mean cell size so
+    the window scales with the chart's size in the frame and its grid density."""
     q = np.asarray(quad, dtype=np.float64)
     top = np.linalg.norm(q[1] - q[0]); bot = np.linalg.norm(q[2] - q[3])
     left = np.linalg.norm(q[3] - q[0]); right = np.linalg.norm(q[2] - q[1])
-    cell_w = 0.5 * (top + bot) / 22.0
-    cell_h = 0.5 * (left + right) / 12.0
+    cell_w = 0.5 * (top + bot) / max(1, ncols)
+    cell_h = 0.5 * (left + right) / max(1, nrows)
     return max(1.0, 0.5 * frac * cell_w), max(1.0, 0.5 * frac * cell_h)
 
 
 def sample_patches(img_u16: np.ndarray, points: Dict[str, Tuple[float, float]],
                    quad, frac: float = 0.5, clip_lo: float = 0.005,
-                   clip_hi: float = 0.995) -> Dict[str, PatchSample]:
+                   clip_hi: float = 0.995, ncols: int = 22,
+                   nrows: int = 12) -> Dict[str, PatchSample]:
     """Sample each patch's device RGB from a central window via a per-channel
-    trimmed mean; flag patches with >2% clipped pixels or out of frame."""
+    trimmed mean; flag patches with >2% clipped pixels or out of frame. ncols/
+    nrows set the grid density so the sampling window scales to the cell size."""
     h, w = img_u16.shape[:2]
     full = 65535.0
     lo, hi = clip_lo * full, clip_hi * full
-    half_w, half_h = _quad_cell_halfsize(quad, frac)
+    half_w, half_h = _quad_cell_halfsize(quad, frac, ncols, nrows)
     out: Dict[str, PatchSample] = {}
     for sid, (cx, cy) in points.items():
         x0 = int(round(cx - half_w)); x1 = int(round(cx + half_w)) + 1
@@ -494,18 +659,27 @@ class CameraFit:
     wb_id: str
 
 
+_NEUTRAL_CHROMA = 6.0   # max CIELab chroma for a patch to count as "neutral"
+
+
 def _pick_wb_id(samples: Dict[str, PatchSample], ref: IT8Reference,
-                preferred: str) -> Optional[str]:
-    """The lightest valid neutral to white-balance on: preferred (GS0) if valid,
-    else the highest-L valid GS patch, else the highest-Y valid patch."""
-    if preferred in samples and samples[preferred].valid and ref.lab(preferred) is not None:
+                preferred: Optional[str] = None) -> Optional[str]:
+    """The lightest valid neutral to white-balance on: `preferred` if given and
+    valid, else the lightest valid near-neutral patch (low Lab chroma, highest
+    L*) — works for any target (classic GS strip or in-grid grays), else the
+    highest-Y valid patch."""
+    if (preferred and preferred in samples and samples[preferred].valid
+            and ref.lab(preferred) is not None):
         return preferred
     best, best_L = None, -1.0
-    for k in GRAY_IDS:
-        if k in samples and samples[k].valid:
-            lab = ref.lab(k)
-            if lab is not None and lab[0] > best_L:
-                best, best_L = k, lab[0]
+    for sid, ps in samples.items():
+        if not ps.valid:
+            continue
+        lab = ref.lab(sid)
+        if lab is None:
+            continue
+        if float(np.hypot(lab[1], lab[2])) < _NEUTRAL_CHROMA and lab[0] > best_L:
+            best, best_L = sid, lab[0]
     if best is not None:
         return best
     best, best_Y = None, -1.0
@@ -517,19 +691,24 @@ def _pick_wb_id(samples: Dict[str, PatchSample], ref: IT8Reference,
 
 
 def fit_camera_matrix(samples: Dict[str, PatchSample], ref: IT8Reference, *,
-                      weight: str = "none", wb_id: str = "GS0") -> CameraFit:
+                      ids: Optional[List[str]] = None, weight: str = "none",
+                      wb_id: Optional[str] = None) -> CameraFit:
     """Fit the 3x3 camera matrix from sampled device RGB + reference XYZ.
 
+    ids: patch ids to use (default: every sampled id present in the reference).
     weight: 'none' (plain XYZ least squares, the documented baseline) or '1/Y'
-    (down-weight bright patches). See spec §5.4."""
+    (down-weight bright patches). wb_id: force the white-balance patch (default:
+    auto-pick the lightest neutral). See spec §5.4."""
     chosen_wb = _pick_wb_id(samples, ref, wb_id)
     if chosen_wb is None:
         raise IT8ReferenceError("No valid neutral patch to white-balance on — "
                                 "check the chart placement and exposure.")
 
+    iter_ids = ids if ids is not None else [s for s in samples
+                                            if ref.xyz(s) is not None]
     used, dropped = [], []
     d_list, x_list = [], []
-    for sid in ALL_IDS:
+    for sid in iter_ids:
         ps = samples.get(sid)
         xyz = ref.xyz(sid)
         if ps is None or xyz is None:

--- a/src/core/it8_profile.py
+++ b/src/core/it8_profile.py
@@ -1,0 +1,630 @@
+"""
+IT8 camera-profile core (pure numpy + OpenCV, no Qt).
+
+Builds a camera *input* ICC profile from a photograph of an IT8 calibration
+target. See spec/it8-camera-profile.md. The pipeline is:
+
+  1. parse_it8_reference()   -- read the batch CGATS.17 reference file
+  2. decode_target()         -- raw-linear device RGB of the target shot
+  3. grid_sample_points()    -- 4-corner homography -> 288 patch centres
+  4. sample_patches()        -- robust per-patch device RGB (clip-rejected)
+  5. fit_camera_matrix()     -- least-squares 3x3 device->XYZ(D50), D50-pinned
+  6. build_camera_icc()      -- valid ICC v2.4 matrix-shaper bytes
+
+The fit reduces to a 3x3 matrix + identity tone curve, exactly what an ICC
+matrix-shaper profile (and FreeCCR's InputProfile apply path) can represent.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+try:
+    import cv2
+    _CV2 = True
+except ImportError:                       # pragma: no cover - cv2 is a hard dep
+    _CV2 = False
+
+from core import color_management
+
+
+class IT8ReferenceError(Exception):
+    """Raised when an IT8 reference (CGATS) file can't be parsed or is invalid.
+    Surfaced to the user instead of a raw traceback."""
+
+
+# --------------------------------------------------------------------------- #
+# Patch identifiers (the geometry the dialog overlays and the fit consumes).
+# --------------------------------------------------------------------------- #
+
+_ROWS = "ABCDEFGHIJKL"                     # 12 rows, top -> bottom
+# Colour grid IDs, column-fastest (A1..A22, B1.., L22) = 264.
+COLOR_IDS: List[str] = [f"{r}{c}" for r in _ROWS for c in range(1, 23)]
+# Grayscale strip GS0..GS23 = 24, left (light/Dmin) -> right (dark/Dmax).
+GRAY_IDS: List[str] = [f"GS{k}" for k in range(24)]
+ALL_IDS: List[str] = COLOR_IDS + GRAY_IDS
+
+# Chart proportions from ArgyllCMS it8.cht (units are template-internal but
+# proportionally exact). The colour block is the user-placed quad; the gray
+# strip is positioned relative to it. See spec §3.2 / §5.2.
+_CELL = 25.625
+_CB_X0, _CB_W = 26.625, 22 * _CELL         # colour block x-origin / width (563.75)
+_CB_Y0, _CB_H = 26.625, 12 * _CELL         # colour block y-origin / height (307.5)
+_GS_CY = 358.75 + 51.25 / 2.0              # gray strip centre y in cht units (384.375)
+GRAY_V0 = (_GS_CY - _CB_Y0) / _CB_H        # gray strip v in colour-block unit space (~1.1634)
+DEFAULT_GRAY_OFFSET = 0.0
+
+
+def _gray_u(k: int) -> float:
+    """Unit-space x (colour-block normalised) of grayscale cell k (0..23)."""
+    return ((k + 0.5) * _CELL - _CB_X0) / _CB_W
+
+
+# --------------------------------------------------------------------------- #
+# 1. Reference file (CGATS.17).
+# --------------------------------------------------------------------------- #
+
+def _normalize_sample_id(sid: str) -> str:
+    """Map a reference SAMPLE_ID onto our canonical ids.
+
+    Colour patches: a letter A-L + column number, with optional zero padding
+    ('A01' -> 'A1'). Grayscale: 'GS'/'GS0n' -> 'GS<int>'. Anything else is
+    upper-cased and returned as-is (ignored downstream if not in ALL_IDS).
+    """
+    s = sid.strip().upper()
+    if not s:
+        return s
+    if s.startswith("GS"):
+        num = s[2:].lstrip("0") or "0"
+        return f"GS{int(num)}" if num.isdigit() else s
+    if s[0] in _ROWS and s[1:].isdigit():
+        return f"{s[0]}{int(s[1:])}"
+    return s
+
+
+def _read_text(path: str) -> str:
+    with open(path, "rb") as f:
+        raw = f.read()
+    if raw[:3] == b"\xef\xbb\xbf":         # strip UTF-8 BOM
+        raw = raw[3:]
+    for enc in ("utf-8", "latin-1"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    return raw.decode("latin-1", "replace")
+
+
+def _strip_comment(line: str) -> str:
+    """Remove a '#' comment (to end of line) but not inside a quoted value."""
+    out, in_q = [], False
+    for ch in line:
+        if ch == '"':
+            in_q = not in_q
+        if ch == "#" and not in_q:
+            break
+        out.append(ch)
+    return "".join(out)
+
+
+@dataclass
+class IT8Reference:
+    chart_type: str = ""                   # 'IT8.7/1' | 'IT8.7/2' | ''
+    batch: str = ""                        # SERIAL value (for display)
+    descriptor: str = ""
+    originator: str = ""
+    fields: List[str] = field(default_factory=list)
+    patches: Dict[str, Dict[str, float]] = field(default_factory=dict)
+
+    def xyz(self, sample_id: str) -> Optional[np.ndarray]:
+        """XYZ (D50, 2deg, Y~=100 scale) for a patch, or None.
+
+        Uses XYZ_* columns when present, else derives from LAB_* via the D50
+        white point.
+        """
+        p = self.patches.get(sample_id)
+        if p is None:
+            return None
+        if "XYZ_X" in p and "XYZ_Y" in p and "XYZ_Z" in p:
+            return np.array([p["XYZ_X"], p["XYZ_Y"], p["XYZ_Z"]], dtype=np.float64)
+        lab = self.lab(sample_id)
+        return None if lab is None else lab_to_xyz(lab)
+
+    def lab(self, sample_id: str) -> Optional[np.ndarray]:
+        """CIE Lab (D50) for a patch, or None. Uses LAB_* columns when present,
+        else derives from XYZ_*."""
+        p = self.patches.get(sample_id)
+        if p is None:
+            return None
+        if "LAB_L" in p and "LAB_A" in p and "LAB_B" in p:
+            return np.array([p["LAB_L"], p["LAB_A"], p["LAB_B"]], dtype=np.float64)
+        if "XYZ_X" in p and "XYZ_Y" in p and "XYZ_Z" in p:
+            return xyz_to_lab(np.array([p["XYZ_X"], p["XYZ_Y"], p["XYZ_Z"]]))
+        return None
+
+    @property
+    def matched_ids(self) -> List[str]:
+        """Canonical ids present in the file (intersection with ALL_IDS)."""
+        return [i for i in ALL_IDS if i in self.patches]
+
+
+def parse_it8_reference(path: str) -> IT8Reference:
+    """Parse a CGATS.17 IT8 reference file. Reads columns dynamically from the
+    DATA_FORMAT block (the field set varies by batch). Raises IT8ReferenceError
+    on a malformed/empty file."""
+    text = _read_text(path)
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+    ref = IT8Reference()
+    state = "PRE"                          # PRE | FORMAT | DATA
+    fmt: List[str] = []
+    n_fields: Optional[int] = None
+    n_sets: Optional[int] = None
+    first_token_seen = False
+    bad_rows = 0
+
+    for raw_line in lines:
+        line = _strip_comment(raw_line).strip()
+        if not line:
+            continue
+
+        if not first_token_seen:
+            first_token_seen = True
+            tok = line.split()[0]
+            if tok.upper().startswith("IT8"):
+                ref.chart_type = tok
+                continue                   # consume the bare type token
+
+        upper = line.upper()
+        if state == "PRE":
+            if upper.startswith("BEGIN_DATA_FORMAT"):
+                state = "FORMAT"
+                continue
+            if upper.startswith("BEGIN_DATA"):
+                state = "DATA"
+                continue
+            parts = line.split(None, 1)
+            kw = parts[0].upper()
+            val = parts[1].strip().strip('"').strip() if len(parts) > 1 else ""
+            if kw == "NUMBER_OF_FIELDS":
+                try:
+                    n_fields = int(val.split()[0])
+                except (ValueError, IndexError):
+                    pass
+            elif kw == "NUMBER_OF_SETS":
+                try:
+                    n_sets = int(val.split()[0])
+                except (ValueError, IndexError):
+                    pass
+            elif kw == "SERIAL":
+                ref.batch = val
+            elif kw == "DESCRIPTOR":
+                ref.descriptor = val
+            elif kw == "ORIGINATOR":
+                ref.originator = val
+            # KEYWORD "NAME" / other preamble keywords are ignored — the
+            # DATA_FORMAT block is the authority on column names.
+        elif state == "FORMAT":
+            if upper.startswith("END_DATA_FORMAT"):
+                state = "PRE"
+                continue
+            fmt.extend(line.split())
+        elif state == "DATA":
+            if upper.startswith("END_DATA"):
+                state = "PRE"
+                continue
+            toks = line.split()
+            if not fmt or len(toks) != len(fmt):
+                # Skip rows whose token count doesn't match DATA_FORMAT — never
+                # zip-truncate them into partial records (a truncated row would
+                # otherwise store e.g. XYZ_X/Y without Z). Gross truncation is
+                # then caught by the patch-count guard below.
+                bad_rows += 1
+                continue
+            rec: Dict[str, float] = {}
+            sid = None
+            for name, tok in zip(fmt, toks):
+                if name.upper() in ("SAMPLE_ID", "SAMPLE_NAME") and sid is None:
+                    sid = tok
+                    continue
+                try:
+                    rec[name.upper()] = float(tok)
+                except ValueError:
+                    pass
+            if sid is not None:
+                ref.patches[_normalize_sample_id(sid)] = rec
+
+    ref.fields = fmt
+    if not fmt:
+        raise IT8ReferenceError(
+            "No DATA_FORMAT block found — this does not look like a CGATS/IT8 "
+            "reference file.")
+    if not ref.patches:
+        extra = (f" ({bad_rows} row(s) had a token count != NUMBER_OF_FIELDS.)"
+                 if bad_rows else "")
+        raise IT8ReferenceError("No data patches found in the reference file."
+                                + extra)
+    # The reliably-present colorimetry must be there for at least the neutrals.
+    if not any(("XYZ_X" in p or "LAB_L" in p) for p in ref.patches.values()):
+        raise IT8ReferenceError(
+            "Reference file has no XYZ_* or LAB_* columns — cannot build a "
+            "profile from it.")
+    if n_sets is not None and len(ref.patches) < min(n_sets, 200) // 2:
+        extra = f" ({bad_rows} malformed row(s) skipped.)" if bad_rows else ""
+        raise IT8ReferenceError(
+            f"Reference file declares {n_sets} patches but only "
+            f"{len(ref.patches)} were parsed — the file looks truncated." + extra)
+    return ref
+
+
+# --------------------------------------------------------------------------- #
+# 2. Target decode (raw-linear device RGB, no input ICC).
+# --------------------------------------------------------------------------- #
+
+SAMPLE_MAX = 2048                          # long-side cap for the sampling decode
+
+
+def decode_target(path: str, sample_max: int = SAMPLE_MAX) -> Optional[np.ndarray]:
+    """Decode the IT8 target shot to raw-linear device RGB (uint16, HxWx3, RGB
+    order), bypassing Positive mode and any active input ICC — the bare device
+    space the profile is fitted on. See spec §5.1 / §6.1.
+
+    read_image is called on a bare CCRImage created via __new__ so the
+    heavyweight __init__ (a redundant 1080px decode + lens correction +
+    thumbnail) is skipped; read_image only needs `source_ops` on the instance.
+    A half-size (preview) decode capped at sample_max gives ample pixels per
+    patch and matches the runtime preview's device space."""
+    from core.ccr_image import CCRImage
+    img = CCRImage.__new__(CCRImage)
+    img.source_ops = []
+    return img.read_image(path, preview=True, max_long_side=sample_max,
+                          positive_override=False, apply_input_icc=False)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Patch grid geometry (4-corner homography -> sample centres).
+# --------------------------------------------------------------------------- #
+
+def _homography(quad: np.ndarray) -> np.ndarray:
+    """Perspective transform mapping the unit square (TL,TR,BR,BL) -> quad."""
+    src = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32)
+    dst = np.asarray(quad, dtype=np.float32)
+    if _CV2:
+        return cv2.getPerspectiveTransform(src, dst)
+    return _perspective_transform_np(src, dst)
+
+
+def _perspective_transform_np(src: np.ndarray, dst: np.ndarray) -> np.ndarray:
+    """Solve the 8-DOF homography (fallback when cv2 is unavailable)."""
+    A, b = [], []
+    for (x, y), (u, v) in zip(src, dst):
+        A.append([x, y, 1, 0, 0, 0, -u * x, -u * y])
+        A.append([0, 0, 0, x, y, 1, -v * x, -v * y])
+        b.extend([u, v])
+    h = np.linalg.solve(np.asarray(A, float), np.asarray(b, float))
+    return np.array([[h[0], h[1], h[2]],
+                     [h[3], h[4], h[5]],
+                     [h[6], h[7], 1.0]], dtype=np.float64)
+
+
+def _apply_h(H: np.ndarray, uv: np.ndarray) -> np.ndarray:
+    """Map (N,2) unit-space points through homography H -> (N,2) array coords."""
+    pts = np.hstack([uv, np.ones((len(uv), 1))])
+    out = pts @ np.asarray(H, float).T
+    return out[:, :2] / out[:, 2:3]
+
+
+def flip_quad(quad):
+    """180-degree relabel of a (TL, TR, BR, BL) quad — for a chart placed
+    upside-down. new TL=old BR, TR=old BL, BR=old TL, BL=old TR."""
+    q = list(quad)
+    return [q[2], q[3], q[0], q[1]]
+
+
+def grid_sample_points(quad, gray_offset: float = DEFAULT_GRAY_OFFSET
+                       ) -> Dict[str, Tuple[float, float]]:
+    """Sample centres (array coords) for all 288 patches.
+
+    quad: the 4 corners (TL, TR, BR, BL) of the COLOUR block in array space.
+    gray_offset nudges the grayscale row vertically (batch variation)."""
+    H = _homography(np.asarray(quad, dtype=np.float64))
+    uv = []
+    for r in range(12):
+        for c in range(22):
+            uv.append(((c + 0.5) / 22.0, (r + 0.5) / 12.0))
+    gv = GRAY_V0 + gray_offset
+    for k in range(24):
+        uv.append((_gray_u(k), gv))
+    pts = _apply_h(H, np.asarray(uv, dtype=np.float64))
+    return {i: (float(x), float(y)) for i, (x, y) in zip(ALL_IDS, pts)}
+
+
+# --------------------------------------------------------------------------- #
+# 4. Patch sampling (robust central window, clip rejection).
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class PatchSample:
+    rgb: np.ndarray                        # (3,) float, device RGB in [0, 65535]
+    valid: bool                            # False if clipped / out of frame
+    n_pix: int
+
+
+def _quad_cell_halfsize(quad: np.ndarray, frac: float) -> Tuple[float, float]:
+    """Half-window (px) for sampling, derived from the colour block's mean cell
+    size so the window scales with the chart's size in the frame."""
+    q = np.asarray(quad, dtype=np.float64)
+    top = np.linalg.norm(q[1] - q[0]); bot = np.linalg.norm(q[2] - q[3])
+    left = np.linalg.norm(q[3] - q[0]); right = np.linalg.norm(q[2] - q[1])
+    cell_w = 0.5 * (top + bot) / 22.0
+    cell_h = 0.5 * (left + right) / 12.0
+    return max(1.0, 0.5 * frac * cell_w), max(1.0, 0.5 * frac * cell_h)
+
+
+def sample_patches(img_u16: np.ndarray, points: Dict[str, Tuple[float, float]],
+                   quad, frac: float = 0.5, clip_lo: float = 0.005,
+                   clip_hi: float = 0.995) -> Dict[str, PatchSample]:
+    """Sample each patch's device RGB from a central window via a per-channel
+    trimmed mean; flag patches with >2% clipped pixels or out of frame."""
+    h, w = img_u16.shape[:2]
+    full = 65535.0
+    lo, hi = clip_lo * full, clip_hi * full
+    half_w, half_h = _quad_cell_halfsize(quad, frac)
+    out: Dict[str, PatchSample] = {}
+    for sid, (cx, cy) in points.items():
+        x0 = int(round(cx - half_w)); x1 = int(round(cx + half_w)) + 1
+        y0 = int(round(cy - half_h)); y1 = int(round(cy + half_h)) + 1
+        x0c, x1c = max(0, x0), min(w, x1)
+        y0c, y1c = max(0, y0), min(h, y1)
+        if x1c - x0c < 2 or y1c - y0c < 2:
+            out[sid] = PatchSample(np.zeros(3), False, 0)
+            continue
+        win = img_u16[y0c:y1c, x0c:x1c, :3].reshape(-1, 3).astype(np.float64)
+        # Per-channel trimmed mean (drop 10/90 tails) — robust to dust/edges.
+        rgb = np.empty(3)
+        for ch in range(3):
+            col = win[:, ch]
+            p10, p90 = np.percentile(col, [10, 90])
+            keep = col[(col >= p10) & (col <= p90)]
+            rgb[ch] = keep.mean() if keep.size else col.mean()
+        clipped_frac = np.mean((win <= lo) | (win >= hi))
+        # Also invalid if the patch fell partly outside the frame.
+        in_frame = (x0 >= 0 and y0 >= 0 and x1 <= w and y1 <= h)
+        out[sid] = PatchSample(rgb, bool(clipped_frac < 0.02 and in_frame), win.shape[0])
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# 5. Colour-science helpers (XYZ<->Lab, deltaE). XYZ on the Y~=100 scale.
+# --------------------------------------------------------------------------- #
+
+_D50_W100 = np.array([96.422, 100.0, 82.521])   # D50 white, Y=100 scale
+_EPS = 216.0 / 24389.0
+_KAPPA = 24389.0 / 27.0
+
+
+def xyz_to_lab(xyz: np.ndarray, white: np.ndarray = _D50_W100) -> np.ndarray:
+    xyz = np.asarray(xyz, dtype=np.float64)
+    xr = xyz / white
+    f = np.where(xr > _EPS, np.cbrt(np.clip(xr, 0, None)), (_KAPPA * xr + 16) / 116)
+    if xyz.ndim == 1:
+        L = 116 * f[1] - 16; a = 500 * (f[0] - f[1]); b = 200 * (f[1] - f[2])
+        return np.array([L, a, b])
+    L = 116 * f[..., 1] - 16
+    a = 500 * (f[..., 0] - f[..., 1])
+    b = 200 * (f[..., 1] - f[..., 2])
+    return np.stack([L, a, b], axis=-1)
+
+
+def lab_to_xyz(lab: np.ndarray, white: np.ndarray = _D50_W100) -> np.ndarray:
+    lab = np.asarray(lab, dtype=np.float64)
+    L, a, b = lab[..., 0], lab[..., 1], lab[..., 2]
+    fy = (L + 16) / 116.0
+    fx = fy + a / 500.0
+    fz = fy - b / 200.0
+    def inv(t):
+        t3 = t ** 3
+        return np.where(t3 > _EPS, t3, (116 * t - 16) / _KAPPA)
+    xyz = np.stack([inv(fx), inv(fy), inv(fz)], axis=-1) * white
+    return xyz
+
+
+def delta_e_76(lab1: np.ndarray, lab2: np.ndarray) -> np.ndarray:
+    return np.linalg.norm(np.asarray(lab1) - np.asarray(lab2), axis=-1)
+
+
+def delta_e_2000(lab1: np.ndarray, lab2: np.ndarray) -> np.ndarray:
+    """CIEDE2000 (kL=kC=kH=1), Sharma formulation. Accepts (N,3) or (3,)."""
+    lab1 = np.atleast_2d(np.asarray(lab1, dtype=np.float64))
+    lab2 = np.atleast_2d(np.asarray(lab2, dtype=np.float64))
+    L1, a1, b1 = lab1.T; L2, a2, b2 = lab2.T
+    C1 = np.hypot(a1, b1); C2 = np.hypot(a2, b2)
+    Cbar = 0.5 * (C1 + C2)
+    G = 0.5 * (1 - np.sqrt(Cbar ** 7 / (Cbar ** 7 + 25.0 ** 7)))
+    a1p, a2p = (1 + G) * a1, (1 + G) * a2
+    C1p, C2p = np.hypot(a1p, b1), np.hypot(a2p, b2)
+    h1p = np.degrees(np.arctan2(b1, a1p)) % 360
+    h2p = np.degrees(np.arctan2(b2, a2p)) % 360
+    dLp = L2 - L1
+    dCp = C2p - C1p
+    dhp = h2p - h1p
+    dhp = np.where(dhp > 180, dhp - 360, dhp)
+    dhp = np.where(dhp < -180, dhp + 360, dhp)
+    dhp = np.where((C1p * C2p) == 0, 0.0, dhp)
+    dHp = 2 * np.sqrt(C1p * C2p) * np.sin(np.radians(dhp) / 2)
+    Lbp = 0.5 * (L1 + L2)
+    Cbp = 0.5 * (C1p + C2p)
+    hsum = h1p + h2p
+    hbp = np.where(np.abs(h1p - h2p) > 180, (hsum + 360) / 2, hsum / 2)
+    hbp = np.where((C1p * C2p) == 0, hsum, hbp)
+    T = (1 - 0.17 * np.cos(np.radians(hbp - 30))
+         + 0.24 * np.cos(np.radians(2 * hbp))
+         + 0.32 * np.cos(np.radians(3 * hbp + 6))
+         - 0.20 * np.cos(np.radians(4 * hbp - 63)))
+    dTheta = 30 * np.exp(-(((hbp - 275) / 25) ** 2))
+    Rc = 2 * np.sqrt(Cbp ** 7 / (Cbp ** 7 + 25.0 ** 7))
+    Sl = 1 + (0.015 * (Lbp - 50) ** 2) / np.sqrt(20 + (Lbp - 50) ** 2)
+    Sc = 1 + 0.045 * Cbp
+    Sh = 1 + 0.015 * Cbp * T
+    Rt = -np.sin(np.radians(2 * dTheta)) * Rc
+    de = np.sqrt((dLp / Sl) ** 2 + (dCp / Sc) ** 2 + (dHp / Sh) ** 2
+                 + Rt * (dCp / Sc) * (dHp / Sh))
+    return de
+
+
+# --------------------------------------------------------------------------- #
+# 6. Matrix fit (device-linear RGB -> XYZ D50), D50 neutral-pinned.
+# --------------------------------------------------------------------------- #
+
+D50_XYZ = np.array(color_management.D50_XYZ, dtype=np.float64)   # [0,1] scale, Y=1
+
+
+@dataclass
+class CameraFit:
+    matrix: np.ndarray                     # (3,3) device-norm RGB[0,1] -> XYZ D50 (Y~1)
+    avg_de: float
+    med_de: float
+    p95_de: float
+    max_de: float
+    per_patch: List[Tuple[str, float]]     # (id, dE2000), worst-first
+    used_ids: List[str]
+    dropped_ids: List[str]
+    wb_id: str
+
+
+def _pick_wb_id(samples: Dict[str, PatchSample], ref: IT8Reference,
+                preferred: str) -> Optional[str]:
+    """The lightest valid neutral to white-balance on: preferred (GS0) if valid,
+    else the highest-L valid GS patch, else the highest-Y valid patch."""
+    if preferred in samples and samples[preferred].valid and ref.lab(preferred) is not None:
+        return preferred
+    best, best_L = None, -1.0
+    for k in GRAY_IDS:
+        if k in samples and samples[k].valid:
+            lab = ref.lab(k)
+            if lab is not None and lab[0] > best_L:
+                best, best_L = k, lab[0]
+    if best is not None:
+        return best
+    best, best_Y = None, -1.0
+    for sid, ps in samples.items():
+        xyz = ref.xyz(sid)
+        if ps.valid and xyz is not None and xyz[1] > best_Y:
+            best, best_Y = sid, xyz[1]
+    return best
+
+
+def fit_camera_matrix(samples: Dict[str, PatchSample], ref: IT8Reference, *,
+                      weight: str = "none", wb_id: str = "GS0") -> CameraFit:
+    """Fit the 3x3 camera matrix from sampled device RGB + reference XYZ.
+
+    weight: 'none' (plain XYZ least squares, the documented baseline) or '1/Y'
+    (down-weight bright patches). See spec §5.4."""
+    chosen_wb = _pick_wb_id(samples, ref, wb_id)
+    if chosen_wb is None:
+        raise IT8ReferenceError("No valid neutral patch to white-balance on — "
+                                "check the chart placement and exposure.")
+
+    used, dropped = [], []
+    d_list, x_list = [], []
+    for sid in ALL_IDS:
+        ps = samples.get(sid)
+        xyz = ref.xyz(sid)
+        if ps is None or xyz is None:
+            continue
+        if not ps.valid:
+            dropped.append(sid)
+            continue
+        used.append(sid)
+        d_list.append(ps.rgb / 65535.0)
+        x_list.append(xyz / 100.0)
+    if len(used) < 6:
+        raise IT8ReferenceError(
+            f"Only {len(used)} usable patches — too few to fit a profile. "
+            "Re-check corner placement, exposure (clipping), and the reference "
+            "file.")
+
+    d = np.asarray(d_list)                  # (N,3) normalised device RGB
+    X = np.asarray(x_list)                  # (N,3) reference XYZ, Y in [0,~1]
+
+    # White balance on the chosen neutral so it becomes equal-RGB.
+    d_wb_ref = samples[chosen_wb].rgb / 65535.0
+    d_wb_ref = np.clip(d_wb_ref, 1e-6, None)
+    gains = d_wb_ref.mean() / d_wb_ref
+    d_wb = d * gains
+
+    # (Weighted) least squares  X ~= d_wb @ A ;  M_wb = A.T  => XYZ = M_wb @ rgb.
+    if weight == "1/Y":
+        w = 1.0 / np.clip(X[:, 1], 0.02, None)
+        sw = np.sqrt(w)[:, None]
+        A, *_ = np.linalg.lstsq(d_wb * sw, X * sw, rcond=None)
+    else:
+        A, *_ = np.linalg.lstsq(d_wb, X, rcond=None)
+    M_wb = A.T
+
+    # Pin so equal-RGB (post-WB) maps exactly to D50 chromaticity (well-behaved
+    # neutral axis). This per-column scale fixes chromaticity but leaves an
+    # overall brightness gain, removed by the exposure step below.
+    white = M_wb @ np.ones(3)
+    white = np.where(np.abs(white) < 1e-9, 1e-9, white)
+    M_pin = M_wb @ np.diag(D50_XYZ / white)
+
+    # Fold WB back so the stored matrix consumes un-white-balanced device RGB.
+    M = M_pin @ np.diag(gains)
+
+    # Normalise overall exposure so the chosen neutral reproduces its reference
+    # Y exactly. This keeps the reported deltaE about colour (not a benign
+    # brightness scale) and makes the fit reproduce the chart when consistent.
+    pred_wb_Y = float((M @ (samples[chosen_wb].rgb / 65535.0))[1])
+    ref_wb_Y = float(ref.xyz(chosen_wb)[1] / 100.0)
+    if pred_wb_Y > 1e-9:
+        M = M * (ref_wb_Y / pred_wb_Y)
+
+    # Quality: predicted Lab vs reference Lab for the used patches.
+    pred_xyz = (d @ M.T) * 100.0
+    pred_lab = xyz_to_lab(pred_xyz)
+    ref_lab = np.array([ref.lab(s) for s in used], dtype=np.float64)
+    de = delta_e_2000(ref_lab, pred_lab)
+    order = np.argsort(-de)
+    per_patch = [(used[i], float(de[i])) for i in order]
+
+    return CameraFit(
+        matrix=M,
+        avg_de=float(de.mean()),
+        med_de=float(np.median(de)),
+        p95_de=float(np.percentile(de, 95)),
+        max_de=float(de.max()),
+        per_patch=per_patch,
+        used_ids=used,
+        dropped_ids=dropped,
+        wb_id=chosen_wb,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 7. ICC synthesis (matrix-shaper, identity TRC).
+# --------------------------------------------------------------------------- #
+
+# Identity parametric (type-3) TRC: y = x for x>=0  (g=1, a=1, b=0, c=1, d=0).
+_IDENTITY_TRC = (1.0, 1.0, 0.0, 1.0, 0.0)
+
+
+def build_camera_icc(fit: CameraFit, desc: str,
+                     copyright_text: str = "Public Domain. No rights reserved."
+                     ) -> bytes:
+    """Synthesise ICC v2.4 matrix-shaper bytes from the fitted camera matrix.
+    Colorant columns are M's columns (already XYZ D50); TRC is identity (the
+    device space is raw-linear). Round-trips through InputProfile.from_bytes."""
+    M = np.asarray(fit.matrix, dtype=np.float64)
+    # The ICC desc/text tag writers only emit ASCII (textType/textDescription),
+    # so coerce user-supplied names + illuminant notes to ASCII to avoid a crash.
+    desc = str(desc).encode("ascii", "replace").decode("ascii")
+    copyright_text = str(copyright_text).encode("ascii", "replace").decode("ascii")
+    return color_management.build_matrix_shaper_icc(
+        desc,
+        tuple(M[:, 0]), tuple(M[:, 1]), tuple(M[:, 2]),
+        _IDENTITY_TRC,
+        copyright_text=copyright_text,
+    )

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -267,6 +267,10 @@ class MainWindow(QMainWindow):
         self.clear_input_icc_action.triggered.connect(self.clear_input_icc_profile)
         self._refresh_input_icc_menu()
 
+        # Build a camera input profile from a photographed IT8 target.
+        self.it8_profile_action = file_menu.addAction("Create Camera Profile from IT8…")
+        self.it8_profile_action.triggered.connect(self.create_camera_profile_from_it8)
+
         # Add Help menu with About, Licenses, Activation, and Help actions
         help_menu = menu_bar.addMenu("Help")
         about_action = help_menu.addAction("About")
@@ -290,7 +294,6 @@ class MainWindow(QMainWindow):
             self.clear_input_icc_action.setEnabled(False)
 
     def set_input_icc_profile(self):
-        from core.color_management import UnsupportedICCError
         start_dir = self._settings.value("import/last_icc_dir", "", type=str)
         path, _ = QFileDialog.getOpenFileName(
             self, "Select Input ICC Profile", start_dir,
@@ -298,6 +301,13 @@ class MainWindow(QMainWindow):
         if not path:
             return
         self._settings.setValue("import/last_icc_dir", os.path.dirname(path))
+        self._apply_input_icc_path(path)
+
+    def _apply_input_icc_path(self, path: str) -> bool:
+        """Activate `path` as the global input ICC profile (parse, persist,
+        reprocess). Returns True on success. Shared by the file picker and the
+        IT8 camera-profile wizard's 'apply now'."""
+        from core.color_management import UnsupportedICCError
         try:
             name = ccr_backend.set_input_icc(path)
         except UnsupportedICCError as e:
@@ -306,16 +316,37 @@ class MainWindow(QMainWindow):
                 f"This profile can't be used as an input profile:\n\n{e}\n\n"
                 "Only RGB matrix-shaper profiles are supported "
                 "(LUT-based, cLUT, or CMYK profiles are not).")
-            return
+            return False
         except Exception as e:
             QMessageBox.warning(self, "Input ICC Profile Error",
                                 f"Could not load the ICC profile:\n\n{e}")
-            return
+            return False
         self._settings.setValue("import/input_icc_path", ccr_backend.input_icc_path)
         self._refresh_input_icc_menu()
         self._reprocess_after_input_icc_change()
         self.sliders_panel.set_temporary_hint(
             f"Input ICC profile set: {name}", duration=3000)
+        return True
+
+    def create_camera_profile_from_it8(self):
+        """Open the IT8 wizard; on success optionally activate the new profile."""
+        from widgets.it8_profile_dialog import IT8ProfileDialog
+        current_path = None
+        idx = self.image_preview.current_idx
+        if idx is not None:
+            img = ccr_backend.get_image_by_index(idx)
+            if img is not None:
+                current_path = img.file_path
+        dlg = IT8ProfileDialog(self, current_path=current_path)
+        if dlg.exec() != QDialog.Accepted or not dlg.saved_path:
+            return
+        base = os.path.basename(dlg.saved_path)
+        if dlg.apply_now and self._apply_input_icc_path(dlg.saved_path):
+            self.sliders_panel.set_temporary_hint(
+                f"Camera profile saved and applied: {base}", duration=4000)
+        else:
+            self.sliders_panel.set_temporary_hint(
+                f"Camera profile saved: {base}", duration=4000)
 
     def clear_input_icc_profile(self):
         ccr_backend.clear_input_icc()

--- a/src/widgets/it8_profile_dialog.py
+++ b/src/widgets/it8_profile_dialog.py
@@ -1,0 +1,603 @@
+"""
+Create-Camera-Profile-from-IT8 wizard (PySide6).
+
+A 5-step QDialog that walks the user from an IT8 target shot to a saved camera
+input ICC profile: pick the shot, pick the batch reference file, locate the patch
+grid (draggable 4-corner overlay), review fit quality (deltaE), and save / apply.
+Core math lives in core.it8_profile; this module is UI only.
+See spec/it8-camera-profile.md.
+"""
+import os
+from datetime import datetime
+from typing import Optional
+
+import numpy as np
+
+from PySide6.QtCore import Qt, QPointF, QRectF, QSettings, Signal
+from PySide6.QtGui import QImage, QPainter, QPen, QBrush, QColor, QPolygonF
+from PySide6.QtWidgets import (
+    QApplication, QCheckBox, QComboBox, QDialog, QFileDialog, QFormLayout,
+    QHBoxLayout, QLabel, QLineEdit, QListWidget, QMessageBox, QPushButton,
+    QSlider, QStackedWidget, QVBoxLayout, QWidget,
+)
+
+from core import it8_profile as it8
+from core.ccr_backend import ccr_backend
+from utils.unicode_path_utils import normalize_unicode_path, validate_unicode_path
+
+_REF_URL = "http://www.targets.coloraid.de/"
+
+
+def _gamma_stretch_to_qimage(arr_u16: np.ndarray) -> QImage:
+    """8-bit gamma-stretched view of a raw-linear 16-bit RGB array (display
+    only — the fit always uses the linear data)."""
+    a = arr_u16.astype(np.float32)
+    # Normalise exposure by a high percentile so the dark linear scan is visible.
+    p = np.percentile(a, 99.5)
+    if p < 1:
+        p = a.max() if a.max() > 0 else 1.0
+    norm = np.clip(a / p, 0.0, 1.0)
+    disp = np.power(norm, 1.0 / 2.2)
+    disp8 = np.ascontiguousarray((disp * 255).astype(np.uint8))
+    h, w = disp8.shape[:2]
+    img = QImage(disp8.data, w, h, 3 * w, QImage.Format_RGB888)
+    out = img.copy()                      # detach from the temporary buffer
+    return out
+
+
+class IT8PatchLocator(QWidget):
+    """Shows the target shot with a draggable 4-corner quad over the colour grid
+    and a live overlay of all 288 sample dots."""
+
+    changed = Signal()
+
+    HANDLE_R = 7
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumSize(520, 360)
+        self.setMouseTracking(True)
+        self._qimg: Optional[QImage] = None
+        self._iw = self._ih = 0
+        self._quad = []                   # 4 (x,y) array-space corners TL,TR,BR,BL
+        self._gray_offset = 0.0
+        self._drag = -1                   # index of handle being dragged, or -1
+        self._scale = 1.0
+        self._ox = self._oy = 0.0
+
+    def set_image(self, arr_u16: np.ndarray):
+        self._qimg = _gamma_stretch_to_qimage(arr_u16)
+        self._ih, self._iw = arr_u16.shape[:2]
+        # Default colour-block quad inset from the image edges.
+        ix, iy = self._iw, self._ih
+        self._quad = [(0.10 * ix, 0.10 * iy), (0.90 * ix, 0.10 * iy),
+                      (0.90 * ix, 0.82 * iy), (0.10 * ix, 0.82 * iy)]
+        self.update()
+        self.changed.emit()
+
+    # --- geometry accessors ---
+    def quad(self):
+        return list(self._quad)
+
+    def gray_offset(self):
+        return self._gray_offset
+
+    def set_gray_offset(self, v: float):
+        self._gray_offset = float(v)
+        self.update()
+        self.changed.emit()
+
+    def flip(self):
+        if self._quad:
+            self._quad = it8.flip_quad(self._quad)
+            self.update()
+            self.changed.emit()
+
+    def points(self):
+        if not self._quad:
+            return {}
+        return it8.grid_sample_points(self._quad, self._gray_offset)
+
+    # --- coordinate mapping (array <-> widget) ---
+    def _recompute_fit(self):
+        if not self._iw:
+            return
+        W, H = self.width(), self.height()
+        self._scale = min(W / self._iw, H / self._ih)
+        self._ox = (W - self._iw * self._scale) / 2
+        self._oy = (H - self._ih * self._scale) / 2
+
+    def _a2w(self, x, y):
+        return QPointF(self._ox + x * self._scale, self._oy + y * self._scale)
+
+    def _w2a(self, x, y):
+        return ((x - self._ox) / self._scale, (y - self._oy) / self._scale)
+
+    # --- painting ---
+    def paintEvent(self, _):
+        p = QPainter(self)
+        p.fillRect(self.rect(), QColor(30, 30, 30))
+        if self._qimg is None:
+            p.setPen(QColor(180, 180, 180))
+            p.drawText(self.rect(), Qt.AlignCenter, "No image")
+            return
+        self._recompute_fit()
+        target = QRectF(self._ox, self._oy, self._iw * self._scale,
+                        self._ih * self._scale)
+        p.drawImage(target, self._qimg)
+        p.setRenderHint(QPainter.Antialiasing, True)
+
+        # Quad outline.
+        poly = QPolygonF([self._a2w(x, y) for (x, y) in self._quad])
+        p.setPen(QPen(QColor(80, 200, 120), 2))
+        p.setBrush(Qt.NoBrush)
+        p.drawPolygon(poly)
+
+        # Sample dots (colour vs gray differ in colour).
+        pts = self.points()
+        for sid, (x, y) in pts.items():
+            w = self._a2w(x, y)
+            if not target.contains(w):
+                p.setPen(QPen(QColor(220, 80, 80), 1))   # out of frame -> red
+            elif sid.startswith("GS"):
+                p.setPen(QPen(QColor(120, 170, 255), 1))
+            else:
+                p.setPen(QPen(QColor(255, 230, 90), 1))
+            p.drawEllipse(w, 1.6, 1.6)
+
+        # Corner handles.
+        for i, (x, y) in enumerate(self._quad):
+            w = self._a2w(x, y)
+            p.setBrush(QBrush(QColor(80, 200, 120)))
+            p.setPen(QPen(QColor(20, 20, 20), 1))
+            p.drawEllipse(w, self.HANDLE_R, self.HANDLE_R)
+        p.end()
+
+    # --- mouse ---
+    def mousePressEvent(self, e):
+        if self._qimg is None:
+            return
+        self._recompute_fit()
+        pos = e.position() if hasattr(e, "position") else QPointF(e.pos())
+        # Pick the nearest handle within grab radius.
+        best, bestd = -1, (self.HANDLE_R + 6) ** 2
+        for i, (x, y) in enumerate(self._quad):
+            w = self._a2w(x, y)
+            d = (w.x() - pos.x()) ** 2 + (w.y() - pos.y()) ** 2
+            if d < bestd:
+                best, bestd = i, d
+        self._drag = best
+
+    def mouseMoveEvent(self, e):
+        if self._drag < 0:
+            return
+        pos = e.position() if hasattr(e, "position") else QPointF(e.pos())
+        ax, ay = self._w2a(pos.x(), pos.y())
+        ax = max(0.0, min(self._iw, ax))
+        ay = max(0.0, min(self._ih, ay))
+        self._quad[self._drag] = (ax, ay)
+        self.update()                      # dots follow live (cheap repaint)
+
+    def mouseReleaseEvent(self, _):
+        was_dragging = self._drag >= 0
+        self._drag = -1
+        if was_dragging:
+            # Re-sample (expensive) only once the drag settles, not per move.
+            self.changed.emit()
+
+
+class IT8ProfileDialog(QDialog):
+    """5-step wizard. On success the profile is written; `self.saved_path` holds
+    the .icc path and `self.apply_now` whether to activate it as input profile."""
+
+    PAGE_TARGET, PAGE_REF, PAGE_LOCATE, PAGE_BUILD, PAGE_SAVE = range(5)
+
+    def __init__(self, parent=None, current_path: Optional[str] = None):
+        super().__init__(parent)
+        self.setWindowTitle("Create Camera Profile from IT8")
+        self.setModal(True)
+        self.setMinimumSize(720, 560)
+        self._settings = QSettings("FreeCCR", "FreeCCR")
+
+        self._current_path = current_path
+        self._target_path: Optional[str] = None
+        self._target_img: Optional[np.ndarray] = None
+        self._ref: Optional[it8.IT8Reference] = None
+        self._fit: Optional[it8.CameraFit] = None
+        self._locator_arr = None           # array currently loaded in the locator
+        self.saved_path: Optional[str] = None
+        self.apply_now = False
+
+        self.stack = QStackedWidget(self)
+        self.stack.addWidget(self._build_target_page())
+        self.stack.addWidget(self._build_ref_page())
+        self.stack.addWidget(self._build_locate_page())
+        self.stack.addWidget(self._build_build_page())
+        self.stack.addWidget(self._build_save_page())
+
+        self.back_btn = QPushButton("Back")
+        self.next_btn = QPushButton("Next")
+        self.cancel_btn = QPushButton("Cancel")
+        self.back_btn.clicked.connect(self._go_back)
+        self.next_btn.clicked.connect(self._go_next)
+        self.cancel_btn.clicked.connect(self.reject)
+
+        nav = QHBoxLayout()
+        nav.addWidget(self.cancel_btn)
+        nav.addStretch(1)
+        nav.addWidget(self.back_btn)
+        nav.addWidget(self.next_btn)
+
+        root = QVBoxLayout(self)
+        root.addWidget(self.stack, 1)
+        root.addLayout(nav)
+        self._update_nav()
+
+    # ------------------------------------------------------------------ #
+    # Pages
+    # ------------------------------------------------------------------ #
+    def _build_target_page(self):
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.addWidget(QLabel("<b>Step 1 — IT8 target shot</b>"))
+        guide = QLabel(
+            "Photograph a printed IT8 chart under your capture light, then "
+            "select that photo here.<br><br>"
+            "<b>Capture tips</b> — broad-spectrum daylight/strobe light (not "
+            "tungsten); even, glare-free lighting; chart flat and square to the "
+            "camera; fill the centre of the frame; expose so the lightest "
+            "grayscale patch is bright but <i>not</i> clipped. <b>Shoot RAW</b> — "
+            "the profile is built from the raw-linear sensor data, the same "
+            "space FreeCCR converts negatives in.<br><br>"
+            "The profile is valid only under the light it was shot in.")
+        guide.setWordWrap(True)
+        lay.addWidget(guide)
+        row = QHBoxLayout()
+        self.use_current_btn = QPushButton("Use current image")
+        self.use_current_btn.setEnabled(bool(self._current_path))
+        self.use_current_btn.clicked.connect(self._use_current)
+        browse = QPushButton("Browse…")
+        browse.clicked.connect(self._browse_target)
+        row.addWidget(self.use_current_btn)
+        row.addWidget(browse)
+        row.addStretch(1)
+        lay.addLayout(row)
+        self.target_label = QLabel("<i>No target selected.</i>")
+        self.target_label.setWordWrap(True)
+        lay.addWidget(self.target_label)
+        lay.addStretch(1)
+        return w
+
+    def _build_ref_page(self):
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.addWidget(QLabel("<b>Step 2 — Batch reference file</b>"))
+        guide = QLabel(
+            "Load the reference data file that matches your chart's printed "
+            "<b>batch/serial number</b>. Each IT8 chart batch is measured "
+            "separately — the wrong file gives wrong colour.<br>"
+            f"Wolf Faust provides free per-batch files: <a href='{_REF_URL}'>"
+            f"{_REF_URL}</a>")
+        guide.setWordWrap(True)
+        guide.setOpenExternalLinks(True)
+        lay.addWidget(guide)
+        row = QHBoxLayout()
+        browse = QPushButton("Browse reference…")
+        browse.clicked.connect(self._browse_ref)
+        row.addWidget(browse)
+        row.addStretch(1)
+        lay.addLayout(row)
+        self.ref_label = QLabel("<i>No reference loaded.</i>")
+        self.ref_label.setWordWrap(True)
+        lay.addWidget(self.ref_label)
+        lay.addStretch(1)
+        return w
+
+    def _build_locate_page(self):
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.addWidget(QLabel(
+            "<b>Step 3 — Locate the patches</b> — drag the four green corners "
+            "onto the outer corners of the 12×22 colour grid. Yellow dots are "
+            "colour patches, blue dots the grayscale strip."))
+        self.locator = IT8PatchLocator()
+        self.locator.changed.connect(self._update_locate_status)
+        lay.addWidget(self.locator, 1)
+        ctl = QHBoxLayout()
+        flip = QPushButton("Flip 180°")
+        flip.clicked.connect(self.locator.flip)
+        ctl.addWidget(flip)
+        ctl.addWidget(QLabel("Gray strip:"))
+        self.gray_slider = QSlider(Qt.Horizontal)
+        self.gray_slider.setMinimum(-100)
+        self.gray_slider.setMaximum(100)
+        self.gray_slider.setValue(0)
+        self.gray_slider.setFixedWidth(160)
+        self.gray_slider.valueChanged.connect(
+            lambda v: self.locator.set_gray_offset(v / 1000.0))
+        ctl.addWidget(self.gray_slider)
+        ctl.addStretch(1)
+        self.locate_status = QLabel("")
+        ctl.addWidget(self.locate_status)
+        lay.addLayout(ctl)
+        return w
+
+    def _build_build_page(self):
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.addWidget(QLabel("<b>Step 4 — Review fit quality</b>"))
+        self.quality_label = QLabel("")
+        self.quality_label.setWordWrap(True)
+        lay.addWidget(self.quality_label)
+        self.worst_list = QListWidget()
+        self.worst_list.setMaximumHeight(150)
+        lay.addWidget(self.worst_list)
+        form = QFormLayout()
+        self.name_edit = QLineEdit()
+        self.illum_combo = QComboBox()
+        self.illum_combo.setEditable(True)
+        self.illum_combo.addItems(["Daylight", "Strobe/Flash", "Tungsten",
+                                   "Fluorescent", "Other"])
+        form.addRow("Profile name:", self.name_edit)
+        form.addRow("Illuminant:", self.illum_combo)
+        lay.addLayout(form)
+        lay.addStretch(1)
+        return w
+
+    def _build_save_page(self):
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.addWidget(QLabel("<b>Step 5 — Save</b>"))
+        self.save_label = QLabel("")
+        self.save_label.setWordWrap(True)
+        lay.addWidget(self.save_label)
+        row = QHBoxLayout()
+        self.save_path_edit = QLineEdit()
+        choose = QPushButton("Choose…")
+        choose.clicked.connect(self._choose_save_path)
+        row.addWidget(self.save_path_edit, 1)
+        row.addWidget(choose)
+        lay.addLayout(row)
+        self.apply_check = QCheckBox("Set as input profile now")
+        self.apply_check.setChecked(True)
+        lay.addWidget(self.apply_check)
+        lay.addStretch(1)
+        return w
+
+    # ------------------------------------------------------------------ #
+    # Page 1 — target
+    # ------------------------------------------------------------------ #
+    def _use_current(self):
+        if self._current_path:
+            self._set_target(self._current_path)
+
+    def _browse_target(self):
+        start = self._settings.value("files/last_open_dir", "", type=str)
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select IT8 target shot", start,
+            "Images (*.dng *.tif *.tiff *.arw *.nef *.cr2 *.cr3 *.raf *.png "
+            "*.jpg *.jpeg *.rw2 *.3fr *.fff);;All Files (*)")
+        if path:
+            self._set_target(path)
+
+    def _set_target(self, path):
+        self._target_path = path
+        self._target_img = None            # force re-decode on Next
+        raw = ", ".join((".dng", ".arw", ".nef", ".cr2", ".cr3", ".raf",
+                         ".rw2", ".3fr", ".fff"))
+        is_raw = os.path.splitext(path)[1].lower() in raw
+        warn = ("" if is_raw else
+                "<br><span style='color:#cc7a00'>Note: not a RAW file — for "
+                "FreeCCR's pipeline a RAW shot gives the matching device "
+                "space.</span>")
+        self.target_label.setText(f"Selected: <b>{os.path.basename(path)}</b>{warn}")
+        self._update_nav()
+
+    def _decode_target(self) -> bool:
+        if self._target_img is not None:
+            return True
+        norm = normalize_unicode_path(self._target_path)
+        if not validate_unicode_path(norm):
+            QMessageBox.warning(self, "Unicode Path",
+                                "This file path can't be processed. Please move "
+                                "it to a simpler path.")
+            return False
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            arr = it8.decode_target(norm)
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.critical(self, "Decode Error",
+                                 f"Could not read the target shot:\n\n{e}")
+            return False
+        QApplication.restoreOverrideCursor()
+        if arr is None or arr.ndim != 3:
+            QMessageBox.critical(self, "Decode Error",
+                                 "Could not decode the target shot.")
+            return False
+        self._target_img = arr
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Page 2 — reference
+    # ------------------------------------------------------------------ #
+    def _browse_ref(self):
+        start = self._settings.value("files/last_it8_ref_dir", "", type=str)
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select IT8 reference file", start,
+            "IT8 reference (*.it8 *.txt *.cie);;All Files (*)")
+        if not path:
+            return
+        self._settings.setValue("files/last_it8_ref_dir", os.path.dirname(path))
+        try:
+            ref = it8.parse_it8_reference(path)
+        except it8.IT8ReferenceError as e:
+            QMessageBox.warning(self, "Reference File", str(e))
+            return
+        except Exception as e:
+            QMessageBox.warning(self, "Reference File",
+                                f"Could not read the reference file:\n\n{e}")
+            return
+        self._ref = ref
+        n = len(ref.matched_ids)
+        self.ref_label.setText(
+            f"Loaded: <b>{os.path.basename(path)}</b><br>"
+            f"Chart type: {ref.chart_type or 'unknown'}<br>"
+            f"Batch / serial: <b>{ref.batch or 'unknown'}</b> — confirm this "
+            f"matches the number printed on your chart.<br>"
+            f"Patches recognised: {n}")
+        self._update_nav()
+
+    # ------------------------------------------------------------------ #
+    # Page 3 — locate
+    # ------------------------------------------------------------------ #
+    def _update_locate_status(self):
+        if self._target_img is None or self._ref is None:
+            return
+        pts = self.locator.points()
+        samples = it8.sample_patches(self._target_img, pts, self.locator.quad())
+        valid = sum(1 for sid in self._ref.matched_ids
+                    if sid in samples and samples[sid].valid)
+        total = len(self._ref.matched_ids)
+        warn = ""
+        if ("GS0" in samples and "GS23" in samples
+                and samples["GS0"].valid and samples["GS23"].valid):
+            if samples["GS0"].rgb.mean() < samples["GS23"].rgb.mean():
+                warn = "  ⚠ GS0 darker than GS23 — try Flip 180°"
+        self.locate_status.setText(f"Valid patches: {valid}/{total}{warn}")
+
+    # ------------------------------------------------------------------ #
+    # Page 4 — build
+    # ------------------------------------------------------------------ #
+    def _run_fit(self) -> bool:
+        err = None
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            pts = self.locator.points()
+            samples = it8.sample_patches(self._target_img, pts, self.locator.quad())
+            fit = it8.fit_camera_matrix(samples, self._ref)
+        except it8.IT8ReferenceError as e:
+            fit, err = None, str(e)
+        finally:
+            QApplication.restoreOverrideCursor()
+        if err is not None:
+            QMessageBox.warning(self, "Fit", err)
+            return False
+        self._fit = fit
+        if fit.avg_de < 2.0:
+            chip, colour = "Good", "#3a8a3a"
+        elif fit.avg_de < 4.0:
+            chip, colour = "OK", "#b08a00"
+        else:
+            chip, colour = "Check placement / capture", "#b03030"
+        self.quality_label.setText(
+            f"<span style='background:{colour};color:white;padding:2px 8px;'>"
+            f"{chip}</span>  &nbsp; "
+            f"avg ΔE2000 <b>{fit.avg_de:.2f}</b> · median {fit.med_de:.2f} · "
+            f"95th {fit.p95_de:.2f} · max {fit.max_de:.2f}<br>"
+            f"Patches used: {len(fit.used_ids)} · dropped "
+            f"(clipped/missing): {len(fit.dropped_ids)} · "
+            f"white-balanced on {fit.wb_id}")
+        self.worst_list.clear()
+        for sid, de in fit.per_patch[:20]:
+            self.worst_list.addItem(f"{sid}\tΔE {de:.2f}")
+        if not self.name_edit.text().strip():
+            illum = self.illum_combo.currentText().strip() or "Daylight"
+            self.name_edit.setText(
+                f"Camera {illum} {datetime.now():%Y-%m-%d}")
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Page 5 — save
+    # ------------------------------------------------------------------ #
+    def _default_save_path(self) -> str:
+        from core.catalog import default_catalog_path
+        folder = os.path.join(os.path.dirname(default_catalog_path()),
+                              "camera_profiles")
+        os.makedirs(folder, exist_ok=True)
+        name = self.name_edit.text().strip() or "Camera Profile"
+        safe = "".join(c if c.isalnum() or c in " -_" else "_" for c in name)
+        return os.path.join(folder, f"{safe}.icc")
+
+    def _choose_save_path(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save camera ICC profile", self.save_path_edit.text(),
+            "ICC Profiles (*.icc)")
+        if path:
+            if not path.lower().endswith(".icc"):
+                path += ".icc"
+            self.save_path_edit.setText(path)
+
+    def _do_save(self) -> bool:
+        path = self.save_path_edit.text().strip()
+        if not path:
+            QMessageBox.warning(self, "Save", "Choose a destination file.")
+            return False
+        illum = self.illum_combo.currentText().strip()
+        name = self.name_edit.text().strip() or "Camera Profile"
+        desc = f"{name} ({illum})" if illum else name
+        try:
+            icc = it8.build_camera_icc(self._fit, desc)
+            os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+            with open(path, "wb") as f:
+                f.write(icc)
+        except Exception as e:
+            QMessageBox.critical(self, "Save Error",
+                                 f"Could not write the profile:\n\n{e}")
+            return False
+        self.saved_path = path
+        self.apply_now = self.apply_check.isChecked()
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Navigation
+    # ------------------------------------------------------------------ #
+    def _go_back(self):
+        i = self.stack.currentIndex()
+        if i > 0:
+            self.stack.setCurrentIndex(i - 1)
+            self._update_nav()
+
+    def _go_next(self):
+        i = self.stack.currentIndex()
+        if i == self.PAGE_TARGET:
+            if not self._target_path:
+                QMessageBox.information(self, "Target", "Select a target shot.")
+                return
+            if not self._decode_target():
+                return
+        elif i == self.PAGE_REF:
+            if self._ref is None:
+                QMessageBox.information(self, "Reference",
+                                        "Load a reference file.")
+                return
+        elif i == self.PAGE_LOCATE:
+            if not self._run_fit():
+                return
+        elif i == self.PAGE_BUILD:
+            if not self.save_path_edit.text().strip():
+                self.save_path_edit.setText(self._default_save_path())
+            self.save_label.setText(
+                "The profile will be written here. With “Set as input profile "
+                "now” ticked it is applied to every loaded image immediately "
+                "(File ▸ Input ICC).")
+        elif i == self.PAGE_SAVE:
+            if self._do_save():
+                self.accept()
+            return
+
+        self.stack.setCurrentIndex(i + 1)
+        # On entering the locate page, (re)load the decoded target into the
+        # locator whenever the underlying array changed (a re-decode produces a
+        # new array object — identity check catches a new same-size target too).
+        if self.stack.currentIndex() == self.PAGE_LOCATE:
+            if self._target_img is not self._locator_arr:
+                self.locator.set_image(self._target_img)
+                self._locator_arr = self._target_img
+            self._update_locate_status()
+        self._update_nav()
+
+    def _update_nav(self):
+        i = self.stack.currentIndex()
+        self.back_btn.setEnabled(i > 0)
+        self.next_btn.setText("Finish" if i == self.PAGE_SAVE else "Next")

--- a/src/widgets/it8_profile_dialog.py
+++ b/src/widgets/it8_profile_dialog.py
@@ -8,6 +8,7 @@ Core math lives in core.it8_profile; this module is UI only.
 See spec/it8-camera-profile.md.
 """
 import os
+import re
 from datetime import datetime
 from typing import Optional
 
@@ -58,22 +59,60 @@ class IT8PatchLocator(QWidget):
         self.setMinimumSize(520, 360)
         self.setMouseTracking(True)
         self._qimg: Optional[QImage] = None
+        self._base = None                 # decoded array as given
+        self._work = None                 # working array (mirrored if requested)
+        self._mirror = False
         self._iw = self._ih = 0
         self._quad = []                   # 4 (x,y) array-space corners TL,TR,BR,BL
         self._gray_offset = 0.0
+        self._mode = "classic"            # "classic" (12x22 + GS strip) | "block"
+        self._rows = []                   # block mode: row letters
+        self._cols = []                   # block mode: column numbers
         self._drag = -1                   # index of handle being dragged, or -1
         self._scale = 1.0
         self._ox = self._oy = 0.0
 
     def set_image(self, arr_u16: np.ndarray):
-        self._qimg = _gamma_stretch_to_qimage(arr_u16)
-        self._ih, self._iw = arr_u16.shape[:2]
-        # Default colour-block quad inset from the image edges.
+        self._base = arr_u16
+        self._rebuild_work()
+
+    def _rebuild_work(self):
+        if self._base is None:
+            return
+        self._work = (np.ascontiguousarray(np.fliplr(self._base))
+                      if self._mirror else self._base)
+        self._qimg = _gamma_stretch_to_qimage(self._work)
+        self._ih, self._iw = self._work.shape[:2]
+        # Default block quad inset from the image edges (re-derived on reload).
         ix, iy = self._iw, self._ih
-        self._quad = [(0.10 * ix, 0.10 * iy), (0.90 * ix, 0.10 * iy),
-                      (0.90 * ix, 0.82 * iy), (0.10 * ix, 0.82 * iy)]
+        self._quad = [(0.12 * ix, 0.16 * iy), (0.88 * ix, 0.16 * iy),
+                      (0.88 * ix, 0.78 * iy), (0.12 * ix, 0.78 * iy)]
         self.update()
         self.changed.emit()
+
+    # --- configuration ---
+    def set_mirror(self, on: bool):
+        if bool(on) != self._mirror:
+            self._mirror = bool(on)
+            self._rebuild_work()
+
+    def set_layout_classic(self):
+        self._mode = "classic"
+        self.update(); self.changed.emit()
+
+    def set_layout_block(self, rows, cols):
+        self._mode = "block"
+        self._rows, self._cols = list(rows), list(cols)
+        self.update(); self.changed.emit()
+
+    def image_array(self):
+        return self._work
+
+    def grid_dims(self):
+        """(ncols, nrows) for sampling-window sizing."""
+        if self._mode == "block":
+            return max(1, len(self._cols)), max(1, len(self._rows))
+        return 22, 12
 
     # --- geometry accessors ---
     def quad(self):
@@ -96,6 +135,10 @@ class IT8PatchLocator(QWidget):
     def points(self):
         if not self._quad:
             return {}
+        if self._mode == "block":
+            if not self._rows or not self._cols:
+                return {}
+            return it8.block_sample_points(self._quad, self._rows, self._cols)
         return it8.grid_sample_points(self._quad, self._gray_offset)
 
     # --- coordinate mapping (array <-> widget) ---
@@ -205,6 +248,7 @@ class IT8ProfileDialog(QDialog):
         self._ref: Optional[it8.IT8Reference] = None
         self._fit: Optional[it8.CameraFit] = None
         self._locator_arr = None           # array currently loaded in the locator
+        self._mode = "classic"             # "classic" (GS strip) | "block" (plain grid)
         self.saved_path: Optional[str] = None
         self.apply_now = False
 
@@ -274,8 +318,9 @@ class IT8ProfileDialog(QDialog):
         lay.addWidget(QLabel("<b>Step 2 — Batch reference file</b>"))
         guide = QLabel(
             "Load the reference data file that matches your chart's printed "
-            "<b>batch/serial number</b>. Each IT8 chart batch is measured "
-            "separately — the wrong file gives wrong colour.<br>"
+            "<b>batch/serial number</b>. Each chart batch is measured "
+            "separately — the wrong file gives wrong colour. Both <b>CGATS</b> "
+            "(.it8/.txt) and <b>CxF</b> (.cxf) reference files are accepted.<br>"
             f"Wolf Faust provides free per-batch files: <a href='{_REF_URL}'>"
             f"{_REF_URL}</a>")
         guide.setWordWrap(True)
@@ -296,23 +341,36 @@ class IT8ProfileDialog(QDialog):
     def _build_locate_page(self):
         w = QWidget()
         lay = QVBoxLayout(w)
-        lay.addWidget(QLabel(
+        self.locate_hint = QLabel(
             "<b>Step 3 — Locate the patches</b> — drag the four green corners "
-            "onto the outer corners of the 12×22 colour grid. Yellow dots are "
-            "colour patches, blue dots the grayscale strip."))
+            "onto the outer corners of the patch grid. Dots mark where each "
+            "patch is sampled; nudge the corners until every dot sits inside "
+            "its patch.")
+        self.locate_hint.setWordWrap(True)
+        lay.addWidget(self.locate_hint)
         self.locator = IT8PatchLocator()
         self.locator.changed.connect(self._update_locate_status)
         lay.addWidget(self.locator, 1)
+
+        # Row 1: orientation controls.
         ctl = QHBoxLayout()
         flip = QPushButton("Flip 180°")
         flip.clicked.connect(self.locator.flip)
         ctl.addWidget(flip)
-        ctl.addWidget(QLabel("Gray strip:"))
+        self.mirror_check = QCheckBox("Mirrored capture")
+        self.mirror_check.setToolTip(
+            "Tick if the shot is left-right mirrored (e.g. a back-lit film "
+            "target shot through its base). The image is flipped horizontally.")
+        self.mirror_check.toggled.connect(self._on_mirror_toggled)
+        ctl.addWidget(self.mirror_check)
+        # Gray-strip nudge (classic IT8 only).
+        self.gray_label = QLabel("Gray strip:")
+        ctl.addWidget(self.gray_label)
         self.gray_slider = QSlider(Qt.Horizontal)
         self.gray_slider.setMinimum(-100)
         self.gray_slider.setMaximum(100)
         self.gray_slider.setValue(0)
-        self.gray_slider.setFixedWidth(160)
+        self.gray_slider.setFixedWidth(140)
         self.gray_slider.valueChanged.connect(
             lambda v: self.locator.set_gray_offset(v / 1000.0))
         ctl.addWidget(self.gray_slider)
@@ -320,7 +378,38 @@ class IT8ProfileDialog(QDialog):
         self.locate_status = QLabel("")
         ctl.addWidget(self.locate_status)
         lay.addLayout(ctl)
+
+        # Row 2: block patch-id range (non-classic grids only).
+        self.block_row = QWidget()
+        brow = QHBoxLayout(self.block_row)
+        brow.setContentsMargins(0, 0, 0, 0)
+        brow.addWidget(QLabel("Top-left patch:"))
+        self.tl_edit = QLineEdit()
+        self.tl_edit.setFixedWidth(70)
+        self.tl_edit.editingFinished.connect(self._apply_block_ids)
+        brow.addWidget(self.tl_edit)
+        brow.addWidget(QLabel("Bottom-right patch:"))
+        self.br_edit = QLineEdit()
+        self.br_edit.setFixedWidth(70)
+        self.br_edit.editingFinished.connect(self._apply_block_ids)
+        brow.addWidget(self.br_edit)
+        brow.addWidget(QLabel("(read the corner patch labels off the chart)"))
+        brow.addStretch(1)
+        lay.addWidget(self.block_row)
+        self.block_row.setVisible(False)
         return w
+
+    def _on_mirror_toggled(self, on):
+        self.locator.set_mirror(bool(on))
+
+    def _apply_block_ids(self):
+        if self._mode != "block":
+            return
+        try:
+            rows, cols = it8.parse_block(self.tl_edit.text(), self.br_edit.text())
+        except ValueError:
+            return
+        self.locator.set_layout_block(rows, cols)
 
     def _build_build_page(self):
         w = QWidget()
@@ -425,12 +514,13 @@ class IT8ProfileDialog(QDialog):
         start = self._settings.value("files/last_it8_ref_dir", "", type=str)
         path, _ = QFileDialog.getOpenFileName(
             self, "Select IT8 reference file", start,
-            "IT8 reference (*.it8 *.txt *.cie);;All Files (*)")
+            "Reference files (*.it8 *.txt *.cie *.cxf);;CxF (*.cxf);;"
+            "CGATS (*.it8 *.txt *.cie);;All Files (*)")
         if not path:
             return
         self._settings.setValue("files/last_it8_ref_dir", os.path.dirname(path))
         try:
-            ref = it8.parse_it8_reference(path)
+            ref = it8.parse_reference(path)
         except it8.IT8ReferenceError as e:
             QMessageBox.warning(self, "Reference File", str(e))
             return
@@ -439,32 +529,53 @@ class IT8ProfileDialog(QDialog):
                                 f"Could not read the reference file:\n\n{e}")
             return
         self._ref = ref
-        n = len(ref.matched_ids)
+        # Classic IT8 has a GS0..GS23 strip; anything else is a plain grid that
+        # the user delimits with corner patch ids (block mode).
+        self._mode = "classic" if "GS0" in ref.patches else "block"
+        n = len(ref.matched_ids if self._mode == "classic" else ref.patches)
+        extent = self._ref_extent()
+        extent_txt = (f"<br>Patch ids: <b>{extent[0]}</b> … <b>{extent[1]}</b>"
+                      if self._mode == "block" and extent else "")
         self.ref_label.setText(
             f"Loaded: <b>{os.path.basename(path)}</b><br>"
             f"Chart type: {ref.chart_type or 'unknown'}<br>"
             f"Batch / serial: <b>{ref.batch or 'unknown'}</b> — confirm this "
             f"matches the number printed on your chart.<br>"
-            f"Patches recognised: {n}")
+            f"Patches recognised: {n}{extent_txt}")
         self._update_nav()
+
+    def _ref_extent(self):
+        """(top-left, bottom-right) patch ids spanning the reference's letter+
+        number grid, e.g. ('A1','L72'). None if no such ids."""
+        rows, cols = set(), set()
+        for sid in self._ref.patches:
+            m = re.match(r'^([A-Za-z])(\d+)$', sid)
+            if m:
+                rows.add(m.group(1).upper())
+                cols.add(int(m.group(2)))
+        if not rows or not cols:
+            return None
+        return (f"{min(rows)}{min(cols)}", f"{max(rows)}{max(cols)}")
 
     # ------------------------------------------------------------------ #
     # Page 3 — locate
     # ------------------------------------------------------------------ #
     def _update_locate_status(self):
-        if self._target_img is None or self._ref is None:
+        img = self.locator.image_array()
+        if img is None or self._ref is None:
             return
         pts = self.locator.points()
-        samples = it8.sample_patches(self._target_img, pts, self.locator.quad())
-        valid = sum(1 for sid in self._ref.matched_ids
-                    if sid in samples and samples[sid].valid)
-        total = len(self._ref.matched_ids)
+        nc, nr = self.locator.grid_dims()
+        samples = it8.sample_patches(img, pts, self.locator.quad(),
+                                     ncols=nc, nrows=nr)
+        in_ref = [sid for sid in samples if sid in self._ref.patches]
+        valid = sum(1 for sid in in_ref if samples[sid].valid)
         warn = ""
         if ("GS0" in samples and "GS23" in samples
                 and samples["GS0"].valid and samples["GS23"].valid):
             if samples["GS0"].rgb.mean() < samples["GS23"].rgb.mean():
                 warn = "  ⚠ GS0 darker than GS23 — try Flip 180°"
-        self.locate_status.setText(f"Valid patches: {valid}/{total}{warn}")
+        self.locate_status.setText(f"Valid patches: {valid}/{len(in_ref)}{warn}")
 
     # ------------------------------------------------------------------ #
     # Page 4 — build
@@ -474,7 +585,9 @@ class IT8ProfileDialog(QDialog):
         QApplication.setOverrideCursor(Qt.WaitCursor)
         try:
             pts = self.locator.points()
-            samples = it8.sample_patches(self._target_img, pts, self.locator.quad())
+            nc, nr = self.locator.grid_dims()
+            samples = it8.sample_patches(self.locator.image_array(), pts,
+                                         self.locator.quad(), ncols=nc, nrows=nr)
             fit = it8.fit_camera_matrix(samples, self._ref)
         except it8.IT8ReferenceError as e:
             fit, err = None, str(e)
@@ -587,15 +700,46 @@ class IT8ProfileDialog(QDialog):
             return
 
         self.stack.setCurrentIndex(i + 1)
-        # On entering the locate page, (re)load the decoded target into the
-        # locator whenever the underlying array changed (a re-decode produces a
-        # new array object — identity check catches a new same-size target too).
+        # On entering the locate page, configure the layout for the reference
+        # type and (re)load the decoded target into the locator whenever the
+        # underlying array changed (a re-decode makes a new array object).
         if self.stack.currentIndex() == self.PAGE_LOCATE:
+            self._configure_locate_page()
             if self._target_img is not self._locator_arr:
                 self.locator.set_image(self._target_img)
                 self._locator_arr = self._target_img
             self._update_locate_status()
         self._update_nav()
+
+    def _configure_locate_page(self):
+        """Show classic (GS-strip) vs block (plain grid) controls per the
+        reference, and seed the block patch-id range from its extent."""
+        block = self._mode == "block"
+        self.block_row.setVisible(block)
+        self.gray_label.setVisible(not block)
+        self.gray_slider.setVisible(not block)
+        if block:
+            self.locate_hint.setText(
+                "<b>Step 3 — Locate the patches</b> — drag the four green "
+                "corners onto the outer corners of the patch grid you "
+                "photographed. Set the top-left / bottom-right patch ids below "
+                "to match the block in frame, then nudge the corners until every "
+                "dot sits inside its patch.")
+            extent = self._ref_extent()
+            if extent and not self.tl_edit.text():
+                self.tl_edit.setText(extent[0])
+                self.br_edit.setText(extent[1])
+            try:
+                rows, cols = it8.parse_block(self.tl_edit.text(), self.br_edit.text())
+                self.locator.set_layout_block(rows, cols)
+            except ValueError:
+                pass
+        else:
+            self.locate_hint.setText(
+                "<b>Step 3 — Locate the patches</b> — drag the four green "
+                "corners onto the outer corners of the 12×22 colour grid. "
+                "Yellow dots are colour patches, blue dots the grayscale strip.")
+            self.locator.set_layout_classic()
 
     def _update_nav(self):
         i = self.stack.currentIndex()

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -1427,21 +1427,17 @@ class SlidersPanel(QWidget):
                 "<b>Black Point:</b> Draw a rect over the transparent/clear film base.", duration=6000)
 
     def _on_clear_white_point(self):
-        """Clear the sampled white point so conversion uses the calibrated
-        default slope (black point only)."""
+        """Clear BOTH sampled B/W points (black film base + white dense point),
+        resetting the Film B/W Point section."""
+        ccr_backend.clear_black_point()
         ccr_backend.clear_white_point()
         mw = self.parent().parent()
         if hasattr(mw, "persist_bwpoint"):
             mw.persist_bwpoint()
         self._update_bwp_mode_label()
-        if ccr_backend.black_point_bgr is None:
-            self.set_temporary_hint(
-                "White point cleared. Set a <b>Black Point</b> (film base), then "
-                "Convert to use the <b>default slope</b>.", duration=6000)
-        else:
-            self.set_temporary_hint(
-                "White point cleared — conversion will use the calibrated "
-                "<b>default slope</b>. Click <b>Convert</b> to apply.", duration=6000)
+        self.set_temporary_hint(
+            "B/W points cleared. Set a <b>Black Point</b> (film base) "
+            "before converting.", duration=6000)
 
     def _update_bwp_mode_label(self):
         """Reflect which slope source the next B/W-point conversion will use."""

--- a/tests/test_it8_profile.py
+++ b/tests/test_it8_profile.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""
+Tests for the IT8 camera-profile core (src/core/it8_profile.py).
+See spec/it8-camera-profile.md §8. Pure numpy/cv2 — no Qt required.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core import it8_profile as it8  # noqa: E402
+from core import color_management as cm  # noqa: E402
+
+D50 = np.array(cm.D50_XYZ)                 # [0,1] scale, Y=1
+
+
+# --------------------------------------------------------------------------- #
+# Reference-file fixtures (CGATS.17), built programmatically.
+# --------------------------------------------------------------------------- #
+
+def _make_cgats(fields, rows, *, chart="IT8.7/1", serial="E111007 Batch",
+                eol="\n", bom=False, comment=True):
+    """Build a minimal CGATS file string. `rows` = list of (sample_id, {field:val})."""
+    lines = [chart,
+             'ORIGINATOR "Wolf Faust"',
+             'DESCRIPTOR "IT8.7/1 light D50, 2 degree"',
+             f'MANUFACTURER "Wolf Faust - http://www.coloraid.de"',
+             f'SERIAL "{serial}"',
+             f'NUMBER_OF_FIELDS {len(fields)}',
+             f'NUMBER_OF_SETS {len(rows)}']
+    if comment:
+        lines.append('KEYWORD "MEAN_DE" # a custom column name')
+    lines.append('BEGIN_DATA_FORMAT')
+    lines.append(' '.join(fields))
+    lines.append('END_DATA_FORMAT')
+    lines.append('BEGIN_DATA')
+    for sid, vals in rows:
+        toks = [sid] + [f"{vals.get(f, 0.0):.4f}" for f in fields[1:]]
+        lines.append('   '.join(toks))
+    lines.append('END_DATA')
+    text = eol.join(lines) + eol
+    if bom:
+        text = '﻿' + text
+    return text
+
+
+def _synthetic_patches():
+    """288 patches: GS0..GS23 neutral (Y ramp * D50), colour patches varied.
+    Returns dict id -> XYZ (Y=100 scale)."""
+    rng = np.random.default_rng(7)
+    patches = {}
+    # Grayscale: neutral, Y from ~89 down to ~1.
+    ys = np.linspace(89.0, 1.0, 24)
+    for k, y in enumerate(ys):
+        patches[f"GS{k}"] = (y / 100.0) * D50 * 100.0   # exactly D50 chromaticity
+    # Colour: random but plausible XYZ (Y 5..85), kept in a sane range.
+    for cid in it8.COLOR_IDS:
+        Y = rng.uniform(5, 85)
+        x = Y * rng.uniform(0.7, 1.3)
+        z = Y * rng.uniform(0.4, 1.2)
+        patches[cid] = np.array([x, Y, z])
+    return patches
+
+
+def _write(tmp_path, name, text):
+    p = tmp_path / name
+    # utf-8 so a BOM ('﻿') round-trips to the EF BB BF the parser strips;
+    # the rest of the fixture is ASCII.
+    p.write_bytes(text.encode('utf-8'))
+    return str(p)
+
+
+def test_parse_18_field(tmp_path):
+    fields = ["SAMPLE_ID", "XYZ_X", "XYZ_Y", "XYZ_Z", "LAB_L", "LAB_A", "LAB_B",
+              "D_RED", "D_GREEN", "D_BLUE", "D_VIS", "STDEV_X", "STDEV_Y",
+              "STDEV_Z", "MEAN_DE", "STDEV_DE"]
+    rows = [("A1", {"XYZ_X": 2.26, "XYZ_Y": 1.91, "XYZ_Z": 1.32,
+                    "LAB_L": 15.02, "LAB_A": 9.49, "LAB_B": 3.12}),
+            ("GS0", {"XYZ_X": 79.8, "XYZ_Y": 82.7, "XYZ_Z": 63.6,
+                     "LAB_L": 92.9, "LAB_A": 0.1, "LAB_B": 0.2}),
+            ("L22", {"XYZ_X": 5.0, "XYZ_Y": 4.0, "XYZ_Z": 3.0,
+                     "LAB_L": 23.0, "LAB_A": 1.0, "LAB_B": -2.0})]
+    ref = it8.parse_it8_reference(_write(tmp_path, "ref18.it8",
+                                         _make_cgats(fields, rows)))
+    assert ref.chart_type == "IT8.7/1"
+    assert ref.batch.startswith("E111007")
+    assert ref.fields[0] == "SAMPLE_ID"
+    assert "A1" in ref.patches and "GS0" in ref.patches and "L22" in ref.patches
+    np.testing.assert_allclose(ref.xyz("A1"), [2.26, 1.91, 1.32])
+    np.testing.assert_allclose(ref.lab("GS0"), [92.9, 0.1, 0.2])
+
+
+def test_parse_17_field_no_xyz_derives_from_lab(tmp_path):
+    # Older layout: Lab present, plus STDEV_LAB, no density columns.
+    fields = ["SAMPLE_ID", "XYZ_X", "XYZ_Y", "XYZ_Z", "LAB_L", "LAB_A", "LAB_B",
+              "LAB_C", "LAB_H", "STDEV_L", "STDEV_A", "STDEV_B"]
+    rows = [("A1", {"XYZ_X": 20.0, "XYZ_Y": 18.0, "XYZ_Z": 10.0,
+                    "LAB_L": 49.5, "LAB_A": 8.0, "LAB_B": 12.0})]
+    ref = it8.parse_it8_reference(_write(tmp_path, "ref17.it8",
+                                         _make_cgats(fields, rows)))
+    assert len(ref.fields) == 12
+    np.testing.assert_allclose(ref.lab("A1"), [49.5, 8.0, 12.0])
+
+
+def test_parse_id_normalization_and_crlf_bom(tmp_path):
+    fields = ["SAMPLE_ID", "XYZ_X", "XYZ_Y", "XYZ_Z"]
+    rows = [("A01", {"XYZ_X": 1, "XYZ_Y": 2, "XYZ_Z": 3}),
+            ("GS00", {"XYZ_X": 80, "XYZ_Y": 82, "XYZ_Z": 64}),
+            ("gs23", {"XYZ_X": 0.1, "XYZ_Y": 0.1, "XYZ_Z": 0.1})]
+    ref = it8.parse_it8_reference(_write(
+        tmp_path, "refn.it8", _make_cgats(fields, rows, eol="\r\n", bom=True)))
+    assert "A1" in ref.patches          # zero-padded -> normalized
+    assert "GS0" in ref.patches and "GS23" in ref.patches
+
+
+def test_parse_errors(tmp_path):
+    with pytest.raises(it8.IT8ReferenceError):
+        it8.parse_it8_reference(_write(tmp_path, "empty.it8", "IT8.7/1\n"))
+    # No colorimetry columns at all.
+    bad = _make_cgats(["SAMPLE_ID", "D_VIS"], [("A1", {"D_VIS": 1.0})])
+    with pytest.raises(it8.IT8ReferenceError):
+        it8.parse_it8_reference(_write(tmp_path, "nocol.it8", bad))
+
+
+def test_parse_skips_count_mismatched_rows(tmp_path):
+    # A row truncated mid-way must NOT become a partial record (which would
+    # later KeyError in lab()); it is skipped, valid rows still parse.
+    fields = ["SAMPLE_ID", "XYZ_X", "XYZ_Y", "XYZ_Z", "LAB_L", "LAB_A", "LAB_B"]
+    good = _make_cgats(fields, [
+        ("A1", {"XYZ_X": 2.0, "XYZ_Y": 1.9, "XYZ_Z": 1.3,
+                "LAB_L": 15.0, "LAB_A": 9.0, "LAB_B": 3.0}),
+        ("GS0", {"XYZ_X": 80.0, "XYZ_Y": 82.0, "XYZ_Z": 64.0,
+                 "LAB_L": 92.0, "LAB_A": 0.0, "LAB_B": 0.0})])
+    # Splice in a truncated A2 row (only 3 tokens) before the DATA terminator.
+    # Match "END_DATA\n" (not the "END_DATA_FORMAT" header) so only the data
+    # block's closing line is targeted.
+    text = good.replace("END_DATA\n", "A2   5.00   4.00\nEND_DATA\n")
+    ref = it8.parse_it8_reference(_write(tmp_path, "trunc.it8", text))
+    assert "A1" in ref.patches and "GS0" in ref.patches
+    assert "A2" not in ref.patches            # malformed row skipped
+    # No partial record => xyz()/lab() never KeyError.
+    assert ref.xyz("A1") is not None and ref.lab("GS0") is not None
+
+
+def test_decode_target_smoke(tmp_path):
+    # decode_target builds a bare CCRImage via __new__ and calls read_image —
+    # verify that path returns a uint16 RGB array (guards the __init__ bypass).
+    import cv2
+    bgr = np.zeros((40, 60, 3), dtype=np.uint8)
+    bgr[..., 2] = 200          # R via BGR
+    path = str(tmp_path / "target.png")
+    cv2.imwrite(path, bgr)
+    arr = it8.decode_target(path, sample_max=2048)
+    assert arr is not None and arr.dtype == np.uint16
+    assert arr.ndim == 3 and arr.shape[2] == 3
+    # RGB order: red channel dominant (input ICC bypassed, no colour transform).
+    assert arr[0, 0, 0] > arr[0, 0, 1] and arr[0, 0, 0] > arr[0, 0, 2]
+
+
+def test_partial_record_does_not_crash():
+    # Even if a partial record somehow exists, xyz()/lab() return None, not raise.
+    ref = it8.IT8Reference()
+    ref.patches["A1"] = {"XYZ_X": 5.0, "XYZ_Y": 4.0}   # missing XYZ_Z
+    assert ref.xyz("A1") is None
+    assert ref.lab("A1") is None
+
+
+# --------------------------------------------------------------------------- #
+# Geometry.
+# --------------------------------------------------------------------------- #
+
+def test_grid_points_unit_quad():
+    quad = [(0, 0), (220, 0), (220, 120), (0, 120)]   # TL,TR,BR,BL
+    pts = it8.grid_sample_points(quad)
+    assert len(pts) == 288
+    # A1 (row0,col0) centre = (0.5/22*220, 0.5/12*120) = (5,5).
+    np.testing.assert_allclose(pts["A1"], (5.0, 5.0), atol=1e-6)
+    # L22 (row11,col21) centre = (21.5/22*220, 11.5/12*120) = (215,115).
+    np.testing.assert_allclose(pts["L22"], (215.0, 115.0), atol=1e-6)
+    # GS strip lies below the colour block (v > 1).
+    assert pts["GS0"][1] > 120 and pts["GS23"][1] > 120
+    assert pts["GS0"][0] < pts["GS23"][0]             # GS0 left of GS23
+
+
+def test_flip_quad():
+    quad = [(0, 0), (220, 0), (220, 120), (0, 120)]
+    flipped = it8.flip_quad(quad)
+    pts0 = it8.grid_sample_points(quad)
+    ptsf = it8.grid_sample_points(flipped)
+    # After a 180 flip, A1 lands where L22 was (and vice versa).
+    np.testing.assert_allclose(ptsf["A1"], pts0["L22"], atol=1e-6)
+    np.testing.assert_allclose(ptsf["L22"], pts0["A1"], atol=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# Sampling.
+# --------------------------------------------------------------------------- #
+
+def test_sample_patches_flat_chart():
+    # Build a synthetic warped chart: each colour cell a flat known RGB.
+    quad = [(0, 0), (220, 0), (220, 120), (0, 120)]
+    img = np.zeros((130, 230, 3), dtype=np.uint16)
+    pts = it8.grid_sample_points(quad)
+    expected = {}
+    for r in range(12):
+        for c in range(22):
+            sid = it8.COLOR_IDS[r * 22 + c]
+            val = np.array([1000 + r * 50, 2000 + c * 40, 3000], dtype=np.uint16)
+            x0, x1 = c * 10, (c + 1) * 10
+            y0, y1 = r * 10, (r + 1) * 10
+            img[y0:y1, x0:x1] = val
+            expected[sid] = val
+    samples = it8.sample_patches(img, pts, quad, frac=0.5)
+    for sid, val in expected.items():
+        np.testing.assert_allclose(samples[sid].rgb, val, atol=1.0)
+        assert samples[sid].valid
+
+
+def test_sample_clip_rejection():
+    quad = [(0, 0), (220, 0), (220, 120), (0, 120)]
+    img = np.full((130, 230, 3), 65535, dtype=np.uint16)   # fully clipped white
+    pts = it8.grid_sample_points(quad)
+    samples = it8.sample_patches(img, pts, quad)
+    assert not samples["A1"].valid                          # clipped -> invalid
+
+
+# --------------------------------------------------------------------------- #
+# Matrix fit — synthetic round-trip (the key test).
+# --------------------------------------------------------------------------- #
+
+def _consistent_samples(M0, patches):
+    """Device samples consistent with XYZ = M0 @ (rgb/65535), i.e. exact data."""
+    Minv = np.linalg.inv(M0)
+    samples = {}
+    for sid, xyz in patches.items():
+        d = Minv @ (xyz / 100.0)            # normalised device RGB in [0,1]
+        rgb = np.clip(d, 0, None) * 65535.0
+        samples[sid] = it8.PatchSample(rgb=rgb, valid=True, n_pix=900)
+    return samples
+
+
+def _ref_from_patches(patches):
+    ref = it8.IT8Reference(chart_type="IT8.7/1", batch="TEST")
+    for sid, xyz in patches.items():
+        lab = it8.xyz_to_lab(xyz)
+        ref.patches[sid] = {"XYZ_X": xyz[0], "XYZ_Y": xyz[1], "XYZ_Z": xyz[2],
+                            "LAB_L": lab[0], "LAB_A": lab[1], "LAB_B": lab[2]}
+    return ref
+
+
+def test_fit_synthetic_roundtrip():
+    M0 = np.array([[0.46, 0.31, 0.17],
+                   [0.23, 0.70, 0.07],
+                   [0.02, 0.12, 0.93]])
+    patches = _synthetic_patches()
+    samples = _consistent_samples(M0, patches)
+    ref = _ref_from_patches(patches)
+    fit = it8.fit_camera_matrix(samples, ref)
+    # Recovered matrix matches the generator (pin + exposure cancel exactly when
+    # the neutral reference is D50 chromaticity).
+    np.testing.assert_allclose(fit.matrix, M0, atol=1e-6)
+    assert fit.avg_de < 1e-3 and fit.max_de < 1e-2
+    assert len(fit.used_ids) == 288 and not fit.dropped_ids
+
+
+def test_fit_neutral_axis_is_neutral():
+    M0 = np.array([[0.50, 0.30, 0.18],
+                   [0.25, 0.68, 0.07],
+                   [0.03, 0.10, 0.90]])
+    patches = _synthetic_patches()
+    samples = _consistent_samples(M0, patches)
+    ref = _ref_from_patches(patches)
+    fit = it8.fit_camera_matrix(samples, ref)
+    # Each grayscale patch's predicted Lab is neutral (a*,b* ~ 0).
+    for k in it8.GRAY_IDS:
+        d = samples[k].rgb / 65535.0
+        lab = it8.xyz_to_lab((fit.matrix @ d) * 100.0)
+        assert abs(lab[1]) < 0.3 and abs(lab[2]) < 0.3
+
+
+def test_fit_drops_invalid_and_missing():
+    M0 = np.eye(3) * 0.8 + 0.05
+    patches = _synthetic_patches()
+    samples = _consistent_samples(M0, patches)
+    samples["A5"] = it8.PatchSample(samples["A5"].rgb, valid=False, n_pix=10)
+    ref = _ref_from_patches(patches)
+    del ref.patches["B7"]                   # missing in reference
+    fit = it8.fit_camera_matrix(samples, ref)
+    assert "A5" in fit.dropped_ids
+    assert "A5" not in fit.used_ids and "B7" not in fit.used_ids
+
+
+def test_fit_wb_fallback_when_gs0_invalid():
+    M0 = np.array([[0.46, 0.31, 0.17],
+                   [0.23, 0.70, 0.07],
+                   [0.02, 0.12, 0.93]])
+    patches = _synthetic_patches()
+    samples = _consistent_samples(M0, patches)
+    samples["GS0"] = it8.PatchSample(samples["GS0"].rgb, valid=False, n_pix=1)
+    ref = _ref_from_patches(patches)
+    fit = it8.fit_camera_matrix(samples, ref)
+    assert fit.wb_id != "GS0" and fit.wb_id.startswith("GS")
+    assert fit.avg_de < 1e-2
+
+
+# --------------------------------------------------------------------------- #
+# Colour-science helpers.
+# --------------------------------------------------------------------------- #
+
+def test_xyz_lab_roundtrip():
+    xyz = np.array([[20.0, 18.0, 10.0], [80.0, 82.0, 64.0], [1.0, 1.0, 1.0]])
+    lab = it8.xyz_to_lab(xyz)
+    back = it8.lab_to_xyz(lab)
+    np.testing.assert_allclose(back, xyz, atol=1e-6)
+
+
+def test_delta_e_2000_sharma_pairs():
+    # Sharma et al. CIEDE2000 test data (subset).
+    cases = [
+        ((50, 2.6772, -79.7751), (50, 0, -82.7485), 2.0425),
+        ((50, 3.1571, -77.2803), (50, 0, -82.7485), 2.8615),
+        ((50, -1.3802, -84.2814), (50, 0, -82.7485), 1.0000),
+        ((50, 0, 0), (50, -1, 2), 2.3669),
+        ((50, 2.49, -0.001), (50, -2.49, 0.0009), 7.1792),
+        ((60.2574, -34.0099, 36.2677), (60.4626, -34.1751, 39.4387), 1.2644),
+    ]
+    for lab1, lab2, expected in cases:
+        got = float(it8.delta_e_2000(np.array(lab1), np.array(lab2))[0])
+        assert abs(got - expected) < 1e-3, f"{lab1}->{lab2}: {got} != {expected}"
+
+
+# --------------------------------------------------------------------------- #
+# ICC synthesis round-trips through the existing InputProfile engine.
+# --------------------------------------------------------------------------- #
+
+def test_build_icc_reparses_as_input_profile():
+    M0 = np.array([[0.46, 0.31, 0.17],
+                   [0.23, 0.70, 0.07],
+                   [0.02, 0.12, 0.93]])
+    patches = _synthetic_patches()
+    fit = it8.fit_camera_matrix(_consistent_samples(M0, patches),
+                                _ref_from_patches(patches))
+    icc = it8.build_camera_icc(fit, "FreeCCR Camera — Test")
+    # Valid ICC header, RGB matrix-shaper, parses without UnsupportedICCError.
+    assert icc[36:40] == b"acsp" and icc[16:20] == b"RGB "
+    prof = cm.InputProfile.from_bytes(icc)
+    assert "Test" in prof.description
+    # Applying to a near-neutral mid-gray device patch yields a near-neutral
+    # sRGB result (R~=G~=B).
+    gs = fit  # use a grayscale patch's device value
+    d_gray = _consistent_samples(M0, patches)["GS8"].rgb.astype(np.uint16)
+    out = prof.apply(np.tile(d_gray, (2, 2, 1)).astype(np.uint16))
+    px = out[0, 0].astype(float)
+    assert px.max() - px.min() < 0.04 * 65535      # near-neutral output
+
+
+def test_end_to_end_render_sample_fit():
+    # Render a synthetic chart from a known matrix, then locate -> sample ->
+    # fit and recover it (exercises geometry + sampling + fit composed).
+    M0 = np.array([[0.46, 0.31, 0.17],
+                   [0.23, 0.70, 0.07],
+                   [0.02, 0.12, 0.93]])
+    patches = _synthetic_patches()
+    devs = _consistent_samples(M0, patches)        # id -> PatchSample(rgb)
+    S = 14
+    ox = oy = 30
+    quad = [(ox, oy), (ox + 22 * S, oy),
+            (ox + 22 * S, oy + 12 * S), (ox, oy + 12 * S)]
+    pts = it8.grid_sample_points(quad)
+    H = int(max(y for _, y in pts.values())) + 2 * S
+    W = int(max(x for x, _ in pts.values())) + 2 * S
+    img = np.zeros((H, W, 3), dtype=np.uint16)
+    half = int(S * 0.45)
+    for sid, (cx, cy) in pts.items():
+        rgb = np.clip(devs[sid].rgb, 0, 65535).astype(np.uint16)
+        x, y = int(round(cx)), int(round(cy))
+        img[max(0, y - half):y + half, max(0, x - half):x + half] = rgb
+    samples = it8.sample_patches(img, pts, quad, frac=0.5)
+    fit = it8.fit_camera_matrix(samples, _ref_from_patches(patches))
+    assert fit.avg_de < 0.5 and fit.max_de < 2.0
+    np.testing.assert_allclose(fit.matrix, M0, atol=2e-3)
+
+
+def test_identity_trc_is_identity():
+    # The camera profile's TRC must be the identity (raw-linear device space):
+    # build a profile and check its parsed TRC LUT is linear via InputProfile.
+    M0 = np.eye(3) * 0.8
+    patches = _synthetic_patches()
+    fit = it8.fit_camera_matrix(_consistent_samples(M0, patches),
+                                _ref_from_patches(patches))
+    prof = cm.InputProfile.from_bytes(it8.build_camera_icc(fit, "lin"))
+    lut0 = prof._luts[0]
+    xs = np.linspace(0, 1, len(lut0))
+    np.testing.assert_allclose(lut0, xs, atol=1e-4)

--- a/tests/test_it8_profile.py
+++ b/tests/test_it8_profile.py
@@ -170,6 +170,141 @@ def test_partial_record_does_not_crash():
 
 
 # --------------------------------------------------------------------------- #
+# CxF reference parsing.
+# --------------------------------------------------------------------------- #
+
+def _make_cxf(rows, *, prefix="", british=True):
+    """Build a minimal CxF3 file. prefix '' = default namespace, 'cc:' =
+    prefixed. british=True uses LaserSoft spelling (Colour*/ColourIEXYZ)."""
+    def t(name):
+        return f"{prefix}{name}"
+    XYZ = "ColourIEXYZ" if british else "ColorCIEXYZ"
+    LAB = "ColourCIELab" if british else "ColorCIELab"
+    CV = "ColourValues" if british else "ColorValues"
+    SREF = "ColourSpecification" if british else "ColorSpecification"
+    SCOL = "ColourSpecificationCollection" if british else "ColorSpecificationCollection"
+    SPEC = "ColourSpecification" if british else "ColorSpecification"
+    nsdecl = (f'xmlns:{prefix[:-1]}="http://colorexchangeformat.com/CxF3-core"'
+              if prefix else 'xmlns="http://colorexchangeformat.com/CxF3-core"')
+    objs = []
+    for name, (X, Y, Z), (L, A, B) in rows:
+        objs.append(
+            f'<{t("Object")} ObjectType="Target" Name="{name}" Id="{name}">'
+            f'<{t(CV)}>'
+            f'<{t(XYZ)} {SREF}="CS1"><{t("X")}>{X}</{t("X")}>'
+            f'<{t("Y")}>{Y}</{t("Y")}><{t("Z")}>{Z}</{t("Z")}></{t(XYZ)}>'
+            f'<{t(LAB)} {SREF}="CS1"><{t("L")}>{L}</{t("L")}>'
+            f'<{t("A")}>{A}</{t("A")}><{t("B")}>{B}</{t("B")}></{t(LAB)}>'
+            f'</{t(CV)}></{t("Object")}>')
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<{t("CxF")} {nsdecl}>'
+        f'<{t("FileInformation")}>'
+        f'<{t("Creator")}>LaserSoft Imaging AG</{t("Creator")}>'
+        f'<{t("Tag")} Name="28178_TargetType" Value="ISO 12641-2 Candidate"/>'
+        f'<{t("Tag")} Name="Serial" Value="E210616"/>'
+        f'</{t("FileInformation")}>'
+        f'<{t("Resources")}><{t("ObjectCollection")}>{"".join(objs)}'
+        f'</{t("ObjectCollection")}>'
+        f'<{t(SCOL)}><{t(SPEC)} Id="CS1"><{t("TristimulusSpec")}>'
+        f'<{t("Illuminant")}>D50</{t("Illuminant")}>'
+        f'<{t("Observer")}>2_Degree</{t("Observer")}>'
+        f'</{t("TristimulusSpec")}></{t(SPEC)}></{t(SCOL)}>'
+        f'</{t("Resources")}></{t("CxF")}>')
+
+
+def test_parse_cxf_british_default_ns(tmp_path):
+    # Matches the user's LaserSoft file: default namespace + British spelling.
+    rows = [("A1", (2.819, 2.434, 1.559), (17.62, 9.14, 4.69)),
+            ("L72", (5.627, 12.305, 1.759), (41.6, -38.0, 35.0))]
+    p = tmp_path / "E210616.cxf"
+    p.write_text(_make_cxf(rows, prefix="", british=True), encoding="utf-8")
+    ref = it8.parse_reference(str(p))
+    assert ref.batch == "E210616"
+    assert "ISO 12641-2" in ref.chart_type
+    assert len(ref.patches) == 2
+    np.testing.assert_allclose(ref.xyz("A1"), [2.819, 2.434, 1.559])
+    np.testing.assert_allclose(ref.lab("L72"), [41.6, -38.0, 35.0])
+
+
+def test_parse_cxf_prefixed_american(tmp_path):
+    # X-Rite style: cc: prefix + American spelling. Tolerated by local-name match.
+    rows = [("R1", (9.243, 9.910, 5.366), (37.99, 13.56, 14.06))]
+    p = tmp_path / "x.cxf"
+    p.write_text(_make_cxf(rows, prefix="cc:", british=False), encoding="utf-8")
+    ref = it8.parse_reference(str(p))
+    assert len(ref.patches) == 1
+    np.testing.assert_allclose(ref.xyz("R1"), [9.243, 9.910, 5.366])
+
+
+def test_parse_reference_dispatch(tmp_path):
+    cxf = tmp_path / "ref.cxf"
+    cxf.write_text(_make_cxf([("A1", (2, 2, 1), (17, 9, 4))]), encoding="utf-8")
+    assert it8.parse_reference(str(cxf)).originator == "LaserSoft Imaging AG"
+    # CGATS text still routes to the CGATS parser.
+    fields = ["SAMPLE_ID", "XYZ_X", "XYZ_Y", "XYZ_Z"]
+    txt = _make_cgats(fields, [("A1", {"XYZ_X": 2, "XYZ_Y": 2, "XYZ_Z": 1})])
+    cg = _write(tmp_path, "ref.txt", txt)
+    assert "A1" in it8.parse_reference(cg).patches
+
+
+def test_parse_cxf_errors(tmp_path):
+    p = tmp_path / "bad.cxf"
+    p.write_text("<NotCxF><x/></NotCxF>", encoding="utf-8")
+    with pytest.raises(it8.IT8ReferenceError):
+        it8.parse_reference(str(p))
+
+
+# --------------------------------------------------------------------------- #
+# Generic block geometry + fit (non-classic targets, e.g. ISO 12641-2).
+# --------------------------------------------------------------------------- #
+
+def test_parse_block():
+    rows, cols = it8.parse_block("A49", "L72")
+    assert rows == list("ABCDEFGHIJKL")
+    assert cols == list(range(49, 73))
+    # order-insensitive
+    assert it8.parse_block("L72", "A49") == (rows, cols)
+
+
+def test_block_sample_points_unit_quad():
+    quad = [(0, 0), (240, 0), (240, 120), (0, 120)]   # TL,TR,BR,BL
+    rows, cols = it8.parse_block("A49", "L72")          # 12 rows x 24 cols
+    pts = it8.block_sample_points(quad, rows, cols)
+    assert len(pts) == 288
+    # A49 (row0,col0) centre = (0.5/24*240, 0.5/12*120) = (5,5).
+    np.testing.assert_allclose(pts["A49"], (5.0, 5.0), atol=1e-6)
+    # L72 (row11,col23) centre = (23.5/24*240, 11.5/12*120) = (235,115).
+    np.testing.assert_allclose(pts["L72"], (235.0, 115.0), atol=1e-6)
+
+
+def test_fit_block_generic_autoneutral():
+    # A 12x24 block with in-grid neutrals (no GS strip): auto-neutral WB must
+    # find a gray and the fit recover the generator.
+    M0 = np.array([[0.46, 0.31, 0.17],
+                   [0.23, 0.70, 0.07],
+                   [0.02, 0.12, 0.93]])
+    rng = np.random.default_rng(11)
+    patches = {}
+    rows, cols = it8.parse_block("A49", "L72")
+    for ri, r in enumerate(rows):
+        for c in cols:
+            if r in "GHIJ":                 # neutral rows (D50 chromaticity)
+                Y = rng.uniform(3, 88)
+                patches[f"{r}{c}"] = (Y / 100.0) * D50 * 100.0
+            else:
+                Y = rng.uniform(5, 85)
+                patches[f"{r}{c}"] = np.array([Y * rng.uniform(0.7, 1.3), Y,
+                                               Y * rng.uniform(0.4, 1.2)])
+    samples = _consistent_samples(M0, patches)
+    ref = _ref_from_patches(patches)
+    fit = it8.fit_camera_matrix(samples, ref)
+    assert fit.wb_id[0] in "GHIJ"           # auto-picked an in-grid neutral
+    np.testing.assert_allclose(fit.matrix, M0, atol=1e-6)
+    assert fit.avg_de < 1e-3
+
+
+# --------------------------------------------------------------------------- #
 # Geometry.
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Consolidates the **IT8 camera ICC-maker** plus four B/W-point / Gain / DNG changes onto `main` (the old-school B/W-point conversion). NamiColor work is parked on `feature/namicolor-bwpoint`.

## IT8 camera ICC profile maker
Merges `feature/it8-camera-profile`: **File ▸ "Create Camera Profile from IT8…"** builds a camera input ICC profile from a photographed IT8 target (pure numpy/cv2, no new deps) and plugs into the existing Input ICC Profile system. Adds `it8_profile.py`, the wizard dialog, a spec, and 27 tests.

## B/W-point / Gain / DNG changes
1. The Film B/W-point **✕** clears **both** the black and white points (was white-only).
2. **Loading a new batch resets** the B/W points so a previous roll's film base / density can't carry over (in-memory only; QSettings restore intact).
3. The top-level **"Gain"** slider now behaves **exactly like Channel-Levels "Master Gain"** — uniform linear `out = in/(1 - v/300)`, byte-identical (CPU + OpenCL).
4. The input ICC is **skipped for `.dng`** sources (DNG carries its own embedded camera profile; an external ICC would double-correct). `.arw`/`.tif` unchanged.

## Verification
- 27 IT8 tests pass; MainWindow builds with the IT8 menu wired.
- Gain == Master Gain byte-identical across the slider range; DNG skips while `.arw`/`.tif` apply.
- Full suite: **zero new failures** (14 pre-existing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
