### PR TITLE
v0.7.1 — cinematic crop ratios + B/W Point row gap fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,16 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: win_installer/FreeCCR_Install_*.exe
-          # Install instructions shown on every release page.
+          # Release notes shown on every release page.
           # KEEP IN SYNC with the macOS job's upload step below.
+          # The body is static, so refresh "## What's New" for each release.
           body: |
+            ## What's New
+
+            **v0.7.1**
+            - **Crop:** added cinematic aspect-ratio presets — Academy (1.37:1), 1.85:1 (Flat), 2:1 (Univisium), 2.35:1 (CinemaScope), and 2.39:1 (Scope).
+            - **Film B/W Point:** closed the empty gap between the Set Black/White Point row and the Convert Current / Convert All row — the slope-source label now stays hidden until a point is sampled.
+
             ## Install
 
             ### Windows
@@ -141,9 +148,16 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: FreeCCR_macOS_*.zip
-          # Install instructions shown on every release page.
+          # Release notes shown on every release page.
           # KEEP IN SYNC with the Windows job's upload step above.
+          # The body is static, so refresh "## What's New" for each release.
           body: |
+            ## What's New
+
+            **v0.7.1**
+            - **Crop:** added cinematic aspect-ratio presets — Academy (1.37:1), 1.85:1 (Flat), 2:1 (Univisium), 2.35:1 (CinemaScope), and 2.39:1 (Scope).
+            - **Film B/W Point:** closed the empty gap between the Set Black/White Point row and the Convert Current / Convert All row — the slope-source label now stays hidden until a point is sampled.
+
             ## Install
 
             ### Windows

--- a/spec/crop-panel.md
+++ b/spec/crop-panel.md
@@ -12,8 +12,10 @@ Crop panel** that covers the right-hand sliders panel while in crop mode — the
 exact pattern used by Dust Removal (`DustRemovalPanel`). The panel exposes "all
 the options" for cropping:
 
-- **Aspect-ratio presets** (Free, Original, 1:1, 5:4, 4:3, 7:5, 3:2, 16:9) with a
-  **portrait/landscape** toggle and a **custom W:H** field. A locked ratio
+- **Aspect-ratio presets** (Free, Original, 1:1, 5:4, 4:3, 7:5, 3:2, 16:9, plus a
+  cinematic group — Academy 1.37, 1.85 Flat, 2:1 Univisium, 2.35 CinemaScope,
+  2.39 Scope) with a **portrait/landscape** toggle and a **custom W:H** field.
+  A locked ratio
   constrains every on-canvas drag (draw, corner, edge) so the box can only ever
   be that shape. The selected ratio **persists across images and sessions**
   (QSettings) so a whole catalogue can be cropped to the same dimensions — the
@@ -80,7 +82,8 @@ rotations never stack. Cancelling leaves the original micro-rotation untouched.
   then a stretch and a button row **Reset | ✓ Done** (Done = primary, like dust).
 
 ### 3.2 Aspect ratio
-- **Combo** lists: Free, Original, 1:1, 5:4, 4:3, 7:5, 3:2, 16:9, Custom…
+- **Combo** lists: Free, Original, 1:1, 5:4, 4:3, 7:5, 3:2, 16:9, Academy (1.37:1),
+  1.85:1 (Flat), 2:1 (Univisium), 2.35:1 (CinemaScope), 2.39:1 (Scope), Custom…
 - **Orientation** (Landscape / Portrait) radios; disabled and ignored for Free,
   Original, and 1:1 (orientation is meaningless there). Toggling swaps the active
   ratio `r ↔ 1/r`.
@@ -117,7 +120,8 @@ No new persistent field on `CCRImage`. The committed result is still exactly
 `crop_angle` (deg). The chosen **aspect ratio is panel/session state**, persisted
 in QSettings (not per image) so it is consistent across the catalogue:
 
-- `crop/aspect_key`: one of `free|original|1:1|5:4|4:3|7:5|3:2|16:9|custom`.
+- `crop/aspect_key`: one of
+  `free|original|1:1|5:4|4:3|7:5|3:2|16:9|academy|1.85:1|2:1|2.35:1|2.39:1|custom`.
 - `crop/custom_w`, `crop/custom_h`: ints for the custom ratio.
 - `crop/orientation`: `landscape|portrait`.
 

