### PR TITLE
feat(crop): dedicated Crop panel with aspect ratios + straighten (#39)

### DIFF
--- a/spec/crop-panel.md
+++ b/spec/crop-panel.md
@@ -1,0 +1,282 @@
+# Spec: Crop Panel (aspect ratios + straighten)
+
+Status: REFINED v1
+Owner: FreeCCR
+Feature branch: `feature/crop-panel-aspect-ratios`
+Issue: #39 — "Feature Request: Aspect Ratios in Cropping & Selection Menus".
+
+## 1. Summary
+
+Replace the crop tool's "just a button + canvas handles" UX with a **dedicated
+Crop panel** that covers the right-hand sliders panel while in crop mode — the
+exact pattern used by Dust Removal (`DustRemovalPanel`). The panel exposes "all
+the options" for cropping:
+
+- **Aspect-ratio presets** (Free, Original, 1:1, 5:4, 4:3, 7:5, 3:2, 16:9) with a
+  **portrait/landscape** toggle and a **custom W:H** field. A locked ratio
+  constrains every on-canvas drag (draw, corner, edge) so the box can only ever
+  be that shape. The selected ratio **persists across images and sessions**
+  (QSettings) so a whole catalogue can be cropped to the same dimensions — the
+  core request in #39.
+- **Straighten** slider (−45°..+45°) that drives the crop box's rotation, kept in
+  sync with the existing on-canvas rotate knob.
+- **Reset** (clear the pending crop + straighten) and **Done** (commit) buttons.
+  Enter/Esc/right-click on the canvas keep working exactly as today.
+
+When entering crop mode, any existing **micro-rotation** (image-level
+`fine_rotation_angle`, the straighten slider under the canvas) is **folded into
+the crop straighten**: the leveling is preserved but re-expressed as the crop
+box's angle, and the image-level micro-rotation is cleared on commit so the two
+rotations never stack. Cancelling leaves the original micro-rotation untouched.
+
+## 2. Goals / Non-goals
+
+### Goals
+- A **Crop panel** (sibling of `sliders_panel`/`dust_panel`, fixed 300px) shown in
+  place of the sliders while crop mode is active; restored on exit — mirroring
+  `MainWindow.toggle_dust_removal`.
+- Aspect-ratio **presets + orientation toggle + custom W:H**, persisted in
+  QSettings (`crop/aspect_key`, `crop/custom_w`, `crop/custom_h`,
+  `crop/orientation`) so the choice is sticky across images and app restarts.
+- A locked ratio constrains **all three** drag interactions (new selection, corner
+  resize, edge resize) and reshapes the current box immediately when chosen.
+- A **Straighten** slider in the panel, two-way-synced with the canvas rotate
+  knob (both edit the single `_pending_crop_angle`).
+- **Fold micro-rotation into crop straighten** on entry; clear
+  `fine_rotation_angle` on commit (undoable in one snapshot); preserve it on
+  cancel. The canvas micro-rotation slider is disabled while in crop mode.
+- **Reset** and **Done** buttons; Enter = Done, Esc = cancel, right-click = clear,
+  Crop button again = exit — unchanged.
+- No change to the export/preview crop math: the panel only changes how
+  `crop_rect` / `crop_angle` are *produced*. `apply_crop_to_image`,
+  `_extract_rotated_crop`, histogram crop, and all three export paths are
+  untouched.
+
+### Non-goals
+- **No aspect ratios for the "selection" tools yet** (reference frame, Slice, Area
+  editing). #39 mentions "selection menus"; that is a follow-up. This change is
+  crop-only. (Documented so the issue can be partially closed.)
+- **No fixed pixel-dimension output** (e.g. force exactly 3000×2000 px). Only the
+  *ratio* is constrained; output resolution is still driven by the existing
+  resize/export logic.
+- **No re-architecture of crop to display the live fine-rotation.** Crop mode keeps
+  showing the un-fine-rotated image and rotates the *box* (`_pending_crop_angle`),
+  as today. Straighten is the same variable, surfaced as a slider.
+- No grid/thirds overlay changes beyond what already exists.
+
+## 3. UX / interaction
+
+### 3.1 Entering / leaving
+- The **Crop** button in `sliders_panel` now routes through
+  `MainWindow.toggle_crop_panel()` (was: directly `enter_crop_mode()`):
+  - On enter: `image_preview.enter_crop_mode()`, hide `sliders_panel`, `bind` and
+    show `crop_panel`.
+  - The single canvas exit chokepoint `_exit_crop_mode()` calls back to
+    `MainWindow` (`on_crop_panel_closed()`) to restore the sliders panel — so
+    **every** exit path (Done, Enter, Esc, right-click clear, Crop-toggle-off,
+    image switch, entering dust mode) restores the panel with no special-casing.
+- The panel header is "Crop". Layout top→bottom: Aspect ratio (combo),
+  orientation radios, custom W:H row, a separator, Straighten slider, a separator,
+  then a stretch and a button row **Reset | ✓ Done** (Done = primary, like dust).
+
+### 3.2 Aspect ratio
+- **Combo** lists: Free, Original, 1:1, 5:4, 4:3, 7:5, 3:2, 16:9, Custom…
+- **Orientation** (Landscape / Portrait) radios; disabled and ignored for Free,
+  Original, and 1:1 (orientation is meaningless there). Toggling swaps the active
+  ratio `r ↔ 1/r`.
+- **Custom W:H**: two spin boxes (1..9999). Editing them selects "Custom" and uses
+  `r = w/h`. Hidden unless Custom is selected (kept compact).
+- Selecting a ratio (or toggling orientation, or editing custom) **immediately
+  reshapes** the current pending box to that ratio (preserving its center and
+  straighten angle; see §5.3) and redraws. With **Free**, nothing is constrained.
+- The selection is **remembered** and re-applied the next time crop mode opens, on
+  the same or a different image (QSettings).
+
+### 3.3 Straighten
+- Slider −45.0°..+45.0° (0.1° steps), centered, double-click → 0 (reuse
+  `CenteringSlider`). Drives `_pending_crop_angle` directly (deg). Dragging it
+  redraws the box overlay.
+- Dragging the canvas rotate knob updates `_pending_crop_angle`; the panel slider
+  re-syncs from `image_preview` via `on_crop_geometry_changed()` after each drag.
+- Drawing a *brand-new* box resets the angle to 0 (existing behavior — a fresh box
+  is axis-aligned); the panel slider re-syncs to 0 accordingly.
+
+### 3.4 Buttons / keys
+- **Done** → `MainWindow.toggle_crop_panel(False)` → `image_preview.confirm_crop()`
+  (commit) → panel restored. Same as pressing Enter.
+- **Reset** → clear the *pending* crop box + straighten (set `_pending_crop_local`
+  = None, `_pending_crop_angle` = 0) and redraw; does not commit. (Pressing Done
+  afterward with the whole image and angle 0 clears any stored crop, as today.)
+- **Esc** → `cancel_crop_mode()` (no change committed). **Right-click** on canvas →
+  `clear_crop()` (remove stored crop). Both restore the panel via the chokepoint.
+
+## 4. Data model
+
+No new persistent field on `CCRImage`. The committed result is still exactly
+`crop_rect` (normalized `(x1,y1,x2,y2)` in un-rotated/un-flipped space) and
+`crop_angle` (deg). The chosen **aspect ratio is panel/session state**, persisted
+in QSettings (not per image) so it is consistent across the catalogue:
+
+- `crop/aspect_key`: one of `free|original|1:1|5:4|4:3|7:5|3:2|16:9|custom`.
+- `crop/custom_w`, `crop/custom_h`: ints for the custom ratio.
+- `crop/orientation`: `landscape|portrait`.
+
+Transient crop-session state on `ImagePreview` (already present, reused):
+`_pending_crop_local` (QRectF, pixel coords), `_pending_crop_angle` (deg). New:
+`_crop_fold_fine` (bool) — was a nonzero `fine_rotation_angle` folded at entry?
+
+## 5. Processing / math
+
+Downstream crop application is **unchanged**. New math lives in a pure,
+Qt-free, unit-tested helper module `src/core/crop_aspect.py`; the drag handlers
+call it.
+
+### 5.1 Ratio definition & coarse-rotation compensation
+Ratio `r = boxwidth / boxheight` is measured in the box's own frame, i.e. on
+`_pending_crop_local` which is in **un-rotated image pixel space**. But the user
+sees the box through `_base_transform` (coarse 90/180/270 rotation + flips). For
+the on-screen box to actually look like the chosen ratio:
+
+```
+effective_r = r            if current_rotation in {0, 180}
+              1 / r        if current_rotation in {90, 270}
+```
+
+Flips do not change a rectangle's aspect, so only 90/270 invert it. All
+constraint math below uses `effective_r`.
+
+`Original` resolves to `current_pixmap.width() / current_pixmap.height()` (the
+un-cropped image shown in crop mode = the native un-rotated aspect); orientation
+is not applied to Original.
+
+### 5.2 Constrained drag (pure helpers in `crop_aspect.py`)
+- `enforce_ratio_size(adx, ady, r) -> (bw, bh)`: given non-negative desired
+  extents, return the smallest box of ratio `r` that **covers** both:
+  `if adx >= ady*r: (adx, adx/r) else: (ady*r, ady)`. Used by new-selection and
+  corner drags (the box grows to include the pointer while holding ratio).
+- `fit_ratio_within(w, h, r) -> (bw, bh)`: largest box of ratio `r` that **fits**
+  inside `w×h`: `if w/h >= r: (h*r, h) else: (w, w/r)`. Used to clamp a drawn box
+  to the image and to reshape on preset change.
+
+Handler wiring (all keep the existing anchor/clamp behavior, just adding ratio):
+- **New selection** (`_update_new_selection`): build the axis-aligned rect from
+  `p0→p1`; if locked, replace `(w,h)` with `enforce_ratio_size(w, h, effective_r)`
+  keeping the `p0` anchor and drag direction; clamp the result into the image with
+  `fit_ratio_within` (scaling about the anchor) so it never spills out.
+- **Corner** (`_drag_corner`): after computing the free `(adx, ady)` in box frame,
+  apply `enforce_ratio_size` before rebuilding the rect (opposite corner stays
+  fixed).
+- **Edge** (`_drag_edge`): the dragged dimension is set from the pointer as today;
+  if locked, derive the perpendicular dimension from `effective_r` symmetric about
+  the box center (so the box keeps its position on the cross axis and the opposite
+  edge fixed on the drag axis). Horizontal edges (`l`/`r`) set width→height;
+  vertical edges (`t`/`b`) set height→width.
+
+### 5.3 Reshape-to-ratio on preset change
+`apply_ratio_to_pending(box | None, effective_r, img_w, img_h)`:
+- If a box exists: keep its center; `bw,bh = fit_ratio_within(box.w, box.h,
+  effective_r)` (shrink to fit *within* the current selection so it never grows
+  past what the user had); return a centered QRectF, clamped into the image.
+- If no box yet: center on the image; `bw,bh = fit_ratio_within(img_w, img_h,
+  effective_r)`; return the centered max box.
+- The straighten `_pending_crop_angle` is preserved.
+
+### 5.4 Straighten fold-in
+Equivalence (derived from the pipeline): `fine_rotation_angle` exports via
+`getRotationMatrix2D(center, -fine_angle)` → positive `fine` rotates content
+**clockwise**; `crop_angle` de-rotates the box → positive rotates content
+**counter-clockwise**. So the same leveling is `crop_angle = -fine_angle`.
+
+- `folded_crop_angle(crop_angle, fine_rotation_angle) = crop_angle -
+  fine_rotation_angle/100.0` (pure helper, tested).
+- `enter_crop_mode`: set `_pending_crop_angle = folded_crop_angle(img.crop_angle,
+  img.fine_rotation_angle)`; `_crop_fold_fine = img.fine_rotation_angle != 0`. If
+  folding and `_pending_crop_local is None`, seed a **full-frame** pending box so
+  the folded angle is visible/committable. Do **not** mutate the image yet
+  (cancel stays clean).
+- `confirm_crop`: when committing an applied crop, if `_crop_fold_fine`, also set
+  `img.fine_rotation_angle = 0` inside the same `push_undo_state()` snapshot — the
+  crop result already reflects the un-fine-rotated display, so this is WYSIWYG and
+  one Ctrl+Z restores both crop and the original micro-rotation.
+- `cancel_crop_mode` / `clear_crop`: never touch `fine_rotation_angle`.
+- The canvas `rotation_slider` is disabled on `enter_crop_mode` and re-enabled by
+  the normal `update_preview` path on exit (it already re-reads the value).
+
+## 6. Integration points
+
+- `src/core/crop_aspect.py` — NEW: presets list + pure helpers (§5). No Qt.
+- `src/widgets/crop_panel.py` — NEW: `CropPanel(QWidget)` mirroring
+  `DustRemovalPanel` (header, controls, `bind_image()`,
+  `on_crop_geometry_changed()`, Reset/Done). Persists ratio via QSettings.
+- `src/ui/main_window.py` — build/insert `crop_panel` as a 300px sibling
+  (after `dust_panel`); add `toggle_crop_panel(on)` and `on_crop_panel_closed()`;
+  call `image_preview.set_crop_panel(crop_panel)`.
+- `src/widgets/image_preview.py`:
+  - `set_crop_panel(panel)`; store `self._crop_panel`.
+  - `enter_crop_mode`: fold-in (§5.4); disable `rotation_slider`; read the active
+    ratio from the panel and reshape if locked; bind panel.
+  - `_update_new_selection` / `_drag_corner` / `_drag_edge`: apply ratio via
+    `crop_aspect` using the panel's active `effective_r` (None = Free).
+  - `update_crop_drag` / `end_crop_drag`: after redraw, call
+    `self._crop_panel.on_crop_geometry_changed()` so the straighten slider stays
+    in sync.
+  - `_exit_crop_mode`: call `self.window().on_crop_panel_closed()` (guarded).
+  - `confirm_crop`: fold-fine commit (§5.4); the `_crop_fold_fine` reset.
+  - A small accessor for the active ratio: the handlers ask
+    `self._crop_panel.current_effective_ratio(self.current_rotation, pixmap)`.
+- `src/widgets/sliders_panel.py` — `_on_crop_clicked` calls
+  `mw.toggle_crop_panel()` (toggle) instead of `enter_crop_mode()` directly; keep
+  the hint. Update the Crop tooltip to mention the panel + aspect ratios.
+
+## 7. Edge cases
+
+- **No current image / unconverted**: Crop is already gated by
+  `set_sliders_enabled`; `toggle_crop_panel` no-ops when `current_idx is None`
+  (like dust).
+- **90/270 coarse rotation**: ratio inverted via `effective_r` so the on-screen
+  box matches the chosen ratio (§5.1). Confirmed result is stored in un-rotated
+  space; downstream coarse rotation is applied after crop (unchanged), giving the
+  expected final orientation.
+- **Custom 0 / degenerate ratio**: guard `h>=1, w>=1`; ignore ratios that produce
+  `< 10px` boxes (min size already enforced by handlers).
+- **Reshape spilling outside image** with a rotated box: `fit_ratio_within` uses
+  the box's own w×h, and confirm already intersects (angle 0) or keeps (angle≠0)
+  as today; no new clamp needed for the rotated case.
+- **Entering dust mode from crop**: `enter_dust_mode` already calls
+  `_exit_crop_mode`, which restores the sliders panel; `toggle_dust_removal` then
+  swaps to the dust panel. One transient, no breakage.
+- **Switching images while in crop mode**: existing behavior unchanged; the exit
+  chokepoint restores the panel.
+- **Panel/QSettings missing** (tests construct `ImagePreview` without a real
+  panel): `set_crop_panel` defaults `_crop_panel=None`; the ratio accessor returns
+  Free and the sync calls are guarded — crop works exactly as before.
+
+## 8. Test plan
+
+Pure helpers (no Qt) in `tests/test_crop_aspect.py`:
+- `enforce_ratio_size`: covers both branches; ratio held exactly; covers the
+  pointer; 1:1 and wide/tall ratios.
+- `fit_ratio_within`: fits within bounds for width-bound and height-bound cases;
+  ratio held; never exceeds.
+- `apply_ratio_to_pending`: shrinks within an existing box; centers in the image
+  when none; preserves center.
+- `folded_crop_angle`: sign/scale (`fine=+200` → `-2.0` added); zero is a no-op;
+  combines with an existing crop_angle.
+- `effective_ratio` helper: inverted for 90/270, unchanged for 0/180; Original
+  from pixmap dims; orientation swap.
+
+GUI-level (offscreen Qt) in `tests/test_crop_panel.py` (mirror
+`test_crop_overlay.py`'s stub host):
+- Locked ratio constrains a simulated `_update_new_selection` /
+  `_drag_corner` (box ratio within tolerance).
+- Fold-in: set `fine_rotation_angle`, `enter_crop_mode`, assert
+  `_pending_crop_angle == folded` and `_crop_fold_fine` True and a full-frame
+  pending box seeded; `confirm_crop` zeroes `fine_rotation_angle`;
+  `cancel_crop_mode` leaves it.
+- `toggle_crop_panel` swaps panel visibility and restores on exit.
+- Existing `test_crop_overlay.py`, `test_histogram_crop.py`, `test_crop_hires.py`
+  still pass (no downstream change).
+
+Regression: run the crop/rotation/export-touching suites
+(`tests/run_tests.py`) — pre-existing unrelated failures noted in repo memory are
+not introduced by this change.

--- a/src/core/crop_aspect.py
+++ b/src/core/crop_aspect.py
@@ -1,0 +1,113 @@
+"""
+Pure (Qt-free) geometry + presets backing the Crop panel's aspect-ratio and
+straighten features. Kept import-light and side-effect-free so it can be unit
+tested without a GUI. See spec/crop-panel.md.
+
+Ratios are width/height in *Landscape* orientation; `oriented_ratio` applies the
+portrait/landscape toggle, and `effective_box_ratio` maps an on-screen target
+ratio onto the un-rotated image space the crop box lives in (90/270 coarse
+rotation swaps width<->height).
+"""
+
+# (label, key, base_ratio): base_ratio is width/height for Landscape, or None
+# for Free, or the sentinel "original" (resolve from the image's own aspect).
+ASPECT_PRESETS = [
+    ("Free", "free", None),
+    ("Original", "original", "original"),
+    ("1:1", "1:1", 1.0),
+    ("5:4", "5:4", 5.0 / 4.0),
+    ("4:3", "4:3", 4.0 / 3.0),
+    ("7:5", "7:5", 7.0 / 5.0),
+    ("3:2", "3:2", 3.0 / 2.0),
+    ("16:9", "16:9", 16.0 / 9.0),
+    ("Custom…", "custom", None),
+]
+
+# Keys for which the Landscape/Portrait toggle is meaningless.
+ORIENTATION_FIXED_KEYS = {"free", "original", "1:1", "custom"}
+
+
+def preset_for_key(key):
+    """Return the (label, key, base_ratio) tuple for `key`, or None."""
+    for entry in ASPECT_PRESETS:
+        if entry[1] == key:
+            return entry
+    return None
+
+
+def oriented_ratio(ratio, landscape):
+    """Apply the orientation toggle to a base (Landscape) width/height ratio.
+    Portrait flips it to height/width. None / non-positive pass through."""
+    if ratio is None or ratio <= 0:
+        return ratio
+    return ratio if landscape else 1.0 / ratio
+
+
+def effective_box_ratio(display_ratio, rotation):
+    """Convert an on-screen target ratio into the box-frame ratio used on the
+    pending crop rect (which lives in un-rotated image space). A 90/270 coarse
+    rotation swaps width<->height as seen on screen; flips don't change a
+    rectangle's aspect."""
+    if display_ratio is None or display_ratio <= 0:
+        return display_ratio
+    if rotation % 180 == 90:
+        return 1.0 / display_ratio
+    return display_ratio
+
+
+def enforce_ratio_size(adx, ady, r):
+    """Smallest box of ratio r = w/h that COVERS the desired extents
+    (|adx|, |ady|). Used while drawing/corner-dragging so the box grows to
+    include the pointer without breaking the ratio. r None/<=0 -> unconstrained."""
+    adx, ady = abs(adx), abs(ady)
+    if r is None or r <= 0:
+        return adx, ady
+    if adx >= ady * r:
+        return adx, adx / r
+    return ady * r, ady
+
+
+def fit_ratio_within(w, h, r):
+    """Largest box of ratio r = w/h that FITS inside w x h (centered use).
+    r None/<=0 or degenerate bounds -> (w, h) unchanged."""
+    if r is None or r <= 0 or w <= 0 or h <= 0:
+        return w, h
+    if w / h >= r:        # height is the binding dimension
+        return h * r, h
+    return w, w / r       # width is the binding dimension
+
+
+def reshape_to_ratio(center, box_wh, img_wh, r):
+    """Compute a box of ratio r for a preset change / auto-seed.
+
+    - center: (cx, cy) of the current box, in image px (ignored when box_wh is
+      falsy — the new box is centered on the image instead).
+    - box_wh: (w, h) of the current pending box, or None to seed from the image.
+    - img_wh: (W, H) of the full image.
+    - r: target box-frame ratio (w/h), or None for Free.
+
+    Returns (cx, cy, bw, bh), or None for Free / degenerate input. When a box
+    exists the result is fit *within* it (never larger than the current
+    selection); otherwise it is the largest centered box of ratio r in the image.
+    """
+    if r is None or r <= 0:
+        return None
+    W, H = img_wh
+    if W <= 0 or H <= 0:
+        return None
+    if box_wh is not None and box_wh[0] >= 2 and box_wh[1] >= 2:
+        cx, cy = center
+        bw, bh = fit_ratio_within(box_wh[0], box_wh[1], r)
+    else:
+        cx, cy = W / 2.0, H / 2.0
+        bw, bh = fit_ratio_within(W, H, r)
+    return cx, cy, bw, bh
+
+
+def folded_crop_angle(crop_angle, fine_rotation_angle):
+    """The crop-box angle that absorbs an image-level micro-rotation, so the two
+    rotations don't stack. `fine_rotation_angle` is in hundredths of a degree
+    (CCRImage convention). Equivalence (see spec §5.4): image fine-rotation
+    rotates content clockwise for positive values, the crop box de-rotates
+    counter-clockwise, hence the sign flip."""
+    return (crop_angle or 0.0) - (fine_rotation_angle or 0) / 100.0

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -6,6 +6,7 @@ from widgets.thumbnail_list import ThumbnailList
 from widgets.image_preview import ImagePreview
 from widgets.sliders_panel import SlidersPanel
 from widgets.dust_panel import DustRemovalPanel
+from widgets.crop_panel import CropPanel
 from widgets.tether_banner import TetherBanner
 from core.ccr_backend import ccr_backend
 from core.tether_watcher import (TetherWatchWorker, FolderScanner, is_supported,
@@ -144,6 +145,14 @@ class MainWindow(QMainWindow):
         self.dust_panel.setVisible(False)
         self.image_preview.set_dust_panel(self.dust_panel)
 
+        # Crop panel — covers the sliders panel while in crop mode, same sibling
+        # pattern as dust_panel (keeps SlidersPanel's parent chain valid). See
+        # spec/crop-panel.md.
+        self.crop_panel = CropPanel(self, self.image_preview)
+        self.crop_panel.setFixedWidth(300)
+        self.crop_panel.setVisible(False)
+        self.image_preview.set_crop_panel(self.crop_panel)
+
         # Tethering (watch-folder capture) state + status banner. The banner is
         # installed INTO image_preview's own layout (not wrapped around it) so
         # ImagePreview's parent().parent() chains stay valid — see
@@ -168,6 +177,7 @@ class MainWindow(QMainWindow):
         self.layout.addWidget(self.image_preview, 3)
         self.layout.addWidget(self.sliders_panel, 0)
         self.layout.addWidget(self.dust_panel, 0)
+        self.layout.addWidget(self.crop_panel, 0)
 
         # Persisted UI preferences (last-open location etc.)
         self._settings = QSettings("FreeCCR", "FreeCCR")
@@ -308,6 +318,42 @@ class MainWindow(QMainWindow):
         self.dust_panel.setVisible(False)
         self.sliders_panel.setVisible(True)
         self._sync_dust_action(False)
+
+    # --- Crop (panel cover + canvas crop mode) ---------------------------
+    def toggle_crop_panel(self, on=None):
+        """Show/hide the Crop panel (covering the sliders) and enter/exit the
+        canvas crop mode. `on=None` flips the current state. Mirrors
+        toggle_dust_removal. Exit is also driven by the canvas chokepoint
+        (_exit_crop_mode -> on_crop_panel_closed) for Enter/Esc/right-click."""
+        if on is None:
+            on = not self.image_preview.crop_mode
+        if on:
+            if self.image_preview.current_idx is None:
+                return
+            if self.image_preview.crop_mode:
+                return
+            if not self.image_preview.enter_crop_mode():
+                return
+            self.sliders_panel.setVisible(False)
+            self.dust_panel.setVisible(False)
+            self.crop_panel.bind_image()
+            self.crop_panel.setVisible(True)
+        else:
+            # Done button: commit the pending crop. confirm_crop -> _exit_crop_mode
+            # -> on_crop_panel_closed restores the panel; if already out of crop
+            # mode, restore directly.
+            if self.image_preview.crop_mode:
+                self.image_preview.confirm_crop()
+            else:
+                self.on_crop_panel_closed()
+
+    def on_crop_panel_closed(self):
+        """Restore the sliders panel after crop mode ends by any path. Guarded
+        so entering dust mode from crop (which also exits crop) doesn't fight the
+        dust panel."""
+        self.crop_panel.setVisible(False)
+        if not self.dust_panel.isVisible():
+            self.sliders_panel.setVisible(True)
 
     def _sync_dust_action(self, checked: bool):
         action = getattr(self.image_preview, "dust_action", None)

--- a/src/widgets/crop_panel.py
+++ b/src/widgets/crop_panel.py
@@ -1,0 +1,276 @@
+"""
+Crop panel — covers the right-hand sliders panel while in crop mode (the same
+cover/restore pattern as DustRemovalPanel). Exposes "all the crop options":
+
+  - Aspect ratio: presets (Free / Original / 1:1 / 5:4 / 4:3 / 7:5 / 3:2 / 16:9 /
+    Custom…) with a Landscape/Portrait toggle. A locked ratio constrains every
+    on-canvas drag and reshapes the current box; the choice persists across
+    images and sessions (QSettings) for catalogue consistency (issue #39).
+  - Straighten: a ±45° slider that drives the crop box's rotation, two-way synced
+    with the on-canvas rotate knob. Any pre-existing image micro-rotation is
+    folded into this on entry (see ImagePreview.enter_crop_mode / spec §5.4).
+  - Reset (clear the pending box + straighten) and Done (commit).
+
+The committed result is still just CCRImage.crop_rect / crop_angle — this panel
+only changes how they are produced interactively. See spec/crop-panel.md.
+"""
+from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
+                               QPushButton, QComboBox, QRadioButton,
+                               QButtonGroup, QSpinBox)
+from PySide6.QtCore import Qt, QSettings
+
+from core import crop_aspect
+from widgets.image_preview import CenteringSlider
+from ui import theme
+
+
+class CropPanel(QWidget):
+    def __init__(self, main_window, image_preview, parent=None):
+        super().__init__(parent)
+        self.main_window = main_window
+        self.image_preview = image_preview
+        self._settings = QSettings("FreeCCR", "FreeCCR")
+        # Guards re-entrancy while widgets are updated programmatically (so a
+        # setValue/setCurrentIndex doesn't fire a handler that mutates state).
+        self._suppress = False
+        self._build_ui()
+        self._restore_prefs()
+
+    # --- UI ---------------------------------------------------------------
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+        theme.apply_panel_spacing(layout)
+
+        header = QLabel("Crop")
+        header.setAlignment(Qt.AlignCenter)
+        header.setStyleSheet("font-size: 14px; font-weight: bold; margin: 4px;")
+        layout.addWidget(header)
+
+        # --- Aspect ratio ---
+        layout.addWidget(self._section_label("Aspect Ratio"))
+        self.aspect_combo = QComboBox()
+        self.aspect_combo.setFixedHeight(theme.CONTROL_H)
+        for label, key, _ratio in crop_aspect.ASPECT_PRESETS:
+            self.aspect_combo.addItem(label, key)
+        self.aspect_combo.currentIndexChanged.connect(self._on_aspect_changed)
+        layout.addWidget(self.aspect_combo)
+
+        # Orientation (Landscape / Portrait)
+        orient_row = QHBoxLayout()
+        orient_row.setSpacing(theme.GAP_TIGHT)
+        self.landscape_radio = QRadioButton("Landscape")
+        self.portrait_radio = QRadioButton("Portrait")
+        self._orient_group = QButtonGroup(self)
+        self._orient_group.addButton(self.landscape_radio)
+        self._orient_group.addButton(self.portrait_radio)
+        self.landscape_radio.setChecked(True)
+        self.landscape_radio.toggled.connect(self._on_orientation_changed)
+        orient_row.addWidget(self.landscape_radio)
+        orient_row.addWidget(self.portrait_radio)
+        orient_row.addStretch(1)
+        layout.addLayout(orient_row)
+
+        # Custom W:H (only shown for the Custom preset)
+        self.custom_row = QHBoxLayout()
+        self.custom_row.setSpacing(theme.GAP_TIGHT)
+        custom_lbl = QLabel("Custom")
+        custom_lbl.setFixedWidth(theme.LABEL_COL_W)
+        self.custom_w_spin = QSpinBox()
+        self.custom_w_spin.setRange(1, 9999)
+        self.custom_w_spin.setValue(3)
+        self.custom_w_spin.setFixedHeight(theme.CONTROL_H)
+        self.custom_h_spin = QSpinBox()
+        self.custom_h_spin.setRange(1, 9999)
+        self.custom_h_spin.setValue(2)
+        self.custom_h_spin.setFixedHeight(theme.CONTROL_H)
+        self.custom_w_spin.valueChanged.connect(self._on_custom_changed)
+        self.custom_h_spin.valueChanged.connect(self._on_custom_changed)
+        custom_colon = QLabel(":")
+        self.custom_row.addWidget(custom_lbl)
+        self.custom_row.addWidget(self.custom_w_spin, 1)
+        self.custom_row.addWidget(custom_colon)
+        self.custom_row.addWidget(self.custom_h_spin, 1)
+        self._custom_widgets = [custom_lbl, self.custom_w_spin, custom_colon,
+                                self.custom_h_spin]
+        layout.addLayout(self.custom_row)
+
+        layout.addWidget(self._separator())
+
+        # --- Straighten ---
+        layout.addWidget(self._section_label("Straighten"))
+        str_row = QHBoxLayout()
+        str_row.setSpacing(theme.GAP_TIGHT)
+        str_lbl = QLabel("Angle")
+        str_lbl.setFixedWidth(theme.LABEL_COL_W)
+        # Value is tenths of a degree: -450..450 -> -45.0°..+45.0°.
+        self.straighten_slider = CenteringSlider(Qt.Horizontal)
+        self.straighten_slider.setMinimum(-450)
+        self.straighten_slider.setMaximum(450)
+        self.straighten_slider.setValue(0)
+        self.straighten_slider.setTickInterval(150)
+        self.straighten_slider.setTickPosition(CenteringSlider.TicksBelow)
+        self.straighten_slider.setFixedHeight(theme.CONTROL_H)
+        self.straighten_slider.valueChanged.connect(self._on_straighten_changed)
+        self.straighten_value = QLabel("+0.0°")
+        self.straighten_value.setFixedWidth(theme.VALUE_COL_W)
+        str_row.addWidget(str_lbl)
+        str_row.addWidget(self.straighten_slider)
+        str_row.addWidget(self.straighten_value)
+        layout.addLayout(str_row)
+
+        hint = QLabel(
+            "Drag on the image to draw a box; drag handles to resize, the top "
+            "knob (or the slider above) to straighten, the center to move. "
+            "Enter = Done, Esc = cancel, right-click = clear.")
+        hint.setWordWrap(True)
+        hint.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
+        layout.addWidget(hint)
+
+        layout.addWidget(self._separator())
+        layout.addStretch(1)
+
+        btns = QHBoxLayout()
+        theme.apply_button_row(btns)
+        self.reset_btn = QPushButton("Reset")
+        self.reset_btn.setFixedHeight(theme.CONTROL_H)
+        self.reset_btn.setToolTip("Clear the pending crop box and straighten.")
+        self.reset_btn.clicked.connect(self._on_reset)
+        self.done_btn = QPushButton("✓  Done")
+        self.done_btn.setMinimumHeight(theme.CONTROL_H_LG)
+        self.done_btn.setToolTip("Apply the crop and return to the adjustment sliders.")
+        theme.style_button(self.done_btn, "primary")
+        self.done_btn.clicked.connect(self._on_done)
+        btns.addWidget(self.reset_btn)
+        btns.addWidget(self.done_btn)
+        layout.addLayout(btns)
+
+    @staticmethod
+    def _section_label(text):
+        lbl = QLabel(text)
+        lbl.setStyleSheet(theme.section_header_qss())
+        return lbl
+
+    @staticmethod
+    def _separator():
+        return theme.section_separator()
+
+    # --- Public API used by MainWindow / ImagePreview ---------------------
+    def bind_image(self):
+        """Refresh panel state when crop mode opens: reflect the (possibly
+        folded) straighten angle, and seed/keep a box matching the remembered
+        ratio. Called by MainWindow.toggle_crop_panel after enter_crop_mode."""
+        self._update_custom_visibility()
+        self.image_preview.seed_crop_ratio_on_entry()
+        self.on_crop_geometry_changed()
+        self.image_preview.redraw_crop_overlay()
+
+    def on_crop_geometry_changed(self):
+        """Re-sync the straighten slider from the canvas (after a knob drag, a
+        fresh-box reset, or a programmatic reshape)."""
+        ang = getattr(self.image_preview, "_pending_crop_angle", 0.0) or 0.0
+        v = int(round(max(-45.0, min(45.0, ang)) * 10))
+        self._suppress = True
+        self.straighten_slider.setValue(v)
+        self.straighten_value.setText(f"{v / 10.0:+.1f}°")
+        self._suppress = False
+
+    def current_display_ratio(self, pixmap=None):
+        """The target on-screen width/height ratio for the active preset, or
+        None for Free / unresolved."""
+        key = self._active_key()
+        if key == "free":
+            return None
+        if key == "original":
+            if pixmap is None:
+                pixmap = self.image_preview.current_pixmap
+            if pixmap is None or pixmap.height() <= 0:
+                return None
+            return pixmap.width() / pixmap.height()
+        if key == "custom":
+            w, h = self.custom_w_spin.value(), self.custom_h_spin.value()
+            return (w / h) if (w >= 1 and h >= 1) else None
+        entry = crop_aspect.preset_for_key(key)
+        if entry is None or entry[2] in (None, "original"):
+            return None
+        return crop_aspect.oriented_ratio(entry[2], self._landscape())
+
+    def current_effective_ratio(self, rotation, pixmap=None):
+        """The ratio to enforce on the pending crop rect (un-rotated image
+        space), accounting for coarse 90/270 rotation."""
+        return crop_aspect.effective_box_ratio(
+            self.current_display_ratio(pixmap), rotation)
+
+    # --- Handlers ---------------------------------------------------------
+    def _on_aspect_changed(self, *_):
+        self._update_custom_visibility()
+        self._save_prefs()
+        self._apply_ratio_now()
+
+    def _on_orientation_changed(self, *_):
+        # QButtonGroup fires twice (off + on); act once, on the checked state.
+        self._save_prefs()
+        self._apply_ratio_now()
+
+    def _on_custom_changed(self, *_):
+        self._save_prefs()
+        self._apply_ratio_now()
+
+    def _on_straighten_changed(self, value):
+        self.straighten_value.setText(f"{value / 10.0:+.1f}°")
+        if self._suppress:
+            return
+        self.image_preview.set_pending_straighten(value / 10.0)
+
+    def _on_reset(self):
+        self.image_preview.reset_pending_crop()
+        # Re-seed a centered ratio box when a ratio is locked (Free -> no box).
+        self.image_preview.seed_crop_ratio_on_entry()
+        self.on_crop_geometry_changed()
+        self.image_preview.redraw_crop_overlay()
+
+    def _on_done(self):
+        self.main_window.toggle_crop_panel(False)
+
+    # --- helpers ----------------------------------------------------------
+    def _active_key(self):
+        return self.aspect_combo.currentData()
+
+    def _landscape(self):
+        return self.landscape_radio.isChecked()
+
+    def _apply_ratio_now(self):
+        if self._suppress:
+            return
+        if self.image_preview.crop_mode:
+            self.image_preview.reapply_crop_ratio(seed_if_empty=True)
+
+    def _update_custom_visibility(self):
+        key = self._active_key()
+        is_custom = key == "custom"
+        for wdg in self._custom_widgets:
+            wdg.setVisible(is_custom)
+        orient_ok = key not in crop_aspect.ORIENTATION_FIXED_KEYS
+        self.landscape_radio.setEnabled(orient_ok)
+        self.portrait_radio.setEnabled(orient_ok)
+
+    def _restore_prefs(self):
+        self._suppress = True
+        key = self._settings.value("crop/aspect_key", "free", type=str)
+        idx = self.aspect_combo.findData(key)
+        self.aspect_combo.setCurrentIndex(idx if idx >= 0 else 0)
+        landscape = self._settings.value(
+            "crop/orientation", "landscape", type=str) != "portrait"
+        (self.landscape_radio if landscape else self.portrait_radio).setChecked(True)
+        self.custom_w_spin.setValue(self._settings.value("crop/custom_w", 3, type=int))
+        self.custom_h_spin.setValue(self._settings.value("crop/custom_h", 2, type=int))
+        self._suppress = False
+        self._update_custom_visibility()
+
+    def _save_prefs(self):
+        if self._suppress:
+            return
+        self._settings.setValue("crop/aspect_key", self._active_key())
+        self._settings.setValue(
+            "crop/orientation", "landscape" if self._landscape() else "portrait")
+        self._settings.setValue("crop/custom_w", self.custom_w_spin.value())
+        self._settings.setValue("crop/custom_h", self.custom_h_spin.value())

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -10,6 +10,7 @@ from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QP
 from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
 from core.ccr_processor import apply_dust_removal
+from core import crop_aspect
 from widgets.export_dialog import ExportSettingsDialog
 from ui import theme
 import math
@@ -788,6 +789,9 @@ class ImagePreview(QWidget):
         self._crop_rerender = False          # guards update_preview while entering crop mode
         self._pending_crop_local = None      # QRectF box (un-rotated) in full-pixmap coords
         self._pending_crop_angle = 0.0       # box rotation, degrees (Qt clockwise-positive)
+        self._crop_fold_fine = False         # did entry fold a nonzero fine_rotation in?
+        self._crop_box_is_seed = False       # is the pending box an auto-seed (vs a user crop)?
+        self._crop_panel = None              # set by MainWindow (aspect ratio + straighten sync)
         self._crop_drag = None               # in-progress handle/new-rect drag state
         self._crop_overlay_item = None
         self._crop_handle_items = []
@@ -1077,7 +1081,10 @@ class ImagePreview(QWidget):
             # Fine rotation is suppressed in dust mode (the canvas shows the
             # un-fine-rotated image), so disable its slider to match — otherwise
             # it would show a value the display ignores and could mutate state.
-            self.rotation_slider.setEnabled(not self.dust_mode)
+            # In crop mode the panel's Straighten slider replaces it (and the
+            # image-level micro-rotation is folded into the crop), so keep it
+            # disabled there too.
+            self.rotation_slider.setEnabled(not self.dust_mode and not self.crop_mode)
             self.pixmap_item = QGraphicsPixmapItem(preview_img)
             self.scene.addItem(self.pixmap_item)
 
@@ -2480,16 +2487,113 @@ class ImagePreview(QWidget):
         finally:
             self._crop_rerender = False
         self._sync_zoom_combo()
+        # Fold any image-level micro-rotation into the crop straighten so the two
+        # rotations never stack: the box angle absorbs fine_rotation_angle, and
+        # confirm clears fine_rotation. Cancel never mutates it. See spec §5.4.
+        fine = getattr(img_obj, "fine_rotation_angle", 0) or 0
+        self._crop_fold_fine = (fine != 0)
+        base_angle = getattr(img_obj, "crop_angle", 0.0) or 0.0
+        self._pending_crop_angle = crop_aspect.folded_crop_angle(base_angle, fine)
+        self._crop_box_is_seed = False
         crop = getattr(img_obj, "crop_rect", None)
         if crop is not None and self.current_pixmap is not None:
             w, h = self.current_pixmap.width(), self.current_pixmap.height()
             self._pending_crop_local = QRectF(
                 crop[0] * w, crop[1] * h,
                 (crop[2] - crop[0]) * w, (crop[3] - crop[1]) * h)
-            self._pending_crop_angle = getattr(img_obj, "crop_angle", 0.0) or 0.0
+        elif fine != 0 and self.current_pixmap is not None:
+            # Folding a straighten but no crop yet: seed a full-frame box so the
+            # folded angle has something to live on (drawing a fresh box would
+            # otherwise reset the angle to 0 and discard the leveling). Marked as
+            # a seed so a remembered aspect ratio may reshape it on entry.
+            w, h = self.current_pixmap.width(), self.current_pixmap.height()
+            self._pending_crop_local = QRectF(0.0, 0.0, float(w), float(h))
+            self._crop_box_is_seed = True
         self._draw_crop_overlay()
         self.view.setCursor(Qt.CrossCursor)
+        # The panel straighten slider replaces the canvas micro-rotation slider
+        # while cropping; disable it so it can't set a second, stacking rotation.
+        self.rotation_slider.setEnabled(False)
         return True
+
+    # ---- Crop panel hooks: aspect ratio + straighten --------------------
+    def set_crop_panel(self, panel):
+        """MainWindow wires the CropPanel here so the crop tool can read the
+        active aspect ratio and keep the straighten slider in sync."""
+        self._crop_panel = panel
+
+    def _active_effective_ratio(self):
+        """The aspect ratio (box-frame, un-rotated space) the crop must hold, or
+        None for Free / when there is no panel."""
+        panel = self._crop_panel
+        if panel is None or self.current_pixmap is None:
+            return None
+        return panel.current_effective_ratio(self.current_rotation, self.current_pixmap)
+
+    def _sync_crop_panel(self):
+        panel = self._crop_panel
+        if panel is not None:
+            panel.on_crop_geometry_changed()
+
+    def redraw_crop_overlay(self):
+        """Public wrapper so the panel can request an overlay redraw."""
+        self._draw_crop_overlay()
+
+    def set_pending_straighten(self, degrees):
+        """Panel straighten slider -> crop box angle (no commit)."""
+        if not self.crop_mode:
+            return
+        self._pending_crop_angle = float(degrees)
+        self._draw_crop_overlay()
+
+    def reset_pending_crop(self):
+        """Reset button: clear the pending box + straighten (no commit)."""
+        if not self.crop_mode:
+            return
+        self._pending_crop_local = None
+        self._pending_crop_angle = 0.0
+        self._crop_box_is_seed = False
+        self._draw_crop_overlay()
+        self._sync_crop_panel()
+
+    def reapply_crop_ratio(self, seed_if_empty=True):
+        """Reshape the pending box to the panel's active ratio (preset change /
+        orientation toggle / custom edit). Free leaves the box untouched."""
+        if not self.crop_mode or self.current_pixmap is None:
+            return
+        r = self._active_effective_ratio()
+        if r is None:
+            return
+        w, h = self.current_pixmap.width(), self.current_pixmap.height()
+        sel = self._pending_crop_local
+        if sel is not None and sel.width() >= 2 and sel.height() >= 2:
+            center = (sel.center().x(), sel.center().y())
+            box_wh = (sel.width(), sel.height())
+        else:
+            if not seed_if_empty:
+                return
+            center, box_wh = (w / 2.0, h / 2.0), None
+        res = crop_aspect.reshape_to_ratio(center, box_wh, (w, h), r)
+        if res is None:
+            return
+        cx, cy, bw, bh = res
+        self._pending_crop_local = QRectF(cx - bw / 2.0, cy - bh / 2.0, bw, bh)
+        self._crop_box_is_seed = False
+        self._draw_crop_overlay()
+        self._sync_crop_panel()
+
+    def seed_crop_ratio_on_entry(self):
+        """On entering crop with a remembered ratio: seed a centered ratio box
+        when there is no user crop yet (None, or a fold-seeded full-frame box).
+        Leaves an existing user crop untouched."""
+        if not self.crop_mode:
+            return
+        sel = self._pending_crop_local
+        has_user_box = (sel is not None and sel.width() >= 2 and sel.height() >= 2
+                        and not self._crop_box_is_seed)
+        if has_user_box:
+            return
+        self.reapply_crop_ratio(seed_if_empty=True)
 
     # ---- Crop drag interaction: new rect + 10 control handles -----------
     # 4 corners (resize), 4 edge midpoints (move that edge), a rotate knob
@@ -2598,6 +2702,8 @@ class ImagePreview(QWidget):
             "box0": QRectF(sel) if sel is not None else None,
             "angle0": self._pending_crop_angle,
         }
+        # Any interaction makes the box user-owned (no longer an auto-seed).
+        self._crop_box_is_seed = False
         if mode != "new":
             self.view.setCursor(self._cursor_for_handle(mode))
         self.update_crop_drag(scene_pos)
@@ -2622,6 +2728,7 @@ class ImagePreview(QWidget):
         elif mode.startswith("edge-"):
             self._drag_edge(drag, p, mode[len("edge-"):])
         self._draw_crop_overlay()
+        self._sync_crop_panel()
 
     def end_crop_drag(self, scene_pos):
         if self._crop_drag is None:
@@ -2631,16 +2738,42 @@ class ImagePreview(QWidget):
 
     def _update_new_selection(self, p0, p1):
         w, h = self.current_pixmap.width(), self.current_pixmap.height()
-        x1 = max(0.0, min(float(w), min(p0.x(), p1.x())))
-        y1 = max(0.0, min(float(h), min(p0.y(), p1.y())))
-        x2 = max(0.0, min(float(w), max(p0.x(), p1.x())))
-        y2 = max(0.0, min(float(h), max(p0.y(), p1.y())))
-        if (x2 - x1) < 3 and (y2 - y1) < 3:
-            # Stray click, not a drag — keep the current selection (and its
-            # angle) so the display keeps matching what Enter will confirm.
+        r = self._active_effective_ratio()
+        if r is None:
+            x1 = max(0.0, min(float(w), min(p0.x(), p1.x())))
+            y1 = max(0.0, min(float(h), min(p0.y(), p1.y())))
+            x2 = max(0.0, min(float(w), max(p0.x(), p1.x())))
+            y2 = max(0.0, min(float(h), max(p0.y(), p1.y())))
+            if (x2 - x1) < 3 and (y2 - y1) < 3:
+                # Stray click, not a drag — keep the current selection (and its
+                # angle) so the display keeps matching what Enter will confirm.
+                return
+            # A freshly drawn box starts axis-aligned
+            self._pending_crop_local = QRectF(x1, y1, x2 - x1, y2 - y1)
+            self._pending_crop_angle = 0.0
             return
-        # A freshly drawn box starts axis-aligned
-        self._pending_crop_local = QRectF(x1, y1, x2 - x1, y2 - y1)
+        # Ratio-locked: anchor at p0, grow toward p1 covering the drag while
+        # holding the ratio, then clamp into the image (scaling about the anchor
+        # keeps the ratio). The new box is axis-aligned (straighten resets).
+        ax = min(max(p0.x(), 0.0), float(w))
+        ay = min(max(p0.y(), 0.0), float(h))
+        sx = 1.0 if (p1.x() - p0.x()) >= 0 else -1.0
+        sy = 1.0 if (p1.y() - p0.y()) >= 0 else -1.0
+        bw, bh = crop_aspect.enforce_ratio_size(p1.x() - p0.x(), p1.y() - p0.y(), r)
+        avail_x = (w - ax) if sx > 0 else ax
+        avail_y = (h - ay) if sy > 0 else ay
+        scale = 1.0
+        if bw > avail_x and bw > 0:
+            scale = min(scale, avail_x / bw)
+        if bh > avail_y and bh > 0:
+            scale = min(scale, avail_y / bh)
+        bw *= scale
+        bh *= scale
+        if bw < 3 and bh < 3:
+            return
+        x1 = min(ax, ax + sx * bw)
+        y1 = min(ay, ay + sy * bh)
+        self._pending_crop_local = QRectF(x1, y1, bw, bh)
         self._pending_crop_angle = 0.0
 
     def _drag_move_box(self, drag, p):
@@ -2694,10 +2827,19 @@ class ImagePreview(QWidget):
         anchor = box0.center() + fwd.map(QPointF(-sx * hw0, -sy * hh0))
         d = unrot.map(p - anchor)  # dragged corner in box frame, rel. anchor
         min_sz = 10.0
-        dx = sx * max(sx * d.x(), min_sz)
-        dy = sy * max(sy * d.y(), min_sz)
+        r = self._active_effective_ratio()
+        adx, ady = abs(d.x()), abs(d.y())
+        if r is not None and r > 0:
+            # Hold the ratio (cover the pointer), then re-hold it after the
+            # min-size clamp so a tiny box stays the right shape.
+            adx, ady = crop_aspect.enforce_ratio_size(adx, ady, r)
+            adx, ady = max(adx, min_sz), max(ady, min_sz)
+            adx, ady = crop_aspect.enforce_ratio_size(adx, ady, r)
+        else:
+            adx, ady = max(adx, min_sz), max(ady, min_sz)
+        dx, dy = sx * adx, sy * ady
         c = anchor + fwd.map(QPointF(dx / 2.0, dy / 2.0))
-        bw, bh = abs(dx), abs(dy)
+        bw, bh = adx, ady
         self._pending_crop_local = QRectF(c.x() - bw / 2.0, c.y() - bh / 2.0, bw, bh)
 
     def _drag_edge(self, drag, p, which):
@@ -2722,6 +2864,18 @@ class ImagePreview(QWidget):
             bottom = max(d.y(), top + min_sz)
         elif which == "t":
             top = min(d.y(), bottom - min_sz)
+        r = self._active_effective_ratio()
+        if r is not None and r > 0:
+            # With a locked ratio an edge can't move alone: derive the
+            # perpendicular dimension symmetric about the box center.
+            if which in ("l", "r"):
+                bw = right - left
+                bh = max(bw / r, min_sz)
+                top, bottom = -bh / 2.0, bh / 2.0
+            else:
+                bh = bottom - top
+                bw = max(bh * r, min_sz)
+                left, right = -bw / 2.0, bw / 2.0
         c = c0 + fwd.map(QPointF((left + right) / 2.0, (top + bottom) / 2.0))
         bw, bh = right - left, bottom - top
         self._pending_crop_local = QRectF(c.x() - bw / 2.0, c.y() - bh / 2.0, bw, bh)
@@ -2852,11 +3006,19 @@ class ImagePreview(QWidget):
                         and new_crop[2] >= 0.999 and new_crop[3] >= 0.999):
                     new_crop = None
                 old_angle = getattr(img_obj, "crop_angle", 0.0) or 0.0
