### PR TITLE
perf: parallelize bulk reset; full-reset all images on input-ICC switch

### DIFF
--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -470,19 +470,12 @@ class CCRBackend:
             else:
                 print(f"Image at index {idx} is not converted.")
 
-    def reset_image_by_index(self, idx: int) -> bool:
-        """Reset the image at idx to its freshly-loaded state: undo the
-        conversion and clear every non-destructive edit (adjustments,
-        reference frame, crop, orientation, colour profile) so it matches a
-        just-imported image. Slicing (source_ops/lineage) is preserved — a
-        slice resets to its un-edited region, not back to the whole file
-        (use "Reset Slice" for that). Returns False if idx is out of range."""
-        if idx is None or not (0 <= idx < len(self.images)):
-            return False
-        image_obj = self.images[idx]
-        # Clear edit state BEFORE reloading so the rebuilt preview reflects
-        # the pristine settings. reload_image() re-decodes resized_raw and
-        # resets the base offsets + conversion_inputs.
+    @staticmethod
+    def _clear_edit_state(image_obj) -> None:
+        """Clear every non-destructive edit (conversion, adjustments, reference
+        frame, crop, orientation, colour profile, undo history) so the image
+        matches a just-imported one. Slicing (source_ops/lineage) is preserved —
+        a slice resets to its un-edited region, not back to the whole file."""
         image_obj.converted = False
         image_obj.adjustment_settings = {}
         image_obj.reference_frame = None
@@ -496,16 +489,72 @@ class CCRBackend:
         # The conversion is gone, so the undo history (which never captured
         # the conversion anyway) would be inconsistent — drop it.
         image_obj.undo_stack = []
+
+    def reset_image_by_index(self, idx: int) -> bool:
+        """Reset the image at idx to its freshly-loaded state: undo the
+        conversion and clear every non-destructive edit (adjustments,
+        reference frame, crop, orientation, colour profile) so it matches a
+        just-imported image. Slicing (source_ops/lineage) is preserved — a
+        slice resets to its un-edited region, not back to the whole file
+        (use "Reset Slice" for that). Returns False if idx is out of range."""
+        if idx is None or not (0 <= idx < len(self.images)):
+            return False
+        image_obj = self.images[idx]
+        # Clear edit state BEFORE reloading so the rebuilt preview reflects
+        # the pristine settings. reload_image() re-decodes resized_raw and
+        # resets the base offsets + conversion_inputs.
+        self._clear_edit_state(image_obj)
         image_obj.reload_image()
         return True
 