--- a/src/core/crop_aspect.py
+++ b/src/core/crop_aspect.py
@@ -20,6 +20,14 @@ ASPECT_PRESETS = [
     ("7:5", "7:5", 7.0 / 5.0),
     ("3:2", "3:2", 3.0 / 2.0),
     ("16:9", "16:9", 16.0 / 9.0),
+    # Cinematic ratios (width/height in Landscape). Academy 1.375 is the classic
+    # 35 mm sound-film frame; the rest are the modern wide theatrical/streaming
+    # standards — DCI Flat 1.85, Univisium 2.0, CinemaScope 2.35, DCI Scope 2.39.
+    ("Academy (1.37:1)", "academy", 1.375),
+    ("1.85:1 (Flat)", "1.85:1", 1.85),
+    ("2:1 (Univisium)", "2:1", 2.0),
+    ("2.35:1 (CinemaScope)", "2.35:1", 2.35),
+    ("2.39:1 (Scope)", "2.39:1", 2.39),
     ("Custom…", "custom", None),
 ]
 

--- a/src/widgets/crop_panel.py
+++ b/src/widgets/crop_panel.py
@@ -3,7 +3,8 @@ Crop panel — covers the right-hand sliders panel while in crop mode (the same
 cover/restore pattern as DustRemovalPanel). Exposes "all the crop options":
 
   - Aspect ratio: presets (Free / Original / 1:1 / 5:4 / 4:3 / 7:5 / 3:2 / 16:9 /
-    Custom…) with a Landscape/Portrait toggle. A locked ratio constrains every
+    cinematic Academy / 1.85 / 2:1 / 2.35 / 2.39 / Custom…) with a
+    Landscape/Portrait toggle. A locked ratio constrains every
     on-canvas drag and reshapes the current box; the choice persists across
     images and sessions (QSettings) for catalogue consistency (issue #39).
   - Straighten: a ±45° slider that drives the crop box's rotation, two-way synced

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -416,6 +416,10 @@ class SlidersPanel(QWidget):
         # Shows which slope source the next conversion will use.
         self.bwp_mode_label = QLabel("")
         self.bwp_mode_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
+        # Starts empty (no black point yet); an empty label would still reserve a
+        # line of height + spacing, leaving a gap between this and the Convert row,
+        # so keep it hidden until it has something to say (_update_bwp_mode_label).
+        self.bwp_mode_label.setVisible(False)
         scroll_layout.addWidget(self.bwp_mode_label)
         self.convert_current_bwp_btn = QPushButton("Convert Current")
         self.convert_all_bwp_btn = QPushButton("Convert All")
@@ -1447,11 +1451,15 @@ class SlidersPanel(QWidget):
         bp_set = ccr_backend.black_point_bgr is not None
         wp_set = ccr_backend.white_point_bgr is not None
         if not bp_set:
-            self.bwp_mode_label.setText("")
+            text = ""
         elif wp_set:
-            self.bwp_mode_label.setText("Slope source: white point (two-point)")
+            text = "Slope source: white point (two-point)"
         else:
-            self.bwp_mode_label.setText("Slope source: default slope (black point only)")
+            text = "Slope source: default slope (black point only)"
+        self.bwp_mode_label.setText(text)
+        # Hide when empty so it reserves no vertical space — keeps the Set-point
+        # row and the Convert row tight together (no gap) until a point is set.
+        self.bwp_mode_label.setVisible(bool(text))
 
     def on_bwpoint_sampled(self, mode):
         label = "White Point" if mode == "white" else "Black Point"


### PR DESCRIPTION
## v0.7.1

### Crop — cinematic aspect ratios
Added a cinematic group to the Crop panel's aspect-ratio dropdown (after `16:9`):

| Label | Ratio |
|---|---|
| Academy (1.37:1) | 1.375 |
| 1.85:1 (Flat) | 1.85 |
| 2:1 (Univisium) | 2.0 |
| 2.35:1 (CinemaScope) | 2.35 |
| 2.39:1 (Scope) | 2.39 |

These are pure entries in `crop_aspect.ASPECT_PRESETS`, so ratio locking, box reshaping, the Landscape/Portrait toggle, and QSettings persistence all apply automatically. Verified the longest label fits the combo.

### Film B/W Point — closed the row gap
The empty "Slope source" label reserved a full line of height, leaving a visible gap between the **Set Black/White Point** row and the **Convert Current / Convert All** row. The label now stays hidden until a point is sampled, so the rows sit tight.

### Release notes
Added a `## What's New` section to the `release.yml` body (both build jobs, kept in sync) describing the v0.7.1 changes.

### Tests
- `tests/test_crop_aspect.py` → 27 passed
- Offscreen captures confirm the tight B/W row and the new dropdown entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