+                fold = self._crop_fold_fine and bool(
+                    getattr(img_obj, "fine_rotation_angle", 0))
                 if (not self._crops_equal(new_crop, img_obj.crop_rect, w, h)
-                        or abs(angle - old_angle) >= 0.05):
+                        or abs(angle - old_angle) >= 0.05 or fold):
                     img_obj.push_undo_state()
                     img_obj.crop_rect = new_crop
                     img_obj.crop_angle = 0.0 if new_crop is None else angle
+                    if fold:
+                        # The folded micro-rotation now lives in the crop angle
+                        # (the cropped result already reflects the un-fine-rotated
+                        # display). Clear it in the same undo snapshot so the two
+                        # rotations don't stack; Ctrl+Z restores both.
+                        img_obj.fine_rotation_angle = 0
                     applied = True
                     cleared = new_crop is None
             else:
@@ -2908,9 +3070,16 @@ class ImagePreview(QWidget):
         self.crop_mode = False
         self._pending_crop_local = None
         self._pending_crop_angle = 0.0
+        self._crop_fold_fine = False
+        self._crop_box_is_seed = False
         self._crop_drag = None
         self._remove_crop_overlay_items()
         self.view.setCursor(Qt.ArrowCursor)
+        # Single chokepoint for every crop exit (Done/Enter/Esc/right-click/
+        # image-switch/entering-dust) — restore the right-hand sliders panel.
+        mw = self.window()
+        if hasattr(mw, "on_crop_panel_closed"):
+            mw.on_crop_panel_closed()
 
     # ===== Area editing (local masked adjustment layers) ==================
     # Mirrors the crop tool: a scene-item overlay with constant-size handles,

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -441,9 +441,9 @@ class SlidersPanel(QWidget):
         # Crop: non-destructive crop of the preview/export (same gating).
         self.crop_btn = QPushButton("Crop")
         self.crop_btn.setToolTip(
-            "Crop the image. Drag to draw a box; drag the handles to resize, "
-            "the top knob to rotate, the center to move. Enter confirms, "
-            "Esc cancels, right-click clears the crop.")
+            "Crop the image. Opens the Crop panel: pick an aspect ratio "
+            "(or Free), straighten, and drag the box on the image. Enter "
+            "confirms, Esc cancels, right-click clears the crop.")
         # Slice: split one scan containing several photos into separate
         # images. Not conversion-gated — slicing is most useful BEFORE
         # converting, so each frame gets its own reference/conversion.