-    def reset_images_by_indices(self, indices) -> bool:
-        """Reset each image in indices to its freshly-loaded state.
-        Returns True if at least one image was reset."""
-        # Materialize the results first: any() over a generator short-circuits
-        # on the first True and would leave the rest of the selection un-reset.
-        results = [self.reset_image_by_index(i) for i in sorted(set(indices))]
-        return any(results)
+    def _reload_decode_parallel(self, imgs, progress_callback=None) -> None:
+        """Re-decode resized_raw for each image concurrently. read_image (RAW
+        decode / file IO) is the slow part and releases the GIL, so a thread
+        pool gives a near-linear speed-up. QPixmap building is deliberately NOT
+        done here — it must run on the GUI thread, so the caller follows up with
+        update_thumbnail_and_preview() per image on the main thread."""
+        if not imgs:
+            return
+        total = len(imgs)
+        max_workers = min(8, os.cpu_count() or 1)
+        done = 0
+        if max_workers <= 1 or total <= 1:
+            for img in imgs:
+                try:
+                    img.reload_image_decode_only()
+                except Exception as e:
+                    print(f"Reset decode failed for {img.file_path}: {e}")
+                done += 1
+                if progress_callback:
+                    progress_callback(done, total)
+            return
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = {ex.submit(img.reload_image_decode_only): img for img in imgs}
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    print(f"Reset decode failed for {futures[future].file_path}: {e}")
+                done += 1
+                if progress_callback:
+                    progress_callback(done, total)
+
+    def reset_images_by_indices(self, indices, progress_callback=None) -> bool:
+        """Reset each image in indices to its freshly-loaded state. The slow
+        per-image re-decode runs in parallel; previews are then rebuilt on the
+        calling (GUI) thread. Returns True if at least one image was reset."""
+        idxs = [i for i in sorted(set(indices))
+                if i is not None and 0 <= i < len(self.images)]
+        if not idxs:
+            return False
+        imgs = [self.images[i] for i in idxs]
+        for img in imgs:
+            self._clear_edit_state(img)
+        self._reload_decode_parallel(imgs, progress_callback)
+        # QPixmap thumbnails/previews on the caller's thread (GUI-thread safe).
+        for img in imgs:
+            img.update_thumbnail_and_preview()
+        return True
 
     def convert_negative_by_index(self, idx: int):
         """
@@ -586,36 +635,14 @@ class CCRBackend:
             pass
 
     def reprocess_all_for_input_icc_change(self, progress_callback=None) -> None:
-        """Re-decode and re-convert every loaded image so a change to the global
-        input ICC takes effect immediately. Re-decoding runs through read_image,
-        which re-applies the (new) global profile; converted images then replay
-        their stored conversion against the freshly-decoded scan."""
-        from core.catalog import _replay_conversion
-        total = len(self.images)
-        for i, img in enumerate(self.images):
-            ci = img.conversion_inputs
-            was_converted = img.converted
-            cb, tb, bb = img.contrast_base, img.temperature_base, img.brightness_base
-            # Slices/duplicates deliberately INHERIT the parent's tint balance
-            # factor (their own region/converted pixels would give a different
-            # one). reload_image unconditionally recomputes it, so preserve the
-            # inherited value for those images.
-            inherited_tbf = bool(img.source_ops) or bool(getattr(img, "is_duplicate", False))
-            tbf = getattr(img, "tint_balance_factor", 1.0)
-            try:
-                img.reload_image()                 # re-decode (ICC re-applied)
-                if inherited_tbf:
-                    img.tint_balance_factor = tbf
-                if was_converted and ci is not None:
-                    _replay_conversion(img, ci)    # re-convert from the new scan
-                # Preserve the user's non-destructive look offsets across the
-                # re-decode (reload_image / replay reset them to defaults).
-                img.contrast_base, img.temperature_base, img.brightness_base = cb, tb, bb
-                img.update_thumbnail_and_preview()
-            except Exception as e:
-                print(f"Reprocess after input ICC change failed for {img.file_path}: {e}")
-            if progress_callback:
-                progress_callback(i + 1, total)
+        """A change to the global input ICC changes the decode itself, so every
+        loaded image is FULLY reset: the conversion and all non-destructive edits
+        (adjustments, reference frame, crop, orientation, colour profile) are
+        dropped and the scan is re-decoded fresh (in parallel). Replaying a
+        conversion that was computed against the old decode would mis-colour the
+        result, so we start from a clean slate. Slicing/lineage is preserved (a
+        slice resets to its un-edited region)."""
+        self.reset_images_by_indices(range(len(self.images)), progress_callback)
 
     def reprocess_all_for_positive_mode_change(self, progress_callback=None) -> None:
         """Re-decode every loaded image after the global Positive-mode toggle.

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -186,11 +186,13 @@ class CCRImage:
         
         return balance_factor
 
-    def reload_image(self) -> None:
-        """
-        Reload the image from the file path and update resized_raw, thumbnail, and preview.
-        This is useful if the image file has been modified externally.
-        """
+    def reload_image_decode_only(self) -> bool:
+        """Re-decode resized_raw + tint balance and reset the base offsets,
+        WITHOUT building the QPixmap thumbnail/preview (QPixmap must be created
+        on the GUI thread). Returns True on success. This is the thread-safe,
+        slow part of a reload — the bulk-reset path runs it concurrently across
+        a thread pool, then builds previews on the main thread via
+        update_thumbnail_and_preview()."""
         self.contrast_base = 0      # Clear base offsets when reverting to original scan
         self.temperature_base = 0
         # -8 is the negative-look baseline; positives reset to a neutral 0 so the
@@ -199,13 +201,21 @@ class CCRImage:
         self.exposure_base = 0.0    # Clear auto-exposure when reverting to original scan
         self.conversion_inputs = None
         img = self.read_image(self.file_path, max_long_side=1080)
-        if img is not None:
-            self.resized_raw = img
-            # Recalculate tint balance factor for the new image
-            self.tint_balance_factor = self._calculate_tint_balance_factor()
-            self.update_thumbnail_and_preview()
-        else:
+        if img is None:
             logging.error(f"Failed to reload image: {self.file_path}")
