### PR TITLE
docs(macos): drop unsupported -r from the xattr quarantine command (#37)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
             ⚠️ **macOS may say the app is "damaged and can't be opened" — it isn't.** FreeCCR isn't notarized by Apple, so Gatekeeper blocks unsigned downloads on first launch. Clear the quarantine flag once by running this in **Terminal**:
 
             ```
-            xattr -r -d com.apple.quarantine /Applications/FreeCCR.app
+            xattr -d com.apple.quarantine /Applications/FreeCCR.app
             ```
 
             Then open the app normally.
@@ -155,7 +155,7 @@ jobs:
             ⚠️ **macOS may say the app is "damaged and can't be opened" — it isn't.** FreeCCR isn't notarized by Apple, so Gatekeeper blocks unsigned downloads on first launch. Clear the quarantine flag once by running this in **Terminal**:
 
             ```
-            xattr -r -d com.apple.quarantine /Applications/FreeCCR.app
+            xattr -d com.apple.quarantine /Applications/FreeCCR.app
             ```
 
             Then open the app normally.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Unzip `FreeCCR_macOS_<version>.zip` and move `FreeCCR.app` to your **Application
 Because the app isn't notarized, Gatekeeper may block the first launch with a *"damaged and can't be opened"* message. **The app isn't damaged** — macOS just flags unsigned downloads. Clear the quarantine flag once in Terminal:
 
 ```bash
-xattr -r -d com.apple.quarantine /Applications/FreeCCR.app
+xattr -d com.apple.quarantine /Applications/FreeCCR.app
 ```
 
 Then open it normally. (Alternatively: right-click the app → **Open** → **Open**.)

--- a/spec/clut-icc-support.md
+++ b/spec/clut-icc-support.md
@@ -1,0 +1,613 @@
+# Spec: cLUT (LUT-based / A2B) ICC Support — Consume + Generate
+
+Status: IMPLEMENTED (branch `feature/clut-icc-support`)
+Owner: FreeCCR
+Feature branch: `feature/clut-icc-support`
+
+## 1. Summary
+
+Extend FreeCCR's in-process ICC handling (`src/core/color_management.py`) from
+matrix-shaper-only to also support **LUT-based (cLUT / A2B) device→PCS ICC
+profiles**, in two directions:
+
+- **CONSUME.** `InputProfile.from_bytes` currently *rejects* any profile that
+  lacks `rXYZ`/`gXYZ`/`bXYZ` + `rTRC`/`gTRC`/`bTRC` (raising `UnsupportedICCError`
+  — see `from_bytes` lines 405–410). A user's real LUT-based `.icm` scanner/camera
+  profile is therefore unusable. We add a parser for the `A2B0`/`A2B1` device→PCS
+  tags in all three ICC encodings (`mft1` lut8, `mft2` lut16, `mAB ` lutAToB),
+  an N-D CLUT interpolator (tetrahedral for 3-channel input), PCS = XYZ **or**
+  Lab handling, and a final PCS-XYZ(D50)→**linear Adobe RGB** step that exactly
+  mirrors the matrix-shaper apply path (`InputProfile.apply`, lines 434–448) so
+  the negative inversion downstream keeps reading consistent linear data.
+
+- **GENERATE.** Add `build_clut_icc(...)` to `color_management` (mirroring
+  `build_matrix_shaper_icc`) writing a valid `mft2` (lut16) RGB→XYZ cLUT, and
+  extend `it8_profile.build_camera_icc` with a `mode` so the IT8 wizard can offer
+  **"cLUT (higher accuracy)"** alongside the existing **"3×3 matrix"**. The cLUT
+  fit is the existing well-behaved 3×3 matrix *plus a smooth scattered-data
+  residual* sampled onto the grid nodes (RBF in a perceptually-even space,
+  regularised, extrapolated outside the patch hull), which removes the 3×3's
+  saturated-corner residuals while staying monotone and artefact-free.
+
+Everything is **pure numpy + struct** (no Pillow / lcms / scipy / colour-science),
+consistent with `color_management.py`'s module contract (lines 1–23) and the IT8
+feature (spec/it8-camera-profile.md §1, §10.1).
+
+### Why this fits FreeCCR exactly
+- The CONSUME path slots into the *same* `InputProfile` apply contract: a parsed
+  cLUT still emits **uint16 linear Adobe RGB** (combined through
+  `M_XYZ_D50_2_ADOBE`, no sRGB OETF), so `_apply_input_icc`/`read_image` and the
+  density inversion are untouched (CLAUDE.md negative-inversion note;
+  `M_XYZ_D50_2_ADOBE` comment, lines 105–110).
+- The decode space is already correct: `read_image` selects the canonical
+  camera-native raw decode (`no_icc_default=False` ⇒ `output_color=raw`,
+  `gamma=(1,1)`, `no_auto_scale=True` + manual white-level scaling) whenever an
+  input ICC is active OR a bare-device profiling decode is requested
+  (`ccr_image.py` lines 459–504; spec/it8-camera-profile.md §12.5). A cLUT ICC
+  consumes and is fitted on this **identical** device RGB — matrix and cLUT ICC
+  share one decode, no new decode plumbing.
+- The GENERATE path reuses the IT8 sampling + fit machinery (`sample_patches`,
+  `fit_camera_matrix`, `xyz_to_lab`/`delta_e_2000`) and only adds a residual-LUT
+  builder and a second ICC writer.
+
+## 2. Goals / Non-goals
+
+### Goals
+- Parse `A2B0` (fallback `A2B1`) in `lut8Type`/`lut16Type`/`lutAToBType`.
+- N-channel input curves → CLUT interpolation (**tetrahedral** for 3-D, trilinear
+  fallback) → output curves → (mAB) matrix + M-curves, in the ICC-defined order.
+- PCS XYZ (`'XYZ '`) and PCS Lab (`'Lab '`) including the v2 legacy vs v4 Lab
+  encodings; PCS white = D50.
+- Final PCS-XYZ(D50) → **linear Adobe RGB** uint16, byte-for-byte consistent with
+  the matrix-shaper apply (reuse `M_XYZ_D50_2_ADOBE`).
+- `InputProfile.from_bytes` **dispatches** matrix-shaper vs A2B and stores the
+  parsed representation; `apply()` branches. **Matrix-shaper path stays
+  byte-identical** (regression-pinned).
+- `build_clut_icc(...)` writes a valid ICC v2.4 `mft2` RGB→XYZ cLUT.
+- `it8_profile.build_camera_icc(fit, desc, *, mode='matrix'|'clut', grid=...)`;
+  the wizard Step 4/5 offers a matrix-vs-cLUT choice.
+- A residual-corrected cLUT fit (3×3 base + RBF residual) with graceful
+  extrapolation, monotone and artefact-free.
+- Vectorised numpy interpolation over the **native grid** (no 65536³ blow-up).
+- Tests: parse each of mft1/mft2/mAB; tetra-interp vs reference; PCS XYZ & Lab;
+  reject CMYK/unsupported; generate→reparse→apply round-trip recovers patches in
+  tight ΔE and beats 3×3 on a non-linear generator; the user's real `.icm` parses.
+
+### Non-goals
+- **No PCS→device (B2A) application.** We only consume `A2B*` (device→PCS); FreeCCR
+  never needs the inverse for an *input* profile.
+- **No CMYK / >4-channel input, no non-RGB device space.** Reject with
+  `UnsupportedICCError` (the `RGB ` data-space guard already exists, `from_bytes`
+  lines 403–404; extend the message).
+- **No multi-intent divergence at apply.** We read `A2B0` and fall back across
+  `A2B0→A2B1` for availability only; we do not implement per-intent selection UI.
+- **No DCP here.** DCP is a separate spec; this spec only notes the shared decode.
+- **No floating-point `mAB` CLUT precision beyond what ICC stores** (uint8/uint16
+  grid entries); the generated profile uses `mft2` 16-bit entries.
+- **No change to export / output color management** (`apply_export_colorspace`,
+  matrix-shaper `build_matrix_shaper_icc`, `SRGB_ICC_BYTES`, `PROPHOTO_ICC_BYTES`
+  untouched).
+- No GPU path; a per-decode CLUT gather is a one-time cost per image at preview /
+  hi-res / export resolution.
+
+## 3. Background (researched)
+
+### 3.1 ICC LUT-based device→PCS tags
+An ICC profile stores its transforms in tags found via the tag table parsed by
+`_read_tag_table` (lines 322–335). Matrix-shaper uses `rXYZ/gXYZ/bXYZ` +
+`rTRC/gTRC/bTRC`. A **LUT-based** profile instead stores a device→PCS transform
+under the rendering-intent tags:
+- `A2B0` — perceptual, `A2B1` — relative colorimetric, `A2B2` — saturation.
+
+Each `A2B*` tag is one of three element types, identified by its first 4 bytes:
+- `mft1` — **lut8Type** (8-bit tables, ICC v2).
+- `mft2` — **lut16Type** (16-bit tables, ICC v2).
+- `mAB ` — **lutAToBType** (ICC v4, the flexible A→B with optional curves +
+  matrix + CLUT, offset-addressed).
+
+PCS is given by header bytes 20–24 (`'XYZ '` or `'Lab '`, read like
+`build_matrix_shaper_icc` writes at offset 20). The connection white is D50
+(header PCS illuminant, offset 68, already used by the writer).
+
+### 3.2 lut8Type (`mft1`) byte layout
+Big-endian, offsets relative to the tag's start `off`:
+```
+off+0   : 'mft1' (4 bytes)
+off+4   : 0 (reserved, 4 bytes)
+off+8   : i  = number of Input  channels  (u8)
+off+9   : o  = number of Output channels  (u8)
+off+10  : g  = CLUT grid points per axis   (u8)
+off+11  : 0 (pad, u8)
+off+12  : e1..e9 = 3x3 s15Fixed16 matrix (9 * 4 = 36 bytes)  [applied to XYZ
+          PCS only; identity in practice for device->PCS RGB]
+off+48  : Input  tables : i * 256  u8 entries   (256 per input channel, fixed)
+        : CLUT          : g^i * o  u8 entries   (output-channel-fastest)
+        : Output tables : o * 256  u8 entries   (256 per output channel, fixed)
+```
+lut8 input/output tables are **fixed 256 entries** per channel. Device and PCS
+values are u8/255 in [0,1]; for PCS XYZ the stored value is scaled so 1.0 ==
+1.0 + 32767/32768 (the ICC "XYZ number" max ≈ 1.99997) — i.e. PCS-side XYZ is
+encoded as `value/255 * (1 + 32767/32768)` for `mft1`/`mft2`. For PCS Lab in
+`mft1`/`mft2` (legacy v2 encoding) L ∈ [0,100] maps to [0,255]/[0,65535]
+(see §3.5).
+
+### 3.3 lut16Type (`mft2`) byte layout
+```
+off+0   : 'mft2'
+off+4   : 0
+off+8   : i  (u8)  number of input channels
+off+9   : o  (u8)  number of output channels
+off+10  : g  (u8)  grid points per axis
+off+11  : 0  (pad)
+off+12  : 3x3 s15Fixed16 matrix (36 bytes)        [XYZ PCS only]
+off+48  : n  = input  table entries per channel (u16)
+off+50  : m  = output table entries per channel (u16)
+off+52  : Input  tables : i * n  u16 entries
+        : CLUT          : g^i * o  u16 entries  (output-channel-fastest)
+        : Output tables : o * m  u16 entries
+```
+`mft2` is `mft1`'s 16-bit sibling with **variable** input/output table lengths
+(`n`,`m`). u16 values are `/65535` in [0,1]; PCS XYZ uses the same
+`*(1+32767/32768)` factor; PCS Lab uses the v2 legacy 16-bit encoding (§3.5).
+This is the container we **generate** (§5.6) — simplest valid 3-D cLUT.
+
+### 3.4 lutAToBType (`mAB `) byte layout
+ICC v4, offset-addressed; any of the stages may be absent (offset 0 ⇒ skip).
+```
+off+0   : 'mAB '
+off+4   : 0
+off+8   : i (u8) number of input  channels
+off+9   : o (u8) number of output channels
+off+10  : 0 (2 bytes pad)
+off+12  : off_B    (u32)  -> "B" curves   (o curves)
+off+16  : off_mat  (u32)  -> matrix (3x4: 9 s15f16 + 3 s15f16 offset = 48 bytes)
+off+20  : off_M    (u32)  -> "M" curves   (o curves)
+off+24  : off_CLUT (u32)  -> CLUT element
+off+28  : off_A    (u32)  -> "A" curves   (i curves)
+```
+**Processing order for A→B (device→PCS)** is fixed by ICC as:
+`A curves → CLUT → M curves → matrix → B curves`.
+- **A curves**: `i` curves, applied to the device input *before* the CLUT.
+- **CLUT element** at `off_CLUT`: 16 bytes of grid points (`gridPoints[16]` u8,
+  one per input channel — only first `i` used), then 1 byte precision
+  (`1`=u8, `2`=u16), 3 pad bytes, then `prod(gridPoints)*o` entries
+  (u8 or u16), output-channel-fastest.
+- **M curves**: `o` curves applied after the CLUT, before the matrix.
+- **matrix**: 3×4 (a 3×3 plus a 3-vector offset), applied to the 3 M-curve
+  outputs: `y = Mx + offset`.
+- **B curves**: `o` curves applied last (closest to the PCS).
+Each curve is a standalone `curv`/`para` element (same encodings
+`_parse_trc_to_lut` already handles, lines 343–366) padded to a 4-byte boundary.
+For a device→PCS RGB→XYZ profile, `o=3`. When matrix/M/B are absent the chain is
+just `A curves → CLUT`.
+
+### 3.5 PCS encodings (XYZ vs Lab, v2 vs v4)
+- **PCS XYZ** (`'XYZ '`): table/CLUT values decode to XYZ via the ICC XYZ-number
+  range — max representable is `1 + 32767/32768 ≈ 1.99997`. So
+  `XYZ = u16/65535 * (1 + 32767/32768)` (Y of the D50 white = 1.0). After the
+  interpolation we have XYZ(D50) directly.
+- **PCS Lab, v4 encoding** (profile version ≥ 4, header bytes 8–12): L ∈ [0,100],
+  a,b ∈ [−128,127] mapped to the full u16 range as
+  `L = u16/65535 * 100`, `a = u16/65535 * 255 − 128`, `b = u16/65535 * 255 − 128`.
+- **PCS Lab, v2 legacy encoding** (in `mft1`/`mft2`, and v2 `mAB`): the historical
+  encoding uses the `0xFF00/0xFFFF` convention —
+  `L = u16/65535 * 100 * 65535/65280`, with a,b shifted by 128 the same way; for
+  `mft1` (8-bit) `L = u8/255*100`, `a=u8−128`, `b=u8−128`. We branch on the
+  profile version byte (header offset 8, top byte ≥ 4 ⇒ v4) to pick the Lab
+  scale. Lab is then converted XYZ via `it8_profile.lab_to_xyz` against D50
+  (white `_D50_W100`, scaled to Y=1).
+PCS XYZ/Lab are **always D50** for an ICC PCS (no chromatic adaptation needed
+before `M_XYZ_D50_2_ADOBE`).
+
+### 3.6 The user's real profile
+A LUT-based `.icm` scanner profile that today raises `UnsupportedICCError`.
+Almost certainly `mft2` (the common v2 scanner output of Argyll/vendor tools),
+3-channel RGB input, PCS Lab or XYZ. This is the canonical CONSUME test fixture
+(§8 "real .icm parses").
+
+### 3.7 Generate: why a residual cLUT beats a 3×3
+A single 3×3 matrix is globally well-behaved (the IT8 fit, spec/it8 §3.4: avg
+ΔE2000 ≈ 1–3) but cannot bend the saturated corners of the gamut where a real
+sensor's response is non-linear — leaving systematic residuals on the most
+saturated patches. A cLUT can store an arbitrary device→PCS map, so encoding
+`matrix + smooth_residual` removes those residuals while the smooth/regularised
+residual keeps the LUT monotone and free of the chroma-noise amplification a raw
+per-node fit would introduce in sparsely-sampled regions.
+
+## 4. Data model & files
+
+### 4.1 `color_management.py` additions (parse)
+New internal representation + dispatch in `InputProfile`:
+```python
+class UnsupportedICCError(Exception): ...   # existing; extend messages
+
+# parsed cLUT representation (all numpy, precomputed for fast apply)
+class _CLUT:
+    n_in: int; n_out: int                   # 3, 3 for our use
+    grid: tuple[int, ...]                    # per-axis gridPoints (len n_in)
+    table: np.ndarray                        # (g0, g1, g2, n_out) float32 in PCS-decoded units (XYZ D50, Y=1)
+    in_luts:  list[np.ndarray]               # n_in device->[0,1] LUTs (len 65536 each, for direct uint16 index)
+    out_curves: list[np.ndarray] | None      # post-CLUT/output curves already folded into `table` when possible
+    # mAB extras (None for mft1/mft2):
+    mab_matrix: np.ndarray | None            # (3,4) M-curve-output -> ... ; None = identity/absent
+    # PCS already decoded to XYZ(D50, Y=1) inside `table`, so apply() is uniform.
+
+class InputProfile:
+    # existing matrix-shaper fields:
+    #   self._matrix (3,3 float32), self._luts (3 x 65536), self.description
+    # new:
+    #   self._kind: str   # 'matrix' | 'clut'
+    #   self._clut: _CLUT | None
+```
+`from_bytes` dispatches: if matrix-shaper tags present → build today's
+representation (`_kind='matrix'`, **unchanged bytes**); elif an `A2B*` tag present
+→ parse cLUT (`_kind='clut'`); else raise `UnsupportedICCError`.
+
+New module-private helpers (mirroring the existing `_parse_*`):
+```python
+def _parse_a2b(icc, off, pcs, version) -> _CLUT          # dispatch on element sig
+def _parse_lut8 (icc, off, pcs, version) -> _CLUT        # 'mft1'
+def _parse_lut16(icc, off, pcs, version) -> _CLUT        # 'mft2'
+def _parse_lutAToB(icc, off, pcs, version) -> _CLUT      # 'mAB '
+def _pcs_decode(values01, pcs, version) -> np.ndarray    # ->XYZ(D50,Y=1)
+def _clut_interp_tetra(d01, clut) -> np.ndarray          # (...,3)->(...,3)
+def _clut_interp_trilinear(d01, clut) -> np.ndarray      # fallback / >3D path
+```
+
+### 4.2 `color_management.py` additions (generate)
+```python
+def build_clut_icc(desc: str,
+                   clut_xyz: np.ndarray,        # (g,g,g,3) XYZ D50 (Y=1), input-R-slowest
+                   grid: int,
+                   wtpt=D50_XYZ,
+                   copyright_text=...) -> bytes
+    # mft2 lut16: identity 3x3 matrix, identity input/output 16-bit tables,
+    # the 3D CLUT carries everything. PCS = 'XYZ '.
+```
+Plus a small `_lut16_type(...)` byte builder alongside `_xyz_type`/`_para_type3`/
+`_text_type` (lines 150–173).
+
+### 4.3 `it8_profile.py` additions (fit the cLUT)
+```python
+def build_residual_clut(fit: CameraFit,
+                        samples: Dict[str, PatchSample],
+                        ref: IT8Reference,
+                        grid: int = 17) -> np.ndarray
+    # returns (grid,grid,grid,3) XYZ D50 (Y=1) cLUT = matrix(node) + RBF residual
+
+def build_camera_icc(fit: CameraFit, desc: str, *,
+                     mode: str = "matrix", grid: int = 17,
+                     samples=None, ref=None,
+                     copyright_text=...) -> bytes
+    # mode='matrix' -> existing build_matrix_shaper_icc path (unchanged default)
+    # mode='clut'   -> build_residual_clut(...) -> color_management.build_clut_icc(...)
+```
+`mode='matrix'` keeps the **current signature behaviour** (default arg), so
+existing callers/tests are unaffected. `mode='clut'` requires `samples`+`ref`
+(the residual needs per-patch device RGB + reference XYZ).
+
+### 4.4 Files touched / added
+- **edit** `src/core/color_management.py` — cLUT parse + dispatch in
+  `InputProfile`; `_CLUT`; interpolators; `build_clut_icc` + `_lut16_type`.
+- **edit** `src/core/it8_profile.py` — `build_residual_clut`, `build_camera_icc`
+  `mode`/`grid` params, RBF helpers.
+- **edit** `src/widgets/it8_profile_dialog.py` — Step 4/5 "3×3 matrix" vs
+  "cLUT (higher accuracy)" selector; pass `mode`/`grid`/`samples`/`ref` to
+  `build_camera_icc` (call site line 837).
+- **add** `tests/test_clut_icc.py` — parse mft1/mft2/mAB, interp, PCS XYZ/Lab,
+  reject CMYK, round-trip, non-linear-generator advantage, real `.icm` parse.
+- **edit** `src/ui/main_window.py` — relax the "Unsupported ICC" guidance text
+  (lines 401–405) now that cLUT is supported (CMYK / B2A-only still rejected).
+
+No new dependency. No change to `build_matrix_shaper_icc`, the export path, or
+`ccr_backend.set_input_icc`/`load_input_icc_from_storage` (a cLUT profile flows
+through them unchanged — they only call `load_input_profile`/`from_bytes`).
+
+## 5. Processing / math
+
+### 5.1 CONSUME — apply pipeline (`InputProfile.apply`, cLUT branch)
+Input is `HxWx3 uint16` camera-native device RGB (the §1 decode). Steps:
+1. **Input curves**: `lin[...,c] = self._clut.in_luts[c][rgb_u16[...,c]]` — the
+   in_luts are length-65536 so a uint16 indexes directly (identical pattern to
+   the matrix path, lines 442–445). Gives device values in [0,1] in the CLUT's
+   input domain.
+2. **CLUT interpolation** → PCS-decoded XYZ(D50, Y=1) (the table is pre-decoded at
+   parse time, §5.3), via **tetrahedral** interpolation (§5.2).
+3. **mAB only**: if `mab_matrix`/M-curves/B-curves were present they are folded
+   so the table already yields XYZ(D50) (§5.4) — apply() stays uniform.
+4. **XYZ(D50) → linear Adobe RGB**: `adobe_lin = xyz @ M_XYZ_D50_2_ADOBE.T`
+   (reuse the existing constant, lines 105–110), `clip[0,1]`, `*65535`, `rint`,
+   `uint16` — byte-identical tail to the matrix path (lines 446–448). **No sRGB
+   OETF**, per the negative-inversion contract.
+
+Result: a cLUT input profile is indistinguishable downstream from a matrix one —
+same linear-Adobe uint16 output that `_apply_input_icc` and the inversion expect.
+
+### 5.2 Tetrahedral interpolation (3-D input)
+Vectorise over all H·W pixels. For normalised device `d ∈ [0,1]^3` and per-axis
+grid sizes `(g0,g1,g2)`:
+- Scale to grid coords `t = d * (g−1)`; base index `i0 = floor(t)` clamped to
+  `g−2`; fractional `f = t − i0 ∈ [0,1]^3` per axis.
+- **Tetrahedral**: decompose the unit cube into 6 tetrahedra by the ordering of
+  `(fr, fg, fb)`. The interpolated value is
+  `V = V000 + sum over the 3 ordered steps of (w_k * (V_{next} − V_prev))`,
+  where the three barycentric weights are the sorted differences of `f`. Concretely
+  (Argyll/standard formulation), with `c000 = table[i0]` and the 7 other cube
+  corners gathered, the 6 cases select which 2 mid-corners enter:
+  - `fr≥fg≥fb`: `c000 + fr(c100−c000) + fg(c110−c100) + fb(c111−c110)`
+  - `fr≥fb≥fg`: `c000 + fr(c100−c000) + fb(c101−c100) + fg(c111−c101)`
+  - `fb≥fr≥fg`: `c000 + fb(c001−c000) + fr(c101−c001) + fg(c111−c101)`
+  - `fb≥fg≥fr`: `c000 + fb(c001−c000) + fg(c011−c001) + fr(c111−c011)`
+  - `fg≥fb≥fr`: `c000 + fg(c010−c000) + fb(c011−c010) + fr(c111−c011)`
+  - `fg≥fr≥fb`: `c000 + fg(c010−c000) + fr(c110−c010) + fb(c111−c110)`
+  Implemented as `np.select` over the 6 boolean masks, each branch a vectorised
+  sum of gathered corner planes. Tetrahedral avoids the trilinear "diagonal
+  desaturation" on neutrals and is the de-facto standard for ICC cLUT apply.
+- **Gather**: flatten the table to `(g0*g1*g2, 3)`; compute the 8 corner linear
+  indices once (`i0` and the +1 neighbours combined by strides), gather all 8
+  corner planes as `(N,3)` arrays, then combine per the selected tetra case.
+- **Trilinear fallback** (`_clut_interp_trilinear`): the full 8-corner weighted
+  sum `Σ V_corner * Πaxis (f or 1−f)`. Used when `n_in != 3` (defensive) and as
+  the reference oracle in tests.
+
+### 5.3 PCS decode at parse time (`_pcs_decode`)
+Decode the **whole CLUT once** at parse (not per pixel): convert the raw
+u8/u16 grid entries to [0,1], then:
+- PCS XYZ → `XYZ = v01 * (1 + 32767/32768)`.
+- PCS Lab → Lab via the version-correct scale (§3.5), then
+  `it8_profile.lab_to_xyz(lab) / 100` (D50, Y=1). (Import `lab_to_xyz` lazily to
+  avoid a core import cycle, the same way `it8_profile` imports `color_management`.)
+Store the decoded `(g0,g1,g2,3)` XYZ(D50,Y=1) float32 table on `_CLUT.table`.
+This keeps `apply()` a pure gather+combine+matmul with no per-pixel branching on
+PCS type.
+
+### 5.4 mAB stage folding
+For `mAB ` with `i=o=3`:
+- Bake **A curves** into `in_luts` (length-65536, like `_parse_trc_to_lut`).
+- After CLUT interpolation, apply **M curves** (3 LUTs), then **matrix** (3×4:
+  `y = M3x3·x + offset`), then **B curves** (3 LUTs), all in PCS-connected order,
+  *before* `_pcs_decode`. To keep `apply()` uniform we fold M/matrix/B into the
+  **decoded table** at parse time: run every grid node value through
+  `M-curve → matrix → B-curve → _pcs_decode` once, storing the result in
+  `table`. Then `apply()` is identical for mft1/mft2/mAB. (Curves are 1-D LUTs;
+  the matrix is a single `(g0*g1*g2,3) @ (3,3).T + offset`.)
+
+### 5.5 Performance / memory (CONSUME)
+- Table memory: a 3-D grid of `g` per axis is `g³ * 3 * 4` bytes. The
+  prohibitive idea is a 65536-per-axis dense LUT (`2.8e14` entries) — impossible.
+  Native-grid tables are tiny: `g=33` ⇒ ~431 KB, `g=17` ⇒ ~59 KB. We interpolate
+  on the native grid; **never** materialise a per-channel 65536³ LUT.
+- Per-decode cost: input curves are three 65536-LUT gathers (cheap, same as
+  matrix path); tetra interp is ~8 gathers of `(N,3)` + a handful of fused
+  adds, fully vectorised. At export full resolution this is one pass over the
+  export array (float32), comparable to the existing matrix matmul — acceptable.
+  In_luts are precomputed; the table is precomputed; nothing is rebuilt per call.
+
+### 5.6 GENERATE — residual cLUT fit (`build_residual_clut`)
+Inputs: the fitted `CameraFit.matrix M` (device-norm RGB[0,1] → XYZ D50, Y≈1),
+the per-patch device RGB (`samples[id].rgb/65535`) and reference XYZ
+(`ref.xyz(id)/100`). Output: `(grid,grid,grid,3)` XYZ(D50,Y=1) cLUT.
+1. **Base.** For each grid node `n ∈ [0,1]^3` (device RGB), base prediction
+   `B(n) = M @ n` — the well-behaved global map.
+2. **Per-patch residual.** For each used patch `i` with device `d_i`, reference
+   `X_i`: residual `r_i = X_i − M @ d_i` (in XYZ, Y=1). To keep the correction
+   perceptually even (avoid over-weighting bright patches) fit the residual in a
+   **scaled space**: work on `r_i` directly in XYZ but distance-weight in device
+   RGB (smooth, monotone in the device domain we interpolate over).
+3. **RBF scatter→grid (numpy, no scipy).** Thin-plate / Gaussian RBF over the
+   device-RGB sample points `{d_i}`:
+   - Kernel: Gaussian `φ(r) = exp(−(r/σ)²)` with `σ` ≈ mean nearest-neighbour
+     device distance (smooth, compact-ish), OR thin-plate `φ(r)=r²·log r`. Default
+     Gaussian (no singularity, easy regularisation).
+   - Solve per XYZ channel: `(Φ + λI) w = r` where `Φ_jk = φ(||d_j − d_k||)`,
+     `λ` a small smoothness/regularisation term (e.g. `λ = 1e-3 * trace(Φ)/N`).
+     A low-order polynomial term (`1, R, G, B`) is appended for affine
+     reproduction and unbiased extrapolation (the standard RBF+polynomial
+     augmented system), solved with `np.linalg.lstsq`.
+   - Evaluate at every grid node: `residual(n) = Σ_i w_i φ(||n − d_i||) + poly(n)`.
+4. **Extrapolation guard (monotone, artefact-free).** Outside the convex hull of
+   the patch device points the RBF can diverge. Mitigate by:
+   - the polynomial term keeping far-field behaviour affine (bounded),
+   - **fading the residual to zero** by a smooth factor of the distance from the
+     patch hull / nearest sample (so nodes far outside fall back to the pure
+     matrix `B(n)`), and
+   - clamping `|residual|` to a fraction of the local node value.
+   This guarantees the LUT degrades to the safe 3×3 in unsampled corners rather
+   than ringing.
+5. **Assemble + bounded-ringing safeguard.** `table[n] = clip(B(n) + corr(n), 0, ~2)`.
+   The kernel is deliberately **broad** (σ ≈ 3× the mean nearest-neighbour device
+   spacing) with a firm `λ`, which captures the systematic saturated-corner bias
+   with little high-frequency overshoot — empirically both lower ΔE *and* far less
+   non-monotonicity than a tight kernel. A safeguard then bounds *gross* ringing:
+   if the correction introduces a per-axis reversal larger than `RINGING_TOL`
+   (0.12 of white) where the linear base is non-decreasing, the whole correction is
+   shrunk toward the base and rechecked (strength 0 = pure 3×3, always safe, so it
+   terminates). **The cLUT is NOT guaranteed strictly monotone** — small reversals
+   are the cost of the bias correction; the 3×3 matrix mode is the strictly-safe
+   default. Tests pin the delivered bound (no reversal > `RINGING_TOL`) and that
+   the cLUT still markedly beats the 3×3 on a non-affine camera.
+
+### 5.7 GENERATE — grid size choice
+- **9³ = 729 nodes** vs **17³ = 4913 nodes**. The IT8 fit has ~288 patches
+  (fewer after clip rejection), so a finer grid is *interpolated*, not
+  independently solved — the RBF is the smoother. `17³` gives ample resolution
+  for smooth saturated-corner correction while the `mft2` table stays ~59 KB and
+  the residual solve is a `~280×280` linear system (instant in numpy). **Default
+  `grid=17`** (justified: smooth, small, more than enough nodes between
+  sparse patches); `9` available as a lighter option. The grid is uniform per
+  axis (identity input curves), so no extra grid-spacing metadata is needed.
+
+### 5.8 GENERATE — ICC writer (`build_clut_icc` → `mft2`)
+Choose **`mft2` (lut16)** over `mAB `: it is the simplest valid 3-D cLUT
+container our existing `mft1/mft2/mAB` *reader* round-trips, needs no
+offset-table bookkeeping, and a v2.4 header matches `build_matrix_shaper_icc`'s
+proven header (lines 226–237). Layout written:
+- header: copy `build_matrix_shaper_icc`'s header but **PCS = `'XYZ '`** (already
+  what the matrix writer uses), device space `'RGB '`, class `mntr`, v2.4, D50
+  PCS illuminant.
+- tag table: `desc`, `wtpt`, `A2B0`, `cprt` (and optionally `A2B1`=`A2B0` alias
+  via the dedup the writer already does, lines 206–219).
+- `A2B0` element bytes (`mft2`):
+  - `'mft2'`, 0, `i=3`, `o=3`, `g=grid`, pad.
+  - 3×3 **identity** matrix (9 s15Fixed16) — XYZ PCS, identity so the CLUT carries
+    everything.
+  - `n=2`, `m=2` (minimal identity input/output tables: 2 entries `[0, 65535]`
+    per channel = linear ramp; the CLUT alone defines the transform).
+  - Input tables: `3 * 2` u16 = `[0,65535]×3`.
+  - CLUT: `grid³ * 3` u16, **encoding XYZ → u16** via
+    `u16 = round(clip(XYZ / (1+32767/32768), 0, 1) * 65535)`, **output-channel-
+    fastest, input-R-slowest** (ICC order: last input channel varies fastest;
+    we lay R slowest, G, B fastest to match `_parse_lut16`'s gather strides —
+    documented and unit-pinned against the parser).
+  - Output tables: `3 * 2` u16 = `[0,65535]×3`.
+- Reuse the writer's 4-byte alignment + offset/dedup loop and the header size
+  field. A `build_clut_icc` round-trips through `_parse_lut16`.
+
+### 5.9 ID/dispatch correctness
+`from_bytes` (extended):
+```python
+tags = _read_tag_table(icc)
+if icc[16:20] != b'RGB ':
+    raise UnsupportedICCError("input profile is not an RGB profile")
+ms = all(t in tags for t in (b'rXYZ',b'gXYZ',b'bXYZ',b'rTRC',b'gTRC',b'bTRC'))
+if ms:
+    ... existing matrix-shaper path, UNCHANGED ...      # _kind='matrix'
+a2b = next((t for t in (b'A2B0', b'A2B1') if t in tags), None)
+if a2b is not None:
+    pcs = icc[20:24]
+    if pcs not in (b'XYZ ', b'Lab '):
+        raise UnsupportedICCError(f"unsupported PCS {pcs!r}")
+    version = icc[8]                                     # top byte of version
+    clut = _parse_a2b(icc, tags[a2b][0], pcs, version)
+    return cls._from_clut(clut, _read_desc(icc, tags))  # _kind='clut'
+raise UnsupportedICCError("only RGB matrix-shaper or A2B cLUT profiles are supported (CMYK / B2A-only not)")
+```
+The `RGB ` guard already rejects CMYK device space. A profile with only `B2A*`
+(no `A2B*`) and no matrix-shaper tags falls through to the final raise.
+
+## 6. Integration points
+
+### 6.1 `InputProfile` (color_management.py)
+- `from_bytes` dispatches (§5.9). `__init__` unchanged for matrix; add
+  `_from_clut` classmethod / `_kind`/`_clut` fields.
+- `apply()` branches on `self._kind`; **matrix branch is the current code verbatim**
+  (regression test asserts byte-identical output for a known matrix profile).
+- `description` read unchanged via `_read_desc` (lines 421–432).
+
+### 6.2 `ccr_backend` / `ccr_image` — no change
+`set_input_icc`/`load_input_icc_from_storage` (lines 592–622) call
+`load_input_profile`→`from_bytes`; a cLUT profile now parses instead of raising,
+so it activates through the *exact same* path. `read_image`'s decode already
+produces the camera-native device RGB a cLUT consumes (lines 459–504); `apply()`
+emits linear Adobe RGB so `_apply_input_icc` (lines 271–287) and the inversion are
+untouched. `_input_icc_will_apply` (lines 289–296) stays correct (any active
+profile ⇒ camera-native decode).
+
+### 6.3 IT8 wizard (it8_profile_dialog.py)
+- Step 4/5 gains a profile-type selector (radio or combo): **"3×3 matrix"** /
+  **"cLUT (higher accuracy)"** (default matrix to preserve current behaviour; a
+  tooltip notes cLUT needs the full patch set and fixes saturated corners).
+- The build call site (line 837) becomes
+  `it8.build_camera_icc(self._fit, desc, mode=chosen_mode, grid=17,
+   samples=self._all_samples, ref=self._ref)`.
+- `saved_path`/`apply_now` flow (lines 845–846) and
+  `main_window.create_camera_profile_from_it8` (lines 418–436) unchanged — they
+  consume whatever ICC bytes were written.
+
+### 6.4 Reuse, not reinvent
+- ICC tag table / XYZ / curve parsing ⇒ `_read_tag_table`, `_parse_xyz`,
+  `_parse_trc_to_lut`, `_eval_para` (lines 322–387) reused for mAB sub-curves.
+- XYZ→Adobe ⇒ `M_XYZ_D50_2_ADOBE` (lines 105–110), shared tail with matrix apply.
+- Lab→XYZ ⇒ `it8_profile.lab_to_xyz` (lines 647–657), D50 white `_D50_W100`.
+- ICC header/tag writer scaffolding ⇒ `build_matrix_shaper_icc`'s alignment/
+  dedup/offset loop (lines 199–237), `_s15f16`, `_xyz_type`, `_text_type`,
+  `_desc_type` (lines 145–173).
+- Fit + quality ⇒ `fit_camera_matrix`, `xyz_to_lab`, `delta_e_2000` (it8_profile).
+
+## 7. UX
+
+cLUT support is **invisible** on the CONSUME side: a user simply selects their
+LUT-based `.icm` via the existing **File ▸ Set Input ICC Profile…** picker
+(`set_input_icc_profile`, main_window lines 383–391) and it now loads instead of
+showing "Unsupported ICC Profile". The warning text (lines 401–405) is relaxed to
+"Only RGB matrix-shaper and cLUT (A2B) profiles are supported (CMYK and
+B2A-only profiles are not)."
+
+On the GENERATE side the only new control is the **profile-type selector** on IT8
+Step 4/5 (§6.3): "3×3 matrix" (default) vs "cLUT (higher accuracy)". The fit
+review (ΔE chip + worst-list, dialog lines 450–456) is shown for the chosen mode
+so the user sees the cLUT's lower residuals before saving. No other UI change.
+
+## 8. Test plan
+
+Unit (`tests/test_clut_icc.py`), all pure (no Qt):
+- **Parse mft1**: hand-built `mft1` bytes (i=o=3, small grid, identity tables,
+  a known CLUT) parse; `_CLUT.grid`/`table` shapes and decoded XYZ correct.
+- **Parse mft2**: same for 16-bit, variable `n`/`m` input/output tables; PCS XYZ.
+- **Parse mAB**: hand-built `mAB ` with A-curves + CLUT + M-curves + 3×4 matrix +
+  B-curves; assert the folded `table` equals a reference manual evaluation.
+- **Tetra interp vs reference**: a CLUT that is an exact affine map `V = A·d`
+  must be reproduced by `_clut_interp_tetra` to ~float precision (affine is exact
+  for tetra); a random smooth CLUT matches `_clut_interp_trilinear` within the
+  known tetra-vs-trilinear bound on a dense query set; neutral axis (`d=(t,t,t)`)
+  stays neutral (no trilinear desaturation).
+- **PCS XYZ and Lab**: a profile whose CLUT encodes a known XYZ map, and the same
+  map via Lab (v2 and v4 encodings), both decode to the same XYZ(D50) within a
+  tight tolerance; the version byte selects the right Lab scale.
+- **Reject**: CMYK device space (`icc[16:20] != b'RGB '`) → `UnsupportedICCError`;
+  a profile with only `B2A0` and no matrix-shaper tags → `UnsupportedICCError`;
+  unsupported PCS → `UnsupportedICCError`.
+- **Matrix path unchanged (regression)**: `build_matrix_shaper_icc(...)` →
+  `from_bytes` → `apply` on a fixed image returns **byte-identical** output to the
+  pre-change implementation (golden array).
+- **Generate round-trip**: `build_residual_clut` → `build_clut_icc` →
+  `InputProfile.from_bytes` → `apply` on the patch device RGB recovers the
+  reference patches within a tight ΔE2000 (≪ the matrix-only avg), and a
+  **synthetic non-linear generator** (a known smooth non-affine device→XYZ map)
+  is recovered by the cLUT with markedly lower max/avg ΔE than the 3×3
+  (`build_camera_icc(mode='clut')` beats `mode='matrix'`).
+- **Bounded ringing / extrapolation**: the generated CLUT adds no per-axis reversal
+  larger than `RINGING_TOL` where the linear base is non-decreasing
+  (`_residual_monotone`); nodes far outside the patch hull equal the pure-matrix
+  prediction (residual faded to ~0).
+- **Build→reparse byte sanity**: `build_clut_icc` output has the `mft2` `A2B0`
+  element, correct `i/o/g`, identity in/out tables, and the header is
+  RGB/`acsp`/v2.4 with PCS `'XYZ '`.
+
+Integration / real-data:
+- **Real `.icm` parses**: the user's actual LUT-based scanner/camera `.icm`
+  loads via `from_bytes` (no `UnsupportedICCError`); `apply` on a neutral patch
+  yields a near-neutral linear-Adobe result and on a saturated patch a plausible
+  saturated result (sanity, not exact — no reference for a third-party profile).
+- **End-to-end (manual)**: set the real `.icm` as input profile via the menu →
+  loaded scans reprocess (`reprocess_all_for_input_icc_change`) without error;
+  IT8 wizard → choose cLUT → save → "apply now" → reprocess; the saved cLUT
+  re-loads on restart through the existing storage path
+  (`load_input_icc_from_storage`).
+- **fit-space == apply-space** stays pinned: a cLUT generated from IT8 samples and
+  then applied via the input-profile decode operates on the *same* camera-native
+  device RGB (the existing IT8 decode-space test extended to the cLUT path).
+
+## 9. Risks & mitigations
+- **CLUT channel order / strides wrong** (the classic ICC footgun) → the writer
+  and `_parse_lut16` are pinned against each other by the generate→reparse
+  round-trip test; layout (R slowest, B fastest, output-channel grouping)
+  documented in §5.8 and asserted.
+- **Lab v2-vs-v4 encoding mismatch** → version-byte branch (§3.5) with explicit
+  tests for both encodings against the same reference XYZ.
+- **mAB stage-order error** (A→CLUT→M→matrix→B is non-obvious) → folded at parse
+  with a hand-evaluated reference test (§8 "Parse mAB").
+- **RBF over-fitting / ringing LUT** (chroma-noise amplification, the parked
+  density-inversion failure mode) → a broad kernel + firm regularisation `λ` +
+  polynomial term + hull-fade to the safe 3×3, and a bounded-ringing safeguard
+  (shrink the correction toward the base until no per-axis reversal exceeds
+  `RINGING_TOL`). Not strict monotonicity — matrix mode is the strictly-safe option
+  (§5.6). Default `grid=17` keeps the LUT smooth.
+- **Performance at full-res export** → native-grid interpolation only (never a
+  65536³ LUT); precomputed in_luts + decoded table; one vectorised pass — on par
+  with the matrix matmul (§5.5).
+- **Breaking the matrix-shaper path** → dispatch only *adds* a branch; the matrix
+  branch is verbatim and guarded by a byte-identical golden regression test.
+- **Tetrahedral edge cases** (degenerate `f` ties) → ties resolved consistently by
+  the `>=` ordering in the 6-way `np.select`; affine-exactness test catches a
+  wrong branch.