@@ -1374,16 +1374,17 @@ class SlidersPanel(QWidget):
     def _on_crop_clicked(self):
         if not (hasattr(self, 'image_preview') and self.image_preview):
             return
-        # Toggle: clicking Crop again leaves crop mode (without changing it)
-        if self.image_preview.crop_mode:
-            self.image_preview.cancel_crop_mode()
+        # Opening crop swaps the sliders panel for the dedicated Crop panel
+        # (aspect ratios + straighten); MainWindow owns that swap.
+        mw = self.window()
+        if mw is None or not hasattr(mw, "toggle_crop_panel"):
+            # Fallback (e.g. tests with a stub host): drive crop mode directly.
+            if self.image_preview.crop_mode:
+                self.image_preview.cancel_crop_mode()
+            else:
+                self.image_preview.enter_crop_mode()
             return
-        if self.image_preview.enter_crop_mode():
-            self.set_temporary_hint(
-                "<b>Crop:</b> Drag to draw a box; drag handles to resize, "
-                "top knob to rotate, center to move. <b>Enter</b> = confirm, "
-                "<b>Esc</b> = cancel, right-click = clear crop, "
-                "<b>Crop</b> again = exit.", duration=12000)
+        mw.toggle_crop_panel(not self.image_preview.crop_mode)
 
     def _on_slice_clicked(self):
         if not (hasattr(self, 'image_preview') and self.image_preview):