+            return False
+        self.resized_raw = img
+        # Recalculate tint balance factor for the new image
+        self.tint_balance_factor = self._calculate_tint_balance_factor()
+        return True
+
+    def reload_image(self) -> None:
+        """
+        Reload the image from the file path and update resized_raw, thumbnail, and preview.
+        This is useful if the image file has been modified externally.
+        """
+        if self.reload_image_decode_only():
+            self.update_thumbnail_and_preview()
 
     def _apply_source_ops(self, img: Optional[np.ndarray]) -> Optional[np.ndarray]:
         """Apply this image's slice chain to a decoded image: each op rotates

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -443,8 +443,9 @@ class MainWindow(QMainWindow):
         self.sliders_panel.set_temporary_hint("Input ICC profile cleared.", duration=3000)
 
     def _reprocess_after_input_icc_change(self):
-        """Re-decode + re-convert loaded images so the profile change shows
-        immediately, then refresh the UI."""
+        """A change to the input ICC fully resets every loaded image (the decode
+        itself changes, so a conversion from the old decode can't be reused),
+        then refreshes the UI."""
         if not ccr_backend.images:
             return
         QApplication.setOverrideCursor(Qt.WaitCursor)
@@ -452,9 +453,15 @@ class MainWindow(QMainWindow):
             ccr_backend.reprocess_all_for_input_icc_change()
         finally:
             QApplication.restoreOverrideCursor()
+        # Every image was re-decoded and reset, so the zoom hi-res cache is stale.
+        self.image_preview._release_hires(refresh=False)
         self.thumbnail_list.update_all_thumbnails()
-        if self.image_preview.current_idx is not None:
-            self.image_preview.update_preview(self.image_preview.current_idx)
+        cur = self.image_preview.current_idx
+        if cur is not None:
+            self.image_preview.update_preview(cur)
+            self.sliders_panel.set_current_idx(cur)   # reflect the cleared settings
+        else:
+            self.image_preview._update_unconvert_action_state()
         ccr_backend.save_catalog()
 
     # --- Positive mode (global, persistent) -------------------------------

--- a/tests/test_color_management.py
+++ b/tests/test_color_management.py
@@ -312,10 +312,11 @@ def test_backend_rejects_lut_profile_unchanged(tmp_path, monkeypatch):
         ccr_backend.input_icc_name = None
 
 
-def test_reprocess_preserves_inherited_tint_factor(tmp_path):
-    """Regression: a slice/duplicate inherits its parent's tint_balance_factor;
-    reprocessing after an input-ICC change must not let reload recompute it from
-    the image's own region. A plain image is free to re-adapt."""
+def test_reprocess_full_resets_all_images(tmp_path):
+    """Switching the input ICC changes the decode itself, so every image is
+    FULLY reset: conversion + non-destructive edits dropped and the scan
+    re-decoded fresh (replaying a conversion computed against the old decode
+    would mis-colour the result)."""
     _make_qapp()
     from core.ccr_image import CCRImage
     from core.ccr_backend import ccr_backend
@@ -324,17 +325,19 @@ def test_reprocess_preserves_inherited_tint_factor(tmp_path):
     saved_images = ccr_backend.images
     cm.set_active_input_profile(None)
     try:
-        plain = CCRImage(p)
-        dup = CCRImage(p)
-        dup.is_duplicate = True
-        SENT = 0.777
-        dup.tint_balance_factor = SENT             # inherited sentinel
-        plain_before = plain.tint_balance_factor
-        ccr_backend.images = [plain, dup]
+        a, b = CCRImage(p), CCRImage(p)
+        for im in (a, b):
+            im.converted = True
+            im.adjustment_settings = {"exposure": 50}
+            im.reference_frame = (1, 1, 50, 50)
+        ccr_backend.images = [a, b]
         cm.set_active_input_profile(cm.InputProfile.from_bytes(_adobe_like_icc()))
         ccr_backend.reprocess_all_for_input_icc_change()
-        assert dup.tint_balance_factor == SENT     # inherited factor preserved
-        assert plain.tint_balance_factor != plain_before  # plain re-adapts to ICC
+        for im in (a, b):
+            assert im.converted is False
+            assert im.adjustment_settings == {}
+            assert im.reference_frame is None
+            assert im.resized_raw is not None      # re-decoded fresh
     finally:
         ccr_backend.images = saved_images
         cm.set_active_input_profile(None)


### PR DESCRIPTION
## Summary
- **Bulk reset is parallelized**: the slow per-image re-decode (RAW/IO, GIL-releasing) runs across a thread pool; QPixmap previews are built on the GUI thread. Split `reload_image` → `reload_image_decode_only()` + `reload_image()`; added `_clear_edit_state` / `_reload_decode_parallel`.
- **Input-ICC switch now fully resets every image** (drops conversion + edits, re-decodes fresh in parallel) instead of replaying a conversion computed against the old decode — which mis-coloured the result. Slicing/lineage preserved; handler releases the stale hi-res cache and refreshes sliders/convert state.

## Tests
Updated `test_reprocess_full_resets_all_images`; full touched-suite run green except the pre-existing `exposure_base` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