--- a/spec/dcp-camera-profile.md
+++ b/spec/dcp-camera-profile.md
@@ -1,0 +1,576 @@
+# Spec: Adobe DCP (DNG Camera Profile) Support — Consume & Generate
+
+Status: IMPLEMENTED (on branch `feature/clut-icc-support`)
+Owner: FreeCCR
+Feature branch: `feature/dcp-camera-profile`
+
+> Supersedes the earlier never-committed DCP draft (memory:
+> `camera-profile-feature`). This is the authoritative on-disk spec.
+
+## 1. Summary
+
+Add **Adobe DCP** (`.dcp` — a DNG camera-profile binary) support to FreeCCR, in
+two directions that mirror the existing input-ICC feature:
+
+- **CONSUME** — `File ▸ Load DCP Profile…` loads an external/Adobe `.dcp`,
+  parses it (in pure-numpy, no `rawpy`-side DNG plumbing), and applies it to
+  every decoded scan in the same decode-time slot the input ICC uses, producing
+  **linear Adobe RGB** so the negative inversion downstream reads consistent
+  `-log10(value/full)` linear data (identical contract to
+  `InputProfile.apply`, see `color_management.py` §"Input ICC profile").
+- **GENERATE** — the existing **IT8 wizard** (`it8_profile_dialog`) gains a
+  **save format choice (`.icc` | `.dcp`)**. The fitted camera matrix
+  (`CameraFit.matrix`, camera-native device RGB[0,1] → XYZ D50) is written as a
+  minimal valid matrix DCP (`ProfileName`, `CalibrationIlluminant1`,
+  `ColorMatrix1`, `ForwardMatrix1`).
+
+A DCP is the **right** container for FreeCCR's camera-native decode: its
+`ColorMatrix`/`ForwardMatrix` are *defined on camera-native raw* — exactly the
+space `read_image` already produces for the ICC path
+(`output_color=raw`, `gamma=(1,1)`, `no_auto_bright`, `use_camera_wb=False`,
+`no_auto_scale` + manual white-level scale — `_raw_color_postprocess_kwargs(
+no_icc_default=False)`, see `spec/it8-camera-profile.md` §12.5). The one
+divergence from the ICC path is **white balance**: a matrix/cLUT ICC bakes WB
+into the fitted matrix, whereas a DCP is fed **unbalanced** raw and applies the
+**as-shot WB at render time** (`raw.camera_whitebalance`). FreeCCR's decode is
+already unbalanced, so it is the correct shared base; the DCP apply path just
+needs the as-shot multipliers threaded through (new plumbing, since
+`InputProfile.apply` is WB-agnostic).
+
+The whole feature is **pure numpy + struct** (both present), reusing the
+binary-IO idioms already in `color_management.py` (`struct`, big/little-endian
+unpacking, `_s15f16`-style fixed-point) and the colour-science helpers in
+`it8_profile.py` (`xyz_to_lab`, `delta_e_2000`, `D50_XYZ`). **No** `rawpy` DNG
+metadata API, `exiftool`, `libdng`, or DNG SDK dependency is added.
+
+## 2. Goals / Non-goals
+
+### Goals
+- **Parse** a `.dcp` (TIFF/DNG-IFD binary) into a `DcpProfile` dataclass:
+  matrices (`ColorMatrix1/2`, `ForwardMatrix1/2`, `CameraCalibration1/2`,
+  `ReductionMatrix1/2`), `CalibrationIlluminant1/2`, optional `HueSatMapData1/2`
+  (+ dims/encoding), optional `LookTableData` (+ dims/encoding), optional
+  `ProfileToneCurve`, `ProfileName`, `ProfileEmbedPolicy`. Handle **II and MM**
+  endianness.
+- **Apply** a `DcpProfile` to camera-native unbalanced raw → **linear Adobe
+  RGB**, with: as-shot WB; dual-illuminant CCT interpolation of
+  Color/Forward(/HueSat) matrices in **mired (1/CCT)** space; ForwardMatrix →
+  XYZ D50 (with the inverse-ColorMatrix fallback when no ForwardMatrix);
+  optional HueSatMap/LookTable/ToneCurve (the subjective "look").
+- A **colorimetric mode (matrices only) by default**, with the look tables
+  (HueSatMap/LookTable/ToneCurve) **off by default** and behind a checkbox —
+  they are subjective Adobe "look", not colorimetry, and the negative pipeline
+  wants a faithful colour map (see §5.7).
+- **Generate** a minimal matrix `.dcp` from the IT8 `CameraFit`
+  (`build_camera_dcp(...)`), single-illuminant.
+- A **global active-DCP slot** mirroring
+  `color_management.get/set_active_input_profile`, **mutually exclusive** with
+  the active input ICC.
+- `read_image` applies **either** an ICC `InputProfile` **or** a `DcpProfile`,
+  threading the as-shot WB for the DCP path; keeps the positive-mode skip and
+  the camera-native decode.
+- Unit tests: parse a self-built synthetic `.dcp`, endianness, SRATIONAL
+  matrices, dual-illuminant interpolation weights, ForwardMatrix vs
+  ColorMatrix-fallback, generate→reparse matrix round-trip, neutral→neutral, and
+  synthetic-camera round-trip.
+
+### Non-goals
+- **No `rawpy`/`libraw` DCP application.** rawpy does not apply DCPs; we apply in
+  numpy on the already-decoded camera-native array.
+- **No DCP authoring beyond a minimal single-illuminant matrix profile.**
+  Generating HueSatMap/LookTable/ToneCurve, dual-illuminant DCPs (needs two
+  charts under two lights), or `CameraCalibration` is out of scope for GENERATE
+  (a fitted IT8 matrix has none of those). Dual-illuminant is noted as future
+  work (§5.8).
+- **No tone/look "rendering intent" emulation of Camera Raw.** We apply the
+  table operators faithfully when enabled, but do not reproduce ACR's default
+  tone/exposure baseline (`BaselineExposureOffset`, `DefaultBlackRender`) — the
+  negative pipeline owns tone. We **read** those tags for completeness but do not
+  apply them by default (§5.7).
+- **No `.dng`-embedded profile extraction** (reading the profile out of a raw
+  file's IFD). Only standalone `.dcp` files. (The parser is IFD-generic, so this
+  is a small later add.)
+- **No simultaneous ICC + DCP.** They occupy the same decode slot; setting one
+  clears the other (§6.3).
+
+## 3. Background (researched & verified)
+
+### 3.1 DCP container = TIFF/DNG IFD
+A `.dcp` is a single-IFD TIFF stream:
+- **8-byte header**: byte-order (`II`=0x4949 little / `MM`=0x4D4D big),
+  magic `42`, then `u32` offset to IFD0.
+- **IFD**: `u16` entry count, then N × 12-byte entries
+  `(tag:u16, type:u16, count:u32, value_or_offset:u32)`. If
+  `type_size × count ≤ 4` the value is **inline** in the last field (left-
+  justified); else the field is a **file offset** to the data. After the entries,
+  a `u32` next-IFD offset (0 for a DCP).
+- **TIFF types** used here: `SHORT`=3 (2 B), `LONG`=4 (4 B), `RATIONAL`=5
+  (2×u32), `ASCII`=2 (1 B), `SRATIONAL`=10 (2×i32), `FLOAT`=11 (4 B IEEE).
+  All multi-byte fields honour the header endianness.
+
+### 3.2 Relevant DNG profile tags (verified)
+Verified against the Adobe DNG Specification 1.4–1.6 and the colour-hdri /
+rawler tag enumerations (see Sources). Decimal tag id → (TIFF type, count):
+
+| Tag (dec) | Name | Type | Count | Meaning |
+|---|---|---|---|---|
+| 50721 | `ColorMatrix1` | SRATIONAL | 3×planes (9) | XYZ(D50-ref-adapted) → camera-native reference RGB, illuminant 1 |
+| 50722 | `ColorMatrix2` | SRATIONAL | 9 | …illuminant 2 |
+| 50723 | `CameraCalibration1` | SRATIONAL | planes² (9) | per-unit camera calibration, illuminant 1 (identity if absent) |
+| 50724 | `CameraCalibration2` | SRATIONAL | 9 | …illuminant 2 |
+| 50725 | `ReductionMatrix1` | SRATIONAL | 9 | (≥3-plane reduction; unused for RGB) |
+| 50726 | `ReductionMatrix2` | SRATIONAL | 9 | |
+| 50727 | `AnalogBalance` | RATIONAL | planes (3) | diag analog gains (identity if absent) |
+| 50728 | `AsShotNeutral` | RATIONAL | planes (3) | as-shot neutral in camera RGB (alt to AsShotWhiteXY; we use `raw.camera_whitebalance`) |
+| 50778 | `CalibrationIlluminant1` | SHORT | 1 | EXIF LightSource enum for matrix set 1 |
+| 50779 | `CalibrationIlluminant2` | SHORT | 1 | …set 2 |
+| 50936 | `ProfileName` | ASCII | n | display name |
+| 50937 | `ProfileHueSatMapDims` | LONG | 3 | (hueDiv, satDiv, valDiv) |
+| 50938 | `ProfileHueSatMapData1` | FLOAT | 3×∏dims | (Δhue°, satScale, valScale) per cell, illuminant 1 |
+| 50939 | `ProfileHueSatMapData2` | FLOAT | 3×∏dims | …illuminant 2 |
+| 50940 | `ProfileToneCurve` | FLOAT | 2×N | interleaved (x,y) ∈[0,1] control points |
+| 50941 | `ProfileEmbedPolicy` | LONG | 1 | 0=allow copying … 3=no embed |
+| 50981 | `ProfileLookTableDims` | LONG | 3 | (hueDiv, satDiv, valDiv) |
+| 50982 | `ProfileLookTableData` | FLOAT | 3×∏dims | (Δhue°, satScale, valScale) per cell |
+| 51107 | `ProfileHueSatMapEncoding` | LONG | 1 | 0=linear, 1=sRGB (value-axis encoding) |
+| 51108 | `ProfileLookTableEncoding` | LONG | 1 | 0=linear, 1=sRGB |
+| 50964 | `ForwardMatrix1` | SRATIONAL | 9 | **white-balanced** camera-native RGB → XYZ **D50**, illuminant 1 |
+| 50965 | `ForwardMatrix2` | SRATIONAL | 9 | …illuminant 2 |
+| 51109 | `BaselineExposureOffset` | SRATIONAL | 1 | read-only (not applied by default) |
+| 51110 | `DefaultBlackRender` | LONG | 1 | read-only (not applied by default) |
+
+`CalibrationIlluminant` enum (EXIF LightSource): **17 = Standard light A**
+(≈2856 K), **20 = D55** (5503 K), **21 = D65** (6504 K), **22 = D75** (7504 K),
+**23 = D50** (5003 K), 1 = Daylight, 2 = Fluorescent, 3 = Tungsten. A typical
+Adobe dual profile is illuminant1=A(17), illuminant2=D65(21).
+
+### 3.3 HueSatMap / LookTable layout (verified)
+A 3-D table over **HSV**: `dims = (hueDivisions, satDivisions, valDivisions)`.
+Data is `FLOAT`, **`3 × hueDiv × satDiv × valDiv`** entries, **value-axis
+fastest, then sat, then hue** (DNG ordering: index =
+`((h·satDiv) + s)·valDiv + v`), each cell a triple
+`(hueShift_degrees, satScale, valScale)`. When `valDiv == 1` the table is
+2-D (hue×sat). `…Encoding` says whether the **value** coordinate is sampled in
+linear (0) or sRGB (1) space before lookup. Applied by converting working RGB →
+HSV, trilinearly interpolating the table at (h,s,v), then `h += Δhue`,
+`s *= satScale`, `v *= valScale`, → RGB. HueSatMap is applied in the
+**ProPhoto-RGB-ish** linear/HSV reference Adobe uses; we apply it in linear
+ProPhoto (D50) for fidelity (§5.5).
+
+### 3.4 Dual-illuminant interpolation (verified — mired space)
+For an as-shot neutral with correlated colour temperature `T` (kelvin), Adobe
+interpolates the two matrix sets in **reciprocal (mired) space**:
+```
+inv(T) = 1e6 / T
+w = clamp( (inv(T) - inv(T2)) / (inv(T1) - inv(T2)), 0, 1 )     # weight on set 1
+M = w · M1 + (1 - w) · M2          # applied to ColorMatrix, ForwardMatrix, CameraCalibration, HueSatMap
+```
+with `T1 = CCT(illuminant1)`, `T2 = CCT(illuminant2)` (e.g. A≈2856, D65≈6504).
+`T` itself is derived from the as-shot camera neutral (§5.3). With one
+illuminant present, `w = 1` and only set 1 is used.
+
+### 3.5 White-balance divergence (verified, load-bearing)
+- A DCP's `ColorMatrix` relates camera-raw balance ↔ illuminant; the profile
+  applies the **as-shot WB at render time** via `ForwardMatrix` on the
+  white-balanced image. ⇒ a DCP **must be fed UNBALANCED raw**.
+- FreeCCR's decode is already unbalanced (`use_camera_wb=False`,
+  `use_auto_wb=False`). The as-shot multipliers come from
+  `raw.camera_whitebalance` (length-4 `[R, G1, B, G2]`; `G2` is usually `0` or
+  `== G1`). These must be threaded from `read_image` into the DCP apply (new
+  plumbing) since `_apply_input_icc` / `InputProfile.apply` are WB-agnostic.
+
+## 4. Data model & files
+
+### 4.1 New module `src/core/dcp_profile.py` (pure logic, no Qt)
+```python
+class DcpError(Exception): ...        # parse/validate failures, surfaced to the user
+
+# Illuminant enum -> CCT kelvin (StdA, D50/55/65/75, daylight/tungsten).
+ILLUMINANT_CCT: dict[int, float]      # {17:2856, 20:5503, 21:6504, 22:7504, 23:5003, ...}
+
+@dataclass
+class DcpProfile:
+    name: str
+    color_matrix_1: np.ndarray                 # (3,3) XYZ->camera, illum 1
+    color_matrix_2: Optional[np.ndarray]
+    forward_matrix_1: Optional[np.ndarray]     # (3,3) wb-cam->XYZ D50, illum 1
+    forward_matrix_2: Optional[np.ndarray]
+    camera_calibration_1: np.ndarray           # (3,3), identity if absent
+    camera_calibration_2: np.ndarray
+    analog_balance: np.ndarray                 # (3,) diag, ones if absent
+    illuminant_1: int                          # EXIF LightSource enum (default 21=D65)
+    illuminant_2: Optional[int]
+    hsm_dims_1: Optional[tuple]; hsm_data_1: Optional[np.ndarray]   # (h,s,v,3)
+    hsm_dims_2: Optional[tuple]; hsm_data_2: Optional[np.ndarray]
+    hsm_encoding: int                          # 0 linear / 1 sRGB
+    look_dims: Optional[tuple]; look_data: Optional[np.ndarray]
+    look_encoding: int
+    tone_curve: Optional[np.ndarray]           # (N,2) (x,y) in [0,1]
+    embed_policy: int
+
+    @property
+    def has_forward(self) -> bool: ...
+    @property
+    def is_dual(self) -> bool: ...
+
+# --- parse ---
+def parse_dcp(path: str) -> DcpProfile         # raises DcpError
+def parse_dcp_bytes(data: bytes) -> DcpProfile
+
+# --- apply (camera-native unbalanced raw in, linear Adobe RGB out) ---
+def apply_dcp(profile: DcpProfile, rgb_u16: np.ndarray, *,
+              as_shot_wb: Optional[np.ndarray],   # length-3 camera-native multipliers
+              apply_look: bool = False) -> np.ndarray
+
+# --- generate (matrix DCP from an IT8 CameraFit) ---
+def build_camera_dcp(fit, name: str, *,
+                     illuminant: int = 23,        # 23 = D50
+                     wb: Optional[np.ndarray] = None) -> bytes
+```
+
+### 4.2 Global active-DCP slot — in `color_management.py`
+Mirror the existing input-profile module globals (kept here so `ccr_image` reads
+the active colour transform from one module without importing the backend, as it
+already does for `get_active_input_profile`):
+```python
+_active_dcp_profile: "Optional[DcpProfile]" = None
+def set_active_dcp_profile(p) -> None
+def get_active_dcp_profile()
+```
+`DcpProfile` lives in `dcp_profile.py`; `color_management` stores it opaquely
+(no import cycle — it only holds/returns the object).
+
+### 4.3 Edits
+- `src/core/ccr_image.py` — `read_image`: select the DCP apply path when a DCP is
+  active (mutually exclusive with the ICC path), threading `raw.camera_whitebalance`
+  (§6.1). `_input_icc_will_apply` generalised to
+  `_camera_profile_will_apply` (ICC **or** DCP active) so the camera-native decode
+  is chosen for both.
+- `src/core/ccr_backend.py` — `set_input_dcp(path)`, `load_input_dcp_from_storage`,
+  `clear_input_dcp` mirroring the ICC trio; setting a DCP clears the active ICC and
+  vice-versa (§6.3). New `input_dcp_path`/`input_dcp_name` persisted state.
+- `src/ui/main_window.py` — File-menu `Load DCP Profile…` /
+  `Clear DCP Profile`, handler `set_input_dcp_profile()` reusing the
+  `_apply_input_icc_path` reprocess flow (factored to a shared
+  `_apply_camera_profile`). The IT8 wizard's save step (`it8_profile_dialog`)
+  gains the `.icc`/`.dcp` format choice.
+- `src/widgets/it8_profile_dialog.py` — Step 5 file-type filter + branch to
+  `dcp_profile.build_camera_dcp` vs `it8_profile.build_camera_icc`.
+
+### 4.4 Storage
+A DCP working copy lives next to the input-ICC copy:
+`<appdata>/input_profile.dcp` (mirror `_input_icc_storage_path`). The persisted
+QSettings key is `import/input_dcp_path`; on startup the saved DCP is restored if
+present (and clears any saved ICC, since they're exclusive). Generated camera
+DCPs are saved to the same per-user `camera_profiles/` folder the ICC wizard
+uses.
+
+## 5. Processing / math (in `dcp_profile.py`)
+
+### 5.1 IFD parsing (`parse_dcp_bytes`)
+- Read `byte_order` from bytes 0:2 → struct prefix `<`/`>`; validate magic `42`;
+  read IFD0 offset.
+- Read entry count, iterate 12-byte entries. A small `_read_values(tag_entry)`
+  resolves inline-vs-offset by `type_size × count`, slices the bytes, and unpacks
+  per type (`SRATIONAL` → `i32/i32` pairs → float; `RATIONAL` → `u32/u32`;
+  `FLOAT` → `f`; `SHORT`/`LONG` → int; `ASCII` → NUL-trimmed str). All with the
+  header endianness.
+- Assemble matrices as `(3,3)` row-major (DNG stores row-major,
+  count `3×planes`). Defaults: `CameraCalibration*` → I₃, `AnalogBalance` → ones,
+  `illuminant_1` → 21 (D65) if absent.
+- `DcpError` on: bad byte-order/magic, truncated IFD, an offset past EOF, a
+  matrix tag whose count ≠ 9, or no `ColorMatrix1` (a profile with no CM1 and no
+  ForwardMatrix is unusable).
+- HueSatMap/LookTable: reshape `data` to `(hueDiv, satDiv, valDiv, 3)` per the
+  DNG ordering (value fastest). Validate `len == 3·∏dims`.
+
+### 5.2 As-shot white balance
+`as_shot_wb` is the length-3 camera-native neutral *multiplier*
+(`m = [mR, mG, mB]`, normalised so `min(m)=1` or `mG=1`, matching DNG's
+"multiply raw by these to neutralise"). Threaded from
+`raw.camera_whitebalance[:3]` (replace a `0` `G` with `1.0`). Apply
+`d_wb = clip(d · m, 0, 1)` on normalised camera RGB `d = rgb_u16/65535`.
+(Adobe applies WB *before* the ForwardMatrix; ForwardMatrix is defined on the
+white-balanced image — §3.5.)
+
+### 5.3 Deriving the working CCT (dual-illuminant only)
+The as-shot neutral in *camera* space is `n = 1/m` (the camera RGB that WB maps
+to grey). To pick the interpolation weight we need its CCT. Use the
+**single-step approximation** Adobe's reference uses for our purposes:
+- Map `n` to XYZ with each illuminant's `ColorMatrix` inverse:
+  `XYZ_i = inv(ColorMatrix_i) · n`; convert to xy; compute CCT via
+  McCamy's approximation `CCT = 449·t³ + 3525·t² + 6823.3·t + 5520.33`,
+  `t = (x − 0.3320)/(0.1858 − y)`.
+- Average the two estimates (or iterate once) → `T`. This only chooses the
+  blend weight; small CCT error ⇒ negligible matrix error. With one illuminant,
+  skip entirely (`w=1`).
+
+### 5.4 Matrix interpolation & forward map
+```
+inv = lambda T: 1e6 / T
+w = clip((inv(T) - inv(T2)) / (inv(T1) - inv(T2)), 0, 1)   # 1.0 if single-illuminant
+FM = w·FM1 + (1-w)·FM2        # if forward matrices present
+CC = w·CC1 + (1-w)·CC2
+AB = diag(analog_balance)
+```
+**Forward path (preferred — ForwardMatrix present):**
+```
+XYZ_D50 = FM · inv(CC · AB) · d_wb
+```
+(`ForwardMatrix` already targets D50, so no further adaptation.) In the common
+case `CC=I`, `AB=I` this is just `XYZ_D50 = FM · d_wb`.
+
+**Fallback (no ForwardMatrix):** invert the (interpolated) `ColorMatrix`, which
+maps XYZ(at the calibration illuminant's adaptation) → camera RGB, and apply it
+to the **un-white-balanced** camera RGB, then Bradford-adapt that illuminant's
+white to D50:
+```
+CM = w·CM1 + (1-w)·CM2
+XYZ_ill = inv(CM · AB) · d            # d = unbalanced normalised camera RGB
+XYZ_D50 = Bradford(white_ill -> D50) · XYZ_ill
+```
+where `white_ill` is the chosen illuminant's XYZ (from `ILLUMINANT_CCT` →
+daylight/blackbody xy → XYZ). Bradford reuses
+`color_management.M_BRADFORD_*`. This fallback is colorimetrically weaker (no
+WB-aware forward map) but valid for matrix-only DCPs without a ForwardMatrix.
+
+### 5.5 Optional "look" stage (only when `apply_look=True`)
+Operate on `XYZ_D50`:
+1. **HueSatMap** (interpolated by `w`): `XYZ_D50 → linear ProPhoto (D50)`
+   (`color_management.M_XYZ2PROPHOTO`), → HSV, trilinear table lookup at
+   `(h, s, v_enc)` (`v_enc` = `srgb_encode(v)` if `hsm_encoding==1` else `v`),
+   apply `h+=Δh, s*=sScale, v*=vScale`, → RGB → XYZ_D50.
+2. **LookTable**: same operator with `look_data`/`look_encoding`.
+3. **ProfileToneCurve**: build a monotone LUT from the `(x,y)` control points
+   (reuse the Fritsch–Carlson interpolation already specced for curves), apply on
+   the ProPhoto-encoded value channel (Adobe applies the tone curve on the RGB
+   channels in the profile's working space). For the negative pipeline this is
+   tone, so it is **off by default**.
+
+### 5.6 Output: linear Adobe RGB (load-bearing)
+Final step for **all** paths (matrices-only and look):
+```
+adobe_lin = M_XYZ_D50_2_ADOBE · XYZ_D50          # reuse color_management constant
+out_u16 = rint(clip(adobe_lin, 0, 1) · 65535)
+```
+This is the **exact** space the no-ICC negative decode and `InputProfile.apply`
+produce (linear Adobe RGB, **no sRGB OETF**), so the density inversion
+(`-log10(value/full)`) reads consistent linear data. Emitting gamma-encoded data
+here would cast the converted negative (the same hazard documented on
+`InputProfile.apply`).
+
+### 5.7 Look vs colorimetric — recommendation
+**Default = colorimetric (matrices only).** HueSatMap/LookTable/ToneCurve are
+Adobe's *subjective camera look* (skin-tone tweaks, film-like tone), authored for
+positive rendering. For a negative scan FreeCCR wants a *faithful* device→XYZ
+map; the look tables would bend hues and tone *before* inversion, fighting the
+v0.2.3 cast-balance and reintroducing exactly the kind of tone-warping the parked
+density experiment showed is fragile (see `CLAUDE.md`). So:
+- `apply_look=False` by default; a **"Apply Adobe look tables"** checkbox in the
+  Load-DCP confirmation (and persisted per-DCP) enables them for users who
+  deliberately want the camera-maker look.
+- `BaselineExposureOffset`/`DefaultBlackRender` are parsed for display but never
+  applied — tone is owned by the negative pipeline + sliders.
+
+### 5.8 GENERATE — `build_camera_dcp(fit, name, illuminant=23, wb=None)`
+The IT8 fit gives `M`: camera-native device RGB[0,1] → XYZ D50 (Y≈1), already
+D50-pinned and WB-folded-in (`it8_profile.fit_camera_matrix` §5.4). A DCP's
+**ForwardMatrix is defined on white-balanced camera RGB**, so:
+1. **Derive the WB the DCP assumes.** The camera neutral is the camera RGB that
+   maps to D50 grey: `n = inv(M) · D50_XYZ`; the DCP WB multiplier is
+   `m = n.max()/n` (so `m·n` is equal-RGB). `AsShotNeutral = n/n.max()`.
+2. **ForwardMatrix** = `M · diag(1/m)` — i.e. `M` re-expressed to consume the
+   **white-balanced** camera RGB `d_wb = m·d` (`FM·d_wb = M·diag(1/m)·m·d = M·d`).
+   Stored as `ForwardMatrix1` (SRATIONAL, count 9, row-major). `CameraCalibration1`
+   and `AnalogBalance` are omitted (⇒ identity), so apply reduces to `XYZ=FM·d_wb`,
+   exactly reproducing the ICC.
+3. **ColorMatrix1** (required) = chromatic-adaptation-aware inverse mapping
+   XYZ(at the calibration illuminant) → camera-native reference RGB:
+   `CM = inv( M · diag(1/m) ) · Bradford(D50 -> white_ill)`. (`CM·XYZ_ill` gives
+   the WB camera RGB; for a single-illuminant D50 profile `white_ill = D50` so the
+   Bradford term is I and `CM = inv(FM)`.) This satisfies the DNG requirement that
+   a profile carry a `ColorMatrix1` even when a ForwardMatrix is present.
+4. **Required tag set** for a minimal valid matrix DCP (Adobe):
+   `ProfileName` (50936, ASCII), `CalibrationIlluminant1` (50778, SHORT — default
+   23=D50, or the wizard's chosen light), `ColorMatrix1` (50721, SRATIONAL×9),
+   `ForwardMatrix1` (50964, SRATIONAL×9). Also write `ProfileEmbedPolicy`
+   (50941 = 1, "allow copying without restriction") and `AsShotNeutral`-free (DCP
+   carries no as-shot data; it's a profile not a raw). **Single-illuminant only**
+   — a dual-illuminant DCP needs two charts shot under two lights (out of scope,
+   §2). Note this in the wizard.
+5. **Write the IFD** (`_build_dcp_bytes`): little-endian (`II`), magic 42, IFD0 at
+   offset 8; tags **sorted ascending** (TIFF requirement); inline values for
+   `SHORT`/`LONG`/short `ASCII` ≤ 4 B, else appended to the data region (offsets
+   4-byte aligned); SRATIONAL matrices encoded as `i32` num/den via a
+   `_to_srational(x)` (denominator `10000` or a reduced fraction). Mirrors the
+   `build_matrix_shaper_icc` byte-layout idiom.
+
+## 6. Integration points
+
+### 6.1 `read_image` (`ccr_image.py`)
+Camera-native decode is already chosen whenever a profile is in play. Generalise:
+```python
+def _camera_profile_will_apply(self) -> bool:
+    return (color_management.get_active_input_profile() is not None
+            or color_management.get_active_dcp_profile() is not None)
+# icc_device_space = (not apply_input_icc or self._camera_profile_will_apply())
+```
+The DCP needs the **as-shot WB**, which only exists in the RAW branch
+(`raw.camera_whitebalance`). Capture it inside the `with rawpy.imread(...)` block
+(`wb = np.asarray(raw.camera_whitebalance[:3], float)`, replace 0→1) and apply:
+```python
+# replaces the single self._apply_input_icc(rgb) tail in the RAW branch
+if positive_decode or not apply_input_icc:
+    return rgb
+dcp = color_management.get_active_dcp_profile()
+if dcp is not None:
+    return self._apply_input_dcp(rgb, wb)        # new: dcp_profile.apply_dcp(...)
+return self._apply_input_icc(rgb)
+```
+`_apply_input_dcp(arr, wb)` mirrors `_apply_input_icc` (try/except → log + return
+input on failure, no-op when no DCP). **Non-RAW files have no as-shot WB**; a DCP
+is a camera-raw profile, so on the non-RAW path `_apply_input_dcp` is called with
+`as_shot_wb=None` and `apply_dcp` falls back to `m=ones` (the profile still maps
+device→Adobe, just unbalanced — acceptable, and rare; surfaced as a warning when
+a DCP is active and a non-RAW image is loaded).
+
+`reprocess_all_for_input_icc_change` already full-resets every image; the DCP
+set/clear reuses it (decode changes ⇒ full reset), so the parked-conversion
+hazard is handled identically.
+
+### 6.2 Backend (`ccr_backend.py`)
+`set_input_dcp(src_path)` parses (`dcp_profile.parse_dcp`, raising `DcpError`
+before mutating), copies to `<appdata>/input_profile.dcp`, calls
+`color_management.set_active_dcp_profile(profile)` **and**
+`set_active_input_profile(None)` + clears the ICC storage (exclusivity),
+sets `input_dcp_path`/`input_dcp_name = profile.name`. `clear_input_dcp` and
+`load_input_dcp_from_storage` mirror the ICC versions. Symmetrically,
+`set_input_icc` clears the active DCP.
+
+### 6.3 Mutual exclusivity & menu
+The File menu shows both "Set Input ICC Profile…" and "Load DCP Profile…"; the
+active one is reflected in its label (`_refresh_input_icc_menu` generalised to
+show whichever of ICC/DCP is active, and both Clear actions). Setting either
+clears the other (a single global "input colour transform" slot with two
+possible kinds). Startup restore prefers whichever path is persisted (ICC and
+DCP keys are never both set because set-one-clears-other also clears the other's
+QSettings key).
+
+### 6.4 Reuse, not reinvent
+- Binary IO idioms (`struct`, fixed-point, IFD/offset table) ⇐ pattern of
+  `build_matrix_shaper_icc` / `_read_tag_table` in `color_management.py`.
+- `M_XYZ_D50_2_ADOBE`, `M_XYZ2PROPHOTO`, `M_BRADFORD_*`, `D50_XYZ`,
+  `srgb_encode` ⇐ `color_management.py` (the apply output + look encodings).
+- `xyz_to_lab`, `delta_e_2000`, monotone-curve LUT ⇐ `it8_profile.py` /
+  `ccr_processor.build_channel_lut` (tone curve + tests).
+- The reprocess/persist/menu plumbing ⇐ the existing input-ICC flow
+  (`_apply_input_icc_path`, `reprocess_all_for_input_icc_change`).
+- Unicode paths ⇐ `normalize_unicode_path`/`validate_unicode_path` on the `.dcp`
+  load + save paths.
+
+## 7. UX
+
+**Consume.** `File ▸ Load DCP Profile…` → file picker (`*.dcp`). On load: parse,
+show a small confirmation (profile name, single/dual-illuminant, whether it has a
+ForwardMatrix, and whether HueSatMap/LookTable/ToneCurve are present), with an
+**"Apply Adobe look tables"** checkbox (default **off**, §5.7). Accept →
+`set_input_dcp` + reprocess (reuses the input-ICC progress/reset machinery).
+A `DcpError` shows a friendly message (mirrors `UnsupportedICCError` handling).
+If a DCP is set while an ICC is active (or vice-versa), a hint notes the other
+was cleared. A warning hint appears if a DCP is active and a **non-RAW** image is
+loaded (no as-shot WB).
+
+**Generate.** The IT8 wizard's Step 5 (Save/apply) "Save profile" dialog gains a
+file-type selector **"ICC profile (*.icc)"** / **"DNG camera profile (*.dcp)"**.
+Choosing `.dcp` writes `build_camera_dcp(fit, name, illuminant=<the wizard's
+illuminant choice mapped to a LightSource enum>)`. A note states the DCP is
+**single-illuminant** (valid under the shot light) and that **"Set as profile
+now"** activates it via the DCP slot (clearing any active ICC). Default save name
+`Camera <illuminant> <date>.dcp`.
+
+## 8. Test plan
+
+Unit (`tests/test_dcp_profile.py`):
+- **Build→parse round-trip (foundational)**: construct a `.dcp` in-test via
+  `build_camera_dcp` from a known `M_true`; `parse_dcp_bytes` recovers
+  `ForwardMatrix1` ≈ `M·diag(1/m)`, `ColorMatrix1` ≈ `inv(M·diag(1/m))`,
+  `illuminant_1`, and `name`; matrices within tolerance of the SRATIONAL
+  quantisation.
+- **Endianness**: write the same synthetic IFD as `II` and `MM` (a tiny manual
+  byte-builder in the test, or byte-swap the generated one); both parse to equal
+  matrices/illuminants.
+- **SRATIONAL decode**: a tag with known num/den pairs decodes to the expected
+  floats (incl. negative values and the inline-vs-offset boundary at count×8>4).
+- **Inline vs offset**: a `SHORT` `CalibrationIlluminant` (inline) and a
+  `LONG[3]` dims (offset) both resolve correctly.
+- **Dual-illuminant interpolation**: a `DcpProfile` with FM1/FM2 and
+  illum1=A(17)/illum2=D65(21); at `T=2856`→`w≈1` (FM≈FM1), at `T=6504`→`w≈0`
+  (FM≈FM2), at a mid mired → the exact `w` from the §3.4 formula; assert the
+  blended matrix equals `w·FM1+(1-w)·FM2`.
+- **ForwardMatrix path vs ColorMatrix fallback**: a profile **with** FM maps a
+  neutral camera value (post-WB equal-RGB) to D50 chromaticity; the **same**
+  profile with FM removed uses `inv(CM)` + Bradford and still lands near-neutral
+  (looser tolerance). Assert both produce linear-Adobe output (no OETF: a 50%
+  linear grey stays ~mid, not sRGB-bumped).
+- **Neutral → neutral**: feeding the camera neutral `n` (so `m·n` is grey) with
+  `as_shot_wb=m` yields equal-RGB linear Adobe output (a*,b* ≈ 0 via
+  `xyz_to_lab`).
+- **Synthetic-camera round-trip (key)**: pick `M_true`; synthesise camera-native
+  RGB for the IT8 reference patches via `inv(M_true)`; `build_camera_dcp` →
+  `parse_dcp_bytes` → `apply_dcp(as_shot_wb=derived m)`; converting the result
+  back through `inv(M_XYZ_D50_2_ADOBE)` to XYZ and to Lab gives **avg ΔE2000 ≈
+  0** vs the reference (the DCP reproduces the chart, parallel to the ICC
+  `test_fit_synthetic_roundtrip`).
+- **Output space parity**: `apply_dcp` (matrices-only) and
+  `InputProfile.apply` of `build_camera_icc(same fit)` produce **near-identical**
+  linear-Adobe arrays for an unbalanced neutral input (pins the two GENERATE
+  paths together, like `test_fit_and_apply_decode_spaces_are_identical`).
+- **Look tables**: a HueSatMap with a single non-identity cell shifts hue/sat as
+  expected when `apply_look=True`, and is a no-op when `apply_look=False`; an
+  identity table is a no-op either way.
+- **Errors**: truncated header, bad byte-order, missing `ColorMatrix1` &
+  ForwardMatrix, matrix count≠9, offset past EOF → `DcpError`.
+
+Manual:
+- Load a real Adobe `.dcp` for a camera FreeCCR can decode; convert a negative;
+  compare colorimetric-only vs look-on; verify no cast (linear-Adobe contract).
+- Generate `.dcp` from an IT8 shot, "apply now", confirm it reprocesses and
+  re-loads on restart; confirm setting a DCP clears an active ICC (and vice
+  versa); non-RAW image while DCP active shows the WB warning.
+
+## 9. Risks & mitigations
+- **Wrong tag id/type** → all load-bearing ids/types verified against the Adobe
+  DNG Spec 1.4–1.6 (Sources); the build→parse round-trip test is the regression
+  guard.
+- **As-shot WB plumbing** (only in the RAW branch) → captured inside
+  `rawpy.imread`; non-RAW path uses `m=ones` with a UI warning. A `0` green
+  multiplier from `camera_whitebalance` is sanitised to `1.0`.
+- **Dual-illuminant CCT estimate** is approximate → it only selects the blend
+  weight; matrix error from a small CCT miss is negligible, and most user DCPs are
+  single-illuminant. Single-illuminant short-circuits the estimate entirely.
+- **Look tables warping the negative** → off by default; documented as subjective
+  (§5.7), behind an explicit checkbox.
+- **ForwardMatrix absent** → documented fallback via `inv(ColorMatrix)` +
+  Bradford; weaker but valid, and tested.
+- **Non-RAW + DCP** → a DCP is a camera-raw profile; surfaced as a warning, applied
+  unbalanced rather than crashing.
+- **ICC/DCP both persisted** → set-one-clears-other (state + QSettings) makes the
+  exclusive-slot invariant impossible to violate across restarts.
+
+---
+
+### Sources (DNG tag verification)
+- Adobe **Digital Negative (DNG) Specification 1.6.0.0** (Dec 2021) and 1.4.0.0
+  — camera-profile tags, illuminant enum, HueSatMap/LookTable/ToneCurve layout,
+  mired-space dual-illuminant interpolation.
+- `colour-hdri` `colour_hdri.models.dng` — interpolation in mired space; A≈2856 K
+  / D65≈6504 K calibration endpoints; XYZ↔camera-neutral CCT derivation.
+- `rawler` `DngTag` enum and `tiny_dng_loader` — confirmed decimal tag ids/types
+  (ColorMatrix1=50721, ColorMatrix2=50722, CameraCalibration1/2=50723/50724,
+  ReductionMatrix1/2=50725/50726, AnalogBalance=50727, AsShotNeutral=50728,
+  CalibrationIlluminant1/2=50778/50779, ProfileName=50936,
+  ProfileHueSatMapDims=50937, ProfileHueSatMapData1/2=50938/50939,
+  ProfileToneCurve=50940, ProfileEmbedPolicy=50941, ProfileLookTableDims=50981,
+  ProfileLookTableData=50982, ProfileHueSatMapEncoding=51107,
+  ProfileLookTableEncoding=51108, BaselineExposureOffset=51109,
+  DefaultBlackRender=51110, ForwardMatrix1/2=50964/50965).

--- a/spec/it8-camera-profile.md
+++ b/spec/it8-camera-profile.md
@@ -569,3 +569,50 @@ so:
   explanatory note) instead of silently mis-mapping the next card.
 - **The window floor is clamped to the screen** (`availableGeometry`) so the
   1024×700 minimum can never push the Back/Next row off a small display.
+
+### 12.5 Canonical camera-profiling decode (researched)
+
+The standard device space for **all** camera colour-characterization profiles —
+matrix ICC, cLUT ICC, and Adobe DCP — is **camera-native, demosaiced, linear,
+16-bit, no auto-brightness, no clipping in the patches**. The reference is Anders
+Torger's DCamProf recipe `dcraw -v -r 1 1 1 1 -o 0 -H 0 -T -6 -W -g 1 1`
+("16-bit linear TIFF without white balancing"). Sources: torger.se/DCamProf, the
+dcraw(1) manpage, the Adobe DNG spec, rawpy/LibRaw docs, ninedegreesbelow (Elle
+Stone), RawPedia.
+
+rawpy mapping (FreeCCR's `_raw_color_postprocess_kwargs(no_icc_default=False)`):
+
+| dcraw | meaning | rawpy |
+|-------|---------|-------|
+| `-o 0` | camera-native (no camera matrix / working space) | `output_color=ColorSpace.raw` |
+| `-g 1 1` | linear gamma 1.0 | `gamma=(1, 1)` |
+| `-6` | 16-bit | `output_bps=16` |
+| `-W` | fixed white level (no auto-bright) | `no_auto_bright=True` + `no_auto_scale=True` + manual `×65535/white_level` |
+| `-r 1 1 1 1` | unbalanced (unity WB) | `use_camera_wb=False`, `use_auto_wb=False` |
+| `-H 0` | no highlight recovery | (clip rejection drops blown patches in the fit) |
+
+**Why camera-native:** `-o 0` outputs sensor RGB *before* `convert_to_rgb()` (the
+camera→XYZ/working-space matrix stage). Fitting on Adobe RGB would make the matrix
+characterize Adobe, not the sensor, and — critically — a **DCP's
+ColorMatrix/ForwardMatrix operate on camera-native raw**, so a working-space decode
+makes DCP application impossible. This is why the decode is camera-native, not the
+v0.5/early-v0.6 Adobe-RGB-for-ICC decode.
+
+**White balance — the one divergence (researched):**
+- **DCP must be UNBALANCED**: it carries WB derivation (the `ColorMatrix` relates
+  raw RGB balance ↔ illuminant CCT) and applies the as-shot WB at render time via
+  the `ForwardMatrix`(+LUT) on the white-balanced image.
+- **Matrix/cLUT ICC is normally white-balanced at decode** (no render-time WB
+  stage) — *but may be fit unbalanced with WB baked into the matrix coefficients.*
+  **FreeCCR does the latter**: the decode is unbalanced (no WB) and
+  `fit_camera_matrix` folds the per-channel `gains` into the stored matrix
+  (§5.4 step 5). So FreeCCR's single unbalanced camera-native decode is the correct
+  shared base for both the matrix ICC **and** a future DCP.
+
+**Implementation:** `read_image` selects the camera-native path
+(`no_icc_default=False`) whenever an input ICC is active *or* the bare-device
+profiling decode is requested (`apply_input_icc=False`), and the Adobe RGB +
+auto-scale default only for a plain unprofiled negative. `decode_target` (the IT8
+fit) and the runtime ICC-apply decode therefore hit the **same** kwargs —
+`test_fit_and_apply_decode_spaces_are_identical` pins this so the two paths can't
+silently diverge.

--- a/spec/it8-camera-profile.md
+++ b/spec/it8-camera-profile.md
@@ -490,3 +490,82 @@ scales to the grid density (`ncols`/`nrows`).
 The full path (CxF parse → un-mirror → 12×24 block A49–L72 → auto-neutral fit)
 on the user's LaserSoft shot yields **avg ΔE2000 ≈ 1.8** (232 of 288 patches;
 dark patches clipped at the low end were rejected).
+
+## 12. Refinement (v3) — usability: bigger window, invalid-patch feedback, multi-card targets
+
+Driven by three field-usability gaps: the wizard was too cramped to place corners
+accurately, the "valid patches: N/M" read-out never said *which* patches were
+bad, and large IT8 targets that ship as **several physical cards** (the patch grid
+split across panels, e.g. columns 1–24 / 25–48 / 49–72) could only contribute one
+card's worth of patches to a fit.
+
+### 12.1 Larger window
+`IT8ProfileDialog` minimum size → **1024×700** (initial 1120×780) and
+`IT8PatchLocator` minimum → **820×480**, so the locate page — the only page whose
+accuracy depends on screen real estate — gives the patch overlay enough room to
+place corners precisely. No layout restructuring; the locator already expands with
+a stretch factor.
+
+### 12.2 Invalid-patch feedback
+**Validity criterion fix.** The old test flagged a patch invalid when >2 % of its
+window pixels were ≤0.5 % of full scale **or** ≥99.5 %. On raw-linear device data
+the low-end half was wrong: a **saturated hue legitimately reads near-zero in its
+complementary channels** (a vivid red → green/blue ≈ 0, a vivid blue → red ≈ 0)
+and **dense film patches read low**, so the most informative patches for the
+matrix fit were all being dropped (a real ISO 12641-2 Provia shot showed only
+217/288 valid, with every saturated red/blue/dark patch reddened). A low linear
+value is *real signal*, not lost information. `sample_patches` now flags a patch
+only when its colour truly can't be trusted:
+- **highlight-clipped** — any channel has >2 % of pixels at the ceiling
+  (`clip_hi`), judged **per channel** so a single blown channel is caught (and
+  doesn't corrupt that primary's fit) rather than diluted across three;
+- **black-crushed** — even the brightest channel's trimmed mean is ≤ `black_floor`
+  (~0.08 % of full), i.e. no signal at all;
+- **out of frame**.
+
+The locate page now **surfaces which ones**:
+- `IT8PatchLocator.set_invalid_ids(ids)` stores the dialog-computed invalid id set;
+  `paintEvent` draws those dots (and any off-frame dot) **red and enlarged** (the
+  prior code only reddened off-frame dots, never clipped-but-in-frame ones).
+- `_update_locate_status` lists the invalid ids inline (first 10 + "(+N more)")
+  with the **full list in the label's tooltip**, instead of only a count. The set is
+  recomputed on every `changed` (i.e. on drag-release / layout change), keeping the
+  red overlay in sync with the live "N/M valid" read-out.
+
+### 12.3 Multi-card targets (accumulate samples across up to 3 images)
+A target whose grid is split across cards is mapped one card per image, the
+**samples accumulating** into a single fit:
+- After locating a **block-mode** card, the wizard **asks (at most twice → up to 3
+  cards total)** "Map another image?". On *yes* it browses + decodes the next card,
+  loads it into the locator, and **auto-advances the block id range by the block's
+  own width** (`it8.next_block_ids`, e.g. `A1–L24` → `A25–L48` → `A49–L72`, clamped
+  to the reference's max column). On *no* it fits.
+- `it8.merge_samples([...])` (new, pure) unions the per-card sample dicts; on the
+  rare overlapping-id collision a **valid** sample wins over an invalid one.
+- The fit consumes the merged set (`_all_samples`); Step 4 notes "combined from N
+  images" when N>1. A "Card N of up to 3" banner shows on the locate page.
+- **Classic** (single 12×22 + GS strip) targets are one physical card, so the
+  prompt is **gated to block mode** — classic users never see it.
+- New pure-logic helpers live in `core.it8_profile` (`merge_samples`,
+  `next_block_ids`) and are unit-tested; the dialog stays thin UI.
+
+### 12.4 Multi-card session robustness (from adversarial review)
+The accumulation state (`_mapped_cards` / `_all_samples` / `_n_images` / `_fit`)
+belongs to the **(target shot, reference)** pair the cards were sampled against,
+so:
+- **`_reset_card_accum()` is called from `_set_target` and `_browse_ref`** —
+  picking a different target or a different batch reference (incl. via *Back*)
+  discards any cards mapped against the abandoned inputs and re-seeds the block id
+  range from the new reference's extent. Without this, stale cards from an
+  abandoned session would silently contaminate the fit (and falsely report
+  "combined from N images").
+- **`_should_ask_more()` is additionally gated on `self._fit is None`** so that
+  *Back-from-build → Next* simply re-runs the fit rather than re-popping the "Map
+  another?" prompt. A genuine new card is added during the forward mapping flow,
+  before any fit exists.
+- **`_advance_block_ids` refuses a degenerate shift** — if the previous card
+  already reached the chart's edge, the auto-advance would collapse to a single
+  column or overlap, so it leaves the ids for the user to set by hand (with an
+  explanatory note) instead of silently mis-mapping the next card.
+- **The window floor is clamped to the screen** (`availableGeometry`) so the
+  1024×700 minimum can never push the Back/Next row off a small display.

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -45,6 +45,9 @@ class CCRBackend:
         # color_management's module-level holder; these mirror it for the UI.
         self.input_icc_path: Optional[str] = None
         self.input_icc_name: Optional[str] = None
+        # Active DCP (DNG camera profile) — mutually exclusive with the input ICC.
+        self.input_dcp_path: Optional[str] = None
+        self.input_dcp_name: Optional[str] = None
         # Catalog entries of ACTUAL images removed from the list this
         # session: {file_path: {"signature": sig, "entries": {name: state}}}.
         # Removal must not lose their stored edits, so saves merge these
@@ -603,6 +606,7 @@ class CCRBackend:
                 != os.path.normcase(os.path.abspath(storage))):
             shutil.copyfile(src_path, storage)
         color_management.set_active_input_profile(profile)
+        self.clear_input_dcp()                       # ICC and DCP are exclusive
         self.input_icc_path = storage
         self.input_icc_name = profile.description or os.path.basename(src_path)
         return self.input_icc_name
@@ -629,6 +633,53 @@ class CCRBackend:
         self.input_icc_name = None
         try:
             storage = self._input_icc_storage_path()
+            if os.path.exists(storage):
+                os.remove(storage)
+        except OSError:
+            pass
+
+    # --- DCP (DNG camera profile) — mirrors the input-ICC trio, exclusive ----
+    def _input_dcp_storage_path(self) -> str:
+        from core.catalog import default_catalog_path
+        return os.path.join(os.path.dirname(default_catalog_path()), "input_profile.dcp")
+
+    def set_input_dcp(self, src_path: str) -> str:
+        """Assign a global DCP from src_path (parsed first, raising DcpError on
+        failure). Clears any active ICC (exclusive slot), copies to the working
+        copy, activates it. Returns the profile name."""
+        from core import color_management, dcp_profile
+        import shutil
+        profile = dcp_profile.parse_dcp(src_path)    # parse before mutating
+        storage = self._input_dcp_storage_path()
+        if (os.path.normcase(os.path.abspath(src_path))
+                != os.path.normcase(os.path.abspath(storage))):
+            shutil.copyfile(src_path, storage)
+        color_management.set_active_dcp_profile(profile)
+        self.clear_input_icc()                       # DCP and ICC are exclusive
+        self.input_dcp_path = storage
+        self.input_dcp_name = profile.name or os.path.basename(src_path)
+        return self.input_dcp_name
+
+    def load_input_dcp_from_storage(self, storage_path: str) -> Optional[str]:
+        from core import color_management, dcp_profile
+        try:
+            profile = dcp_profile.parse_dcp(storage_path)
+        except Exception as e:
+            print(f"Could not load saved DCP {storage_path}: {e}")
+            return None
+        color_management.set_active_dcp_profile(profile)
+        self.input_dcp_path = storage_path
+        self.input_dcp_name = profile.name or os.path.basename(storage_path)
+        return self.input_dcp_name
+
+    def clear_input_dcp(self) -> None:
+        """Remove the global DCP and its working copy."""
+        from core import color_management
+        color_management.set_active_dcp_profile(None)
+        self.input_dcp_path = None
+        self.input_dcp_name = None
+        try:
+            storage = self._input_dcp_storage_path()
             if os.path.exists(storage):
                 os.remove(storage)
         except OSError:

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -270,10 +270,11 @@ class CCRImage:
 
     def _apply_input_icc(self, arr: Optional[np.ndarray]) -> Optional[np.ndarray]:
         """Convert a freshly-decoded scan from the globally-assigned input ICC
-        profile into the working sRGB encoding, before any conversion or
-        adjustment. No-op when no input profile is set. Applied inside
-        read_image so preview, hi-res zoom, and export all inherit it
-        identically (resolution-independent point operation)."""
+        profile into the working LINEAR Adobe RGB space (the same space the
+        no-ICC decode produces, so the density-based inversion sees consistent
+        linear data), before any conversion or adjustment. No-op when no input
+        profile is set. Applied inside read_image so preview, hi-res zoom, and
+        export all inherit it identically (resolution-independent point op)."""
         if arr is None:
             return arr
         profile = color_management.get_active_input_profile()

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -287,13 +287,29 @@ class CCRImage:
             return arr
 
     def _input_icc_will_apply(self) -> bool:
-        """Whether read_image will burn an external input ICC into this scan —
-        i.e. a matrix-shaper input profile is active (mirrors _apply_input_icc's
-        guard). Drives the negative RAW decode: an ICC-corrected decode is raw
-        camera primaries with absolute sensor values (no_auto_scale=True + manual
-        white-level scaling); the no-ICC default decode is Adobe RGB,
-        rawpy-auto-scaled."""
-        return color_management.get_active_input_profile() is not None
+        """Whether read_image will burn an external camera profile into this scan
+        — an input ICC **or** a DCP is active (mirrors the apply guard). Drives the
+        negative RAW decode: a profiled decode is camera-native raw with absolute
+        sensor values (no_auto_scale=True + manual white-level scaling); the
+        unprofiled default decode is Adobe RGB, rawpy-auto-scaled."""
+        return (color_management.get_active_input_profile() is not None
+                or color_management.get_active_dcp_profile() is not None)
+
+    def _apply_input_dcp(self, arr, as_shot_wb) -> Optional[np.ndarray]:
+        """Burn the globally-active DCP into a freshly-decoded camera-native scan
+        (-> linear Adobe RGB), threading the as-shot WB. No-op when no DCP is set.
+        Mirrors _apply_input_icc; failures log and pass the input through."""
+        if arr is None:
+            return arr
+        profile = color_management.get_active_dcp_profile()
+        if profile is None:
+            return arr
+        try:
+            from core import dcp_profile
+            return dcp_profile.apply_dcp(profile, arr, as_shot_wb=as_shot_wb)
+        except Exception as e:
+            logging.warning(f"DCP profile could not be applied: {e}")
+            return arr
 
     @staticmethod
     def _positive_mode_active() -> bool:
@@ -403,6 +419,12 @@ class CCRImage:
                 with rawpy.imread(file_path) as raw:
                     # Capture sensor ceiling before postprocess (e.g. 16383 for 14-bit)
                     white_level = raw.white_level
+                    # As-shot white-balance multipliers (for the DCP apply path,
+                    # which renders WB at apply time). RGB channels only.
+                    try:
+                        as_shot_wb = np.asarray(raw.camera_whitebalance[:3], dtype=float)
+                    except Exception:
+                        as_shot_wb = None
 
                     # Full processed output size, valid even when half_size=True.
                     # Kept LOCAL until after the (slow) postprocess: with a
@@ -457,14 +479,25 @@ class CCRImage:
                         elif rgb.shape[2] == 1:
                             rgb = np.repeat(rgb, 3, axis=2)
                     else:
-                        # Positive mode: decode as a normal sRGB photo. Negative
-                        # mode: ALWAYS the Adobe RGB + rawpy auto-scale (thr=0)
-                        # working decode. An active input ICC (incl. the IT8
-                        # camera profile) is applied on top afterwards, and IT8
-                        # profiling samples this same space with the ICC step
-                        # skipped (apply_input_icc=False) — so fit-space ==
-                        # apply-space.
-                        no_icc_default = True
+                        # Device space for the negative decode. Whenever an input
+                        # ICC is in play —
+                        #   • it is active and will be burned in now
+                        #     (_input_icc_will_apply), or
+                        #   • the caller wants the bare device RGB to FIT one on
+                        #     (IT8 profiling, apply_input_icc=False)
+                        # — decode in the CANONICAL camera-profiling space: raw
+                        # camera-native primaries (output_color=raw, no camera
+                        # matrix / no working-space conversion), linear gamma,
+                        # no_auto_bright, no white balance, no_auto_scale + manual
+                        # white-level scaling for fixed absolute sensor values.
+                        # This is the standard input for matrix/cLUT ICC and DCP
+                        # (`dcraw -o 0 -g 1 1 -W -r 1 1 1 1`, see
+                        # spec/it8-camera-profile.md §12.5), and makes fit-space ==
+                        # apply-space EXACTLY. A plain unprofiled negative keeps the
+                        # Adobe RGB + rawpy auto-scale camera-independent default.
+                        icc_device_space = (not apply_input_icc
+                                            or self._input_icc_will_apply())
+                        no_icc_default = not icc_device_space
                         rgb = raw.postprocess(
                             **self._raw_color_postprocess_kwargs(
                                 positive_decode, preview, no_icc_default))
@@ -494,13 +527,18 @@ class CCRImage:
                 
                 elapsed_time = time.time() - start_time
                 print(f"RAW processing completed in {elapsed_time:.3f} seconds")
-                # Burn in the global input ICC (if any) on the decoded scan,
-                # before negative conversion / adjustments. Skipped in positive
-                # mode (the decode is already a ready sRGB positive — the input
-                # ICC is a negative-scanning tool) and when the caller opted out
-                # (apply_input_icc=False, e.g. IT8 profiling wants bare device RGB).
-                if positive_decode or not apply_input_icc:
+                # Burn in the global camera profile (ICC or DCP, if any) on the
+                # decoded camera-native scan, before negative conversion. Skipped
+                # in positive mode (the decode is already a ready sRGB positive)
+                # and when the caller opted out (apply_input_icc=False, e.g. IT8
+                # profiling wants bare device RGB). A monochrome sensor has no
+                # colour to profile and is NOT decoded camera-native, so skip it
+                # too. A DCP (mutually exclusive with the ICC) renders the as-shot
+                # WB at apply time.
+                if positive_decode or not apply_input_icc or is_monochrome:
                     return rgb
+                if color_management.get_active_dcp_profile() is not None:
+                    return self._apply_input_dcp(rgb, as_shot_wb)
                 return self._apply_input_icc(rgb)
             except Exception as e:
                 logging.exception(f"Failed to read RAW image: {file_path}")
@@ -587,11 +625,13 @@ class CCRImage:
             self.original_full_size = (img.shape[0], img.shape[1])
             if max_long_side:
                 img = self.resize_image_to_max_pixel(img, max_long_side)
-            # Burn in the global input ICC (if any) before conversion/adjustments.
-            # Skipped in positive mode (treat the file as a ready sRGB positive)
-            # and when the caller opted out (apply_input_icc=False).
+            # Burn in the global camera profile (ICC or DCP) before conversion.
+            # Skipped in positive mode and when the caller opted out. A non-RAW
+            # file has no as-shot WB, so a DCP applies unbalanced (warned in the UI).
             if positive_mode or not apply_input_icc:
                 return img
+            if color_management.get_active_dcp_profile() is not None:
+                return self._apply_input_dcp(img, None)
             return self._apply_input_icc(img)
         
     def update_thumbnail_and_preview(self, thumbnail_size: int = 156, preview_size: int = 1080) -> None:

--- a/src/core/color_management.py
+++ b/src/core/color_management.py
@@ -95,6 +95,20 @@ _M_SRGB2PROPHOTO_F32 = M_SRGB2PROPHOTO.astype(np.float32)   # export math runs i
 # Combined XYZ(D50) -> linear sRGB(D65) (used by InputProfile to reach working space).
 M_XYZ_D50_2_SRGB = M_XYZ2SRGB @ M_BRADFORD_D50_D65
 
+# Adobe RGB (1998) primaries -> XYZ (D65); columns are the Adobe primaries.
+M_ADOBE2XYZ_D65 = np.array([
+    [0.5767309, 0.1855540, 0.1881852],
+    [0.2973769, 0.6273491, 0.0752741],
+    [0.0270343, 0.0706872, 0.9911085],
+], dtype=np.float64)
+M_XYZ2ADOBE_D65 = np.linalg.inv(M_ADOBE2XYZ_D65)            # XYZ(D65) -> linear Adobe
+# Combined XYZ(D50) -> LINEAR Adobe RGB. The negative pipeline's no-ICC decode is
+# linear Adobe RGB (output_color=Adobe, gamma=(1,1)) and the density-based
+# inversion reads -log10(value/full) assuming LINEAR input, so an input ICC must
+# land an image in this SAME linear-Adobe space (NOT sRGB-gamma-encoded) — else the
+# optical-density cast balance mis-reads every channel and casts the result.
+M_XYZ_D50_2_ADOBE = M_XYZ2ADOBE_D65 @ M_BRADFORD_D50_D65
+
 # D50 PCS white point (ICC reference illuminant).
 D50_XYZ = (0.9642, 1.0000, 0.8249)
 
@@ -378,7 +392,7 @@ class InputProfile:
     pixels into the working sRGB encoding."""
 
     def __init__(self, combined_matrix: np.ndarray, luts: list, desc: str):
-        self._matrix = combined_matrix.astype(np.float32)   # device-linRGB -> linear sRGB
+        self._matrix = combined_matrix.astype(np.float32)   # device-linRGB -> linear Adobe RGB
         # 3 device->linear LUTs, length 65536 so a uint16 value indexes directly.
         self._luts = [np.ascontiguousarray(l, dtype=np.float32) for l in luts]
         self.description = desc
@@ -398,7 +412,7 @@ class InputProfile:
         g = _parse_xyz(icc, tags[b'gXYZ'][0])
         b = _parse_xyz(icc, tags[b'bXYZ'][0])
         m_colorants = np.stack([r, g, b], axis=1)        # columns = primaries (XYZ D50)
-        combined = M_XYZ_D50_2_SRGB @ m_colorants        # device-linRGB -> linear sRGB
+        combined = M_XYZ_D50_2_ADOBE @ m_colorants       # device-linRGB -> linear Adobe RGB
         luts = [_parse_trc_to_lut(icc, tags[t][0])
                 for t in (b'rTRC', b'gTRC', b'bTRC')]
         desc = cls._read_desc(icc, tags)
@@ -418,13 +432,17 @@ class InputProfile:
         return ""
 
     def apply(self, rgb_u16: np.ndarray) -> np.ndarray:
-        """Convert HxWx3 uint16 device RGB into uint16 sRGB-encoded working RGB."""
+        """Convert HxWx3 uint16 device RGB into uint16 **linear Adobe RGB** — the
+        exact working space the no-ICC negative decode produces, so the
+        density-based inversion downstream (-log10(value/full)) reads consistent
+        LINEAR data. Emitting sRGB-gamma-encoded data here mis-feeds that optical
+        density and casts the converted image (severe green/blue shift)."""
         if rgb_u16.ndim != 3 or rgb_u16.shape[2] != 3 or rgb_u16.dtype != np.uint16:
             return rgb_u16
         # LUTs are length 65536, so a uint16 value indexes them directly.
         lin = np.empty(rgb_u16.shape, dtype=np.float32)
         for c in range(3):
             lin[..., c] = self._luts[c][rgb_u16[..., c]]
-        srgb_lin = lin @ self._matrix.T
-        out = srgb_encode(np.clip(srgb_lin, 0.0, 1.0))
+        adobe_lin = lin @ self._matrix.T                 # device -> linear Adobe RGB
+        out = np.clip(adobe_lin, 0.0, 1.0)               # stay linear (no sRGB OETF)
         return np.rint(out * 65535.0).astype(np.uint16)

--- a/src/core/color_management.py
+++ b/src/core/color_management.py
@@ -24,7 +24,8 @@ via tifffile tag 34675 and to parse + build a transform under littleCMS).
 from __future__ import annotations
 
 import struct
-from typing import Optional, Tuple
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -48,6 +49,21 @@ def set_active_input_profile(profile) -> None:
 
 def get_active_input_profile():
     return _active_input_profile
+
+
+# Global active DCP (DNG camera profile). Mutually exclusive with the input ICC
+# (a single "input colour transform" slot with two possible kinds). Stored
+# opaquely here so ccr_image can read it without importing dcp_profile/backend.
+_active_dcp_profile = None
+
+
+def set_active_dcp_profile(profile) -> None:
+    global _active_dcp_profile
+    _active_dcp_profile = profile
+
+
+def get_active_dcp_profile():
+    return _active_dcp_profile
 
 
 def load_input_profile(path: str) -> "InputProfile":
@@ -392,31 +408,53 @@ class InputProfile:
     pixels into the working sRGB encoding."""
 
     def __init__(self, combined_matrix: np.ndarray, luts: list, desc: str):
+        self._kind = "matrix"                               # "matrix" | "clut"
         self._matrix = combined_matrix.astype(np.float32)   # device-linRGB -> linear Adobe RGB
         # 3 device->linear LUTs, length 65536 so a uint16 value indexes directly.
         self._luts = [np.ascontiguousarray(l, dtype=np.float32) for l in luts]
+        self._clut: Optional["_CLUT"] = None
         self.description = desc
+
+    @classmethod
+    def _from_clut(cls, clut: "_CLUT", desc: str) -> "InputProfile":
+        """Build a LUT-based (cLUT / A2B) input profile — same apply contract
+        (device RGB -> linear Adobe RGB), interpolated through the CLUT."""
+        self = cls.__new__(cls)
+        self._kind = "clut"
+        self._matrix = None
+        self._luts = None
+        self._clut = clut
+        self.description = desc
+        return self
 
     @classmethod
     def from_bytes(cls, icc: bytes) -> "InputProfile":
         tags = _read_tag_table(icc)
         if icc[16:20] != b'RGB ':
             raise UnsupportedICCError("input profile is not an RGB profile")
+        # Matrix-shaper: colorant + TRC tags. Kept verbatim (byte-identical path).
         needed = [b'rXYZ', b'gXYZ', b'bXYZ', b'rTRC', b'gTRC', b'bTRC']
-        if any(t not in tags for t in needed):
-            # Missing colorant/TRC tags => LUT-based or otherwise unsupported.
-            raise UnsupportedICCError(
-                "only RGB matrix-shaper ICC profiles are supported "
-                "(LUT/cLUT/CMYK profiles are not)")
-        r = _parse_xyz(icc, tags[b'rXYZ'][0])
-        g = _parse_xyz(icc, tags[b'gXYZ'][0])
-        b = _parse_xyz(icc, tags[b'bXYZ'][0])
-        m_colorants = np.stack([r, g, b], axis=1)        # columns = primaries (XYZ D50)
-        combined = M_XYZ_D50_2_ADOBE @ m_colorants       # device-linRGB -> linear Adobe RGB
-        luts = [_parse_trc_to_lut(icc, tags[t][0])
-                for t in (b'rTRC', b'gTRC', b'bTRC')]
-        desc = cls._read_desc(icc, tags)
-        return cls(combined, luts, desc)
+        if all(t in tags for t in needed):
+            r = _parse_xyz(icc, tags[b'rXYZ'][0])
+            g = _parse_xyz(icc, tags[b'gXYZ'][0])
+            b = _parse_xyz(icc, tags[b'bXYZ'][0])
+            m_colorants = np.stack([r, g, b], axis=1)    # columns = primaries (XYZ D50)
+            combined = M_XYZ_D50_2_ADOBE @ m_colorants   # device-linRGB -> linear Adobe RGB
+            luts = [_parse_trc_to_lut(icc, tags[t][0])
+                    for t in (b'rTRC', b'gTRC', b'bTRC')]
+            return cls(combined, luts, cls._read_desc(icc, tags))
+        # LUT-based: an A2B0 (fall back A2B1) device->PCS cLUT in mft1/mft2/mAB.
+        a2b = next((t for t in (b'A2B0', b'A2B1') if t in tags), None)
+        if a2b is not None:
+            pcs = icc[20:24]
+            if pcs not in (b'XYZ ', b'Lab '):
+                raise UnsupportedICCError(f"unsupported PCS {pcs!r:s} (only XYZ/Lab)")
+            is_v4 = icc[8] >= 4                           # major version byte
+            clut = _parse_a2b(icc, tags[a2b][0], pcs, is_v4)
+            return cls._from_clut(clut, cls._read_desc(icc, tags))
+        raise UnsupportedICCError(
+            "only RGB matrix-shaper or A2B cLUT ICC profiles are supported "
+            "(CMYK / B2A-only profiles are not)")
 
     @staticmethod
     def _read_desc(icc: bytes, tags: dict) -> str:
@@ -439,6 +477,8 @@ class InputProfile:
         density and casts the converted image (severe green/blue shift)."""
         if rgb_u16.ndim != 3 or rgb_u16.shape[2] != 3 or rgb_u16.dtype != np.uint16:
             return rgb_u16
+        if self._kind == "clut":
+            return self._apply_clut(rgb_u16)
         # LUTs are length 65536, so a uint16 value indexes them directly.
         lin = np.empty(rgb_u16.shape, dtype=np.float32)
         for c in range(3):
@@ -446,3 +486,333 @@ class InputProfile:
         adobe_lin = lin @ self._matrix.T                 # device -> linear Adobe RGB
         out = np.clip(adobe_lin, 0.0, 1.0)               # stay linear (no sRGB OETF)
         return np.rint(out * 65535.0).astype(np.uint16)
+
+    def _apply_clut(self, rgb_u16: np.ndarray) -> np.ndarray:
+        """cLUT apply: device input curves -> tetrahedral CLUT interpolation ->
+        XYZ(D50) -> linear Adobe RGB. Same uint16 linear-Adobe output as the
+        matrix path, so the downstream density inversion is untouched."""
+        clut = self._clut
+        lin = np.empty(rgb_u16.shape, dtype=np.float32)
+        for c in range(3):                               # input curves (65536 LUTs)
+            lin[..., c] = clut.in_luts[c][rgb_u16[..., c]]
+        xyz = _clut_interp_tetra(lin, clut)              # (...,3) XYZ D50 (Y=1)
+        adobe_lin = xyz @ M_XYZ_D50_2_ADOBE.T            # -> linear Adobe RGB
+        out = np.clip(adobe_lin, 0.0, 1.0)               # stay linear (no sRGB OETF)
+        return np.rint(out * 65535.0).astype(np.uint16)
+
+
+# --------------------------------------------------------------------------- #
+# LUT-based (cLUT / A2B) ICC support — parse + interpolate. See
+# spec/clut-icc-support.md. Device->PCS only (A2B), PCS decoded to XYZ(D50, Y=1)
+# at parse time so apply() is a uniform gather+interpolate+matmul.
+# --------------------------------------------------------------------------- #
+
+_XYZ_ENC = 1.0 + 32767.0 / 32768.0          # ICC lut8/lut16 XYZ-number max (~1.99997)
+
+
+@dataclass
+class _CLUT:
+    grid: Tuple[int, ...]                    # per-axis grid points (len = n_in, == 3)
+    table: np.ndarray                        # (g0,g1,g2,3) XYZ D50 (Y=1), float32
+    in_luts: List[np.ndarray]                # 3 device->[0,1] LUTs, len 65536 (uint16 index)
+
+
+def _pcs_decode(v01: np.ndarray, pcs: bytes, is_v4: bool, eight_bit: bool) -> np.ndarray:
+    """Decode normalised [0,1] PCS grid values to XYZ(D50, Y=1)."""
+    v01 = np.asarray(v01, dtype=np.float64)
+    if pcs == b'XYZ ':
+        return v01 * _XYZ_ENC
+    # PCS Lab. v4 and 8-bit legacy use the plain scale; v2 16-bit legacy maps
+    # L*=100 to 0xFF00 (not 0xFFFF), hence the 65535/65280 correction.
+    scale = 1.0 if (is_v4 or eight_bit) else (65535.0 / 65280.0)
+    L = v01[..., 0] * 100.0 * scale
+    a = v01[..., 1] * 255.0 * scale - 128.0
+    b = v01[..., 2] * 255.0 * scale - 128.0
+    lab = np.stack([L, a, b], axis=-1)
+    from core.it8_profile import lab_to_xyz       # lazy: it8_profile imports us
+    return lab_to_xyz(lab) / 100.0                # D50 white, Y=1
+
+
+def _clut_interp_trilinear(d01: np.ndarray, clut: "_CLUT") -> np.ndarray:
+    """Trilinear interpolation over the 3-D CLUT grid (reference / fallback)."""
+    table = clut.table
+    dims = np.array(table.shape[:3])
+    shape = d01.shape[:-1]
+    pts = np.asarray(d01, dtype=np.float32).reshape(-1, 3)
+    t = pts * (dims - 1)
+    i0 = np.clip(np.floor(t).astype(np.intp), 0, dims - 2)
+    f = (t - i0).astype(np.float32)
+    ir, ig, ib = i0[:, 0], i0[:, 1], i0[:, 2]
+    out = np.zeros((pts.shape[0], 3), dtype=np.float32)
+    for cx in (0, 1):
+        for cy in (0, 1):
+            for cz in (0, 1):
+                w = ((f[:, 0] if cx else 1 - f[:, 0])
+                     * (f[:, 1] if cy else 1 - f[:, 1])
+                     * (f[:, 2] if cz else 1 - f[:, 2]))
+                out += w[:, None] * table[ir + cx, ig + cy, ib + cz]
+    return out.reshape(*shape, 3)
+
+
+def _tetra_chunk(pts: np.ndarray, table: np.ndarray, dims: np.ndarray) -> np.ndarray:
+    """Tetrahedral interpolation for one flat chunk of (N,3) device points."""
+    t = pts * (dims - 1).astype(np.float32)
+    i0 = np.clip(np.floor(t).astype(np.intp), 0, dims - 2)
+    f = (t - i0).astype(np.float32)
+    fr, fg, fb = f[:, 0], f[:, 1], f[:, 2]
+    ir, ig, ib = i0[:, 0], i0[:, 1], i0[:, 2]
+
+    def C(dx, dy, dz):
+        return table[ir + dx, ig + dy, ib + dz]
+    c000 = C(0, 0, 0); c100 = C(1, 0, 0); c010 = C(0, 1, 0); c001 = C(0, 0, 1)
+    c110 = C(1, 1, 0); c101 = C(1, 0, 1); c011 = C(0, 1, 1); c111 = C(1, 1, 1)
+    R, G, B = fr[:, None], fg[:, None], fb[:, None]
+    # The six tetrahedra of the unit cube, by the ordering of (fr,fg,fb).
+    v1 = c000 + R * (c100 - c000) + G * (c110 - c100) + B * (c111 - c110)  # r>=g>=b
+    v2 = c000 + R * (c100 - c000) + B * (c101 - c100) + G * (c111 - c101)  # r>=b>=g
+    v3 = c000 + B * (c001 - c000) + R * (c101 - c001) + G * (c111 - c101)  # b>=r>=g
+    v4 = c000 + B * (c001 - c000) + G * (c011 - c001) + R * (c111 - c011)  # b>=g>=r
+    v5 = c000 + G * (c010 - c000) + B * (c011 - c010) + R * (c111 - c011)  # g>=b>=r
+    v6 = c000 + G * (c010 - c000) + R * (c110 - c010) + B * (c111 - c110)  # g>=r>=b
+    conds = [(fr >= fg) & (fg >= fb), (fr >= fb) & (fb >= fg),
+             (fb >= fr) & (fr >= fg), (fb >= fg) & (fg >= fr),
+             (fg >= fb) & (fb >= fr), (fg >= fr) & (fr >= fb)]
+    return np.select([c[:, None] for c in conds], [v1, v2, v3, v4, v5, v6],
+                     default=c000)
+
+
+def _clut_interp_tetra(d01: np.ndarray, clut: "_CLUT") -> np.ndarray:
+    """Tetrahedral interpolation (ICC-standard; affine-exact, no neutral-axis
+    desaturation). Chunked to bound memory at full-resolution export."""
+    table = clut.table
+    dims = np.array(table.shape[:3])
+    if np.any(dims < 2):
+        return _clut_interp_trilinear(d01, clut)
+    shape = d01.shape[:-1]
+    pts = np.ascontiguousarray(np.asarray(d01, dtype=np.float32).reshape(-1, 3))
+    n = pts.shape[0]
+    out = np.empty((n, 3), dtype=np.float32)
+    for s in range(0, n, _TETRA_CHUNK):
+        out[s:s + _TETRA_CHUNK] = _tetra_chunk(pts[s:s + _TETRA_CHUNK], table, dims)
+    return out.reshape(*shape, 3)
+
+
+_TETRA_CHUNK = 1 << 22                                    # rows per pass (bounds memory)
+
+
+# --- A2B element parsers --------------------------------------------------- #
+
+def _assemble_clut(in_tab: np.ndarray, clut_grid: np.ndarray, out_tab: np.ndarray,
+                   grid: Tuple[int, ...], pcs: bytes, is_v4: bool,
+                   eight_bit: bool) -> "_CLUT":
+    """Common tail for mft1/mft2: input curves -> 65536 LUTs; output curves +
+    PCS decode folded into the table."""
+    xs = np.linspace(0.0, 1.0, 65536)
+    in_luts = []
+    for c in range(in_tab.shape[0]):
+        src = np.linspace(0.0, 1.0, in_tab.shape[1])
+        in_luts.append(np.interp(xs, src, in_tab[c]).astype(np.float32))
+    tbl = np.array(clut_grid, dtype=np.float64)
+    for j in range(out_tab.shape[0]):
+        src = np.linspace(0.0, 1.0, out_tab.shape[1])
+        tbl[..., j] = np.interp(tbl[..., j], src, out_tab[j])
+    table = _pcs_decode(tbl, pcs, is_v4, eight_bit).astype(np.float32)
+    return _CLUT(grid=grid, table=table, in_luts=in_luts)
+
+
+def _parse_lut8(icc: bytes, off: int, pcs: bytes, is_v4: bool) -> "_CLUT":
+    i, o, g = icc[off + 8], icc[off + 9], icc[off + 10]
+    if i != 3 or o != 3:
+        raise UnsupportedICCError("only 3->3 cLUT input profiles are supported")
+    if g < 2:
+        raise UnsupportedICCError("degenerate CLUT grid")
+    p = off + 48                                          # after 'mft1'+rsv+i/o/g/pad+3x3 matrix
+    in_tab = (np.frombuffer(icc[p:p + i * 256], dtype=np.uint8)
+              .astype(np.float64).reshape(i, 256) / 255.0)
+    p += i * 256
+    n = g ** i * o
+    clut = np.frombuffer(icc[p:p + n], dtype=np.uint8).astype(np.float64) / 255.0
+    p += n
+    out_tab = (np.frombuffer(icc[p:p + o * 256], dtype=np.uint8)
+               .astype(np.float64).reshape(o, 256) / 255.0)
+    return _assemble_clut(in_tab, clut.reshape(g, g, g, o), out_tab,
+                          (g, g, g), pcs, is_v4, eight_bit=True)
+
+
+def _parse_lut16(icc: bytes, off: int, pcs: bytes, is_v4: bool) -> "_CLUT":
+    i, o, g = icc[off + 8], icc[off + 9], icc[off + 10]
+    if i != 3 or o != 3:
+        raise UnsupportedICCError("only 3->3 cLUT input profiles are supported")
+    if g < 2:
+        raise UnsupportedICCError("degenerate CLUT grid")
+    n = struct.unpack('>H', icc[off + 48:off + 50])[0]    # input table entries
+    m = struct.unpack('>H', icc[off + 50:off + 52])[0]    # output table entries
+    p = off + 52
+    in_tab = (np.frombuffer(icc[p:p + i * n * 2], dtype='>u2')
+              .astype(np.float64).reshape(i, n) / 65535.0)
+    p += i * n * 2
+    cn = g ** i * o
+    clut = np.frombuffer(icc[p:p + cn * 2], dtype='>u2').astype(np.float64) / 65535.0
+    p += cn * 2
+    out_tab = (np.frombuffer(icc[p:p + o * m * 2], dtype='>u2')
+               .astype(np.float64).reshape(o, m) / 65535.0)
+    return _assemble_clut(in_tab, clut.reshape(g, g, g, o), out_tab,
+                          (g, g, g), pcs, is_v4, eight_bit=False)
+
+
+def _curve_len(icc: bytes, off: int) -> int:
+    """Byte length (padded to 4) of a standalone 'curv'/'para' element."""
+    sig = icc[off:off + 4]
+    if sig == b'curv':
+        count = struct.unpack('>I', icc[off + 8:off + 12])[0]
+        ln = 12 + 2 * count
+    elif sig == b'para':
+        func = struct.unpack('>H', icc[off + 8:off + 10])[0]
+        nparams = {0: 1, 1: 3, 2: 4, 3: 5, 4: 7}.get(func)
+        if nparams is None:
+            raise UnsupportedICCError(f"unsupported parametric curve type {func}")
+        ln = 12 + 4 * nparams
+    else:
+        raise UnsupportedICCError(f"unsupported curve element {sig!r:s}")
+    return ln + (-ln % 4)
+
+
+def _read_curve_set(icc: bytes, off: int, count: int) -> List[np.ndarray]:
+    """`count` consecutive curve elements -> list of 65536-entry [0,1]->[0,1] LUTs."""
+    luts, p = [], off
+    for _ in range(count):
+        luts.append(_parse_trc_to_lut(icc, p))
+        p += _curve_len(icc, p)
+    return luts
+
+
+def _parse_lutAToB(icc: bytes, off: int, pcs: bytes, is_v4: bool) -> "_CLUT":
+    i, o = icc[off + 8], icc[off + 9]
+    if i != 3 or o != 3:
+        raise UnsupportedICCError("only 3->3 cLUT input profiles are supported")
+    off_B, off_mat, off_M, off_clut, off_A = struct.unpack(
+        '>5I', icc[off + 12:off + 32])
+    xs = np.linspace(0.0, 1.0, 65536)
+    in_luts = (_read_curve_set(icc, off + off_A, i) if off_A
+               else [xs.astype(np.float32) for _ in range(i)])
+    in_luts = [np.asarray(l, dtype=np.float32) for l in in_luts]
+    if not off_clut:
+        raise UnsupportedICCError("lutAToB without a CLUT is not supported")
+    grid, clut_grid = _read_clut_element(icc, off + off_clut, i, o)
+    tbl = np.array(clut_grid, dtype=np.float64)
+    if off_M:
+        for j, lut in enumerate(_read_curve_set(icc, off + off_M, o)):
+            tbl[..., j] = np.interp(tbl[..., j], xs, lut)
+    if off_mat:
+        vals = np.array(struct.unpack('>12i', icc[off + off_mat:off + off_mat + 48]),
+                        dtype=np.float64) / 65536.0
+        tbl = tbl @ vals[:9].reshape(3, 3).T + vals[9:12]
+    if off_B:
+        for j, lut in enumerate(_read_curve_set(icc, off + off_B, o)):
+            tbl[..., j] = np.interp(tbl[..., j], xs, lut)
+    table = _pcs_decode(tbl, pcs, is_v4, eight_bit=False).astype(np.float32)
+    return _CLUT(grid=grid, table=table, in_luts=in_luts)
+
+
+def _read_clut_element(icc: bytes, off: int, i: int, o: int):
+    """Parse an mAB CLUT element -> (grid dims, (g0,..,o) [0,1] float grid)."""
+    gp = [icc[off + k] for k in range(i)]                 # gridPoints[16], first i used
+    if any(x < 2 for x in gp):
+        raise UnsupportedICCError("degenerate CLUT grid")
+    prec = icc[off + 16]                                  # 1=u8, 2=u16
+    p = off + 20
+    count = o
+    for x in gp:
+        count *= x
+    if prec == 1:
+        raw = np.frombuffer(icc[p:p + count], dtype=np.uint8).astype(np.float64) / 255.0
+    elif prec == 2:
+        raw = np.frombuffer(icc[p:p + count * 2], dtype='>u2').astype(np.float64) / 65535.0
+    else:
+        raise UnsupportedICCError(f"unsupported CLUT precision {prec}")
+    return tuple(gp), raw.reshape(*gp, o)
+
+
+def _parse_a2b(icc: bytes, off: int, pcs: bytes, is_v4: bool) -> "_CLUT":
+    sig = icc[off:off + 4]
+    if sig == b'mft1':
+        return _parse_lut8(icc, off, pcs, is_v4)
+    if sig == b'mft2':
+        return _parse_lut16(icc, off, pcs, is_v4)
+    if sig == b'mAB ':
+        return _parse_lutAToB(icc, off, pcs, is_v4)
+    raise UnsupportedICCError(f"unsupported A2B element type {sig!r:s}")
+
+
+# --------------------------------------------------------------------------- #
+# cLUT ICC synthesis (lut16 / 'mft2', RGB device -> XYZ PCS). Round-trips through
+# _parse_lut16 above. See spec/clut-icc-support.md §5.8.
+# --------------------------------------------------------------------------- #
+
+def _lut16_type(clut_xyz: np.ndarray, grid: int) -> bytes:
+    """lut16Type ('mft2') element: identity 3x3 + identity 2-entry input/output
+    tables; the 3-D CLUT carries the whole RGB->XYZ(D50) transform. `clut_xyz` is
+    (grid,grid,grid,3) XYZ D50 (Y=1), indexed [R][G][B][channel]."""
+    body = struct.pack('>4sI', b'mft2', 0)
+    body += struct.pack('>BBBx', 3, 3, grid)              # i=3, o=3, g=grid, pad
+    for v in (1, 0, 0, 0, 1, 0, 0, 0, 1):                 # identity 3x3 (s15Fixed16)
+        body += struct.pack('>i', _s15f16(v))
+    body += struct.pack('>HH', 2, 2)                      # n=2 in, m=2 out table entries
+    for _ in range(3):                                    # identity input tables
+        body += struct.pack('>HH', 0, 65535)
+    enc = np.clip(np.asarray(clut_xyz, dtype=np.float64) / _XYZ_ENC, 0.0, 1.0)
+    body += np.rint(enc * 65535.0).astype('>u2').tobytes()  # R slowest, B fastest, ch fastest
+    for _ in range(3):                                    # identity output tables
+        body += struct.pack('>HH', 0, 65535)
+    return body
+
+
+def build_clut_icc(desc: str, clut_xyz: np.ndarray, grid: int,
+                   wtpt: Tuple[float, float, float] = D50_XYZ,
+                   copyright_text: str = "Public Domain. No rights reserved.") -> bytes:
+    """Build a valid ICC v2.4 RGB->XYZ cLUT (lut16) profile. `clut_xyz` is a
+    (grid,grid,grid,3) XYZ D50 (Y=1) table indexed [R][G][B]. Parses back via
+    InputProfile.from_bytes (cLUT path)."""
+    desc = str(desc).encode('ascii', 'replace').decode('ascii')
+    copyright_text = str(copyright_text).encode('ascii', 'replace').decode('ascii')
+    tags = {
+        'desc': _desc_type(desc),
+        'wtpt': _xyz_type(*wtpt),
+        'A2B0': _lut16_type(clut_xyz, grid),
+        'cprt': _text_type(copyright_text),
+    }
+    order = ['desc', 'A2B0', 'wtpt', 'cprt']
+    n = len(order)
+    base = 128 + 4 + n * 12
+    data = b''
+    entries = []
+    seen: dict = {}
+    for name in order:
+        payload = tags[name]
+        key = bytes(payload)
+        if key in seen:
+            off, ln = seen[key]
+        else:
+            if len(data) % 4:
+                data += b'\x00' * (4 - len(data) % 4)
+            off = base + len(data)
+            ln = len(payload)
+            data += payload
+            seen[key] = (off, ln)
+        entries.append((name.encode('ascii'), off, ln))
+    table = struct.pack('>I', n)
+    for tag, off, ln in entries:
+        table += struct.pack('>4sII', tag, off, ln)
+    total = 128 + len(table) + len(data)
+    header = bytearray(128)
+    struct.pack_into('>I', header, 0, total)
+    struct.pack_into('>4s', header, 4, b'lcms')
+    struct.pack_into('>I', header, 8, 0x02400000)         # v2.4.0
+    struct.pack_into('>4s', header, 12, b'mntr')
+    struct.pack_into('>4s', header, 16, b'RGB ')
+    struct.pack_into('>4s', header, 20, b'XYZ ')
+    struct.pack_into('>4s', header, 36, b'acsp')
+    struct.pack_into('>i', header, 68, _s15f16(wtpt[0]))
+    struct.pack_into('>i', header, 72, _s15f16(wtpt[1]))
+    struct.pack_into('>i', header, 76, _s15f16(wtpt[2]))
+    return bytes(header) + table + data

--- a/src/core/dcp_profile.py
+++ b/src/core/dcp_profile.py
@@ -1,0 +1,463 @@
+"""
+Adobe DCP (DNG camera profile) support — parse, apply, generate. Pure numpy +
+struct (no rawpy DNG API / DNG SDK). See spec/dcp-camera-profile.md.
+
+A .dcp is a single-IFD TIFF stream carrying DNG camera-profile tags. The profile
+operates on CAMERA-NATIVE raw (the space read_image already produces for the ICC
+path) and, like InputProfile.apply, outputs LINEAR Adobe RGB so the negative
+inversion downstream reads consistent linear data.
+"""
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from core import color_management as cm
+
+
+class DcpError(Exception):
+    """Raised when a .dcp can't be parsed or is invalid (surfaced to the user)."""
+
+
+# EXIF LightSource enum -> approximate correlated colour temperature (kelvin).
+ILLUMINANT_CCT: Dict[int, float] = {
+    0: 5500, 1: 5500, 2: 4150, 3: 2856, 4: 5500,    # default/daylight/fluor/tungsten/flash
+    9: 5500, 10: 5500, 11: 5500,
+    17: 2856, 18: 4874, 19: 6774, 20: 5503, 21: 6504, 22: 7504, 23: 5003, 24: 3200,
+}
+
+# DNG profile tag ids (decimal) — verified against the Adobe DNG Spec 1.4-1.6.
+_T_COLORMATRIX1 = 50721; _T_COLORMATRIX2 = 50722
+_T_CAMERACALIB1 = 50723; _T_CAMERACALIB2 = 50724
+_T_ANALOGBAL = 50727; _T_ASSHOTNEUTRAL = 50728
+_T_ILLUM1 = 50778; _T_ILLUM2 = 50779
+_T_PROFILENAME = 50936
+_T_HSMDIMS = 50937; _T_HSMDATA1 = 50938; _T_HSMDATA2 = 50939
+_T_TONECURVE = 50940; _T_EMBEDPOLICY = 50941
+_T_LOOKDIMS = 50981; _T_LOOKDATA = 50982
+_T_HSMENC = 51107; _T_LOOKENC = 51108
+_T_FORWARDMATRIX1 = 50964; _T_FORWARDMATRIX2 = 50965
+
+_TYPE_SIZE = {1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 6: 1, 7: 1, 8: 2, 9: 4, 10: 8, 11: 4, 12: 8}
+
+
+@dataclass
+class DcpProfile:
+    name: str = ""
+    color_matrix_1: Optional[np.ndarray] = None      # (3,3) XYZ(D50) -> camera, illum 1
+    color_matrix_2: Optional[np.ndarray] = None
+    forward_matrix_1: Optional[np.ndarray] = None    # (3,3) wb-camera -> XYZ D50, illum 1
+    forward_matrix_2: Optional[np.ndarray] = None
+    camera_calibration_1: Optional[np.ndarray] = None
+    camera_calibration_2: Optional[np.ndarray] = None
+    analog_balance: Optional[np.ndarray] = None
+    illuminant_1: int = 21                            # default D65
+    illuminant_2: Optional[int] = None
+    hsm_dims: Optional[Tuple[int, int, int]] = None
+    hsm_data_1: Optional[np.ndarray] = None           # (h,s,v,3): dHue, sScale, vScale
+    hsm_data_2: Optional[np.ndarray] = None
+    hsm_encoding: int = 0
+    look_dims: Optional[Tuple[int, int, int]] = None
+    look_data: Optional[np.ndarray] = None
+    look_encoding: int = 0
+    tone_curve: Optional[np.ndarray] = None           # (N,2) (x,y) in [0,1]
+    embed_policy: int = 1
+
+    @property
+    def has_forward(self) -> bool:
+        return self.forward_matrix_1 is not None
+
+    @property
+    def is_dual(self) -> bool:
+        return self.color_matrix_2 is not None and self.illuminant_2 is not None
+
+
+# --------------------------------------------------------------------------- #
+# Parse.
+# --------------------------------------------------------------------------- #
+
+def parse_dcp(path: str) -> DcpProfile:
+    with open(path, "rb") as f:
+        return parse_dcp_bytes(f.read())
+
+
+def _read_values(data: bytes, field: bytes, typ: int, cnt: int, en: str):
+    size = _TYPE_SIZE.get(typ)
+    if size is None:
+        return None
+    total = size * cnt
+    if total <= 4:
+        raw = field[:total]
+    else:
+        off = struct.unpack(en + 'I', field)[0]
+        if off + total > len(data):
+            raise DcpError("tag value offset past end of file")
+        raw = data[off:off + total]
+    if typ == 2:                                       # ASCII
+        return raw.split(b'\x00')[0].decode('ascii', 'replace')
+    if typ == 3:                                       # SHORT
+        return list(struct.unpack(en + '%dH' % cnt, raw))
+    if typ == 4:                                       # LONG
+        return list(struct.unpack(en + '%dI' % cnt, raw))
+    if typ == 5:                                       # RATIONAL
+        nd = struct.unpack(en + '%dI' % (2 * cnt), raw)
+        return [nd[2 * i] / nd[2 * i + 1] if nd[2 * i + 1] else 0.0 for i in range(cnt)]
+    if typ == 10:                                      # SRATIONAL
+        nd = struct.unpack(en + '%di' % (2 * cnt), raw)
+        return [nd[2 * i] / nd[2 * i + 1] if nd[2 * i + 1] else 0.0 for i in range(cnt)]
+    if typ == 11:                                      # FLOAT
+        return list(struct.unpack(en + '%df' % cnt, raw))
+    return None
+
+
+def _read_ifd(data: bytes, off: int, en: str) -> Dict[int, object]:
+    if off + 2 > len(data):
+        raise DcpError("truncated IFD")
+    count = struct.unpack(en + 'H', data[off:off + 2])[0]
+    entries: Dict[int, object] = {}
+    p = off + 2
+    for _ in range(count):
+        if p + 12 > len(data):
+            raise DcpError("truncated IFD entry")
+        tag, typ, cnt = struct.unpack(en + 'HHI', data[p:p + 8])
+        entries[tag] = _read_values(data, data[p + 8:p + 12], typ, cnt, en)
+        p += 12
+    return entries
+
+
+def parse_dcp_bytes(data: bytes) -> DcpProfile:
+    if len(data) < 8:
+        raise DcpError("file too short to be a DCP")
+    bo = data[0:2]
+    if bo == b'II':
+        en = '<'
+    elif bo == b'MM':
+        en = '>'
+    else:
+        raise DcpError("not a TIFF/DCP (bad byte-order mark)")
+    if struct.unpack(en + 'H', data[2:4])[0] != 42:
+        raise DcpError("not a TIFF/DCP (bad magic)")
+    ifd_off = struct.unpack(en + 'I', data[4:8])[0]
+    e = _read_ifd(data, ifd_off, en)
+
+    def mat(tag):
+        v = e.get(tag)
+        if v is None:
+            return None
+        a = np.asarray(v, dtype=np.float64)
+        if a.size != 9:
+            raise DcpError(f"matrix tag {tag} has {a.size} values (expected 9)")
+        return a.reshape(3, 3)
+
+    def vec(tag, n):
+        v = e.get(tag)
+        return np.asarray(v, dtype=np.float64) if v is not None and len(v) >= n else None
+
+    p = DcpProfile()
+    p.color_matrix_1 = mat(_T_COLORMATRIX1)
+    p.color_matrix_2 = mat(_T_COLORMATRIX2)
+    p.forward_matrix_1 = mat(_T_FORWARDMATRIX1)
+    p.forward_matrix_2 = mat(_T_FORWARDMATRIX2)
+    cc1 = mat(_T_CAMERACALIB1); cc2 = mat(_T_CAMERACALIB2)
+    p.camera_calibration_1 = cc1 if cc1 is not None else np.eye(3)
+    p.camera_calibration_2 = cc2 if cc2 is not None else np.eye(3)
+    ab = vec(_T_ANALOGBAL, 3)
+    p.analog_balance = ab[:3] if ab is not None else np.ones(3)
+    if e.get(_T_ILLUM1):                              # truthy guards count-0 tags ([] is falsy)
+        p.illuminant_1 = int(e[_T_ILLUM1][0])
+    if e.get(_T_ILLUM2):
+        p.illuminant_2 = int(e[_T_ILLUM2][0])
+    if isinstance(e.get(_T_PROFILENAME), str):
+        p.name = e[_T_PROFILENAME]
+    if e.get(_T_EMBEDPOLICY):
+        p.embed_policy = int(e[_T_EMBEDPOLICY][0])
+
+    def hsv_table(dims_tag, data_tag):
+        dims = e.get(dims_tag)
+        dat = e.get(data_tag)
+        if not dims or dat is None:
+            return None, None
+        if len(dims) < 3:
+            raise DcpError("HueSat/Look dims must have 3 values")
+        dims = tuple(int(x) for x in dims[:3])
+        if len(dat) != 3 * dims[0] * dims[1] * dims[2]:
+            raise DcpError("HueSat/Look table size mismatch")
+        return dims, np.asarray(dat, dtype=np.float64).reshape(*dims, 3)
+
+    p.hsm_dims, p.hsm_data_1 = hsv_table(_T_HSMDIMS, _T_HSMDATA1)
+    _, p.hsm_data_2 = hsv_table(_T_HSMDIMS, _T_HSMDATA2)
+    p.look_dims, p.look_data = hsv_table(_T_LOOKDIMS, _T_LOOKDATA)
+    if e.get(_T_HSMENC):
+        p.hsm_encoding = int(e[_T_HSMENC][0])
+    if e.get(_T_LOOKENC):
+        p.look_encoding = int(e[_T_LOOKENC][0])
+    tc = e.get(_T_TONECURVE)
+    if tc is not None and len(tc) >= 4 and len(tc) % 2 == 0:
+        p.tone_curve = np.asarray(tc, dtype=np.float64).reshape(-1, 2)
+
+    if p.color_matrix_1 is None and p.forward_matrix_1 is None:
+        raise DcpError("DCP has no ColorMatrix1 or ForwardMatrix1 — unusable")
+    return p
+
+
+# --------------------------------------------------------------------------- #
+# Apply (camera-native unbalanced raw -> linear Adobe RGB).
+# --------------------------------------------------------------------------- #
+
+_D50 = np.array(cm.D50_XYZ)
+
+
+def _xy(xyz: np.ndarray) -> Tuple[float, float]:
+    s = float(np.sum(xyz))
+    if s <= 1e-9:
+        return 0.3457, 0.3585
+    return float(xyz[0] / s), float(xyz[1] / s)
+
+
+def _mccamy_cct(x: float, y: float) -> float:
+    denom = (0.1858 - y)
+    if abs(denom) < 1e-9:
+        return 6504.0
+    nn = (x - 0.3320) / denom
+    return 449 * nn ** 3 + 3525 * nn ** 2 + 6823.3 * nn + 5520.33
+
+
+def _neutral_cct(profile: DcpProfile, m: np.ndarray) -> float:
+    """CCT of the as-shot neutral (camera RGB = 1/m) via the ColorMatrices."""
+    n = 1.0 / np.clip(m, 1e-6, None)
+    n = n / np.max(n)
+    cms = [c for c in (profile.color_matrix_1, profile.color_matrix_2) if c is not None]
+    ts = []
+    for cmat in cms:
+        try:
+            xyz = np.linalg.inv(cmat) @ n
+        except np.linalg.LinAlgError:
+            continue
+        ts.append(_mccamy_cct(*_xy(xyz)))
+    return float(np.mean(ts)) if ts else 6504.0
+
+
+def _interp_weight(profile: DcpProfile, m: np.ndarray) -> float:
+    """Mired-space blend weight on illuminant-set 1 (1.0 if single-illuminant)."""
+    if not profile.is_dual:
+        return 1.0
+    T = _neutral_cct(profile, m)
+    T1 = ILLUMINANT_CCT.get(profile.illuminant_1, 6504.0)
+    T2 = ILLUMINANT_CCT.get(profile.illuminant_2, 2856.0)
+    inv = lambda t: 1e6 / t
+    denom = inv(T1) - inv(T2)
+    if abs(denom) < 1e-9:
+        return 1.0
+    return float(np.clip((inv(T) - inv(T2)) / denom, 0.0, 1.0))
+
+
+def _blend(a, b, w):
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return w * a + (1.0 - w) * b
+
+
+def apply_dcp(profile: DcpProfile, rgb_u16: np.ndarray, *,
+              as_shot_wb: Optional[np.ndarray] = None,
+              apply_look: bool = False) -> np.ndarray:
+    """Camera-native unbalanced raw (uint16) -> uint16 LINEAR Adobe RGB.
+
+    as_shot_wb: length-3 camera-native WB multipliers (raw.camera_whitebalance);
+    None -> unity (a DCP is a raw profile, so this is a degraded path). apply_look
+    enables the subjective HueSatMap/LookTable/ToneCurve (off by default)."""
+    if rgb_u16.ndim != 3 or rgb_u16.shape[2] != 3 or rgb_u16.dtype != np.uint16:
+        return rgb_u16
+    d = rgb_u16.astype(np.float64) / 65535.0
+    m = (np.asarray(as_shot_wb, dtype=np.float64)[:3].copy()
+         if as_shot_wb is not None else np.ones(3))
+    m[m <= 0] = 1.0
+
+    w = _interp_weight(profile, m)
+    FM = _blend(profile.forward_matrix_1, profile.forward_matrix_2, w)
+    CM = _blend(profile.color_matrix_1, profile.color_matrix_2, w)
+    CC = _blend(profile.camera_calibration_1, profile.camera_calibration_2, w)
+    AB = np.diag(profile.analog_balance[:3])
+    inv_cc_ab = np.linalg.inv(CC @ AB)
+
+    d_wb = d * m                                      # as-shot white balance (unclipped)
+    if FM is not None:
+        xyz = d_wb @ (FM @ inv_cc_ab).T               # ForwardMatrix -> XYZ D50
+    else:
+        # ColorMatrix-only fallback: inv(CM) on the white-balanced camera RGB
+        # (colorimetrically weaker than the ForwardMatrix path; CM is D50-referenced).
+        xyz = d_wb @ np.linalg.inv(CM @ AB).T
+
+    if apply_look:
+        xyz = _apply_look(profile, xyz, w)
+
+    adobe = xyz @ cm.M_XYZ_D50_2_ADOBE.T
+    return np.rint(np.clip(adobe, 0.0, 1.0) * 65535.0).astype(np.uint16)
+
+
+# --------------------------------------------------------------------------- #
+# Optional "look" stage (HueSatMap / LookTable / ToneCurve), apply_look only.
+# --------------------------------------------------------------------------- #
+
+def _rgb_to_hsv(rgb: np.ndarray):
+    r, g, b = rgb[..., 0], rgb[..., 1], rgb[..., 2]
+    mx = np.max(rgb, axis=-1); mn = np.min(rgb, axis=-1); df = mx - mn
+    h = np.zeros_like(mx)
+    nz = df > 1e-12
+    im = (mx == r) & nz
+    h[im] = (60.0 * ((g - b)[im] / df[im])) % 360.0
+    im = (mx == g) & nz
+    h[im] = 60.0 * ((b - r)[im] / df[im]) + 120.0
+    im = (mx == b) & nz
+    h[im] = 60.0 * ((r - g)[im] / df[im]) + 240.0
+    s = np.where(mx > 1e-12, df / np.maximum(mx, 1e-12), 0.0)
+    return h % 360.0, s, mx
+
+
+def _hsv_to_rgb(h, s, v):
+    h = h % 360.0
+    c = v * s
+    x = c * (1 - np.abs((h / 60.0) % 2 - 1))
+    m = v - c
+    z = np.zeros_like(h)
+    seg = (h // 60).astype(int) % 6
+    r = np.select([seg == 0, seg == 1, seg == 2, seg == 3, seg == 4, seg == 5],
+                  [c, x, z, z, x, c])
+    g = np.select([seg == 0, seg == 1, seg == 2, seg == 3, seg == 4, seg == 5],
+                  [x, c, c, x, z, z])
+    b = np.select([seg == 0, seg == 1, seg == 2, seg == 3, seg == 4, seg == 5],
+                  [z, z, x, c, c, x])
+    return np.stack([r + m, g + m, b + m], axis=-1)
+
+
+def _hsv_map(xyz: np.ndarray, dims, data: np.ndarray, encoding: int) -> np.ndarray:
+    """Apply a DNG HueSat/Look table (hue°,satScale,valScale) in linear ProPhoto."""
+    pp = np.clip(xyz @ cm.M_XYZ2PROPHOTO.T, 0.0, None)
+    h, s, v = _rgb_to_hsv(pp)
+    hd, sd, vd = dims
+    v_enc = cm.srgb_encode(np.clip(v, 0, 1)) if encoding == 1 else np.clip(v, 0, 1)
+    # fractional table coordinates (hue wraps, sat/val clamp)
+    hf = (h / 360.0) * hd
+    sf = np.clip(s, 0, 1) * (sd - 1)
+    vf = np.clip(v_enc, 0, 1) * (vd - 1) if vd > 1 else np.zeros_like(v)
+    h0 = np.floor(hf).astype(int) % hd
+    h1 = (h0 + 1) % hd
+    s0 = np.clip(np.floor(sf).astype(int), 0, sd - 1); s1 = np.minimum(s0 + 1, sd - 1)
+    v0 = np.clip(np.floor(vf).astype(int), 0, vd - 1); v1 = np.minimum(v0 + 1, vd - 1)
+    fh = (hf - np.floor(hf))[..., None]
+    fs = (sf - s0)[..., None]
+    fv = (vf - v0)[..., None]
+
+    def cell(hi, si, vi):
+        return data[hi, si, vi]
+    c000 = cell(h0, s0, v0); c100 = cell(h1, s0, v0)
+    c010 = cell(h0, s1, v0); c110 = cell(h1, s1, v0)
+    c001 = cell(h0, s0, v1); c101 = cell(h1, s0, v1)
+    c011 = cell(h0, s1, v1); c111 = cell(h1, s1, v1)
+    c00 = c000 * (1 - fh) + c100 * fh
+    c10 = c010 * (1 - fh) + c110 * fh
+    c01 = c001 * (1 - fh) + c101 * fh
+    c11 = c011 * (1 - fh) + c111 * fh
+    c0 = c00 * (1 - fs) + c10 * fs
+    c1 = c01 * (1 - fs) + c11 * fs
+    delta = c0 * (1 - fv) + c1 * fv                   # (...,3): dHue, sScale, vScale
+
+    h2 = h + delta[..., 0]
+    s2 = np.clip(s * delta[..., 1], 0.0, 1.0)
+    v2 = v * delta[..., 2]
+    rgb = _hsv_to_rgb(h2, s2, v2)
+    return rgb @ np.linalg.inv(cm.M_XYZ2PROPHOTO).T
+
+
+def _apply_tone(xyz: np.ndarray, tone: np.ndarray) -> np.ndarray:
+    """Apply the ProfileToneCurve on the ProPhoto value channel (max RGB)."""
+    pp = np.clip(xyz @ cm.M_XYZ2PROPHOTO.T, 0.0, None)
+    v = np.max(pp, axis=-1, keepdims=True)
+    xs = np.clip(tone[:, 0], 0, 1); ys = np.clip(tone[:, 1], 0, 1)
+    order = np.argsort(xs)
+    nv = np.interp(np.clip(v, 0, 1), xs[order], ys[order])
+    scale = np.where(v > 1e-6, nv / np.maximum(v, 1e-6), 1.0)
+    return (pp * scale) @ np.linalg.inv(cm.M_XYZ2PROPHOTO).T
+
+
+def _apply_look(profile: DcpProfile, xyz: np.ndarray, w: float) -> np.ndarray:
+    out = xyz
+    if profile.hsm_data_1 is not None and profile.hsm_dims is not None:
+        data = _blend(profile.hsm_data_1, profile.hsm_data_2, w)
+        out = _hsv_map(out, profile.hsm_dims, data, profile.hsm_encoding)
+    if profile.look_data is not None and profile.look_dims is not None:
+        out = _hsv_map(out, profile.look_dims, profile.look_data, profile.look_encoding)
+    if profile.tone_curve is not None:
+        out = _apply_tone(out, profile.tone_curve)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Generate a minimal single-illuminant matrix DCP from an IT8 CameraFit.
+# --------------------------------------------------------------------------- #
+
+def _to_srational(x: float, den: int = 1000000) -> Tuple[int, int]:
+    return int(round(x * den)), den
+
+
+def _write_ifd(tags: Dict[int, Tuple[str, object]]) -> bytes:
+    """Build a little-endian single-IFD TIFF from {tag: (kind, value)}. Tags are
+    emitted in ascending order; values >4 bytes go to a word-aligned data block."""
+    items = sorted(tags.items())
+    n = len(items)
+    ifd_size = 2 + n * 12 + 4
+    data_base = 8 + ifd_size
+    entry_bytes = b''
+    data_bytes = b''
+    for tag, (kind, val) in items:
+        if kind == 'ascii':
+            raw = val.encode('ascii', 'replace') + b'\x00'
+            tcode, cnt = 2, len(raw)
+        elif kind == 'short':
+            tcode, cnt = 3, len(val)
+            raw = b''.join(struct.pack('<H', int(v) & 0xFFFF) for v in val)
+        elif kind == 'long':
+            tcode, cnt = 4, len(val)
+            raw = b''.join(struct.pack('<I', int(v) & 0xFFFFFFFF) for v in val)
+        elif kind == 'srational':
+            tcode, cnt = 10, len(val)
+            raw = b''.join(struct.pack('<ii', *_to_srational(v)) for v in val)
+        else:
+            raise ValueError(kind)
+        if len(raw) <= 4:
+            field = raw + b'\x00' * (4 - len(raw))
+        else:
+            field = struct.pack('<I', data_base + len(data_bytes))
+            data_bytes += raw
+            if len(data_bytes) % 2:
+                data_bytes += b'\x00'
+        entry_bytes += struct.pack('<HHI', tag, tcode, cnt) + field
+    header = struct.pack('<2sHI', b'II', 42, 8)
+    ifd = struct.pack('<H', n) + entry_bytes + struct.pack('<I', 0)
+    return header + ifd + data_bytes
+
+
+def build_camera_dcp(fit, name: str, *, illuminant: int = 23) -> bytes:
+    """Synthesise a minimal single-illuminant matrix DCP from the IT8 fit.
+
+    M (camera-native device[0,1] -> XYZ D50, Y~1) is re-expressed as a
+    ForwardMatrix on white-balanced camera RGB plus the required ColorMatrix.
+    Parses back via parse_dcp_bytes."""
+    M = np.asarray(fit.matrix, dtype=np.float64)
+    N = np.linalg.inv(M) @ _D50                       # camera RGB that maps to D50 grey
+    N = N / np.max(np.abs(N))                          # DNG-style neutral, max 1
+    FM = M @ np.diag(N)                                # wb-camera -> XYZ D50 (FM @ 1 = D50)
+    CM = np.linalg.inv(FM)                             # XYZ D50 -> camera (single-illuminant)
+    name = str(name).encode('ascii', 'replace').decode('ascii')
+    tags = {
+        _T_PROFILENAME: ('ascii', name),
+        _T_EMBEDPOLICY: ('long', [1]),                # allow copying
+        _T_ILLUM1: ('short', [int(illuminant)]),
+        _T_COLORMATRIX1: ('srational', list(CM.ravel())),
+        _T_FORWARDMATRIX1: ('srational', list(FM.ravel())),
+    }
+    return _write_ifd(tags)

--- a/src/core/it8_profile.py
+++ b/src/core/it8_profile.py
@@ -851,20 +851,118 @@ def fit_camera_matrix(samples: Dict[str, PatchSample], ref: IT8Reference, *,
 _IDENTITY_TRC = (1.0, 1.0, 0.0, 1.0, 0.0)
 
 
-def build_camera_icc(fit: CameraFit, desc: str,
+def build_camera_icc(fit: CameraFit, desc: str, *,
+                     mode: str = "matrix", grid: int = 17,
+                     samples: Optional[Dict[str, "PatchSample"]] = None,
+                     ref: Optional[IT8Reference] = None,
                      copyright_text: str = "Public Domain. No rights reserved."
                      ) -> bytes:
-    """Synthesise ICC v2.4 matrix-shaper bytes from the fitted camera matrix.
-    Colorant columns are M's columns (already XYZ D50); TRC is identity (the
-    device space is raw-linear). Round-trips through InputProfile.from_bytes."""
-    M = np.asarray(fit.matrix, dtype=np.float64)
-    # The ICC desc/text tag writers only emit ASCII (textType/textDescription),
-    # so coerce user-supplied names + illuminant notes to ASCII to avoid a crash.
+    """Synthesise camera-profile ICC bytes from the fit. Round-trips through
+    InputProfile.from_bytes.
+
+    mode='matrix' (default) writes a 3x3 matrix-shaper (M's columns are the XYZ
+    D50 colorants, identity TRC). mode='clut' writes a higher-accuracy lut16 cLUT
+    (the 3x3 base + a smooth RBF residual; needs `samples`+`ref`)."""
     desc = str(desc).encode("ascii", "replace").decode("ascii")
     copyright_text = str(copyright_text).encode("ascii", "replace").decode("ascii")
+    if mode == "clut":
+        if samples is None or ref is None:
+            raise ValueError("cLUT mode requires the sampled patches and reference")
+        clut_xyz = build_residual_clut(fit, samples, ref, grid=grid)
+        return color_management.build_clut_icc(
+            desc, clut_xyz, grid, copyright_text=copyright_text)
+    M = np.asarray(fit.matrix, dtype=np.float64)
     return color_management.build_matrix_shaper_icc(
         desc,
         tuple(M[:, 0]), tuple(M[:, 1]), tuple(M[:, 2]),
         _IDENTITY_TRC,
         copyright_text=copyright_text,
     )
+
+
+def build_residual_clut(fit: CameraFit, samples: Dict[str, "PatchSample"],
+                        ref: IT8Reference, grid: int = 17) -> np.ndarray:
+    """A (grid,grid,grid,3) XYZ D50 (Y=1) cLUT = the 3x3 matrix base + a smooth
+    scattered-data residual that bends the saturated corners the 3x3 can't reach.
+
+    The residual is a broad Gaussian-RBF-with-polynomial fit of the per-patch
+    errors `X_i - M·d_i` over the device-RGB sample points, regularised and faded
+    to zero outside the patch hull so the LUT degrades to the safe 3x3 in unsampled
+    regions. Gross per-axis reversals (the chroma-noise/ringing failure mode) are
+    bounded to ≤ RINGING_TOL by shrinking the correction toward the base if needed;
+    the LUT is NOT guaranteed strictly monotone — small reversals are the cost of
+    the bias correction, and the 3x3 matrix mode remains the strictly-safe default.
+    Indexed [R][G][B]."""
+    M = np.asarray(fit.matrix, dtype=np.float64)
+    d_list, r_list = [], []
+    for sid in fit.used_ids:
+        ps = samples.get(sid)
+        xyz = ref.xyz(sid)
+        if ps is None or xyz is None:
+            continue
+        di = ps.rgb / 65535.0
+        d_list.append(di)
+        r_list.append(xyz / 100.0 - M @ di)              # residual in XYZ (Y=1)
+    d = np.asarray(d_list, dtype=np.float64)             # (N,3) device
+    r = np.asarray(r_list, dtype=np.float64)             # (N,3) XYZ residual
+    n = len(d)
+
+    ax = np.linspace(0.0, 1.0, grid)
+    Rg, Gg, Bg = np.meshgrid(ax, ax, ax, indexing="ij")
+    nodes = np.stack([Rg, Gg, Bg], axis=-1).reshape(-1, 3)
+    base = nodes @ M.T                                    # (G,3) pure-matrix prediction
+
+    if n < 5:                                             # too few patches to bend safely
+        return np.clip(base, 0.0, 2.0).reshape(grid, grid, grid, 3)
+
+    # Gaussian RBF. A BROAD kernel (≈3× the mean nearest-neighbour device spacing)
+    # plus a firm smoothness regularisation captures the systematic saturated-corner
+    # bias without the high-frequency overshoot that a tight kernel rings with — it
+    # gives both lower ΔE and far less non-monotonicity than a narrow fit.
+    dd = np.sqrt(np.maximum(((d[:, None, :] - d[None, :, :]) ** 2).sum(-1), 0.0))
+    nn = dd + np.eye(n) * 1e9
+    sigma = max(float(nn.min(1).mean()) * 3.0, 1e-3)
+    Phi = np.exp(-(dd / sigma) ** 2)
+    Phi = Phi + (1e-2 * np.trace(Phi) / n) * np.eye(n)   # smoothness regularisation
+    P = np.concatenate([np.ones((n, 1)), d], axis=1)     # affine polynomial term
+    A = np.zeros((n + 4, n + 4))
+    A[:n, :n] = Phi; A[:n, n:] = P; A[n:, :n] = P.T
+    rhs = np.zeros((n + 4, 3)); rhs[:n] = r
+    sol, *_ = np.linalg.lstsq(A, rhs, rcond=None)
+
+    dn = np.sqrt(np.maximum(((nodes[:, None, :] - d[None, :, :]) ** 2).sum(-1), 0.0))
+    resid = np.exp(-(dn / sigma) ** 2) @ sol[:n] + np.concatenate(
+        [np.ones((len(nodes), 1)), nodes], axis=1) @ sol[n:]
+    # Fade the residual to zero beyond ~one kernel width from the patch hull, so
+    # unsampled corners fall back to the pure matrix instead of ringing.
+    fade = np.exp(-(np.maximum(dn.min(1) - sigma, 0.0) / (2.0 * sigma)) ** 2)
+    corr = (resid * fade[:, None])
+
+    # Ringing safeguard: the correction must not introduce a *gross* per-axis
+    # reversal the linear base lacks (the parked density experiment's failure
+    # mode). If it does, shrink the whole correction toward the base and recheck —
+    # strength 0 is the pure 3×3 (always safe), so this terminates. Small reversals
+    # are tolerated: they are the cost of the bias correction (see RINGING_TOL).
+    base_grid = base.reshape(grid, grid, grid, 3)
+    table = base_grid
+    for strength in (1.0, 0.7, 0.5, 0.35, 0.2, 0.1, 0.0):
+        table = np.clip(base + corr * strength, 0.0, 2.0).reshape(grid, grid, grid, 3)
+        if _residual_monotone(base_grid, table):
+            break
+    return table
+
+
+RINGING_TOL = 0.12   # max per-axis reversal (fraction of white) the cLUT may add
+
+
+def _residual_monotone(base_grid: np.ndarray, table: np.ndarray,
+                       tol: float = RINGING_TOL) -> bool:
+    """True if `table` introduces no per-axis reversal larger than `tol` where the
+    linear `base_grid` is non-decreasing. NOT strict monotonicity — small reversals
+    are allowed (the bias correction's cost); only gross ringing is rejected."""
+    for axis in range(3):
+        db = np.diff(base_grid, axis=axis)
+        dt = np.diff(table, axis=axis)
+        if np.any((db >= 0) & (dt < -tol)):
+            return False
+    return True

--- a/src/core/it8_profile.py
+++ b/src/core/it8_profile.py
@@ -493,6 +493,26 @@ def parse_block(tl_id: str, br_id: str):
     return rows, cols
 
 
+def next_block_ids(tl_id: str, br_id: str, max_col: Optional[int] = None
+                   ) -> Tuple[str, str]:
+    """Advance a block's column range by its own width for the next card of a
+    multi-card target (e.g. ('A1','L24') -> ('A25','L48') -> ('A49','L72')).
+
+    Rows are preserved; only the columns shift. If `max_col` is given the new
+    range is clamped so the right column never exceeds it (the last card of a
+    target that doesn't divide evenly). Raises ValueError on an unparseable id.
+    """
+    rows, cols = parse_block(tl_id, br_id)
+    r0, r1 = rows[0], rows[-1]
+    c0, c1 = cols[0], cols[-1]
+    width = c1 - c0 + 1
+    nc0, nc1 = c0 + width, c1 + width
+    if max_col is not None and nc1 > max_col:
+        nc1 = max_col
+        nc0 = min(nc0, nc1)
+    return f"{r0}{nc0}", f"{r1}{nc1}"
+
+
 def block_sample_points(quad, rows, cols) -> Dict[str, Tuple[float, float]]:
     """Sample centres (array coords) for a regular len(rows)×len(cols) grid laid
     on the 4-corner quad (TL,TR,BR,BL). IDs are '<row><col>' (e.g. 'A49')."""
@@ -531,15 +551,30 @@ def _quad_cell_halfsize(quad: np.ndarray, frac: float,
 
 
 def sample_patches(img_u16: np.ndarray, points: Dict[str, Tuple[float, float]],
-                   quad, frac: float = 0.5, clip_lo: float = 0.005,
-                   clip_hi: float = 0.995, ncols: int = 22,
+                   quad, frac: float = 0.5, clip_hi: float = 0.995,
+                   black_floor: float = 0.0008, ncols: int = 22,
                    nrows: int = 12) -> Dict[str, PatchSample]:
     """Sample each patch's device RGB from a central window via a per-channel
-    trimmed mean; flag patches with >2% clipped pixels or out of frame. ncols/
-    nrows set the grid density so the sampling window scales to the cell size."""
+    trimmed mean and flag only the genuinely unusable ones. ncols/nrows set the
+    grid density so the sampling window scales to the cell size.
+
+    A patch is invalid only when its colour can't be trusted:
+      * **highlight-clipped** — any channel has >2% of pixels pinned at the
+        sensor ceiling (`clip_hi`), so information above it is lost; or
+      * **black-crushed** — even its brightest channel sits at/below the black
+        floor (`black_floor`), i.e. no signal at all; or
+      * partly **out of frame**.
+
+    A merely *low* channel is NOT a defect on raw-linear device data: a saturated
+    hue legitimately reads near-zero in one or two complementary channels while
+    carrying full signal in the rest (a vivid red has green/blue ≈ 0), and dense
+    film patches read low — yet these saturated/dark patches are the most
+    informative for the matrix fit. The previous "any pixel below 0.5 % of full
+    scale counts as clipped" test wrongly rejected all of them."""
     h, w = img_u16.shape[:2]
     full = 65535.0
-    lo, hi = clip_lo * full, clip_hi * full
+    hi = clip_hi * full
+    floor = black_floor * full
     half_w, half_h = _quad_cell_halfsize(quad, frac, ncols, nrows)
     out: Dict[str, PatchSample] = {}
     for sid, (cx, cy) in points.items():
@@ -558,11 +593,33 @@ def sample_patches(img_u16: np.ndarray, points: Dict[str, Tuple[float, float]],
             p10, p90 = np.percentile(col, [10, 90])
             keep = col[(col >= p10) & (col <= p90)]
             rgb[ch] = keep.mean() if keep.size else col.mean()
-        clipped_frac = np.mean((win <= lo) | (win >= hi))
-        # Also invalid if the patch fell partly outside the frame.
+        # Highlight clipping is judged per-channel (a blown channel loses info);
+        # black-crush on the brightest channel so saturated hues survive.
+        hi_frac = np.mean(win >= hi, axis=0)
+        highlight_clipped = bool(np.any(hi_frac >= 0.02))
+        black_crushed = bool(rgb.max() <= floor)
         in_frame = (x0 >= 0 and y0 >= 0 and x1 <= w and y1 <= h)
-        out[sid] = PatchSample(rgb, bool(clipped_frac < 0.02 and in_frame), win.shape[0])
+        valid = (not highlight_clipped) and (not black_crushed) and in_frame
+        out[sid] = PatchSample(rgb, bool(valid), win.shape[0])
     return out
+
+
+def merge_samples(cards: List[Dict[str, PatchSample]]) -> Dict[str, PatchSample]:
+    """Combine the per-card sample dicts of a multi-card target into one set.
+
+    Each card photographs a different block of patch ids, so the union covers
+    the whole chart. On the rare id collision (overlapping blocks) a *valid*
+    sample always wins over an invalid one; on equal validity the first (earlier)
+    card in the list is kept. The merged dict feeds straight into
+    `fit_camera_matrix`.
+    """
+    merged: Dict[str, PatchSample] = {}
+    for samples in cards:
+        for sid, ps in samples.items():
+            old = merged.get(sid)
+            if old is None or (ps.valid and not old.valid):
+                merged[sid] = ps
+    return merged
 
 
 # --------------------------------------------------------------------------- #

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -191,9 +191,14 @@ class MainWindow(QMainWindow):
         # Restore a previously-chosen global input ICC profile (applied to every
         # decode). Done before any images load so the first batch picks it up.
         saved_icc = self._settings.value("import/input_icc_path", "", type=str)
+        saved_dcp = self._settings.value("import/input_dcp_path", "", type=str)
         if saved_icc and os.path.exists(saved_icc):
             if ccr_backend.load_input_icc_from_storage(saved_icc) is None:
                 self._settings.remove("import/input_icc_path")
+            self._refresh_input_icc_menu()
+        elif saved_dcp and os.path.exists(saved_dcp):
+            if ccr_backend.load_input_dcp_from_storage(saved_dcp) is None:
+                self._settings.remove("import/input_dcp_path")
             self._refresh_input_icc_menu()
 
         # Ctrl+Z (Cmd+Z on macOS): undo the last action on the current image;
@@ -352,6 +357,11 @@ class MainWindow(QMainWindow):
         self.input_icc_action.triggered.connect(self.set_input_icc_profile)
         self.clear_input_icc_action = file_menu.addAction("Clear Input ICC Profile")
         self.clear_input_icc_action.triggered.connect(self.clear_input_icc_profile)
+        # DCP (DNG camera profile) — exclusive alternative to the input ICC.
+        self.input_dcp_action = file_menu.addAction("Load DCP Profile…")
+        self.input_dcp_action.triggered.connect(self.set_input_dcp_profile)
+        self.clear_input_dcp_action = file_menu.addAction("Clear DCP Profile")
+        self.clear_input_dcp_action.triggered.connect(self.clear_input_dcp_profile)
         self._refresh_input_icc_menu()
 
         # Build a camera input profile from a photographed IT8 target.
@@ -371,7 +381,7 @@ class MainWindow(QMainWindow):
 
     # --- Input ICC profile (global, persistent) ---------------------------
     def _refresh_input_icc_menu(self):
-        """Reflect the active input profile in the File-menu actions."""
+        """Reflect the active input profile (ICC or DCP) in the File-menu actions."""
         name = getattr(ccr_backend, "input_icc_name", None)
         if name:
             self.input_icc_action.setText(f"Input ICC: {name}…")
@@ -379,6 +389,14 @@ class MainWindow(QMainWindow):
         else:
             self.input_icc_action.setText("Set Input ICC Profile…")
             self.clear_input_icc_action.setEnabled(False)
+        if hasattr(self, "input_dcp_action"):
+            dcp_name = getattr(ccr_backend, "input_dcp_name", None)
+            if dcp_name:
+                self.input_dcp_action.setText(f"DCP: {dcp_name}…")
+                self.clear_input_dcp_action.setEnabled(True)
+            else:
+                self.input_dcp_action.setText("Load DCP Profile…")
+                self.clear_input_dcp_action.setEnabled(False)
 
     def set_input_icc_profile(self):
         start_dir = self._settings.value("import/last_icc_dir", "", type=str)
@@ -401,19 +419,64 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(
                 self, "Unsupported ICC Profile",
                 f"This profile can't be used as an input profile:\n\n{e}\n\n"
-                "Only RGB matrix-shaper profiles are supported "
-                "(LUT-based, cLUT, or CMYK profiles are not).")
+                "Only RGB matrix-shaper and cLUT (A2B) profiles are supported "
+                "(CMYK and output/B2A-only profiles are not).")
             return False
         except Exception as e:
             QMessageBox.warning(self, "Input ICC Profile Error",
                                 f"Could not load the ICC profile:\n\n{e}")
             return False
         self._settings.setValue("import/input_icc_path", ccr_backend.input_icc_path)
+        self._settings.remove("import/input_dcp_path")   # ICC cleared the DCP
         self._refresh_input_icc_menu()
         self._reprocess_after_input_icc_change()
         self.sliders_panel.set_temporary_hint(
             f"Input ICC profile set: {name}", duration=3000)
         return True
+
+    def set_input_dcp_profile(self):
+        start_dir = self._settings.value("import/last_dcp_dir", "", type=str)
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select DCP Profile", start_dir,
+            "DNG Camera Profiles (*.dcp);;All Files (*)")
+        if not path:
+            return
+        self._settings.setValue("import/last_dcp_dir", os.path.dirname(path))
+        self._apply_input_dcp_path(path)
+
+    def _apply_input_dcp_path(self, path: str) -> bool:
+        """Activate `path` as the global DCP (parse, persist, reprocess). Clears
+        any active ICC. Shared by the picker and the IT8 wizard's 'apply now'."""
+        from core.dcp_profile import DcpError
+        try:
+            name = ccr_backend.set_input_dcp(path)
+        except DcpError as e:
+            QMessageBox.warning(self, "DCP Profile",
+                                f"This .dcp can't be used:\n\n{e}")
+            return False
+        except Exception as e:
+            QMessageBox.warning(self, "DCP Profile Error",
+                                f"Could not load the DCP profile:\n\n{e}")
+            return False
+        self._settings.setValue("import/input_dcp_path", ccr_backend.input_dcp_path)
+        self._settings.remove("import/input_icc_path")   # DCP cleared the ICC
+        self._refresh_input_icc_menu()
+        self._reprocess_after_input_icc_change()
+        msg = f"DCP profile set: {name}"
+        _raw = (".cr3", ".cr2", ".nef", ".arw", ".dng", ".rw2", ".orf",
+                ".raf", ".srw", ".pef", ".3fr")
+        if any(not (getattr(im, "file_path", "") or "").lower().endswith(_raw)
+               for im in ccr_backend.images):
+            msg += " — note: a DCP applies to RAW only; non-RAW files will be colour-shifted"
+        self.sliders_panel.set_temporary_hint(msg, duration=5000)
+        return True
+
+    def clear_input_dcp_profile(self):
+        ccr_backend.clear_input_dcp()
+        self._settings.remove("import/input_dcp_path")
+        self._refresh_input_icc_menu()
+        self._reprocess_after_input_icc_change()
+        self.sliders_panel.set_temporary_hint("DCP profile cleared.", duration=3000)
 
     def create_camera_profile_from_it8(self):
         """Open the IT8 wizard; on success optionally activate the new profile."""
@@ -428,7 +491,11 @@ class MainWindow(QMainWindow):
         if dlg.exec() != QDialog.Accepted or not dlg.saved_path:
             return
         base = os.path.basename(dlg.saved_path)
-        if dlg.apply_now and self._apply_input_icc_path(dlg.saved_path):
+        is_dcp = dlg.saved_path.lower().endswith(".dcp")
+        applied = dlg.apply_now and (
+            self._apply_input_dcp_path(dlg.saved_path) if is_dcp
+            else self._apply_input_icc_path(dlg.saved_path))
+        if applied:
             self.sliders_panel.set_temporary_hint(
                 f"Camera profile saved and applied: {base}", duration=4000)
         else:

--- a/src/widgets/it8_profile_dialog.py
+++ b/src/widgets/it8_profile_dialog.py
@@ -56,7 +56,7 @@ class IT8PatchLocator(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setMinimumSize(520, 360)
+        self.setMinimumSize(820, 480)
         self.setMouseTracking(True)
         self._qimg: Optional[QImage] = None
         self._base = None                 # decoded array as given
@@ -65,6 +65,7 @@ class IT8PatchLocator(QWidget):
         self._iw = self._ih = 0
         self._quad = []                   # 4 (x,y) array-space corners TL,TR,BR,BL
         self._gray_offset = 0.0
+        self._invalid_ids = set()         # ids the dialog flagged clipped/off-frame
         self._mode = "classic"            # "classic" (12x22 + GS strip) | "block"
         self._rows = []                   # block mode: row letters
         self._cols = []                   # block mode: column numbers
@@ -104,6 +105,14 @@ class IT8PatchLocator(QWidget):
         self._mode = "block"
         self._rows, self._cols = list(rows), list(cols)
         self.update(); self.changed.emit()
+
+    def set_invalid_ids(self, ids):
+        """Ids whose sampled patch is invalid (clipped or off-frame); their dots
+        are drawn red. Computed by the dialog after each (re)sample."""
+        new = set(ids)
+        if new != self._invalid_ids:
+            self._invalid_ids = new
+            self.update()
 
     def image_array(self):
         return self._work
@@ -176,17 +185,19 @@ class IT8PatchLocator(QWidget):
         p.setBrush(Qt.NoBrush)
         p.drawPolygon(poly)
 
-        # Sample dots (colour vs gray differ in colour).
+        # Sample dots (colour vs gray differ in colour; invalid patches red).
         pts = self.points()
         for sid, (x, y) in pts.items():
             w = self._a2w(x, y)
-            if not target.contains(w):
-                p.setPen(QPen(QColor(220, 80, 80), 1))   # out of frame -> red
+            bad = (not target.contains(w)) or sid in self._invalid_ids
+            if bad:
+                p.setPen(QPen(QColor(230, 70, 70), 2))   # invalid/off-frame -> red
             elif sid.startswith("GS"):
                 p.setPen(QPen(QColor(120, 170, 255), 1))
             else:
                 p.setPen(QPen(QColor(255, 230, 90), 1))
-            p.drawEllipse(w, 1.6, 1.6)
+            r = 2.6 if bad else 1.6                       # enlarge bad dots
+            p.drawEllipse(w, r, r)
 
         # Corner handles.
         for i, (x, y) in enumerate(self._quad):
@@ -239,7 +250,18 @@ class IT8ProfileDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Create Camera Profile from IT8")
         self.setModal(True)
-        self.setMinimumSize(720, 560)
+        # Big enough for accurate corner placement (≥1024 wide), but clamp the
+        # floor to the screen so the nav row can't be pushed off a small display.
+        scr = self.screen() or QApplication.primaryScreen()
+        avail = scr.availableGeometry() if scr is not None else None
+        min_w, min_h, init_w, init_h = 1024, 700, 1120, 780
+        if avail is not None:
+            min_w = min(min_w, avail.width() - 40)
+            min_h = min(min_h, avail.height() - 80)
+            init_w = min(init_w, avail.width() - 40)
+            init_h = min(init_h, avail.height() - 80)
+        self.setMinimumSize(min_w, min_h)
+        self.resize(max(min_w, init_w), max(min_h, init_h))
         self._settings = QSettings("FreeCCR", "FreeCCR")
 
         self._current_path = current_path
@@ -251,6 +273,13 @@ class IT8ProfileDialog(QDialog):
         self._mode = "classic"             # "classic" (GS strip) | "block" (plain grid)
         self.saved_path: Optional[str] = None
         self.apply_now = False
+        # Multi-card targets (block mode): samples accumulate across up to 3
+        # photographed cards before the fit. _mapped_cards holds the finalised
+        # sample dicts of the cards already mapped; the card in the locator is
+        # the current one. _all_samples is the merged set the fit consumes.
+        self._mapped_cards: list = []
+        self._all_samples: dict = {}
+        self._n_images = 1
 
         self.stack = QStackedWidget(self)
         self.stack.addWidget(self._build_target_page())
@@ -374,6 +403,10 @@ class IT8ProfileDialog(QDialog):
         self.gray_slider.valueChanged.connect(
             lambda v: self.locator.set_gray_offset(v / 1000.0))
         ctl.addWidget(self.gray_slider)
+        # Multi-card progress indicator (block-mode targets only).
+        self.card_label = QLabel("")
+        self.card_label.setStyleSheet("color:#9cc4ff; font-weight:bold;")
+        ctl.addWidget(self.card_label)
         ctl.addStretch(1)
         self.locate_status = QLabel("")
         ctl.addWidget(self.locate_status)
@@ -469,7 +502,22 @@ class IT8ProfileDialog(QDialog):
         if path:
             self._set_target(path)
 
+    def _reset_card_accum(self):
+        """Discard any in-progress multi-card accumulation. The target shot and
+        reference define what the mapped cards belong to, so changing either
+        must throw the accumulated cards away — otherwise samples from an
+        abandoned session silently contaminate the next fit."""
+        self._mapped_cards = []
+        self._all_samples = {}
+        self._n_images = 1
+        self._fit = None
+        # Let the block range re-seed from the (possibly new) reference extent.
+        if hasattr(self, "tl_edit"):
+            self.tl_edit.clear()
+            self.br_edit.clear()
+
     def _set_target(self, path):
+        self._reset_card_accum()           # a new target starts a fresh session
         self._target_path = path
         self._target_img = None            # force re-decode on Next
         raw = ", ".join((".dng", ".arw", ".nef", ".cr2", ".cr3", ".raf",
@@ -528,6 +576,7 @@ class IT8ProfileDialog(QDialog):
             QMessageBox.warning(self, "Reference File",
                                 f"Could not read the reference file:\n\n{e}")
             return
+        self._reset_card_accum()           # a new reference starts a fresh session
         self._ref = ref
         # Classic IT8 has a GS0..GS23 strip; anything else is a plain grid that
         # the user delimits with corner patch ids (block mode).
@@ -563,19 +612,153 @@ class IT8ProfileDialog(QDialog):
     def _update_locate_status(self):
         img = self.locator.image_array()
         if img is None or self._ref is None:
+            self.locator.set_invalid_ids(set())
             return
         pts = self.locator.points()
         nc, nr = self.locator.grid_dims()
         samples = it8.sample_patches(img, pts, self.locator.quad(),
                                      ncols=nc, nrows=nr)
         in_ref = [sid for sid in samples if sid in self._ref.patches]
-        valid = sum(1 for sid in in_ref if samples[sid].valid)
+        invalid = [sid for sid in in_ref if not samples[sid].valid]
+        self.locator.set_invalid_ids(set(invalid))
+        valid = len(in_ref) - len(invalid)
         warn = ""
         if ("GS0" in samples and "GS23" in samples
                 and samples["GS0"].valid and samples["GS23"].valid):
             if samples["GS0"].rgb.mean() < samples["GS23"].rgb.mean():
                 warn = "  ⚠ GS0 darker than GS23 — try Flip 180°"
-        self.locate_status.setText(f"Valid patches: {valid}/{len(in_ref)}{warn}")
+        if invalid:
+            shown = ", ".join(invalid[:10])
+            more = (f", … (+{len(invalid) - 10} more)"
+                    if len(invalid) > 10 else "")
+            self.locate_status.setText(
+                f"Valid patches: {valid}/{len(in_ref)} — "
+                f"<span style='color:#e64646;'>invalid (red): {shown}{more}"
+                f"</span>{warn}")
+            self.locate_status.setToolTip(
+                "Invalid patches (drawn red — highlight-clipped, essentially "
+                "black, or off-frame; nudge the corners or re-expose):\n"
+                + ", ".join(invalid))
+        else:
+            self.locate_status.setText(
+                f"Valid patches: {valid}/{len(in_ref)}{warn}")
+            self.locate_status.setToolTip("")
+
+    # ------------------------------------------------------------------ #
+    # Page 3b — multi-card mapping (block-mode targets split across cards)
+    # ------------------------------------------------------------------ #
+    def _sample_current(self):
+        """Sample the card currently in the locator -> {id: PatchSample}, or
+        None if no image is loaded."""
+        img = self.locator.image_array()
+        if img is None:
+            return None
+        pts = self.locator.points()
+        nc, nr = self.locator.grid_dims()
+        return it8.sample_patches(img, pts, self.locator.quad(),
+                                  ncols=nc, nrows=nr)
+
+    def _should_ask_more(self) -> bool:
+        """Offer another card only for block-mode targets, at most twice (so up
+        to 3 cards total, e.g. columns 1-24 / 25-48 / 49-72), and only while no
+        fit has been built yet — so Back-from-build → Next just re-fits instead
+        of re-popping the prompt. A target/reference change clears _fit."""
+        return (self._mode == "block" and len(self._mapped_cards) < 2
+                and self._fit is None)
+
+    def _prompt_map_another(self) -> str:
+        """Ask whether to map another card. Returns 'another' or 'build'."""
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Question)
+        box.setWindowTitle("Map another image?")
+        n = len(self._mapped_cards) + 1
+        box.setText(f"Mapped {n} image(s) so far.")
+        box.setInformativeText(
+            "Some IT8 targets are split across several physical cards (e.g. "
+            "columns 1–24, 25–48, 49–72). If you photographed more than one "
+            "card, map the next image now — its patches are added to the same "
+            "profile. Otherwise build the profile from what you've mapped.")
+        another = box.addButton("Map another image…", QMessageBox.AcceptRole)
+        box.addButton("Build profile", QMessageBox.RejectRole)
+        box.setDefaultButton(another)
+        box.exec()
+        return "another" if box.clickedButton() is another else "build"
+
+    def _browse_next_target(self) -> Optional[str]:
+        start = self._settings.value("files/last_open_dir", "", type=str)
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select the next IT8 card image", start,
+            "Images (*.dng *.tif *.tiff *.arw *.nef *.cr2 *.cr3 *.raf *.png "
+            "*.jpg *.jpeg *.rw2 *.3fr *.fff);;All Files (*)")
+        return path or None
+
+    def _load_card_image(self, path: str) -> bool:
+        """Decode `path` and load it into the locator as the next card. Returns
+        False (with a message shown) on a bad path / decode failure."""
+        norm = normalize_unicode_path(path)
+        if not validate_unicode_path(norm):
+            QMessageBox.warning(self, "Unicode Path",
+                                "This file path can't be processed. Please move "
+                                "it to a simpler path.")
+            return False
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            arr = it8.decode_target(norm)
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.critical(self, "Decode Error",
+                                 f"Could not read the card image:\n\n{e}")
+            return False
+        QApplication.restoreOverrideCursor()
+        if arr is None or arr.ndim != 3:
+            QMessageBox.critical(self, "Decode Error",
+                                 "Could not decode the card image.")
+            return False
+        self._target_path = path
+        self._target_img = arr
+        self.locator.set_image(arr)        # resets the quad for the new shot
+        self._locator_arr = arr
+        return True
+
+    def _advance_block_ids(self):
+        """Shift the block's patch-id range to the next card's columns. If the
+        previous card already reached the chart edge there is no distinct next
+        block to advance into (the shift would collapse to a single column or
+        overlap), so leave the ids for the user to set by hand."""
+        if self._mode != "block":
+            return
+        max_col = None
+        extent = self._ref_extent()
+        if extent:
+            m = re.match(r'^[A-Za-z](\d+)$', extent[1])
+            if m:
+                max_col = int(m.group(1))
+        try:
+            prev_rows, prev_cols = it8.parse_block(self.tl_edit.text(),
+                                                   self.br_edit.text())
+            tl, br = it8.next_block_ids(self.tl_edit.text(),
+                                       self.br_edit.text(), max_col)
+            new_rows, new_cols = it8.parse_block(tl, br)
+        except ValueError:
+            return
+        if len(new_cols) < 2 or min(new_cols) <= max(prev_cols):
+            QMessageBox.information(
+                self, "Set this card's patches",
+                "Couldn't auto-advance the patch-id range — the previous card "
+                "already reached the edge of the chart. Set the top-left / "
+                "bottom-right patch ids for this card by hand.")
+            return
+        self.tl_edit.setText(tl)
+        self.br_edit.setText(br)
+        self._apply_block_ids()
+
+    def _update_card_banner(self):
+        if self._mode == "block":
+            n = len(self._mapped_cards) + 1
+            self.card_label.setText(f"Card {n} of up to 3")
+            self.card_label.setVisible(True)
+        else:
+            self.card_label.setVisible(False)
 
     # ------------------------------------------------------------------ #
     # Page 4 — build
@@ -584,10 +767,9 @@ class IT8ProfileDialog(QDialog):
         err = None
         QApplication.setOverrideCursor(Qt.WaitCursor)
         try:
-            pts = self.locator.points()
-            nc, nr = self.locator.grid_dims()
-            samples = it8.sample_patches(self.locator.image_array(), pts,
-                                         self.locator.quad(), ncols=nc, nrows=nr)
+            # _all_samples is the merge of every mapped card; fall back to the
+            # current card alone if the fit is somehow reached un-accumulated.
+            samples = self._all_samples or self._sample_current() or {}
             fit = it8.fit_camera_matrix(samples, self._ref)
         except it8.IT8ReferenceError as e:
             fit, err = None, str(e)
@@ -603,6 +785,8 @@ class IT8ProfileDialog(QDialog):
             chip, colour = "OK", "#b08a00"
         else:
             chip, colour = "Check placement / capture", "#b03030"
+        combined = (f" · combined from {self._n_images} images"
+                    if self._n_images > 1 else "")
         self.quality_label.setText(
             f"<span style='background:{colour};color:white;padding:2px 8px;'>"
             f"{chip}</span>  &nbsp; "
@@ -610,7 +794,7 @@ class IT8ProfileDialog(QDialog):
             f"95th {fit.p95_de:.2f} · max {fit.max_de:.2f}<br>"
             f"Patches used: {len(fit.used_ids)} · dropped "
             f"(clipped/missing): {len(fit.dropped_ids)} · "
-            f"white-balanced on {fit.wb_id}")
+            f"white-balanced on {fit.wb_id}{combined}")
         self.worst_list.clear()
         for sid, de in fit.per_patch[:20]:
             self.worst_list.addItem(f"{sid}\tΔE {de:.2f}")
@@ -685,6 +869,26 @@ class IT8ProfileDialog(QDialog):
                                         "Load a reference file.")
                 return
         elif i == self.PAGE_LOCATE:
+            cur = self._sample_current()
+            if cur is None:
+                QMessageBox.information(self, "Locate",
+                                        "No target image to sample.")
+                return
+            # Offer to map another card (up to 3 total) before fitting.
+            if self._should_ask_more() and self._prompt_map_another() == "another":
+                path = self._browse_next_target()
+                if not path:
+                    return                        # browse cancelled — stay put
+                self._mapped_cards.append(cur)
+                if not self._load_card_image(path):
+                    self._mapped_cards.pop()      # decode failed — roll back
+                    return
+                self._advance_block_ids()
+                self._update_card_banner()
+                self._update_locate_status()
+                return                            # stay on locate for next card
+            self._n_images = len(self._mapped_cards) + 1
+            self._all_samples = it8.merge_samples(self._mapped_cards + [cur])
             if not self._run_fit():
                 return
         elif i == self.PAGE_BUILD:
@@ -723,8 +927,10 @@ class IT8ProfileDialog(QDialog):
                 "<b>Step 3 — Locate the patches</b> — drag the four green "
                 "corners onto the outer corners of the patch grid you "
                 "photographed. Set the top-left / bottom-right patch ids below "
-                "to match the block in frame, then nudge the corners until every "
-                "dot sits inside its patch.")
+                "to match the block <i>in this frame</i>, then nudge the corners "
+                "until every dot sits inside its patch. If the target is split "
+                "across several cards (e.g. columns 1–24, 25–48, 49–72), map just "
+                "this card — you'll be asked for the next one.")
             extent = self._ref_extent()
             if extent and not self.tl_edit.text():
                 self.tl_edit.setText(extent[0])
@@ -740,6 +946,7 @@ class IT8ProfileDialog(QDialog):
                 "corners onto the outer corners of the 12×22 colour grid. "
                 "Yellow dots are colour patches, blue dots the grayscale strip.")
             self.locator.set_layout_classic()
+        self._update_card_banner()
 
     def _update_nav(self):
         i = self.stack.currentIndex()

--- a/src/widgets/it8_profile_dialog.py
+++ b/src/widgets/it8_profile_dialog.py
@@ -29,6 +29,18 @@ from utils.unicode_path_utils import normalize_unicode_path, validate_unicode_pa
 _REF_URL = "http://www.targets.coloraid.de/"
 
 
+def _illuminant_enum(illum: str) -> int:
+    """Map the wizard's capture-light label to a DNG CalibrationIlluminant
+    (EXIF LightSource) code. The fit is D50-referenced, so this is metadata for a
+    single-illuminant DCP; tungsten/fluorescent are tagged, everything else D50."""
+    s = (illum or "").lower()
+    if "tungsten" in s:
+        return 17                                    # Standard light A
+    if "fluor" in s:
+        return 2                                     # Fluorescent
+    return 23                                        # D50
+
+
 def _gamma_stretch_to_qimage(arr_u16: np.ndarray) -> QImage:
     """8-bit gamma-stretched view of a raw-linear 16-bit RGB array (display
     only — the fit always uses the linear data)."""
@@ -460,8 +472,15 @@ class IT8ProfileDialog(QDialog):
         self.illum_combo.setEditable(True)
         self.illum_combo.addItems(["Daylight", "Strobe/Flash", "Tungsten",
                                    "Fluorescent", "Other"])
+        self.type_combo = QComboBox()
+        self.type_combo.addItems(["3×3 matrix", "cLUT (higher accuracy)"])
+        self.type_combo.setToolTip(
+            "3×3 matrix: a compact, well-behaved linear profile. cLUT: a 3-D "
+            "lookup table that also corrects the saturated-corner residuals a "
+            "matrix can't reach (uses the full sampled patch set).")
         form.addRow("Profile name:", self.name_edit)
         form.addRow("Illuminant:", self.illum_combo)
+        form.addRow("Profile type:", self.type_combo)
         lay.addLayout(form)
         lay.addStretch(1)
         return w
@@ -817,12 +836,12 @@ class IT8ProfileDialog(QDialog):
         return os.path.join(folder, f"{safe}.icc")
 
     def _choose_save_path(self):
-        path, _ = QFileDialog.getSaveFileName(
-            self, "Save camera ICC profile", self.save_path_edit.text(),
-            "ICC Profiles (*.icc)")
+        path, sel = QFileDialog.getSaveFileName(
+            self, "Save camera profile", self.save_path_edit.text(),
+            "ICC profile (*.icc);;DNG camera profile (*.dcp)")
         if path:
-            if not path.lower().endswith(".icc"):
-                path += ".icc"
+            if not path.lower().endswith((".icc", ".dcp")):
+                path += ".dcp" if "dcp" in sel.lower() else ".icc"
             self.save_path_edit.setText(path)
 
     def _do_save(self) -> bool:
@@ -833,11 +852,27 @@ class IT8ProfileDialog(QDialog):
         illum = self.illum_combo.currentText().strip()
         name = self.name_edit.text().strip() or "Camera Profile"
         desc = f"{name} ({illum})" if illum else name
+        clut = self.type_combo.currentIndex() == 1
+        if path.lower().endswith(".dcp") and clut:
+            QMessageBox.information(
+                self, "DCP is matrix-only",
+                "DCP export writes a 3×3 matrix profile; the cLUT "
+                "(higher-accuracy) correction is not included. Save as .icc to "
+                "keep the cLUT.")
         try:
-            icc = it8.build_camera_icc(self._fit, desc)
+            if path.lower().endswith(".dcp"):
+                from core import dcp_profile
+                blob = dcp_profile.build_camera_dcp(
+                    self._fit, desc, illuminant=_illuminant_enum(illum))
+            elif clut:
+                blob = it8.build_camera_icc(
+                    self._fit, desc, mode="clut", grid=17,
+                    samples=self._all_samples, ref=self._ref)
+            else:
+                blob = it8.build_camera_icc(self._fit, desc)
             os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
             with open(path, "wb") as f:
-                f.write(icc)
+                f.write(blob)
         except Exception as e:
             QMessageBox.critical(self, "Save Error",
                                  f"Could not write the profile:\n\n{e}")

--- a/tests/test_clut_icc.py
+++ b/tests/test_clut_icc.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""
+Tests for LUT-based (cLUT / A2B) ICC support in core.color_management — parse
+(mft1/mft2/mAB), tetrahedral interpolation, PCS XYZ/Lab, reject unsupported, and
+the generate (residual cLUT) round-trip. See spec/clut-icc-support.md §8.
+Pure numpy/struct — no Qt.
+"""
+import os
+import struct
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core import color_management as cm        # noqa: E402
+from core import it8_profile as it8            # noqa: E402
+
+D50 = np.array(cm.D50_XYZ)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers: wrap an A2B element in a minimal valid RGB ICC; build mft1/mft2/mAB.
+# --------------------------------------------------------------------------- #
+
+def _wrap(element: bytes, pcs=b'XYZ ', version=0x02400000) -> bytes:
+    tags = {'desc': cm._desc_type('t'), 'A2B0': element,
+            'wtpt': cm._xyz_type(*cm.D50_XYZ), 'cprt': cm._text_type('x')}
+    order = ['desc', 'A2B0', 'wtpt', 'cprt']
+    n = len(order); base = 128 + 4 + n * 12
+    data = b''; entries = []; seen = {}
+    for name in order:
+        payload = tags[name]; key = bytes(payload)
+        if key in seen:
+            off, ln = seen[key]
+        else:
+            if len(data) % 4:
+                data += b'\x00' * (4 - len(data) % 4)
+            off = base + len(data); ln = len(payload); data += payload
+            seen[key] = (off, ln)
+        entries.append((name.encode(), off, ln))
+    table = struct.pack('>I', n)
+    for tag, off, ln in entries:
+        table += struct.pack('>4sII', tag, off, ln)
+    h = bytearray(128)
+    struct.pack_into('>I', h, 0, 128 + len(table) + len(data))
+    struct.pack_into('>I', h, 8, version)
+    struct.pack_into('>4s', h, 12, b'mntr')
+    struct.pack_into('>4s', h, 16, b'RGB ')
+    struct.pack_into('>4s', h, 20, pcs)
+    struct.pack_into('>4s', h, 36, b'acsp')
+    return bytes(h) + table + data
+
+
+def _grid_vals(grid, fn):
+    ax = np.linspace(0.0, 1.0, grid)
+    out = np.empty((grid, grid, grid, 3))
+    for ir in range(grid):
+        for ig in range(grid):
+            for ib in range(grid):
+                out[ir, ig, ib] = fn(ax[ir], ax[ig], ax[ib])
+    return out
+
+
+def _mft1_element(grid, vals01):
+    body = struct.pack('>4sI', b'mft1', 0) + struct.pack('>BBBx', 3, 3, grid)
+    for v in (1, 0, 0, 0, 1, 0, 0, 0, 1):
+        body += struct.pack('>i', cm._s15f16(v))
+    ramp = np.rint(np.linspace(0, 255, 256)).astype(np.uint8).tobytes()
+    body += ramp * 3
+    body += np.rint(np.clip(vals01, 0, 1) * 255).astype(np.uint8).tobytes()
+    body += ramp * 3
+    return body
+
+
+def _mft2_element(grid, vals01):
+    body = struct.pack('>4sI', b'mft2', 0) + struct.pack('>BBBx', 3, 3, grid)
+    for v in (1, 0, 0, 0, 1, 0, 0, 0, 1):
+        body += struct.pack('>i', cm._s15f16(v))
+    body += struct.pack('>HH', 2, 2)
+    for _ in range(3):
+        body += struct.pack('>HH', 0, 65535)
+    body += np.rint(np.clip(vals01, 0, 1) * 65535).astype('>u2').tobytes()
+    for _ in range(3):
+        body += struct.pack('>HH', 0, 65535)
+    return body
+
+
+def _mAB_element(grid, vals01, *, matrix=None):
+    """mAB with identity A-curves + CLUT (+ optional 3x4 matrix on the output)."""
+    curv0 = struct.pack('>4sII', b'curv', 0, 0)          # identity 'curv', 12 bytes
+    A = curv0 * 3
+    off_A = 32
+    off_clut = off_A + len(A)
+    gp = bytes([grid] * 3) + bytes(13)                   # gridPoints[16]
+    clut = gp + bytes([2, 0, 0, 0])                      # u16 precision + pad
+    clut += np.rint(np.clip(vals01, 0, 1) * 65535).astype('>u2').tobytes()
+    off_mat = 0
+    mat_bytes = b''
+    if matrix is not None:
+        off_mat = off_clut + len(clut)
+        m = np.asarray(matrix, float).ravel()            # 12 (3x3 + offset)
+        mat_bytes = b''.join(struct.pack('>i', cm._s15f16(v)) for v in m)
+    body = struct.pack('>4sI', b'mAB ', 0) + struct.pack('>BB2x', 3, 3)
+    body += struct.pack('>5I', 0, off_mat, 0, off_clut, off_A)   # B,mat,M,CLUT,A
+    body += A + clut + mat_bytes
+    return body
+
+
+# --------------------------------------------------------------------------- #
+# Parse + interpolation.
+# --------------------------------------------------------------------------- #
+
+M0 = np.array([[0.46, 0.31, 0.17], [0.23, 0.70, 0.07], [0.02, 0.12, 0.93]])
+
+
+def _affine_xyz(r, g, b):
+    return M0 @ np.array([r, g, b])              # XYZ D50, Y=1, in range for grid<=1
+
+
+def _parse(element, pcs=b'XYZ ', version=0x02400000):
+    return cm.InputProfile.from_bytes(_wrap(element, pcs, version))
+
+
+def test_parse_mft2_affine_roundtrip():
+    g = 9
+    vals = _grid_vals(g, lambda r, gg, b: _affine_xyz(r, gg, b) / cm._XYZ_ENC)
+    prof = _parse(_mft2_element(g, vals))
+    assert prof._kind == 'clut' and prof._clut.grid == (g, g, g)
+    rng = np.random.default_rng(1)
+    dev = (rng.uniform(0, 1, (8, 8, 3)) * 65535).astype(np.uint16)
+    out = prof.apply(dev)
+    d01 = dev.astype(np.float64) / 65535.0
+    expect = np.clip(d01 @ (cm.M_XYZ_D50_2_ADOBE @ M0).T, 0, 1)
+    err = np.abs(out.astype(int) - np.rint(expect * 65535).astype(int)).max()
+    assert err < 12                              # tetra affine-exact; err = u16 quantisation
+
+
+def test_parse_mft1_8bit():
+    g = 7
+    vals = _grid_vals(g, lambda r, gg, b: _affine_xyz(r, gg, b) / cm._XYZ_ENC)
+    prof = _parse(_mft1_element(g, vals))
+    assert prof._kind == 'clut'
+    # 8-bit storage is coarse; the neutral axis should still be near-neutral XYZ.
+    xyz = prof._clut.table[g // 2, g // 2, g // 2]
+    assert xyz[1] > 0                            # non-zero Y at mid-grey
+
+
+def test_parse_mAB_with_matrix():
+    g = 5
+    # CLUT outputs 0.5*the value; the mAB matrix (2*I) doubles it -> affine map.
+    vals = _grid_vals(g, lambda r, gg, b: 0.5 * (M0 @ np.array([r, gg, b])) / cm._XYZ_ENC)
+    # ICC mAB matrix element = 9 row-major 3x3 values THEN 3 offset values.
+    mat12 = np.concatenate([np.diag([2.0, 2.0, 2.0]).ravel(), [0.0, 0.0, 0.0]])
+    prof = _parse(_mAB_element(g, vals, matrix=mat12))
+    # corner (1,1,1): CLUT 0.5*M0@1 /_XYZ_ENC, *2 (matrix), *_XYZ_ENC (decode) = M0@1
+    got = prof._clut.table[-1, -1, -1]
+    np.testing.assert_allclose(got, M0 @ np.ones(3), atol=2e-3)
+
+
+def test_tetra_affine_exact_and_neutral():
+    g = 9
+    vals = _grid_vals(g, lambda r, gg, b: _affine_xyz(r, gg, b) / cm._XYZ_ENC)
+    clut = _parse(_mft2_element(g, vals))._clut
+    q = np.random.default_rng(2).uniform(0, 1, (200, 3)).astype(np.float32)
+    tetra = cm._clut_interp_tetra(q, clut)
+    tri = cm._clut_interp_trilinear(q, clut)
+    # affine -> both exact; tetra ~ trilinear
+    np.testing.assert_allclose(tetra, q @ M0.T, atol=2e-3)
+    np.testing.assert_allclose(tetra, tri, atol=2e-3)
+
+
+def test_pcs_lab_v4_decodes_to_xyz():
+    g = 6
+    def lab01(r, gg, b):
+        xyz = _affine_xyz(r, gg, b)                       # Y=1
+        L, a, bb = it8.xyz_to_lab(xyz * 100.0)
+        return np.array([L / 100.0, (a + 128) / 255.0, (bb + 128) / 255.0])
+    vals = _grid_vals(g, lab01)
+    prof = _parse(_mft2_element(g, vals), pcs=b'Lab ', version=0x04200000)
+    # table is decoded XYZ(D50,Y=1); compare to the affine map at a node
+    node = prof._clut.table[-1, -1, -1]
+    np.testing.assert_allclose(node, _affine_xyz(1, 1, 1), atol=2e-3)
+
+
+# --------------------------------------------------------------------------- #
+# Rejection.
+# --------------------------------------------------------------------------- #
+
+def test_reject_cmyk():
+    g = 5
+    vals = _grid_vals(g, lambda r, gg, b: _affine_xyz(r, gg, b) / cm._XYZ_ENC)
+    icc = bytearray(_wrap(_mft2_element(g, vals)))
+    icc[16:20] = b'CMYK'
+    with pytest.raises(cm.UnsupportedICCError):
+        cm.InputProfile.from_bytes(bytes(icc))
+
+
+def test_reject_unsupported_pcs():
+    g = 5
+    vals = _grid_vals(g, lambda r, gg, b: _affine_xyz(r, gg, b) / cm._XYZ_ENC)
+    with pytest.raises(cm.UnsupportedICCError):
+        cm.InputProfile.from_bytes(_wrap(_mft2_element(g, vals), pcs=b'FOO '))
+
+
+def test_reject_degenerate_grid_mft():
+    # g < 2 in mft1/mft2 must be rejected at PARSE time (was a deferred IndexError).
+    for builder in (_mft1_element, _mft2_element):
+        vals = np.zeros((1, 1, 1, 3))
+        el = builder(1, vals)                      # g = 1
+        with pytest.raises(cm.UnsupportedICCError):
+            cm.InputProfile.from_bytes(_wrap(el))
+
+
+def test_reject_non_3channel_and_mAB_guards():
+    # i != 3 (e.g. CMYK-style 4-in) rejected by the parser (distinct from the
+    # header RGB guard).
+    el = bytearray(_mft2_element(4, _grid_vals(4, lambda r, g, b: _affine_xyz(r, g, b) / cm._XYZ_ENC)))
+    el[8] = 4                                       # i = 4
+    with pytest.raises(cm.UnsupportedICCError):
+        cm.InputProfile.from_bytes(_wrap(bytes(el)))
+    # mAB without a CLUT (off_clut == 0) rejected.
+    g = 4
+    vals = _grid_vals(g, lambda r, gg, b: _affine_xyz(r, gg, b) / cm._XYZ_ENC)
+    mab = bytearray(_mAB_element(g, vals))
+    struct.pack_into('>5I', mab, 12, 0, 0, 0, 0, 32)      # off_clut = 0
+    with pytest.raises(cm.UnsupportedICCError):
+        cm.InputProfile.from_bytes(_wrap(bytes(mab)))
+
+
+def test_pcs_lab_v2_16bit_and_mft1_8bit():
+    g = 6
+    def lab01(r, gg, b, scale):
+        xyz = _affine_xyz(r, gg, b)
+        L, a, bb = it8.xyz_to_lab(xyz * 100.0)
+        return np.array([L / 100.0, (a + 128) / 255.0, (bb + 128) / 255.0]) * scale
+    # v2 16-bit legacy: stored so L*=100 -> 0xFF00, i.e. divide by 65535/65280.
+    s = 65280.0 / 65535.0
+    prof = _parse(_mft2_element(g, _grid_vals(g, lambda r, gg, b: lab01(r, gg, b, s))),
+                  pcs=b'Lab ', version=0x02400000)
+    np.testing.assert_allclose(prof._clut.table[-1, -1, -1], _affine_xyz(1, 1, 1), atol=3e-3)
+    # mft1 8-bit Lab (scale 1.0): coarse but the mid node should be plausible XYZ.
+    p8 = _parse(_mft1_element(g, _grid_vals(g, lambda r, gg, b: lab01(r, gg, b, 1.0))),
+                pcs=b'Lab ', version=0x02400000)
+    assert p8._clut.table[g // 2, g // 2, g // 2][1] > 0
+
+
+def test_tetra_keeps_neutral_where_trilinear_desaturates():
+    # A table neutral ON the diagonal but chroma-shifted OFF it. A diagonal query
+    # d=(t,t,t): tetra interpolates only the two neutral diagonal corners (stays
+    # neutral); trilinear weights all 8 corners incl. the chroma off-diagonal ones
+    # (desaturates). This is the property the tetra path exists for (spec §5.2).
+    g = 5
+    ax = np.linspace(0, 1, g)
+    tbl = np.empty((g, g, g, 3))
+    for i in range(g):
+        for j in range(g):
+            for k in range(g):
+                v = np.array([ax[i], ax[j], ax[k]])
+                m = v.mean(); spread = v.max() - v.min()
+                tbl[i, j, k] = m + 0.3 * spread * np.array([1.0, -0.5, -0.5])
+    clut = cm._CLUT(grid=(g, g, g), table=tbl.astype(np.float32),
+                    in_luts=[np.linspace(0, 1, 65536).astype(np.float32)] * 3)
+    diag = np.stack([np.linspace(0.05, 0.95, 20)] * 3, axis=1).astype(np.float32)
+    te = cm._clut_interp_tetra(diag, clut)
+    tr = cm._clut_interp_trilinear(diag, clut)
+    assert float(np.abs(te.max(1) - te.min(1)).max()) < 1e-4    # tetra: neutral preserved
+    assert float(np.abs(tr.max(1) - tr.min(1)).max()) > 1e-2    # trilinear: desaturates
+
+
+def test_tetra_chunk_boundary(monkeypatch):
+    # Exercise the multi-chunk loop cheaply by shrinking the chunk size.
+    g = 5
+    vals = _grid_vals(g, lambda r, gg, b: _affine_xyz(r, gg, b) / cm._XYZ_ENC)
+    clut = _parse(_mft2_element(g, vals))._clut
+    monkeypatch.setattr(cm, "_TETRA_CHUNK", 50)
+    q = np.random.default_rng(5).uniform(0, 1, (137, 3)).astype(np.float32)   # > 2 chunks
+    out = cm._clut_interp_tetra(q, clut)
+    np.testing.assert_allclose(out, q @ M0.T, atol=2e-3)        # boundary rows correct
+
+
+def test_residual_clut_bounded_ringing():
+    samples, ref = _nonaffine_camera()
+    fit = it8.fit_camera_matrix(samples, ref)
+    tbl = it8.build_residual_clut(fit, samples, ref, grid=17)
+    ax = np.linspace(0, 1, 17)
+    base = (np.stack(np.meshgrid(ax, ax, ax, indexing="ij"), -1).reshape(-1, 3)
+            @ fit.matrix.T).reshape(17, 17, 17, 3)
+    assert it8._residual_monotone(base, tbl)                    # no reversal > RINGING_TOL
+
+
+def test_reject_b2a_only():
+    # An RGB profile with neither matrix-shaper tags nor an A2B tag.
+    h = bytearray(128)
+    struct.pack_into('>4s', h, 16, b'RGB ')
+    struct.pack_into('>4s', h, 20, b'XYZ ')
+    struct.pack_into('>4s', h, 36, b'acsp')
+    table = struct.pack('>I', 1) + struct.pack('>4sII', b'B2A0', 128 + 16, 4) + b'\x00' * 4
+    with pytest.raises(cm.UnsupportedICCError):
+        cm.InputProfile.from_bytes(bytes(h) + table)
+
+
+# --------------------------------------------------------------------------- #
+# Matrix-shaper path unchanged (regression).
+# --------------------------------------------------------------------------- #
+
+def test_matrix_shaper_path_still_matrix():
+    adapted = cm.M_BRADFORD_D65_D50 @ cm.M_SRGB2XYZ
+    icc = cm.build_matrix_shaper_icc(
+        'm', tuple(adapted[:, 0]), tuple(adapted[:, 1]), tuple(adapted[:, 2]),
+        (1.0, 1.0, 0.0, 1.0, 0.0))
+    prof = cm.InputProfile.from_bytes(icc)
+    assert prof._kind == 'matrix' and prof._clut is None
+    img = (np.random.default_rng(3).uniform(0, 1, (4, 4, 3)) * 65535).astype(np.uint16)
+    assert prof.apply(img).shape == img.shape
+
+
+# --------------------------------------------------------------------------- #
+# Generate: build_clut_icc round-trip + residual cLUT beats the 3x3 matrix.
+# --------------------------------------------------------------------------- #
+
+def test_build_clut_icc_reparses():
+    g = 9
+    clut = _grid_vals(g, _affine_xyz)
+    icc = cm.build_clut_icc('gen', clut, g)
+    assert icc[36:40] == b'acsp' and icc[16:20] == b'RGB ' and icc[20:24] == b'XYZ '
+    prof = cm.InputProfile.from_bytes(icc)
+    assert prof._kind == 'clut' and prof._clut.grid == (g, g, g)
+
+
+def _nonaffine_camera():
+    """Synthetic patches whose device->XYZ is non-affine, so a 3x3 leaves
+    residuals a cLUT can remove."""
+    patches = {}
+    for k, Y in enumerate(np.linspace(89, 3, 24)):
+        patches[f'GS{k}'] = (Y / 100.0) * D50 * 100.0
+    rng = np.random.default_rng(7)
+    for cid in it8.COLOR_IDS:
+        Y = rng.uniform(5, 85)
+        patches[cid] = np.array([Y * rng.uniform(0.7, 1.3), Y, Y * rng.uniform(0.4, 1.2)])
+    Minv = np.linalg.inv(M0)
+    samples = {}
+    for sid, xyz in patches.items():
+        d = np.clip(Minv @ (xyz / 100.0), 0, None)
+        d = d + 0.06 * (d ** 2 - d)                       # non-affine distortion
+        samples[sid] = it8.PatchSample(np.clip(d, 0, 1) * 65535.0, True, 900)
+    ref = it8.IT8Reference(batch='S')
+    for sid, xyz in patches.items():
+        lab = it8.xyz_to_lab(xyz)
+        ref.patches[sid] = {'XYZ_X': xyz[0], 'XYZ_Y': xyz[1], 'XYZ_Z': xyz[2],
+                            'LAB_L': lab[0], 'LAB_A': lab[1], 'LAB_B': lab[2]}
+    return samples, ref
+
+
+def _patch_des(prof, fit, samples, ref):
+    Ainv = np.linalg.inv(cm.M_XYZ_D50_2_ADOBE)
+    de = []
+    for sid in fit.used_ids:
+        dev = np.clip(samples[sid].rgb, 0, 65535).astype(np.uint16).reshape(1, 1, 3)
+        out = prof.apply(np.tile(dev, (2, 2, 1)))[0, 0].astype(np.float64) / 65535.0
+        xyz = (Ainv @ out) * 100.0
+        de.append(float(it8.delta_e_2000(it8.xyz_to_lab(xyz), ref.lab(sid))[0]))
+    return float(np.mean(de)), float(np.max(de))
+
+
+def test_clut_beats_matrix_on_nonaffine_camera():
+    samples, ref = _nonaffine_camera()
+    fit = it8.fit_camera_matrix(samples, ref)
+    mp = cm.InputProfile.from_bytes(it8.build_camera_icc(fit, 'm', mode='matrix'))
+    cp = cm.InputProfile.from_bytes(
+        it8.build_camera_icc(fit, 'c', mode='clut', grid=17, samples=samples, ref=ref))
+    m_avg, m_max = _patch_des(mp, fit, samples, ref)
+    c_avg, c_max = _patch_des(cp, fit, samples, ref)
+    assert c_avg < 0.6 * m_avg                            # markedly lower residual
+    assert c_max <= m_max
+
+
+def test_build_camera_icc_clut_requires_samples():
+    samples, ref = _nonaffine_camera()
+    fit = it8.fit_camera_matrix(samples, ref)
+    with pytest.raises(ValueError):
+        it8.build_camera_icc(fit, 'c', mode='clut')      # no samples/ref

--- a/tests/test_color_management.py
+++ b/tests/test_color_management.py
@@ -306,6 +306,58 @@ def test_backend_set_and_clear_input_icc(tmp_path, monkeypatch):
         ccr_backend.input_icc_name = None
 
 
+def _camera_dcp():
+    from core import dcp_profile
+
+    class _F:
+        matrix = np.array([[0.46, 0.31, 0.17], [0.23, 0.70, 0.07], [0.02, 0.12, 0.93]])
+    return dcp_profile.build_camera_dcp(_F(), "Cam")
+
+
+def test_read_image_applies_active_dcp(tmp_path):
+    _make_qapp()
+    from core.ccr_image import CCRImage
+    from core import dcp_profile
+    p = str(tmp_path / "neg.png")
+    _write_negative_png(p)
+    cm.set_active_dcp_profile(None)
+    try:
+        a = CCRImage(p).resized_raw.copy()             # no profile
+        cm.set_active_dcp_profile(dcp_profile.parse_dcp_bytes(_camera_dcp()))
+        b = CCRImage(p).resized_raw.copy()             # DCP burned in at decode
+        assert a.shape == b.shape and not np.array_equal(a, b)
+    finally:
+        cm.set_active_dcp_profile(None)
+
+
+def test_backend_dcp_exclusivity_and_storage(tmp_path, monkeypatch):
+    _make_qapp()
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    from core.ccr_backend import ccr_backend
+    dsrc = tmp_path / "c.dcp"; dsrc.write_bytes(_camera_dcp())
+    isrc = tmp_path / "p.icc"; isrc.write_bytes(_adobe_like_icc())
+    icc_store = str(tmp_path / "FreeCCR" / "input_profile.icc")
+    dcp_store = str(tmp_path / "FreeCCR" / "input_profile.dcp")
+    try:
+        ccr_backend.set_input_icc(str(isrc))
+        ccr_backend.set_input_dcp(str(dsrc))           # DCP set -> ICC must clear
+        assert cm.get_active_dcp_profile() is not None
+        assert cm.get_active_input_profile() is None
+        assert os.path.exists(dcp_store) and not os.path.exists(icc_store)
+        ccr_backend.set_input_icc(str(isrc))           # ICC set -> DCP must clear
+        assert cm.get_active_input_profile() is not None
+        assert cm.get_active_dcp_profile() is None
+        assert not os.path.exists(dcp_store)
+        ccr_backend.clear_input_icc()
+        ccr_backend.clear_input_dcp()
+        assert cm.get_active_dcp_profile() is None and cm.get_active_input_profile() is None
+    finally:
+        cm.set_active_input_profile(None)
+        cm.set_active_dcp_profile(None)
+        ccr_backend.input_icc_path = ccr_backend.input_icc_name = None
+        ccr_backend.input_dcp_path = ccr_backend.input_dcp_name = None
+
+
 def test_backend_rejects_lut_profile_unchanged(tmp_path, monkeypatch):
     _make_qapp()
     monkeypatch.setenv("APPDATA", str(tmp_path))

--- a/tests/test_color_management.py
+++ b/tests/test_color_management.py
@@ -165,12 +165,29 @@ def test_input_profile_applies_and_preserves_shape():
     assert not np.array_equal(out, img)
 
 
-def test_input_profile_srgb_is_near_identity():
+def test_input_profile_adobe_linear_is_near_identity():
+    # The input-profile working space is LINEAR Adobe RGB (so the density-based
+    # negative inversion sees consistent linear data). An Adobe-primary profile
+    # with a LINEAR TRC therefore round-trips to (near) the input.
+    adobe_d50 = cm.M_BRADFORD_D65_D50 @ cm.M_ADOBE2XYZ_D65
+    icc = cm.build_matrix_shaper_icc(
+        "Adobe-linear", tuple(adobe_d50[:, 0]), tuple(adobe_d50[:, 1]),
+        tuple(adobe_d50[:, 2]), (1.0, 1.0, 0.0, 1.0, 0.0))   # linear (identity) TRC
+    ip = cm.InputProfile.from_bytes(icc)
+    img = _rand_u16(seed=9)
+    out = ip.apply(img)
+    # Identity up to ICC s15Fixed16 colorant precision.
+    assert int(np.abs(out.astype(int) - img.astype(int)).max()) < 64
+
+
+def test_input_profile_srgb_relinearizes_to_adobe():
+    # An sRGB profile is NO LONGER identity: it linearises the sRGB-encoded input
+    # and re-expresses it in linear Adobe primaries (the working space), so the
+    # output must differ substantially from the input.
     ip = cm.InputProfile.from_bytes(cm.SRGB_ICC_BYTES)
     img = _rand_u16(seed=9)
     out = ip.apply(img)
-    # sRGB-in -> sRGB-working is identity up to ICC s15Fixed16 colorant precision.
-    assert int(np.abs(out.astype(int) - img.astype(int)).max()) < 64
+    assert int(np.abs(out.astype(int) - img.astype(int)).max()) > 64
 
 
 def test_input_profile_passthrough_non_rgb():

--- a/tests/test_dcp_profile.py
+++ b/tests/test_dcp_profile.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+Tests for Adobe DCP (DNG camera profile) support — core.dcp_profile. Parse
+(II/MM, SRATIONAL, inline/offset), apply (ForwardMatrix + ColorMatrix fallback,
+dual-illuminant), generate (build_camera_dcp round-trip), and the linear-Adobe
+output contract. See spec/dcp-camera-profile.md §8. Pure numpy/struct — no Qt.
+"""
+import os
+import struct
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core import dcp_profile as dcp        # noqa: E402
+from core import it8_profile as it8        # noqa: E402
+from core import color_management as cm    # noqa: E402
+
+D50 = np.array(cm.D50_XYZ)
+M0 = np.array([[0.46, 0.31, 0.17], [0.23, 0.70, 0.07], [0.02, 0.12, 0.93]])
+
+
+class _Fit:
+    def __init__(self, m): self.matrix = m
+
+
+def _neutral(M):
+    n = np.linalg.inv(M) @ D50
+    return n / np.max(np.abs(n))
+
+
+# --------------------------------------------------------------------------- #
+# Generate -> parse round-trip.
+# --------------------------------------------------------------------------- #
+
+def test_build_parse_roundtrip():
+    data = dcp.build_camera_dcp(_Fit(M0), "Cam D50", illuminant=23)
+    assert data[0:2] == b'II' and struct.unpack('<H', data[2:4])[0] == 42
+    p = dcp.parse_dcp_bytes(data)
+    assert p.name == "Cam D50" and p.illuminant_1 == 23
+    assert p.has_forward and not p.is_dual
+    N = _neutral(M0)
+    np.testing.assert_allclose(p.forward_matrix_1, M0 @ np.diag(N), atol=1e-4)
+    np.testing.assert_allclose(p.color_matrix_1, np.linalg.inv(M0 @ np.diag(N)), atol=1e-4)
+
+
+def test_parse_big_endian_mm():
+    # A minimal MM (big-endian) DCP with only ColorMatrix1 (SRATIONAL, offset).
+    en = '>'
+    vals = M0.ravel()
+    data_off = 8 + 2 + 12 + 4
+    body = b''.join(struct.pack(en + 'ii', int(round(v * 1e6)), 1000000) for v in vals)
+    entry = struct.pack(en + 'HHI', 50721, 10, 9) + struct.pack(en + 'I', data_off)
+    ifd = struct.pack(en + 'H', 1) + entry + struct.pack(en + 'I', 0)
+    blob = struct.pack(en + '2sHI', b'MM', 42, 8) + ifd + body
+    p = dcp.parse_dcp_bytes(blob)
+    np.testing.assert_allclose(p.color_matrix_1, M0, atol=1e-5)
+    assert not p.has_forward                        # CM-only -> fallback path
+
+
+def test_inline_short_and_negative_srational():
+    p = dcp.parse_dcp_bytes(dcp.build_camera_dcp(_Fit(M0), "x", illuminant=17))
+    assert p.illuminant_1 == 17                      # SHORT inline
+    # ColorMatrix has negative entries (inverse of a positive matrix) -> SRATIONAL signs
+    assert np.any(p.color_matrix_1 < 0)
+
+
+# --------------------------------------------------------------------------- #
+# Apply.
+# --------------------------------------------------------------------------- #
+
+def test_apply_forward_roundtrip_and_icc_parity():
+    p = dcp.parse_dcp_bytes(dcp.build_camera_dcp(_Fit(M0), "c"))
+    N = _neutral(M0)
+    rng = np.random.default_rng(0)
+    cam = np.clip(N * rng.uniform(0, 1, (8, 8, 3)), 0, 1)     # in-range after WB
+    cam_u16 = (cam * 65535).astype(np.uint16)
+    out = dcp.apply_dcp(p, cam_u16, as_shot_wb=1.0 / N)
+    expect = np.clip((cam_u16 / 65535.0) @ (cm.M_XYZ_D50_2_ADOBE @ M0).T, 0, 1)
+    assert np.abs(out.astype(int) - np.rint(expect * 65535).astype(int)).max() <= 3
+    # parity: the same fit as a matrix ICC produces the same linear-Adobe output.
+    mp = cm.InputProfile.from_bytes(it8.build_camera_icc(_Fit(M0), "m"))
+    assert np.abs(out.astype(int) - mp.apply(cam_u16).astype(int)).max() <= 3
+
+
+def test_apply_is_linear_not_srgb():
+    # A 50% linear-Adobe grey must come out ~mid (linear), not sRGB-bumped (~0.73).
+    p = dcp.parse_dcp_bytes(dcp.build_camera_dcp(_Fit(M0), "c"))
+    N = _neutral(M0)
+    cam = np.clip(N * 0.5, 0, 1)
+    cam_u16 = np.tile((cam * 65535).astype(np.uint16).reshape(1, 1, 3), (2, 2, 1))
+    out = dcp.apply_dcp(p, cam_u16, as_shot_wb=1.0 / N)[0, 0].astype(float) / 65535.0
+    assert out.max() - out.min() < 0.03              # near-neutral
+    assert 0.40 < out.mean() < 0.60                  # linear ~0.5, not ~0.73
+
+
+def test_colormatrix_fallback_near_neutral():
+    # A profile with ONLY a ColorMatrix (no ForwardMatrix): the fallback path
+    # still lands the camera neutral near-neutral in linear Adobe.
+    N = _neutral(M0)
+    CM = np.linalg.inv(M0 @ np.diag(N))
+    p = dcp.DcpProfile(name="cm-only", color_matrix_1=CM, illuminant_1=23,
+                       camera_calibration_1=np.eye(3), camera_calibration_2=np.eye(3),
+                       analog_balance=np.ones(3))
+    assert not p.has_forward
+    grey = np.tile((np.clip(N * 0.5, 0, 1) * 65535).astype(np.uint16).reshape(1, 1, 3),
+                   (2, 2, 1))
+    out = dcp.apply_dcp(p, grey, as_shot_wb=1.0 / N)[0, 0].astype(float)
+    assert out.max() - out.min() < 0.06 * 65535
+
+
+# --------------------------------------------------------------------------- #
+# Dual-illuminant interpolation.
+# --------------------------------------------------------------------------- #
+
+def test_dual_illuminant_weight_and_blend():
+    FM1 = M0 @ np.diag(_neutral(M0))
+    FM2 = (M0 * 1.1) @ np.diag(_neutral(M0 * 1.1))
+    p = dcp.DcpProfile(name="dual", forward_matrix_1=FM1, forward_matrix_2=FM2,
+                       color_matrix_1=np.linalg.inv(FM1), color_matrix_2=np.linalg.inv(FM2),
+                       illuminant_1=21, illuminant_2=17,        # D65 / StdA
+                       camera_calibration_1=np.eye(3), camera_calibration_2=np.eye(3),
+                       analog_balance=np.ones(3))
+    assert p.is_dual
+    # weight is in [0,1] and the mired formula hits the endpoints at the cal CCTs
+    inv = lambda t: 1e6 / t
+    T1, T2 = 6504.0, 2856.0
+    for T, expect in [(6504.0, 1.0), (2856.0, 0.0)]:
+        w = np.clip((inv(T) - inv(T2)) / (inv(T1) - inv(T2)), 0, 1)
+        assert abs(w - expect) < 1e-6
+    # a dual profile applies and the result lies between the two single-FM results
+    N = _neutral(M0)
+    cam = np.tile((np.clip(N * 0.4, 0, 1) * 65535).astype(np.uint16).reshape(1, 1, 3), (2, 2, 1))
+    out = dcp.apply_dcp(p, cam, as_shot_wb=1.0 / N)
+    assert out.shape == cam.shape and out.dtype == np.uint16
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic-camera round-trip (key).
+# --------------------------------------------------------------------------- #
+
+def test_synthetic_camera_roundtrip():
+    # IT8 reference patches; camera-native device via inv(M0); build DCP; apply;
+    # back to XYZ -> Lab gives avg dE2000 ~ 0 (the DCP reproduces the chart).
+    patches = {}
+    for k, Y in enumerate(np.linspace(89, 3, 24)):
+        patches[f'GS{k}'] = (Y / 100.0) * D50 * 100.0
+    rng = np.random.default_rng(7)
+    for cid in it8.COLOR_IDS[:60]:
+        Y = rng.uniform(8, 80)
+        patches[cid] = np.array([Y * rng.uniform(0.8, 1.2), Y, Y * rng.uniform(0.6, 1.1)])
+    N = _neutral(M0)
+    fit = _Fit(M0)
+    p = dcp.parse_dcp_bytes(dcp.build_camera_dcp(fit, "c"))
+    Ainv = np.linalg.inv(cm.M_XYZ_D50_2_ADOBE)
+    de = []
+    for xyz in patches.values():
+        cam = np.linalg.inv(M0) @ (xyz / 100.0)               # camera-native device
+        if np.any(cam < 0) or np.any(cam * (1.0 / N) > 1):    # skip out-of-gamut/clipped
+            continue
+        cu = np.tile((np.clip(cam, 0, 1) * 65535).astype(np.uint16).reshape(1, 1, 3), (2, 2, 1))
+        out = dcp.apply_dcp(p, cu, as_shot_wb=1.0 / N)[0, 0].astype(float) / 65535.0
+        got = (Ainv @ out) * 100.0
+        de.append(float(it8.delta_e_2000(it8.xyz_to_lab(got), it8.xyz_to_lab(xyz))[0]))
+    assert len(de) > 20 and float(np.mean(de)) < 0.5
+
+
+# --------------------------------------------------------------------------- #
+# Look tables (apply_look).
+# --------------------------------------------------------------------------- #
+
+def test_look_table_off_by_default_and_identity_noop():
+    N = _neutral(M0)
+    cam = (np.clip(N * 0.6, 0, 1) * 65535).astype(np.uint16)
+    img = np.tile(cam.reshape(1, 1, 3), (4, 4, 1))
+    dims = (6, 4, 1)
+    identity = np.zeros((*dims, 3)); identity[..., 1] = 1.0; identity[..., 2] = 1.0  # dH0,sS1,vS1
+    p = dcp.DcpProfile(name="look", forward_matrix_1=M0 @ np.diag(N),
+                       color_matrix_1=np.linalg.inv(M0 @ np.diag(N)), illuminant_1=23,
+                       camera_calibration_1=np.eye(3), camera_calibration_2=np.eye(3),
+                       analog_balance=np.ones(3), hsm_dims=dims, hsm_data_1=identity)
+    base = dcp.apply_dcp(p, img, as_shot_wb=1.0 / N, apply_look=False)
+    ident = dcp.apply_dcp(p, img, as_shot_wb=1.0 / N, apply_look=True)
+    assert np.abs(base.astype(int) - ident.astype(int)).max() <= 4      # identity look ~ no-op
+
+
+def test_look_table_saturation_scale_changes_output():
+    N = _neutral(M0)
+    cam = (np.clip(N * 0.6, 0, 1) * 65535).astype(np.uint16)
+    img = np.tile(cam.reshape(1, 1, 3), (4, 4, 1))
+    dims = (6, 4, 1)
+    boost = np.zeros((*dims, 3)); boost[..., 0] = 0.0; boost[..., 1] = 1.5; boost[..., 2] = 1.0
+    p = dcp.DcpProfile(name="look", forward_matrix_1=M0 @ np.diag(N),
+                       color_matrix_1=np.linalg.inv(M0 @ np.diag(N)), illuminant_1=23,
+                       camera_calibration_1=np.eye(3), camera_calibration_2=np.eye(3),
+                       analog_balance=np.ones(3), hsm_dims=dims, hsm_data_1=boost)
+    off = dcp.apply_dcp(p, img, as_shot_wb=1.0 / N, apply_look=False)
+    on = dcp.apply_dcp(p, img, as_shot_wb=1.0 / N, apply_look=True)
+    assert np.abs(off.astype(int) - on.astype(int)).max() > 4           # sat boost changes it
+
+
+# --------------------------------------------------------------------------- #
+# Errors.
+# --------------------------------------------------------------------------- #
+
+def test_errors():
+    with pytest.raises(dcp.DcpError):
+        dcp.parse_dcp_bytes(b"xx")                              # too short
+    with pytest.raises(dcp.DcpError):
+        dcp.parse_dcp_bytes(b"ZZ" + b"\x00" * 10)               # bad byte-order
+    # valid TIFF but no ColorMatrix1/ForwardMatrix1 -> unusable
+    en = '<'
+    ifd = struct.pack(en + 'H', 1) + struct.pack(en + 'HHI', 50936, 2, 2) + b'ab' + b'\x00\x00'
+    ifd += struct.pack(en + 'I', 0)
+    blob = struct.pack(en + '2sHI', b'II', 42, 8) + ifd
+    with pytest.raises(dcp.DcpError):
+        dcp.parse_dcp_bytes(blob)
+
+
+# --------------------------------------------------------------------------- #
+# Hand-built IFD coverage: type decoding, error guards, look tables.
+# --------------------------------------------------------------------------- #
+
+def _srat(vals):
+    return b''.join(struct.pack('<ii', int(round(v * 1e6)), 1000000) for v in vals)
+
+
+def _ifd(entries):
+    """entries: list of (tag, type_code, count, raw_bytes). Little-endian DCP."""
+    n = len(entries)
+    base = 8 + 2 + n * 12 + 4
+    ent = b''; data = b''
+    for tag, tc, cnt, raw in entries:
+        if len(raw) <= 4:
+            field = raw + b'\x00' * (4 - len(raw))
+        else:
+            field = struct.pack('<I', base + len(data)); data += raw
+            if len(data) % 2:
+                data += b'\x00'
+        ent += struct.pack('<HHI', tag, tc, cnt) + field
+    return (struct.pack('<2sHI', b'II', 42, 8) + struct.pack('<H', n) + ent
+            + struct.pack('<I', 0) + data)
+
+
+_CM1 = (50721, 10, 9, _srat(M0.ravel()))       # a valid ColorMatrix1 entry
+
+
+def test_parse_offset_past_eof():
+    # ColorMatrix1 (SRATIONAL×9 -> 72 bytes, offset-typed) with offset past EOF.
+    ent = struct.pack('<HHI', 50721, 10, 9) + struct.pack('<I', 10 ** 6)
+    blob = (struct.pack('<2sHI', b'II', 42, 8) + struct.pack('<H', 1) + ent
+            + struct.pack('<I', 0))
+    with pytest.raises(dcp.DcpError):
+        dcp.parse_dcp_bytes(blob)
+
+
+def test_parse_matrix_count_not_9():
+    blob = _ifd([(50721, 10, 6, _srat([1, 2, 3, 4, 5, 6]))])     # count 6, not 9
+    with pytest.raises(dcp.DcpError, match="9"):
+        dcp.parse_dcp_bytes(blob)
+
+
+def test_parse_rational_and_tonecurve():
+    ab = struct.pack('<IIIIII', 1, 1, 0, 0, 2, 1)               # 1/1, 0/0 (zero-denom), 2/1
+    tone = struct.pack('<6f', 0.0, 0.0, 0.5, 0.6, 1.0, 1.0)
+    blob = _ifd([_CM1, (50727, 5, 3, ab), (50940, 11, 6, tone)])
+    p = dcp.parse_dcp_bytes(blob)
+    np.testing.assert_allclose(p.analog_balance, [1.0, 0.0, 2.0])   # RATIONAL + zero-denom guard
+    assert p.tone_curve.shape == (3, 2)
+    np.testing.assert_allclose(p.tone_curve, [[0, 0], [0.5, 0.6], [1, 1]])
+
+
+def test_parse_huesatmap_ordering_and_size_mismatch():
+    dims = (2, 2, 2)
+    flat = []
+    for h in range(2):
+        for s in range(2):
+            for v in range(2):
+                flat += [h * 100 + s * 10 + v, 1.0, 1.0]        # marker in component 0
+    data = struct.pack('<%df' % len(flat), *flat)
+    blob = _ifd([_CM1, (50937, 4, 3, struct.pack('<3I', *dims)), (50938, 11, len(flat), data)])
+    p = dcp.parse_dcp_bytes(blob)
+    assert p.hsm_data_1.shape == (2, 2, 2, 3)
+    # value-axis-fastest C-order: cell (h,s,v) component0 == h*100+s*10+v
+    assert p.hsm_data_1[1, 0, 1, 0] == 101 and p.hsm_data_1[0, 1, 1, 0] == 11
+    # wrong-length data -> DcpError
+    bad = _ifd([_CM1, (50937, 4, 3, struct.pack('<3I', *dims)),
+                (50938, 11, 12, struct.pack('<12f', *([0.0] * 12)))])
+    with pytest.raises(dcp.DcpError):
+        dcp.parse_dcp_bytes(bad)
+
+
+def test_parse_count0_scalar_and_bad_dims():
+    # CalibrationIlluminant1 (SHORT) with count 0 must not IndexError.
+    blob = _ifd([_CM1, (50778, 3, 0, b'')])
+    p = dcp.parse_dcp_bytes(blob)
+    assert p.illuminant_1 == 21                                 # left at default
+    # HueSatMapDims with < 3 values -> DcpError, not IndexError.
+    bad = _ifd([_CM1, (50937, 4, 2, struct.pack('<2I', 2, 2)),
+                (50938, 11, 12, struct.pack('<12f', *([0.0] * 12)))])
+    with pytest.raises(dcp.DcpError):
+        dcp.parse_dcp_bytes(bad)
+
+
+def test_apply_as_shot_wb_none_is_unbalanced():
+    p = dcp.parse_dcp_bytes(dcp.build_camera_dcp(_Fit(M0), "c"))
+    cam = (np.clip(_neutral(M0) * 0.5, 0, 1) * 65535).astype(np.uint16)
+    img = np.tile(cam.reshape(1, 1, 3), (2, 2, 1))
+    none_out = dcp.apply_dcp(p, img)                            # m = ones (unbalanced)
+    wb_out = dcp.apply_dcp(p, img, as_shot_wb=1.0 / _neutral(M0))
+    assert none_out.dtype == np.uint16 and none_out.shape == img.shape
+    assert not np.array_equal(none_out, wb_out)                # WB genuinely matters
+
+
+def test_apply_highlight_not_preclipped():
+    # d*m can exceed 1 (film-base highlights); the matrix must see the unclipped
+    # value (clip only at the final Adobe output), matching the ICC path.
+    p = dcp.parse_dcp_bytes(dcp.build_camera_dcp(_Fit(M0), "c"))
+    N = _neutral(M0)
+    m = (1.0 / N) * 1.4
+    cam = (np.clip(N * 0.9, 0, 1) * 65535).astype(np.uint16)    # d*m ≈ 1.26 in-channel
+    img = np.tile(cam.reshape(1, 1, 3), (2, 2, 1))
+    out = dcp.apply_dcp(p, img, as_shot_wb=m)[0, 0]
+    FM = p.forward_matrix_1
+    expect = np.clip(((cam / 65535.0 * m) @ FM.T) @ cm.M_XYZ_D50_2_ADOBE.T, 0, 1)
+    np.testing.assert_allclose(out / 65535.0, expect, atol=1e-3)   # no pre-matrix clip
+
+
+def test_interp_weight_clamps_outside_calibration_range():
+    FM1 = M0 @ np.diag(_neutral(M0))
+    p = dcp.DcpProfile(name="d", forward_matrix_1=FM1, forward_matrix_2=FM1 * 1.1,
+                       color_matrix_1=np.eye(3), color_matrix_2=np.eye(3),
+                       illuminant_1=21, illuminant_2=17,        # D65 / StdA
+                       camera_calibration_1=np.eye(3), camera_calibration_2=np.eye(3),
+                       analog_balance=np.ones(3))
+    # CM=I so _neutral_cct uses the neutral n=1/m directly as XYZ -> xy -> McCamy.
+    hot = 1.0 / np.array([0.6, 0.9, 1.6])      # blue-heavy neutral -> very high CCT
+    cold = 1.0 / np.array([1.6, 0.9, 0.5])     # red-heavy neutral -> very low CCT
+    assert dcp._interp_weight(p, hot) == 1.0    # clamped to set 1 (D65)
+    assert dcp._interp_weight(p, cold) == 0.0   # clamped to set 2 (StdA)
+    mid = dcp._interp_weight(p, 1.0 / np.array([1.0, 1.0, 1.0]))
+    assert 0.0 <= mid <= 1.0

--- a/tests/test_it8_profile.py
+++ b/tests/test_it8_profile.py
@@ -267,6 +267,43 @@ def test_parse_block():
     assert it8.parse_block("L72", "A49") == (rows, cols)
 
 
+def test_next_block_ids_advances_columns():
+    # The classic 3-card split: each card shifts by its own column width.
+    assert it8.next_block_ids("A1", "L24") == ("A25", "L48")
+    assert it8.next_block_ids("A25", "L48") == ("A49", "L72")
+    # Rows are preserved; order of the input ids doesn't matter (parse_block sorts).
+    assert it8.next_block_ids("L48", "A25") == ("A49", "L72")
+    # Clamp the right column to the reference's extent on an uneven last card.
+    assert it8.next_block_ids("A49", "L72", max_col=72) == ("A72", "L72")
+    assert it8.next_block_ids("A40", "L60", max_col=72) == ("A61", "L72")
+    with pytest.raises(ValueError):
+        it8.next_block_ids("nope", "L24")
+
+
+def test_merge_samples_prefers_valid():
+    def ps(v, valid):
+        return it8.PatchSample(rgb=np.array([float(v)] * 3), valid=valid, n_pix=9)
+    card_a = {"A1": ps(1, True), "A2": ps(2, False)}
+    card_b = {"A2": ps(3, True), "A3": ps(4, True)}
+    merged = it8.merge_samples([card_a, card_b])
+    assert set(merged) == {"A1", "A2", "A3"}
+    # The valid A2 from card_b overrides the invalid A2 from card_a...
+    assert merged["A2"].valid and merged["A2"].rgb[0] == 3.0
+    # ...and a later *invalid* sample must not clobber an existing valid one.
+    merged2 = it8.merge_samples([card_b, card_a])
+    assert merged2["A2"].valid and merged2["A2"].rgb[0] == 3.0
+
+
+def test_merge_samples_union_covers_all_cards():
+    def ps(v):
+        return it8.PatchSample(rgb=np.array([float(v)] * 3), valid=True, n_pix=9)
+    c1 = {f"A{c}": ps(c) for c in range(1, 25)}      # columns 1-24
+    c2 = {f"A{c}": ps(c) for c in range(25, 49)}     # columns 25-48
+    c3 = {f"A{c}": ps(c) for c in range(49, 73)}     # columns 49-72
+    merged = it8.merge_samples([c1, c2, c3])
+    assert len(merged) == 72 and merged["A50"].rgb[0] == 50.0
+
+
 def test_block_sample_points_unit_quad():
     quad = [(0, 0), (240, 0), (240, 120), (0, 120)]   # TL,TR,BR,BL
     rows, cols = it8.parse_block("A49", "L72")          # 12 rows x 24 cols
@@ -361,6 +398,30 @@ def test_sample_clip_rejection():
     pts = it8.grid_sample_points(quad)
     samples = it8.sample_patches(img, pts, quad)
     assert not samples["A1"].valid                          # clipped -> invalid
+
+
+def test_sample_keeps_saturated_and_dark():
+    # Raw-linear: a saturated hue reads near-zero in its complementary channels;
+    # that is real signal, not clipping, so the patch must stay VALID. Only a
+    # blown highlight or a truly-black patch is dropped.
+    quad = [(0, 0), (220, 0), (220, 120), (0, 120)]
+    img = np.zeros((130, 230, 3), dtype=np.uint16)
+
+    def fill(sid, val):
+        i = it8.COLOR_IDS.index(sid)
+        r, c = divmod(i, 22)
+        img[r * 10:(r + 1) * 10, c * 10:(c + 1) * 10] = val
+
+    fill("A1", [60000, 180, 120])      # saturated red (G/B ~ 0) -> still valid
+    fill("A2", [120, 150, 58000])      # saturated blue (R ~ 0) -> still valid
+    fill("A3", [4200, 3900, 3600])     # ordinary mid-tone -> valid
+    fill("A4", [65535, 65535, 65535])  # blown highlight -> invalid
+    fill("A5", [9, 7, 5])              # essentially black -> invalid
+    pts = it8.grid_sample_points(quad)
+    samples = it8.sample_patches(img, pts, quad, frac=0.5)
+    assert samples["A1"].valid and samples["A2"].valid and samples["A3"].valid
+    assert not samples["A4"].valid     # highlight-clipped dropped
+    assert not samples["A5"].valid     # black-crush dropped
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_positive_mode.py
+++ b/tests/test_positive_mode.py
@@ -93,11 +93,13 @@ class TestRawPostprocessKwargs:
 
 # --------------------------------------------------------------------------- #
 # read_image decode WIRING (RAW branch). The pure kwargs builder is tested above;
-# these pin read_image's behaviour: the negative decode is ALWAYS the Adobe RGB +
-# rawpy auto-scale (thr=0) working space, and an active input ICC is applied ON
-# TOP (skipped for the IT8 profiling decode, apply_input_icc=False), so fit-space
-# == apply-space. Verified by stubbing the heavy rawpy decode. (DNG is not
-# special-cased: it applies the input ICC like any RAW.)
+# these pin read_image's behaviour: a plain unprofiled negative decodes to Adobe
+# RGB + rawpy auto-scale (thr=0), while ANY ICC path — an active input ICC, or the
+# bare-device decode used to FIT one (apply_input_icc=False) — uses the canonical
+# camera-profiling space: raw camera-native primaries + no_auto_scale + manual
+# white-level scaling. So fit-space == apply-space EXACTLY. Verified by stubbing
+# the heavy rawpy decode. (DNG is not special-cased: it applies the input ICC
+# like any RAW.)
 # --------------------------------------------------------------------------- #
 from core import color_management as cm  # noqa: E402
 
@@ -129,6 +131,7 @@ class _FakeRaw:
         self.num_colors = 3
         self.color_desc = b'RGGB'
         self.raw_pattern = np.array([[0, 1], [1, 2]])
+        self.camera_whitebalance = [2.0, 1.0, 1.5, 0.0]   # as-shot WB (for DCP)
 
     def __enter__(self):
         return self
@@ -187,12 +190,77 @@ class TestInputIccWillApply:
         finally:
             cm.set_active_input_profile(None)
 
+    def test_true_when_dcp_active(self):
+        # A DCP (no ICC) also flips the decode to camera-native.
+        from core import dcp_profile
+
+        class _F:
+            matrix = np.array([[0.46, 0.31, 0.17], [0.23, 0.70, 0.07], [0.02, 0.12, 0.93]])
+        cm.set_active_input_profile(None)
+        cm.set_active_dcp_profile(dcp_profile.parse_dcp_bytes(
+            dcp_profile.build_camera_dcp(_F(), "c")))
+        try:
+            assert self._img("x.arw")._input_icc_will_apply() is True
+        finally:
+            cm.set_active_dcp_profile(None)
+
+
+def _camera_dcp_bytes():
+    from core import dcp_profile
+
+    class _F:
+        matrix = np.array([[0.46, 0.31, 0.17], [0.23, 0.70, 0.07], [0.02, 0.12, 0.93]])
+    return dcp_profile.build_camera_dcp(_F(), "c")
+
+
+class _FakeRawMono(_FakeRaw):
+    def __init__(self, rec):
+        super().__init__(rec)
+        self.num_colors = 1
+
+    def postprocess(self, **kw):
+        self._rec['kwargs'] = kw
+        return np.full((32, 48), 12000, dtype=np.uint16)     # single channel
+
+
+class TestDcpDecodeWiring:
+    def _decode(self, monkeypatch, fake_cls=_FakeRaw, dcp_active=True, apply_icc=True):
+        from core import dcp_profile
+        rec = {}
+        monkeypatch.setattr(rawpy, "imread", lambda p: fake_cls(rec))
+        cm.set_active_input_profile(None)
+        cm.set_active_dcp_profile(dcp_profile.parse_dcp_bytes(_camera_dcp_bytes())
+                                  if dcp_active else None)
+        try:
+            img = CCRImage.__new__(CCRImage)
+            img.source_ops = []
+            img.file_path = "scan.arw"
+            out = img.read_image("scan.arw", preview=True, positive_override=False,
+                                 apply_input_icc=apply_icc)
+        finally:
+            cm.set_active_dcp_profile(None)
+        return rec.get("kwargs"), out
+
+    def test_dcp_uses_camera_native_and_applies(self, monkeypatch):
+        kw, out = self._decode(monkeypatch, dcp_active=True, apply_icc=True)
+        assert kw["output_color"] == rawpy.ColorSpace.raw     # camera-native for DCP
+        assert kw["no_auto_scale"] is True
+        _, bare = self._decode(monkeypatch, dcp_active=True, apply_icc=False)  # bare device
+        assert not np.array_equal(out, bare)                  # DCP was applied
+
+    def test_dcp_skipped_for_monochrome(self, monkeypatch):
+        _, with_dcp = self._decode(monkeypatch, fake_cls=_FakeRawMono, dcp_active=True)
+        _, without = self._decode(monkeypatch, fake_cls=_FakeRawMono, dcp_active=False)
+        assert np.array_equal(with_dcp, without)              # no profile burned into mono
+
 
 class TestRawDecodeSpaceWiring:
-    # The negative decode is ALWAYS the Adobe RGB + auto-scale (thr=0) working
-    # space — independent of input-ICC / bare-device state. An active ICC is
-    # applied ON TOP; IT8 profiling samples this same space with the ICC step
-    # skipped, so fit-space == apply-space. _FakeRaw returns a flat 10000 decode.
+    # No profile + normal decode → Adobe RGB + auto-scale (the camera-independent
+    # default). ANY ICC path — active ICC, or the bare-device decode used to FIT
+    # one (apply_input_icc=False) — → canonical camera-native raw + no_auto_scale +
+    # manual white-level scaling, so the profile is fitted in and applied to the
+    # SAME device space. _FakeRaw returns a flat 10000 decode, white_level=16383
+    # (manual scaling ×65535/16383 ≈ 4 when it applies).
     def test_no_profile_is_adobe_autoscaled(self, monkeypatch):
         kw, out = _decode_raw(monkeypatch, "scan.arw", profile=None)
         assert kw["output_color"] == rawpy.ColorSpace.Adobe
@@ -200,31 +268,44 @@ class TestRawDecodeSpaceWiring:
         assert kw["adjust_maximum_thr"] == 0.0
         assert int(out.max()) == 10000          # manual white-level scaling skipped
 
-    def test_profile_active_same_space_icc_on_top(self, monkeypatch):
-        # Same Adobe+autoscale decode as no-profile, but the ICC is applied on top.
+    def test_profile_active_is_camera_native(self, monkeypatch):
+        # Active ICC → camera-native raw + no_auto_scale device space, ICC on top.
         kw, out = _decode_raw(monkeypatch, "scan.arw",
                               profile=_matrix_shaper_profile())
-        assert kw["output_color"] == rawpy.ColorSpace.Adobe
-        assert kw["no_auto_scale"] is False
+        assert kw["output_color"] == rawpy.ColorSpace.raw
+        assert kw["no_auto_scale"] is True
         _, bare = _decode_raw(monkeypatch, "scan.arw", profile=None)
-        assert not np.array_equal(out, bare)    # ICC changed the pixels
+        assert not np.array_equal(out, bare)    # different space + ICC applied
 
     def test_dng_matches_other_raws(self, monkeypatch):
         kw, _ = _decode_raw(monkeypatch, "scan.dng",
                             profile=_matrix_shaper_profile())
-        assert kw["output_color"] == rawpy.ColorSpace.Adobe
-        assert kw["no_auto_scale"] is False
+        assert kw["output_color"] == rawpy.ColorSpace.raw
+        assert kw["no_auto_scale"] is True
 
-    def test_profiling_decode_is_same_space_without_icc(self, monkeypatch):
-        # IT8 profiling: apply_input_icc=False samples the SAME Adobe+autoscale
-        # working space, but the ICC is NOT applied (bare RGB to fit on), and the
-        # manual white-level scaling stays skipped.
+    def test_profiling_decode_is_camera_native_without_icc(self, monkeypatch):
+        # IT8 profiling: apply_input_icc=False decodes the bare camera-native raw
+        # device RGB (no ICC), WITH the manual white-level scaling applied so the
+        # values are absolute — the exact space the ICC is later applied in.
         kw, out = _decode_raw(monkeypatch, "scan.arw",
                               profile=_matrix_shaper_profile(),
                               apply_input_icc=False)
-        assert kw["output_color"] == rawpy.ColorSpace.Adobe
-        assert kw["no_auto_scale"] is False
-        assert int(out.max()) == 10000          # no ICC + no manual scaling
+        assert kw["output_color"] == rawpy.ColorSpace.raw
+        assert kw["no_auto_scale"] is True
+        # 10000 × 65535/16383 ≈ 40009 — manual white-level scaling applied.
+        assert 39000 < int(out.max()) < 41000
+
+    def test_fit_and_apply_decode_spaces_are_identical(self, monkeypatch):
+        # The crux of a correct camera profile: the kwargs used to FIT the profile
+        # (apply_input_icc=False) must equal those used to APPLY it (active ICC).
+        fit_kw, _ = _decode_raw(monkeypatch, "scan.arw",
+                                profile=_matrix_shaper_profile(),
+                                apply_input_icc=False)
+        apply_kw, _ = _decode_raw(monkeypatch, "scan.arw",
+                                  profile=_matrix_shaper_profile())
+        for key in ("output_color", "no_auto_scale", "gamma", "no_auto_bright",
+                    "use_camera_wb", "use_auto_wb", "output_bps"):
+            assert fit_kw[key] == apply_kw[key], f"fit/apply diverge on {key}"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes #37.

`xattr -r -d com.apple.quarantine /Applications/FreeCCR.app` fails with **"option -r not recognized"** on some macOS `xattr` versions. The quarantine attribute sits on the top-level `.app` bundle, so the non-recursive form clears it (confirmed by the reporter, and the owner agreed to fix it):

```bash
xattr -d com.apple.quarantine /Applications/FreeCCR.app
```

Updated the user-facing instruction in `README.md` and both macOS release-note templates in `.github/workflows/release.yml`. The build scripts' build-time `xattr -cr` is left untouched — that runs on the build machine where `-r` is supported.