--- a/tests/test_crop_aspect.py
+++ b/tests/test_crop_aspect.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the pure (Qt-free) crop aspect-ratio + straighten helpers in
+core.crop_aspect. See spec/crop-panel.md §5/§8.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core import crop_aspect as c  # noqa: E402
+
+TOL = 1e-9
+
+
+def _ratio(wh):
+    return wh[0] / wh[1]
+
+
+class TestEnforceRatioSize:
+    def test_wide_drag_covers_and_holds_ratio(self):
+        # adx dominates: width kept, height derived.
+        bw, bh = c.enforce_ratio_size(100, 10, 1.5)
+        assert bw == 100
+        assert _ratio((bw, bh)) == pytest.approx(1.5)
+        assert bh >= 10                       # covers the pointer's y extent
+
+    def test_tall_drag_covers_and_holds_ratio(self):
+        bw, bh = c.enforce_ratio_size(10, 100, 1.5)
+        assert bh == 100
+        assert _ratio((bw, bh)) == pytest.approx(1.5)
+        assert bw >= 10
+
+    def test_square_ratio(self):
+        assert c.enforce_ratio_size(40, 80, 1.0) == (80, 80)
+
+    def test_uses_absolute_values(self):
+        assert c.enforce_ratio_size(-100, -10, 1.5) == c.enforce_ratio_size(100, 10, 1.5)
+
+    def test_none_ratio_passes_through(self):
+        assert c.enforce_ratio_size(30, 40, None) == (30, 40)
+        assert c.enforce_ratio_size(30, 40, 0) == (30, 40)
+
+
+class TestFitRatioWithin:
+    def test_width_bound(self):
+        # 300x300, want 1.5 -> width is the binding side.
+        bw, bh = c.fit_ratio_within(300, 300, 1.5)
+        assert (bw, bh) == pytest.approx((300, 200))
+        assert _ratio((bw, bh)) == pytest.approx(1.5)
+
+    def test_height_bound(self):
+        bw, bh = c.fit_ratio_within(300, 300, 0.5)
+        assert (bw, bh) == pytest.approx((150, 300))
+        assert _ratio((bw, bh)) == pytest.approx(0.5)
+
+    def test_never_exceeds_bounds(self):
+        for r in (0.3, 1.0, 1.777, 4.0):
+            bw, bh = c.fit_ratio_within(123, 456, r)
+            assert bw <= 123 + TOL and bh <= 456 + TOL
+            assert _ratio((bw, bh)) == pytest.approx(r)
+
+    def test_degenerate_passes_through(self):
+        assert c.fit_ratio_within(100, 50, None) == (100, 50)
+        assert c.fit_ratio_within(0, 50, 1.5) == (0, 50)
+
+
+class TestEffectiveBoxRatio:
+    def test_unchanged_for_0_and_180(self):
+        assert c.effective_box_ratio(1.5, 0) == pytest.approx(1.5)
+        assert c.effective_box_ratio(1.5, 180) == pytest.approx(1.5)
+
+    def test_inverted_for_90_and_270(self):
+        assert c.effective_box_ratio(1.5, 90) == pytest.approx(1 / 1.5)
+        assert c.effective_box_ratio(1.5, 270) == pytest.approx(1 / 1.5)
+
+    def test_none_passes_through(self):
+        assert c.effective_box_ratio(None, 90) is None
+
+
+class TestOrientedRatio:
+    def test_landscape_unchanged(self):
+        assert c.oriented_ratio(1.5, True) == pytest.approx(1.5)
+
+    def test_portrait_inverted(self):
+        assert c.oriented_ratio(1.5, False) == pytest.approx(1 / 1.5)
+
+    def test_none_passes_through(self):
+        assert c.oriented_ratio(None, False) is None
+
+
+class TestReshapeToRatio:
+    def test_fits_within_existing_box(self):
+        # Current box 200x100 (ratio 2.0); reshape to 1.5 must fit inside it.
+        res = c.reshape_to_ratio((150, 150), (200, 100), (400, 300), 1.5)
+        cx, cy, bw, bh = res
+        assert (cx, cy) == (150, 150)            # center preserved
+        assert bw <= 200 + TOL and bh <= 100 + TOL
+        assert _ratio((bw, bh)) == pytest.approx(1.5)
+
+    def test_seeds_centered_in_image_when_no_box(self):
+        res = c.reshape_to_ratio((0, 0), None, (400, 300), 1.5)
+        cx, cy, bw, bh = res
+        assert (cx, cy) == (200, 150)            # image center
+        assert bw <= 400 + TOL and bh <= 300 + TOL
+        assert _ratio((bw, bh)) == pytest.approx(1.5)
+
+    def test_free_returns_none(self):
+        assert c.reshape_to_ratio((0, 0), None, (400, 300), None) is None
+
+    def test_degenerate_image_returns_none(self):
+        assert c.reshape_to_ratio((0, 0), None, (0, 300), 1.5) is None
+
+
+class TestFoldedCropAngle:
+    def test_zero_fine_is_noop(self):
+        assert c.folded_crop_angle(0.0, 0) == 0.0
+        assert c.folded_crop_angle(3.5, 0) == 3.5
+
+    def test_sign_and_scale(self):
+        # fine is hundredths of a degree; +200 -> +2.0 deg content CW -> crop -2.0
+        assert c.folded_crop_angle(0.0, 200) == pytest.approx(-2.0)
+        assert c.folded_crop_angle(0.0, -150) == pytest.approx(1.5)
+
+    def test_combines_with_existing_crop_angle(self):
+        assert c.folded_crop_angle(1.0, -150) == pytest.approx(2.5)
+
+    def test_handles_none(self):
+        assert c.folded_crop_angle(None, None) == 0.0
+
+
+class TestPresets:
+    def test_keys_unique_and_ratios_sane(self):
+        keys = [k for _l, k, _r in c.ASPECT_PRESETS]
+        assert len(keys) == len(set(keys))
+        for _label, _key, ratio in c.ASPECT_PRESETS:
+            if isinstance(ratio, (int, float)):
+                assert ratio > 0
+
+    def test_expected_keys_present(self):
+        keys = {k for _l, k, _r in c.ASPECT_PRESETS}
+        assert {"free", "original", "1:1", "3:2", "16:9", "custom"} <= keys
+
+    def test_preset_for_key(self):
+        assert c.preset_for_key("3:2")[2] == pytest.approx(1.5)
+        assert c.preset_for_key("nope") is None
+
+    def test_orientation_fixed_keys(self):
+        assert {"free", "original", "1:1", "custom"} <= c.ORIENTATION_FIXED_KEYS
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_crop_panel.py
+++ b/tests/test_crop_panel.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+GUI-level tests (offscreen Qt) for the Crop panel + ImagePreview crop
+integration: aspect-ratio-constrained drags, straighten/reset hooks, and the
+micro-rotation fold-in on enter/confirm. See spec/crop-panel.md §8.
+"""
+
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import (QApplication, QWidget, QVBoxLayout,  # noqa: E402
+                               QGraphicsPixmapItem)
+from PySide6.QtGui import QPixmap, QColor  # noqa: E402
+from PySide6.QtCore import QPointF, QRectF  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+from widgets.image_preview import ImagePreview  # noqa: E402
+from widgets.crop_panel import CropPanel  # noqa: E402
+
+TOL = 0.02
+
+
+class _StubPanel:
+    def set_sliders_enabled(self, *a):
+        pass
+
+
+class _Host(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.sliders_panel = _StubPanel()
+        self.mid = QWidget(self)
+
+
+class _RatioPanel:
+    """Minimal stand-in for CropPanel that just reports a fixed ratio."""
+    def __init__(self, r):
+        self._r = r
+
+    def current_effective_ratio(self, rotation, pixmap):
+        return self._r
+
+    def on_crop_geometry_changed(self):
+        pass
+
+
+class _Img:
+    """CCRImage stand-in carrying just the crop/rotation fields the crop flow
+    reads/writes, plus a recording undo stub."""
+    def __init__(self, crop_rect=None, crop_angle=0.0, fine=0):
+        self.crop_rect = crop_rect
+        self.crop_angle = crop_angle
+        self.fine_rotation_angle = fine
+        self.converted = True
+        self.undo = []
+
+    def push_undo_state(self):
+        self.undo.append((self.crop_rect, self.crop_angle, self.fine_rotation_angle))
+
+    def update_thumbnail_and_preview(self):
+        pass
+
+
+_HOSTS = []
+
+
+def _make_preview(w=400, h=300):
+    host = _Host()
+    _HOSTS.append(host)
+    layout = QVBoxLayout(host)
+    layout.addWidget(host.mid)
+    mid_layout = QVBoxLayout(host.mid)
+    ip = ImagePreview(host.mid)
+    mid_layout.addWidget(ip)
+    pm = QPixmap(w, h)
+    pm.fill(QColor(128, 128, 128))
+    ip.current_pixmap = pm
+    ip.pixmap_item = QGraphicsPixmapItem(pm)
+    ip.scene.addItem(ip.pixmap_item)
+    ip.current_rotation = 0
+    ip.current_horizontal_flip = False
+    ip.current_vertical_flip = False
+    ip.crop_mode = True
+    ip.current_idx = 0
+    return ip, host
+
+
+def _box_ratio(rect):
+    return rect.width() / rect.height()
+
+
+# --------------------------------------------------------------------------
+# Aspect-ratio-constrained drags
+# --------------------------------------------------------------------------
+class TestConstrainedDrags:
+    def test_new_selection_holds_ratio(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(1.5))
+        ip._update_new_selection(QPointF(50, 50), QPointF(250, 100))
+        rect = ip._pending_crop_local
+        assert rect is not None
+        assert _box_ratio(rect) == pytest.approx(1.5, abs=TOL)
+        # Anchored at the start corner.
+        assert rect.left() == pytest.approx(50, abs=0.5)
+        assert rect.top() == pytest.approx(50, abs=0.5)
+
+    def test_new_selection_clamped_into_image_keeps_ratio(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(1.5))
+        # Drag well past the right/bottom edges from near the corner.
+        ip._update_new_selection(QPointF(380, 280), QPointF(900, 900))
+        rect = ip._pending_crop_local
+        assert rect.right() <= 400 + 0.5 and rect.bottom() <= 300 + 0.5
+        assert _box_ratio(rect) == pytest.approx(1.5, abs=TOL)
+
+    def test_free_is_unconstrained(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(None))
+        ip._update_new_selection(QPointF(10, 10), QPointF(300, 50))
+        rect = ip._pending_crop_local
+        assert rect.width() == pytest.approx(290, abs=0.5)
+        assert rect.height() == pytest.approx(40, abs=0.5)
+
+    def test_corner_drag_holds_ratio(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(1.5))
+        drag = {"box0": QRectF(100, 100, 120, 80), "angle0": 0.0}
+        ip._drag_corner(drag, QPointF(320, 260), "br")
+        rect = ip._pending_crop_local
+        assert _box_ratio(rect) == pytest.approx(1.5, abs=TOL)
+
+    def test_edge_drag_holds_ratio(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(1.5))
+        drag = {"box0": QRectF(100, 100, 120, 80), "angle0": 0.0}
+        ip._drag_edge(drag, QPointF(280, 140), "r")
+        rect = ip._pending_crop_local
+        assert _box_ratio(rect) == pytest.approx(1.5, abs=TOL)
+
+
+# --------------------------------------------------------------------------
+# Reshape / seed / straighten / reset hooks
+# --------------------------------------------------------------------------
+class TestCropHooks:
+    def test_reapply_reshapes_existing_box(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(1.5))
+        ip._pending_crop_local = QRectF(50, 50, 200, 100)  # ratio 2.0
+        ip.reapply_crop_ratio()
+        assert _box_ratio(ip._pending_crop_local) == pytest.approx(1.5, abs=TOL)
+
+    def test_seed_on_entry_creates_centered_box_when_locked(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(1.5))
+        ip._pending_crop_local = None
+        ip.seed_crop_ratio_on_entry()
+        rect = ip._pending_crop_local
+        assert rect is not None
+        assert _box_ratio(rect) == pytest.approx(1.5, abs=TOL)
+        assert rect.center().x() == pytest.approx(200, abs=0.5)
+        assert rect.center().y() == pytest.approx(150, abs=0.5)
+
+    def test_seed_leaves_user_box_untouched(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(1.5))
+        ip._pending_crop_local = QRectF(10, 10, 100, 100)  # user box, ratio 1.0
+        ip._crop_box_is_seed = False
+        ip.seed_crop_ratio_on_entry()
+        assert _box_ratio(ip._pending_crop_local) == pytest.approx(1.0, abs=TOL)
+
+    def test_seed_free_leaves_box_empty(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(None))
+        ip._pending_crop_local = None
+        ip.seed_crop_ratio_on_entry()
+        assert ip._pending_crop_local is None
+
+    def test_set_pending_straighten(self):
+        ip, _h = _make_preview()
+        ip._pending_crop_local = QRectF(50, 50, 100, 100)
+        ip.set_pending_straighten(3.5)
+        assert ip._pending_crop_angle == pytest.approx(3.5)
+
+    def test_reset_pending_crop(self):
+        ip, _h = _make_preview()
+        ip.set_crop_panel(_RatioPanel(1.5))
+        ip._pending_crop_local = QRectF(50, 50, 100, 100)
+        ip._pending_crop_angle = 7.0
+        ip.reset_pending_crop()
+        assert ip._pending_crop_local is None
+        assert ip._pending_crop_angle == 0.0
+
+
+# --------------------------------------------------------------------------
+# Micro-rotation fold-in (enter / confirm / cancel)
+# --------------------------------------------------------------------------
+class TestStraightenFoldIn:
+    def _entered(self, fine, crop_rect=None, crop_angle=0.0):
+        ip, host = _make_preview()
+        ip.crop_mode = False                      # let enter_crop_mode flip it
+        img = _Img(crop_rect=crop_rect, crop_angle=crop_angle, fine=fine)
+        ccr_backend.images = [img]
+        ip.update_preview = lambda *a, **k: None  # skip the heavy re-render
+        ok = ip.enter_crop_mode()
+        return ip, img, ok
+
+    def test_enter_folds_fine_into_box_angle(self):
+        ip, _img, ok = self._entered(fine=200)        # +2.0 deg micro-rotation
+        assert ok
+        assert ip._crop_fold_fine is True
+        assert ip._pending_crop_angle == pytest.approx(-2.0)
+        # Seeds a full-frame box so the folded angle is committable.
+        assert ip._crop_box_is_seed is True
+        rect = ip._pending_crop_local
+        assert rect.width() == pytest.approx(400) and rect.height() == pytest.approx(300)
+
+    def test_enter_combines_existing_crop_angle(self):
+        ip, _img, ok = self._entered(fine=-150, crop_rect=(0.1, 0.1, 0.9, 0.9),
+                                     crop_angle=1.0)
+        assert ok
+        assert ip._pending_crop_angle == pytest.approx(2.5)   # 1.0 - (-1.5)
+        assert ip._crop_box_is_seed is False                  # used the real crop
+
+    def test_no_fine_does_not_fold(self):
+        ip, _img, ok = self._entered(fine=0)
+        assert ok
+        assert ip._crop_fold_fine is False
+        assert ip._pending_crop_angle == pytest.approx(0.0)
+        assert ip._pending_crop_local is None                 # no crop, no seed
+
+    def test_confirm_clears_fine_rotation(self):
+        ip, img, _ok = self._entered(fine=200)
+        ip.confirm_crop()
+        assert img.fine_rotation_angle == 0                   # folded away
+        assert img.crop_angle == pytest.approx(-2.0)          # leveling preserved
+        assert img.crop_rect is not None
+        assert img.undo                                       # one undo snapshot
+        # The snapshot captured the ORIGINAL fine rotation (undoable).
+        assert img.undo[-1][2] == 200
+
+    def test_cancel_preserves_fine_rotation(self):
+        ip, img, _ok = self._entered(fine=300)
+        ip.cancel_crop_mode()
+        assert img.fine_rotation_angle == 300                 # untouched on cancel
+
+
+# --------------------------------------------------------------------------
+# CropPanel widget: aspect-ratio resolution + visibility
+# --------------------------------------------------------------------------
+class TestCropPanelWidget:
+    def _panel(self):
+        ip, host = _make_preview()
+        panel = CropPanel(host, ip)
+        ip.set_crop_panel(panel)
+        return panel, ip
+
+    @staticmethod
+    def _select(panel, key, landscape=True, cw=16, ch=9):
+        # _suppress avoids touching real QSettings / triggering reshape.
+        panel._suppress = True
+        panel.aspect_combo.setCurrentIndex(panel.aspect_combo.findData(key))
+        (panel.landscape_radio if landscape else panel.portrait_radio).setChecked(True)
+        panel.custom_w_spin.setValue(cw)
+        panel.custom_h_spin.setValue(ch)
+        panel._update_custom_visibility()
+        panel._suppress = False
+
+    def test_free_ratio_none(self):
+        panel, ip = self._panel()
+        self._select(panel, "free")
+        assert panel.current_display_ratio(ip.current_pixmap) is None
+
+    def test_one_to_one(self):
+        panel, ip = self._panel()
+        self._select(panel, "1:1")
+        assert panel.current_display_ratio(ip.current_pixmap) == pytest.approx(1.0)
+
+    def test_three_two_orientation(self):
+        panel, ip = self._panel()
+        self._select(panel, "3:2", landscape=True)
+        assert panel.current_display_ratio(ip.current_pixmap) == pytest.approx(1.5)
+        self._select(panel, "3:2", landscape=False)
+        assert panel.current_display_ratio(ip.current_pixmap) == pytest.approx(1 / 1.5)
+
+    def test_custom(self):
+        panel, ip = self._panel()
+        self._select(panel, "custom", cw=16, ch=9)
+        assert panel.current_display_ratio(ip.current_pixmap) == pytest.approx(16 / 9)
+
+    def test_original_from_pixmap(self):
+        panel, ip = self._panel()                      # pixmap is 400x300
+        self._select(panel, "original")
+        assert panel.current_display_ratio(ip.current_pixmap) == pytest.approx(400 / 300)
+
+    def test_effective_inverts_on_90(self):
+        panel, ip = self._panel()
+        self._select(panel, "3:2", landscape=True)
+        assert panel.current_effective_ratio(0, ip.current_pixmap) == pytest.approx(1.5)
+        assert panel.current_effective_ratio(90, ip.current_pixmap) == pytest.approx(1 / 1.5)
+
+    def test_custom_visibility_and_orientation_gating(self):
+        panel, ip = self._panel()
+        self._select(panel, "custom")
+        assert panel.custom_w_spin.isHidden() is False
+        assert panel.landscape_radio.isEnabled() is False   # custom is orientation-fixed
+        self._select(panel, "3:2")
+        assert panel.custom_w_spin.isHidden() is True
+        assert panel.landscape_radio.isEnabled() is True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes the core of #39 (fixed aspect ratios in cropping).

## What

Crop becomes a **dedicated panel** that covers the right-hand sliders panel while in crop mode — the same sibling/`setVisible` swap the Dust Removal panel uses. The panel exposes the full set of crop options:

- **Aspect-ratio presets** — Free, Original, 1:1, 5:4, 4:3, 7:5, 3:2, 16:9, plus **Custom W:H** — with a **Landscape/Portrait** toggle. A locked ratio constrains every on-canvas drag (draw / corner / edge) and reshapes the box. The choice **persists across images and sessions** (QSettings), so a whole catalogue can be cropped to identical dimensions — the request in #39.
- **Straighten** slider (±45°) that drives the crop box angle, two-way synced with the on-canvas rotate knob.
- **Reset** and **Done** buttons; Enter / Esc / right-click behave as before.

### Micro-rotation fold-in
Entering crop folds any existing image-level micro-rotation (`fine_rotation_angle`) into the crop straighten — `crop_angle = old_crop_angle − fine/100` (derived from the export pipeline) — and **Done** clears `fine_rotation_angle` in the same undo snapshot so the two rotations never stack (Ctrl+Z restores both). Cancel/right-click-clear leave the micro-rotation untouched. The canvas micro-rotation slider is disabled while cropping.

## How

- `src/core/crop_aspect.py` — pure, Qt-free geometry/preset helpers (ratio cover/fit, 90/270 coarse-rotation compensation, reshape, fold-in math).
- `src/widgets/crop_panel.py` — the `CropPanel` widget (+ QSettings persistence).
- `src/widgets/image_preview.py` — ratio constraints in the three drag handlers, straighten/reset/reshape hooks, fold-in on `enter_crop_mode`, fold reset on `confirm_crop`, panel-restore on the single `_exit_crop_mode` chokepoint.
- `src/ui/main_window.py` — `toggle_crop_panel()` / `on_crop_panel_closed()` (mirror `toggle_dust_removal`).
- `src/widgets/sliders_panel.py` — Crop button routes through `toggle_crop_panel`.

**Downstream crop application is unchanged** (`apply_crop_to_image`, preview/export, histogram) — the panel only changes how `crop_rect`/`crop_angle` are produced.

Spec: `spec/crop-panel.md`.

## Scope / follow-up

Crop only. #39 also mentions "selection menus" (reference frame / Slice / Area) — aspect ratios there are a documented non-goal/follow-up.

## Testing

- New: `tests/test_crop_aspect.py` (pure helpers) + `tests/test_crop_panel.py` (constrained drags, fold-in enter/confirm/cancel, panel-widget ratio resolution) — **72 pass**.
- Existing crop/dust/slice/area/settings/histogram/curves/catalog/export/color-management suites pass (≈449 across batches). The only failures are the pre-existing `exposure_base` ones in `test_color_profile`/`test_positive_mode`/`test_color_bands`, unrelated to this change. The full-dir run hits the known environmental native access-violation hang (also unrelated).
- Manual: full `MainWindow` integration smoke (real converted image) — fold (−2.5°), 3:2 seed, straighten sync, Done commits `crop_angle` + clears `fine_rotation`, panel swap/restore, undo restores both. Panel rendered and visually checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
