### PR TITLE
feat(merge): 3-way RGB-light (trichrome) merge mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,8 @@ jobs:
           body: |
             ## What's New
 
-            **v0.7.1**
-            - **Crop:** added cinematic aspect-ratio presets — Academy (1.37:1), 1.85:1 (Flat), 2:1 (Univisium), 2.35:1 (CinemaScope), and 2.39:1 (Scope).
-            - **Film B/W Point:** closed the empty gap between the Set Black/White Point row and the Convert Current / Convert All row — the slope-source label now stays hidden until a point is sampled.
+            **v0.8.0**
+            - **3-way RGB merge (trichrome capture):** new toggle on Settings → Color Management. Shoot a static scene three times under pure red, then green, then blue light; on import, every 3 RAWs (sorted by filename) merge into one colour image — each frame contributes only its own channel, with no demosaicing — then convert as a negative. Bayer RAW only; the selected count must be a multiple of 3.
 
             ## Install
 
@@ -154,9 +153,8 @@ jobs:
           body: |
             ## What's New
 
-            **v0.7.1**
-            - **Crop:** added cinematic aspect-ratio presets — Academy (1.37:1), 1.85:1 (Flat), 2:1 (Univisium), 2.35:1 (CinemaScope), and 2.39:1 (Scope).
-            - **Film B/W Point:** closed the empty gap between the Set Black/White Point row and the Convert Current / Convert All row — the slope-source label now stays hidden until a point is sampled.
+            **v0.8.0**
+            - **3-way RGB merge (trichrome capture):** new toggle on Settings → Color Management. Shoot a static scene three times under pure red, then green, then blue light; on import, every 3 RAWs (sorted by filename) merge into one colour image — each frame contributes only its own channel, with no demosaicing — then convert as a negative. Bayer RAW only; the selected count must be a multiple of 3.
 
             ## Install
 

--- a/spec/three-way-rgb-merge.md
+++ b/spec/three-way-rgb-merge.md
@@ -1,0 +1,430 @@
+# 3-Way RGB-Light Merge Mode
+
+> Status: refined (post adversarial review). Round-2 decisions are folded inline;
+> see the "Review resolutions" note at the end for the rationale trail.
+
+## Summary
+
+A capture/import mode for **trichrome (three-colour) photography**: the user
+shoots one static scene three times, each under a single pure light — **red,
+then green, then blue** — and FreeCCR merges every consecutive triplet of source
+RAWs into one full-colour image by taking each frame's *own* colour channel and
+discarding the other two, **without demosaicing**. The merged image then flows
+into the existing negative-inversion pipeline unchanged.
+
+The mode is a global toggle on the **Settings → Color Management** tab, mirroring
+the existing Positive-mode toggle.
+
+## Goals
+
+- Add a persistent boolean setting **"3-way RGB merge mode"** in the Color
+  Management tab of the Settings dialog.
+- When ON, importing images (Open Files **and** Open Folder):
+  1. requires the input count to be a **multiple of 3** (else a clear error,
+     nothing loads);
+  2. **sorts** the inputs by filename (basename, case-insensitive);
+  3. groups every 3 consecutive files into one triplet `(R, G, B)`;
+  4. merges each triplet into a single RGB image by **channel selection without
+     demosaicing** — R-plane from file 1, G-plane from file 2, B-plane from file 3;
+  5. presents the merged image as a normal loaded image that continues into the
+     existing negative-inversion / adjustment / export pipeline.
+- Merged images survive the full lifecycle: preview, convert (negative
+  inversion), slider adjustments, zoom hi-res detail, export, **Duplicate, and
+  Slice** (the latter two by re-merging on re-read — see Integration).
+- Keep the merge maths pure and unit-testable, independent of rawpy/Qt.
+
+## Non-Goals
+
+- **No image registration / alignment.** The three frames are assumed already
+  aligned (tripod, static scene). Misalignment is the user's responsibility.
+- **No cross-session catalog persistence of merged images.** A merged image is a
+  session artifact derived from 3 files; it is excluded from the per-file edit
+  catalog on every serialization path. Re-importing re-merges fresh.
+  *Consequence (intended):* edits to a merged image (reference frame, conversion,
+  crop, sliders, dust) are **not saved between sessions**. A first-merge hint
+  states this. (Follow-up: key the catalog on a composite of the 3 source
+  signatures.)
+- **Bayer (RGGB) sensors only.** "Do not demosaic / take one channel" is a 2×2
+  Bayer-CFA concept. X-Trans (Fujifilm `.raf`), monochrome, and 4-colour
+  (CYGM/RGBE) sensors are rejected at decode time with a clear message.
+- **Non-RAW inputs are not supported.** Validated by extension up front and by a
+  Bayer-CFA guard at decode.
+- **No full-sensor-resolution output.** A no-demosaic channel extraction is
+  inherently a 2×2-binned, half-sensor-resolution image. That binned size *is*
+  the merged image's full resolution.
+- The mode is global; no per-image override. No change to the non-merge flow when
+  the toggle is OFF.
+- **Positive mode is assumed OFF for merge.** Trichrome frames are negatives; the
+  request is to invert them. The two toggles are conceptually opposite (see Edge
+  Cases) — we surface a hint rather than force an override.
+
+## UX / Interaction
+
+### The toggle
+
+`src/widgets/settings_dialog.py` → `_build_color_management_page()`. Add a new
+group box after the existing "Negative conversion" group, mirroring the
+Positive-mode pattern (descriptive group title; behaviour in the checkbox +
+muted text):
+
+```
+[ Negative inversion ]                 (existing group)
+   ☐ Positive mode …
+
+[ Trichrome capture ]                  (new group)
+   ☐ 3-way RGB merge (combine red/green/blue-light exposures)
+   <muted>  Shoot a static scene three times under pure red, then green, then
+            blue light. On your NEXT import, every 3 RAWs (sorted by filename)
+            are merged into one colour image — each frame contributes only its
+            own channel, no demosaicing — then converted as a negative. RAW
+            (Bayer) only; the selected count must be a multiple of 3. Applies to
+            the next import only; merged-image edits are not saved between
+            sessions.
+```
+
+- Checkbox `self._cb_rgb_merge`, `toggled` → `self._on_rgb_merge(checked)` →
+  `self._mw.on_rgb_merge_mode_toggled(checked)` (same delegation as `_on_positive`).
+- `refresh_color_management()` syncs the checkbox from
+  `ccr_backend.rgb_merge_mode` with `blockSignals`, like `_cb_positive`.
+
+### Behaviour on import
+
+- **Toggle is sticky/global**, persisted in `QSettings` under
+  `import/rgb_merge_mode`; restored at startup before any image loads.
+- Toggling does **not** retroactively re-merge loaded images; it affects only the
+  **next** import. Transient hints:
+  - on: *"3-way RGB merge on — your next import merges every 3 RAWs (R,G,B by
+    filename)."* If Positive mode is also on, append: *" Positive mode is on;
+    merged frames are negatives — turn Positive off to invert them."*
+  - off: *"3-way RGB merge off."*
+- On import with the mode ON:
+  - **Valid**: triplets merge in parallel; the list shows N/3 merged items, each
+    named `<firstStem>_RGB<ext>` (de-duplicated within the batch).
+  - **Invalid count** (not a multiple of 3): *"3-way RGB merge needs a multiple of
+    3 images (got N). Select 3 frames per shot: red, green, blue."* — nothing
+    loads.
+  - **Non-RAW present**: *"3-way RGB merge requires RAW (Bayer) files. These are
+    not supported RAW: …"* — nothing loads.
+  - **Non-Bayer RAW** (X-Trans/mono/4-colour, only detectable at decode): the
+    triplet is rejected at decode; the import reports it via `last_merge_error`.
+
+### Error surfacing across both entry points
+
+`load_images_from_folder` already delegates to `load_images_from_files` (it ends
+with `load_images_from_files(sorted(file_paths), …)`), so **the merge branch lives
+only in `load_images_from_files`** and both entry points inherit it.
+
+- `open_files` holds the validated list, so it **pre-validates** with
+  `validate_merge_inputs` and shows the `QMessageBox` *before* starting the loader
+  (immediate feedback; returns without starting a loader — does not rely on
+  `_cleanup_loader`).
+- The backend also validates defensively (covers the folder path and decode-time
+  Bayer rejection) and records `ccr_backend.last_merge_error`. The main thread
+  surfaces it in `_cleanup_loader` (runs on the GUI thread via `thread.finished`,
+  after `load_thumbnails` has rendered the now-empty panel) with a `QMessageBox`.
+- `last_merge_error` is **reset to `None` at the very top of
+  `load_images_from_files`** (next to the B/W-point clears) and **read-then-cleared**
+  in `_cleanup_loader`, making it strictly per-load (no cross-load staleness).
+
+## Data Model
+
+### CCRImage (`src/core/ccr_image.py`)
+
+New constructor kwargs + attributes:
+
+- `is_merged: bool = False`
+- `merge_sources: Optional[list[str]] = None` — the 3 absolute source paths in
+  `(R, G, B)` order.
+
+`self.file_path = merge_sources[0]` (the red exposure) so existing machinery
+(lensfun EXIF read, lens correction, the nominal path) works on a real RAW of the
+right camera/lens. `display_name` defaults to `<stem(file_path)>_RGB<ext>`.
+
+`read_image()` gains a dispatch at the very top (after path normalisation, before
+the extension branch and before `positive_mode` is read):
+
+```python
+if self.is_merged and self.merge_sources:
+    return self._read_merged(preview=preview, max_long_side=max_long_side)
+```
+
+`_read_merged(preview, max_long_side)` mirrors the tail of the RAW branch:
+
+```python
+from core.ccr_merge import merge_raw_channels
+rgb, full_decode_size = merge_raw_channels(self.merge_sources)  # half-sensor res
+rgb = self._apply_source_ops(rgb)                # identity for a non-slice
+self.original_full_size = self._ops_full_size(full_decode_size)
+if max_long_side:
+    rgb = self.resize_image_to_max_pixel(rgb, max_long_side)
+return rgb
+```
+
+`preview` is accepted but ignored: the merge's native resolution **is**
+half-sensor (the 2×2 bin is the no-demosaic step); there is no cheaper/higher
+decode. Size control is purely via `max_long_side`.
+
+Because the dispatch lives inside `read_image`, **export, zoom hi-res replay,
+slicing, and duplication all compose for free** — each re-reads through
+`read_image(self.file_path)` and transparently re-merges from `merge_sources`
+(slice children and duplicates carry `is_merged`/`merge_sources`; see
+Integration). `_stamp_profile_signature` is left as-is; merged images decode
+camera-native and may show a profile-mismatch ⚠ if the active profile later
+changes — acceptable for v1 (documented).
+
+**`backend.file_paths`** after a merge load holds one path per merged image (the
+red exposure of each triplet). The G/B sources do not appear in `file_paths`.
+
+### Backend (`src/core/ccr_backend.py`)
+
+- `self.rgb_merge_mode: bool = False` (in `_init()`, next to `positive_mode`).
+- `self.last_merge_error: Optional[str] = None`.
+
+### Catalog (`src/core/catalog.py` + backend serialization paths)
+
+Merged images must never enter the per-file catalog. Guard **every** path:
+
+- `update_for_images()` skips `getattr(img, "is_merged", False)`.
+- `remove_images_by_indices()` (`ccr_backend.py:1177`) skips `is_merged` images —
+  does **not** add them to `_catalog_preserved` (this was the review's blocker:
+  removing a merged image would otherwise serialize its edits under the red RAW's
+  key).
+- `serialize_image()` is belt-and-suspenders: callers above already skip merged,
+  but a one-line note documents the invariant. (No functional change required if
+  the two callers are guarded; we still add the guard at the loop level.)
+
+## Processing / Maths
+
+### Why half resolution and "no demosaic"
+
+A Bayer sensor records one colour per photosite in a 2×2 tile (RGGB). A normal
+decode *demosaics* — interpolates the two missing colours at every site. The
+requirement is the opposite: take only the photosites that natively measured the
+wanted colour, discard the rest, do not interpolate. The clean way is to collapse
+each 2×2 CFA tile to one output pixel: `R = R-site`, `G = mean(two G-sites)`,
+`B = B-site`. That is exactly rawpy/libraw `half_size=True` — a pure bin, **no
+interpolation**. The result is a half-width × half-height RGB image, which is the
+merged frame's full resolution.
+
+### Per-frame native decode
+
+For each source RAW, decode in **camera-native colour with no channel mixing**:
+
+```python
+raw.postprocess(
+    output_bps=16,
+    no_auto_bright=True,
+    gamma=(1, 1),                 # linear
+    user_flip=0,
+    demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,  # inert under half_size
+    half_size=True,               # 2×2 bin == the no-demosaic channel extraction
+    use_camera_wb=False,          # no WB scaling
+    use_auto_wb=False,
+    output_color=rawpy.ColorSpace.raw,   # camera-native: NO 3×3 matrix → no mixing
+    no_auto_scale=True,           # absolute sensor values; we scale manually
+    adjust_maximum_thr=0.0,
+    four_color_rgb=False,
+)
+```
+
+Verified empirically on `example_raw/DSC07096.ARW`: this yields a byte-identical
+2×2 bin to a manual black-subtracted bin — unmixed, no interpolation; `LINEAR`
+vs `AHD` are identical under `half_size` (the bin, not the algorithm, is what
+avoids interpolation). libraw subtracts the black level during postprocess
+(per-channel min = 0 with `no_auto_scale=True`), so we **do not** black-subtract
+again. The purity guarantee rests on `half_size` + `output_color=raw`, not on the
+demosaic algorithm.
+
+### Bayer guard (decode-time)
+
+After `rawpy.imread`, require a 2×2 RGB Bayer mosaic, else raise a clear error
+(surfaced via `last_merge_error`):
+
+- `raw.num_colors == 3`,
+- `raw.color_desc` contains exactly the letters `R`, `G`, `B` (a permutation like
+  `RGBG`), and
+- `raw.raw_pattern` has shape `(2, 2)`.
+
+Rejects X-Trans (`.raf`, 6×6), monochrome (`num_colors == 1`), and 4-colour
+sensors with a message naming the offending file and reason.
+
+### Channel selection by `color_desc` (not hardcoded indices)
+
+`output_color=raw` emits channels in libraw's internal colour-index order, which
+is defined by `color_desc`. For the canonical `b'RGBG'`, index 0 = R, 1 = G,
+2 = B — but this must be **derived**, not assumed, so a permuted desc is handled
+and an invalid one is rejected:
+
+```python
+def bayer_channel_indices(color_desc: bytes) -> tuple[int, int, int]:
+    s = color_desc.decode("ascii", "ignore").upper()
+    r, g, b = s.find("R"), s.find("G"), s.find("B")
+    if -1 in (r, g, b):
+        raise ValueError(f"non-RGB Bayer color_desc {color_desc!r}")
+    return r, g, b   # (RGBG) -> (0, 1, 2)
+```
+
+For the **red-light** frame pick channel `r`, the **green-light** frame channel
+`g`, the **blue-light** frame channel `b`.
+
+### White-level scaling
+
+Scale each picked plane by `65535 / white_level` (clipped to `[0, 65535]`),
+**matching `read_image` lines 546–552** for pipeline consistency. (Because the
+data is already black-subtracted, the true ceiling is `white_level − black_level`,
+so saturated pixels land slightly below 65535 — identical behaviour to every
+other negative decode; intentional, not a merge-specific bug.) Per-frame scaling
+means differing exposures normalise consistently. Output contract matches the
+inversion pipeline: `(H, W, 3)` `uint16`, `[0, 65535]`, **linear**, RGB order.
+
+### Performance note
+
+`_read_merged` performs **3 rawpy decodes** per call. Export and every zoom
+hi-res tile re-read via `read_image`, so a merged image costs ~3× a normal
+image's re-decode. Acceptable for v1 (no session cache); documented so it isn't
+filed as a regression.
+
+### Module API (`src/core/ccr_merge.py`)
+
+```python
+# Exactly read_image's rawpy-Bayer-decodable set (== export_estimator.RAW_EXTS);
+# deliberately NOT the broader folder glob, and excludes .fff (treated as TIFF).
+RAW_EXTENSIONS = frozenset({
+    ".cr3", ".cr2", ".nef", ".arw", ".dng", ".rw2", ".orf", ".raf",
+    ".srw", ".pef", ".3fr",
+})
+
+def is_raw_path(path) -> bool
+def sort_for_merge(paths) -> list[str]                 # basename, case-insensitive
+def group_into_triplets(sorted_paths) -> list[tuple[str, str, str]]
+def validate_merge_inputs(paths) -> tuple[bool, Optional[str]]
+        # (ok, error). Checks: non-empty, len % 3 == 0, all is_raw_path.
+def bayer_channel_indices(color_desc) -> tuple[int, int, int]   # pure
+def combine_channels(plane_r, plane_g, plane_b, white_levels) -> np.ndarray  # pure
+        # crop to common (min H, min W); scale each by 65535/wl; clip; stack -> uint16
+def merge_raw_channels(sources) -> tuple[np.ndarray, tuple[int, int]]
+        # decode 3 RAWs native half-size, Bayer-guard, pick planes via
+        # bayer_channel_indices, combine_channels; returns (merged, (H, W)).
+```
+
+`merge_raw_channels` is the only rawpy-touching function; everything else is pure
+and unit-tested.
+
+## Integration Points
+
+| Where | Change |
+|---|---|
+| `src/core/ccr_merge.py` | **New module** (API above). |
+| `ccr_image.py` `__init__` | Accept `is_merged`/`merge_sources`; store **before** the `read_image` call; default `display_name` to `<stem>_RGB<ext>` when merged. |
+| `ccr_image.py` `read_image` | Top-of-method dispatch to `_read_merged`; add `_read_merged`. |
+| `ccr_backend.py` `_init` | `rgb_merge_mode=False`, `last_merge_error=None`. |
+| `ccr_backend.py` `load_images_from_files` | Reset `last_merge_error`; if `rgb_merge_mode`: `sort_for_merge` → `validate_merge_inputs` (fail ⇒ set `last_merge_error`, load nothing) → `group_into_triplets` → set `self.file_paths` to triplet reps (red paths) up front so the progress count tops out at N → build one merged `CCRImage` per triplet in the pool (`_load_merged_triplet`, catches decode errors → records `last_merge_error`, skips triplet) → de-dup display names → sort + assign. |
+| `catalog.py` `update_for_images` | Skip `is_merged` images. |
+| `ccr_backend.py` `remove_images_by_indices` | Skip `is_merged` (don't preserve into catalog). |
+| `ccr_backend.py` `duplicate_images_by_indices` | Pass `is_merged`/`merge_sources` to the dup `CCRImage` so re-reads re-merge. |
+| `ccr_backend.py` `slice_image_by_index` | Pass `is_merged`/`merge_sources` to each child so hi-res/export re-reads re-merge (parent's shared decode already re-merges). |
+| `export_estimator.py` `get_original_dims` | If `is_merged`, never probe `file_path` (full-sensor RAW = 2× wrong); use `original_full_size` / `resized_raw` dims. |
+| `settings_dialog.py` | New group box + `_cb_rgb_merge`; `_on_rgb_merge`; sync in `refresh_color_management`. |
+| `main_window.py` `__init__` | Restore `import/rgb_merge_mode` → `ccr_backend.rgb_merge_mode` before first load. |
+| `main_window.py` | `on_rgb_merge_mode_toggled(checked)`: set backend flag, persist QSettings, hint (incl. Positive-mode note). |
+| `main_window.py` `open_files` | When merge mode on, pre-validate via `validate_merge_inputs`; on failure show `QMessageBox`, return without loading. |
+| `main_window.py` `_cleanup_loader` | If `ccr_backend.last_merge_error`, show `QMessageBox.warning`, then clear it. |
+
+### Loader detail
+
+```python
+def _load_merged_triplet(triplet, order):           # runs in the pool
+    if cancel_flag and cancel_flag(): return None
+    r, g, b = triplet
+    try:
+        img = CCRImage(r, is_merged=True, merge_sources=[r, g, b])
+    except Exception as e:
+        self.last_merge_error = str(e)               # e.g. non-Bayer reason
+        return None
+    img._catalog_order = order
+    return img
+```
+
+Triplet display names are de-duplicated within the batch (append `_2`, `_3` on
+collision), mirroring the existing duplicate/slice naming guards. The post-load
+sort by `(basename, _catalog_order)` keys on the (unique) red basenames, keeping
+triplet order stable.
+
+## Edge Cases
+
+- **Count not a multiple of 3** → rejected, nothing loads (both entry points).
+- **Non-RAW file present** → rejected up front with the offending names.
+- **Non-Bayer RAW** (X-Trans/mono/4-colour) → rejected at decode via the Bayer
+  guard; reported through `last_merge_error`.
+- **A source fails to decode** → `merge_raw_channels` raises; the pool task
+  catches, records `last_merge_error`, skips that triplet; others still load.
+- **Differing frame dimensions** in a triplet → `combine_channels` crops to the
+  common min H/W.
+- **Duplicate of a merged image** → carries `is_merged`/`merge_sources`; initial
+  preview reuses the copied `resized_raw`, and zoom/export re-merge correctly.
+- **Slice of a merged image** → children carry `is_merged`/`merge_sources`; the
+  parent's shared decode re-merges, children crop via `source_ops`, and their
+  hi-res/export re-reads re-merge then crop. (Could not be end-to-end tested
+  without a real triplet fixture; correct by the verified `read_image` dispatch
+  composition. `_read_merged` raises if a source file is missing, failing loudly
+  rather than silently wrong.)
+- **Positive mode + merge** → conceptually opposite. v1 does **not** override:
+  with Positive mode on, merged frames are decoded but treated as positives
+  (not inverted), which is wrong for trichrome. We surface a hint when enabling
+  merge while Positive is on. Toggling Positive after a merge import re-decodes
+  (re-merges) correctly but still treats them as positives. Documented; the user
+  should keep Positive off for trichrome.
+- **Mode toggled while images are loaded** → no retroactive change; only the next
+  import is affected.
+
+## Test Plan
+
+`tests/test_three_way_merge.py` — pure-function unit tests (no rawpy/Qt):
+
+1. `validate_merge_inputs`:
+   - empty → invalid; 3/6 RAW → valid; 4 RAW → invalid, **message contains the
+     count "4"**; 3 with a `.jpg` → invalid, **message lists the `.jpg`**;
+   - `.fff` and `.heic` are rejected by `is_raw_path` (not in `RAW_EXTENSIONS`).
+2. `is_raw_path` accepts each of the 11 `RAW_EXTENSIONS` (case-insensitive),
+   rejects `.jpg/.png/.tif/.tiff/.fff/.heic`.
+3. `sort_for_merge` orders by case-insensitive basename, ignoring directory;
+   **stable across files that collide on basename in different dirs**.
+4. `group_into_triplets` of 6 sorted paths → 2 triplets, correct membership/order.
+5. `bayer_channel_indices`: `b'RGBG'` → `(0,1,2)`; `b'GRBG'` → `(1,0,2)` (or the
+   documented mapping); raises on `b'RGBE'`/`b'G'`.
+6. `combine_channels`:
+   - constructs three distinct constant-colour planes; asserts merged R == frame0
+     R-plane, G == frame1 G-plane, B == frame2 B-plane (correct frame→channel);
+   - white-level scaling: `white_level = 32767` ⇒ values ≈ double toward 65535;
+   - size-mismatch inputs crop to common min, no raise;
+   - output dtype `uint16`, shape `(H, W, 3)`, range `[0, 65535]`.
+
+Manual / launch verification:
+- App launches; Settings → Color Management shows the new toggle; toggling
+  persists across restart (QSettings).
+- `merge_raw_channels` and slice/duplicate-of-merged cannot be CI-tested here:
+  `example_raw/` has only 2 ARWs (no aligned trichrome triplet). Note this; a
+  small synthetic 3-RAW fixture or an env-gated manual test is a follow-up.
+
+Existing suite: `pytest tests/ -v`; the known pre-existing failures
+(`exposure_base`, occasional native crash) are unrelated.
+
+## Review resolutions (round 2)
+
+Folded from adversarial review: catalog isolation extended to
+`remove_images_by_indices`/serialize paths (was a blocker); Duplicate & Slice now
+thread `is_merged`/`merge_sources` (avoid silent wrong export); decode-time Bayer
+guard + `color_desc`-derived channel mapping (portability); `RAW_EXTENSIONS`
+pinned to read_image's exact Bayer set excluding `.fff`; `last_merge_error` reset
+per-load; progress count fixed via early `file_paths`; `export_estimator`
+`is_merged` guard; Positive-mode interaction documented with a hint; folder
+loader needs no change (delegates to files); display-name de-dup; white-level
+wording clarified.
+
+Round 3 (implementation review): `_load_merged_triplets` clears
+`last_merge_error` when the load was cancelled (the worker pool has joined, so
+the write has landed) — a cancelled import never pops a stray decode-error
+dialog. `load_images_from_folder`'s diagnostic failure count is computed in
+triplet units when merge mode is on. The per-worker `last_merge_error` is a
+single last-writer-wins slot (accepted: the message is deliberately generic and
+the set of loaded images is deterministic regardless).

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -210,6 +210,10 @@ def update_for_images(images, path: str = None, preserved: dict = None) -> None:
     catalog = load_catalog(path)
     grouped = {}
     for img in images:
+        # Merged (trichrome) images are session-only — never persist their edits
+        # under a source RAW's per-file key. See spec/three-way-rgb-merge.md.
+        if getattr(img, "is_merged", False):
+            continue
         grouped.setdefault(_file_key(img.file_path), []).append(img)
     preserved_by_key = {}
     for file_path, record in (preserved or {}).items():

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -38,6 +38,15 @@ class CCRBackend:
         # bypassed — every image is editable/exportable directly. App-wide, like
         # the input ICC profile; persisted by MainWindow. See spec/positive-mode.md.
         self.positive_mode: bool = False
+        # 3-way RGB-light merge (trichrome): when True, an import sorts files by
+        # name, requires a multiple of 3, and merges every (red, green, blue)
+        # triplet into one camera-native image (no demosaicing). Global, like
+        # positive_mode; persisted by MainWindow. See spec/three-way-rgb-merge.md.
+        self.rgb_merge_mode: bool = False
+        # Last merge-import rejection (bad count / non-RAW / non-Bayer / decode
+        # failure), set by the loader and surfaced by the UI after load, then
+        # cleared. Reset at the top of every load so it never goes stale.
+        self.last_merge_error: Optional[str] = None
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area
         # Global input ICC profile (one app-wide setting; applied to every
@@ -69,9 +78,17 @@ class CCRBackend:
         # QSettings copy is intact and still restores at next app start.
         self.black_point_bgr = None
         self.white_point_bgr = None
+        # Per-load merge error: reset up front so a prior load's message can't
+        # carry over and be shown after this (possibly successful) one.
+        self.last_merge_error = None
         # Preserved removal states belong to the previous batch (the open
         # flows save the catalog before loading a new one)
         self._catalog_preserved = {}
+
+        # 3-way RGB merge: handle the whole batch on a dedicated path (sort,
+        # validate multiple-of-3 + RAW, group into triplets, merge each).
+        if self.rgb_merge_mode:
+            return self._load_merged_triplets(file_paths, cancel_flag)
 
         # Read the catalog ONCE for the whole batch — per-file reads would
         # re-parse the entire JSON N times across the loader threads.
@@ -132,6 +149,94 @@ class CCRBackend:
         # Keep file_paths derived from actually-loaded images so the two lists stay in sync
         self.file_paths = [img.file_path for img in self.images]
         return loaded_file_count
+
+    def _load_merged_triplets(self, file_paths: List[str], cancel_flag=None) -> int:
+        """3-way RGB merge load: sort by filename, validate (multiple of 3, all
+        RAW), group into (red, green, blue) triplets, and merge each into one
+        CCRImage (in parallel). Returns the number of merged images produced. A
+        validation failure records last_merge_error and loads nothing; a per-
+        triplet decode failure (e.g. non-Bayer sensor) is recorded and skipped.
+        See spec/three-way-rgb-merge.md."""
+        from core import ccr_merge
+
+        ordered = ccr_merge.sort_for_merge(file_paths)
+        ok, err = ccr_merge.validate_merge_inputs(ordered)
+        if not ok:
+            self.last_merge_error = err
+            self.images = []
+            self.file_paths = []
+            return 0
+
+        triplets = ccr_merge.group_into_triplets(ordered)
+        # Progress bar in merged units: total = number of triplets (not 3N files).
+        self.file_paths = [t[0] for t in triplets]
+
+        def load_triplet(order, triplet):
+            if cancel_flag and cancel_flag():
+                return None
+            red = triplet[0]
+            try:
+                img = CCRImage(red, is_merged=True, merge_sources=list(triplet))
+            except Exception as e:
+                print(f"3-way merge failed for {os.path.basename(red)}: {e}")
+                self.last_merge_error = (
+                    "3-way RGB merge could not process some frames:\n\n"
+                    f"{e}")
+                return None
+            img._catalog_order = order
+            return img
+
+        max_workers = min(8, os.cpu_count() or 1)
+        results = []
+        if max_workers == 1:
+            for order, triplet in enumerate(triplets):
+                if cancel_flag and cancel_flag():
+                    break
+                img = load_triplet(order, triplet)
+                if img is not None:
+                    results.append(img)
+        else:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = {executor.submit(load_triplet, order, triplet): order
+                           for order, triplet in enumerate(triplets)}
+                for future in concurrent.futures.as_completed(futures):
+                    if cancel_flag and cancel_flag():
+                        break
+                    img = future.result()
+                    if img is not None:
+                        results.append(img)
+
+        # User cancelled mid-load: suppress any decode error a worker recorded
+        # for the aborted import (the pool above has joined, so every write has
+        # landed before this check) — don't pop an error dialog for a load the
+        # user deliberately stopped.
+        if cancel_flag and cancel_flag():
+            self.last_merge_error = None
+
+        # Stable order: unique red basenames, with catalog_order as a tiebreak.
+        results.sort(key=lambda im: (os.path.basename(im.file_path),
+                                     getattr(im, "_catalog_order", 0)))
+        self._dedupe_display_names(results)
+        self.images = results
+        self.file_paths = [im.file_path for im in self.images]
+        return len(results)
+
+    @staticmethod
+    def _dedupe_display_names(images) -> None:
+        """Ensure each image's display_name is unique within the batch (append
+        _2, _3 …), so export filenames and name-keyed lookups can't collide —
+        mirrors the duplicate/slice naming guards."""
+        seen = set()
+        for im in images:
+            name = im.display_name or os.path.basename(im.file_path)
+            if name in seen:
+                stem, ext = os.path.splitext(name)
+                n = 2
+                while f"{stem}_{n}{ext}" in seen:
+                    n += 1
+                name = f"{stem}_{n}{ext}"
+                im.display_name = name
+            seen.add(name)
 
     def clear(self):
         """
@@ -210,9 +315,12 @@ class CCRBackend:
         print(f"Found {len(file_paths)} files total: {file_paths[:5]}...")  # Show first 5 files
         
         # Load images and track success/failure (counted in FILES — a sliced
-        # file restores as several images)
+        # file restores as several images). In 3-way merge mode the loader
+        # returns MERGED images (one per triplet), so the diagnostic baseline is
+        # the triplet count, not the raw file count.
         loaded_files = self.load_images_from_files(sorted(file_paths), cancel_flag=cancel_flag) or 0
-        failed_count = len(file_paths) - loaded_files
+        expected = (len(file_paths) // 3) if self.rgb_merge_mode else len(file_paths)
+        failed_count = max(0, expected - loaded_files)
 
         print(f"Loading complete: {loaded_files} files loaded successfully "
               f"({len(self.images)} images), {failed_count} failed")
@@ -1175,6 +1283,12 @@ class CCRBackend:
             from core.catalog import serialize_image, remove_duplicate_entries
             duplicate_removals = {}
             for img in removed_images:
+                # Merged (trichrome) images are session-only: never serialize
+                # their edits into a source RAW's per-file record (the red
+                # exposure's key), which would corrupt that file on a later
+                # plain open. See spec/three-way-rgb-merge.md.
+                if getattr(img, "is_merged", False):
+                    continue
                 if getattr(img, "is_duplicate", False):
                     if img.display_name:
                         duplicate_removals.setdefault(img.file_path,
@@ -1222,6 +1336,10 @@ class CCRBackend:
                 preloaded_full_size=img.original_full_size,
                 display_name=f"{stem}_copy{n}{ext}",
                 color_profile=img.color_profile,
+                # A copy of a merged image must itself re-merge on any re-read
+                # (zoom/export), not decode the red RAW alone.
+                is_merged=getattr(img, "is_merged", False),
+                merge_sources=getattr(img, "merge_sources", None),
             )
             dup.reference_frame = img.reference_frame
             dup.conversion_inputs = (dict(img.conversion_inputs)
@@ -1404,6 +1522,11 @@ class CCRBackend:
                     slice_group=slice_group,
                     slice_parent=dict(slice_parent),
                     color_profile=img_obj.color_profile,
+                    # A slice of a merged image re-merges (then crops via
+                    # source_ops) on hi-res zoom / export, so the detail layer
+                    # and exported file match the merged preview.
+                    is_merged=getattr(img_obj, "is_merged", False),
+                    merge_sources=getattr(img_obj, "merge_sources", None),
                 )
                 child.conversion_inputs = child_ci
                 # Slices descend from the parent's loaded content — carry its

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -53,9 +53,19 @@ class CCRImage:
         slice_parent: Optional[Dict[str, Any]] = None,
         color_profile: str = "color",
         areas: Optional[List[Dict[str, Any]]] = None,
+        is_merged: bool = False,
+        merge_sources: Optional[list] = None,
         ):
         # Normalize file path to handle Unicode characters properly
         self.file_path = os.path.normpath(file_path)
+        # 3-way RGB-light merge (trichrome): this image is synthesized from three
+        # source RAWs (red, green, blue exposures) by taking each frame's own
+        # channel without demosaicing. file_path is the RED source (a real RAW,
+        # so EXIF/lensfun work); read_image dispatches to a re-merge whenever the
+        # pixels are needed again (export, zoom, slice, duplicate). Session-only:
+        # excluded from the per-file edit catalog. See spec/three-way-rgb-merge.md.
+        self.is_merged = bool(is_merged)
+        self.merge_sources = list(merge_sources) if merge_sources else None
         # Sliced images own a chain of slice operations applied to the source
         # file by read_image in every path (preview load, hi-res zoom,
         # full-res export, B/W sampling). Each op is
@@ -65,7 +75,11 @@ class CCRImage:
         # frame. Nested slices simply append ops. [] = whole file.
         self.source_ops: list = list(source_ops) if source_ops else []
         # Display/export name override (e.g. "scan_s2.ARW" for slice #2);
-        # None = use the file's basename.
+        # None = use the file's basename. A merged image with no explicit name
+        # reads as "<redStem>_RGB<ext>" so the list/export filename is sensible.
+        if display_name is None and self.is_merged:
+            _stem, _ext = os.path.splitext(os.path.basename(self.file_path))
+            display_name = f"{_stem}_RGB{_ext}"
         self.display_name = display_name
         # True for working copies made via Duplicate. Duplicates are session
         # artifacts: removing one from the list also removes its catalog
@@ -399,6 +413,22 @@ class CCRImage:
             four_color_rgb=False,     # Standard 3-color processing
         )
 
+    def _read_merged(self, preview: bool = True,
+                     max_long_side: Optional[int] = None) -> Optional[np.ndarray]:
+        """Decode a 3-way RGB-merged image from its source RAWs. Mirrors the tail
+        of read_image's RAW branch (slice ops, full-size capture, optional
+        downsize) so export / zoom / slice all compose. `preview` is accepted but
+        ignored: the merge's native resolution IS half-sensor (the 2x2 bin is the
+        no-demosaic step); size is controlled purely by max_long_side."""
+        from core import ccr_merge
+        rgb, full_decode_size = ccr_merge.merge_raw_channels(self.merge_sources)
+        # Sliced merged children read only their region of the source.
+        rgb = self._apply_source_ops(rgb)
+        self.original_full_size = self._ops_full_size(full_decode_size)
+        if max_long_side:
+            rgb = self.resize_image_to_max_pixel(rgb, max_long_side)
+        return rgb
+
     def read_image(self, file_path: str, preview = True, max_long_side: Optional[int] = None,
                    positive_override: Optional[bool] = None, apply_input_icc: bool = True) -> Optional[np.ndarray]:
         """
@@ -416,6 +446,14 @@ class CCRImage:
         together they yield the bare device RGB an input profile is fitted on.
         Both default to current behaviour, so existing callers are unaffected.
         """
+        # 3-way RGB merge: this image has no single backing file — it is
+        # re-synthesized from its three source RAWs. Dispatch BEFORE the
+        # extension branch and BEFORE positive_mode is read (a merged frame is
+        # always a camera-native negative). All re-read call sites (export,
+        # zoom, slice, duplicate) flow through here, so they re-merge for free.
+        if getattr(self, "is_merged", False) and self.merge_sources:
+            return self._read_merged(preview=preview, max_long_side=max_long_side)
+
         # Ensure file path is properly encoded for Unicode support
         file_path = os.path.normpath(file_path)
         ext = os.path.splitext(file_path)[1].lower()

--- a/src/core/ccr_merge.py
+++ b/src/core/ccr_merge.py
@@ -1,0 +1,192 @@
+"""
+3-way RGB-light merge — trichrome (three-colour) capture.
+
+The user shoots one static scene three times under a single pure light each —
+red, then green, then blue — and every consecutive triplet of source RAWs is
+merged into one full-colour image by taking each frame's OWN colour channel and
+discarding the other two, WITHOUT demosaicing.
+
+"No demosaic" means: collapse each 2x2 Bayer (RGGB) tile to one output pixel
+(R = R-site, G = mean of the two G-sites, B = B-site) — a pure bin, no
+interpolation. That is exactly what libraw/rawpy `half_size=True` does, so the
+merged frame is half-sensor resolution (which IS its full resolution). Decoding
+in camera-native colour (`output_color=raw`, no white balance) keeps each output
+channel an unmixed sensor colour, so picking a single channel is faithful.
+
+This module is split so everything except `merge_raw_channels` is pure and
+unit-testable without rawpy/Qt. See spec/three-way-rgb-merge.md.
+"""
+import os
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+
+# Exactly read_image's rawpy-Bayer-decodable extension set (ccr_image.py:434,
+# == export_estimator.RAW_EXTS). Deliberately NOT the broader folder glob, and
+# excludes .fff (read_image treats it as TIFF, not a CFA). Only files this set
+# covers can be channel-extracted, so anything else is rejected in merge mode.
+RAW_EXTENSIONS = frozenset({
+    ".cr3", ".cr2", ".nef", ".arw", ".dng", ".rw2", ".orf", ".raf",
+    ".srw", ".pef", ".3fr",
+})
+
+# Number of source frames per merged image (red, green, blue).
+MERGE_GROUP_SIZE = 3
+
+
+def is_raw_path(path: str) -> bool:
+    """True when the file extension is a RAW format this module can merge."""
+    return os.path.splitext(path)[1].lower() in RAW_EXTENSIONS
+
+
+def sort_for_merge(paths: Sequence[str]) -> List[str]:
+    """Order paths by case-insensitive basename (directory ignored), so the
+    triplet ordering is determined purely by filename, as the feature requires.
+    Ties (same basename in different dirs) keep a stable order via the full
+    normalized path as a secondary key."""
+    return sorted(paths, key=lambda p: (os.path.basename(p).lower(),
+                                        os.path.normcase(p)))
+
+
+def group_into_triplets(sorted_paths: Sequence[str]) -> List[Tuple[str, str, str]]:
+    """Group an already-sorted path list into consecutive (R, G, B) triplets.
+    The caller is responsible for validating the count is a multiple of 3 first;
+    any trailing remainder (< 3) is dropped here."""
+    n = (len(sorted_paths) // MERGE_GROUP_SIZE) * MERGE_GROUP_SIZE
+    return [tuple(sorted_paths[i:i + MERGE_GROUP_SIZE])  # type: ignore[misc]
+            for i in range(0, n, MERGE_GROUP_SIZE)]
+
+
+def validate_merge_inputs(paths: Sequence[str]) -> Tuple[bool, Optional[str]]:
+    """Pre-decode validation for a merge import. Returns (ok, error_message).
+
+    Checks, in order: non-empty, every file is a supported RAW, count is a
+    multiple of 3. The Bayer-CFA check can only happen at decode time (see
+    merge_raw_channels), so it is NOT done here."""
+    if not paths:
+        return False, "No files selected for 3-way RGB merge."
+    non_raw = [p for p in paths if not is_raw_path(p)]
+    if non_raw:
+        shown = "\n".join(os.path.basename(p) for p in non_raw[:8])
+        if len(non_raw) > 8:
+            shown += f"\n… and {len(non_raw) - 8} more"
+        return False, ("3-way RGB merge requires RAW (Bayer) files. "
+                       f"These are not supported RAW:\n\n{shown}")
+    if len(paths) % MERGE_GROUP_SIZE != 0:
+        return False, ("3-way RGB merge needs a multiple of 3 images "
+                       f"(got {len(paths)}). Select 3 frames per shot: "
+                       "red, green, blue.")
+    return True, None
+
+
+def bayer_channel_indices(color_desc) -> Tuple[int, int, int]:
+    """Map (R, G, B) to the output-channel indices a camera-native (output_color
+    =raw) decode emits, which follow libraw's internal colour order == the
+    `color_desc` string. For the canonical b'RGBG' this is (0, 1, 2); a permuted
+    desc is honoured. Raises ValueError when the sensor is not an R/G/B Bayer
+    (e.g. monochrome b'G', or 4-colour b'RGBE'/CYGM), which must be rejected."""
+    if isinstance(color_desc, (bytes, bytearray)):
+        s = bytes(color_desc).decode("ascii", "ignore").upper()
+    else:
+        s = str(color_desc).upper()
+    r, g, b = s.find("R"), s.find("G"), s.find("B")
+    if -1 in (r, g, b):
+        raise ValueError(
+            f"3-way merge requires a Bayer (RGGB) sensor; color_desc "
+            f"{color_desc!r} is not R/G/B (X-Trans, monochrome or 4-colour).")
+    return r, g, b
+
+
+def combine_channels(plane_r: np.ndarray, plane_g: np.ndarray, plane_b: np.ndarray,
+                     white_levels: Sequence[float]) -> np.ndarray:
+    """Pure merge core: take the red frame's R-plane, the green frame's G-plane,
+    and the blue frame's B-plane (each a 2-D array, already the correct channel),
+    scale each by 65535/white_level (matching read_image's white-level scaling),
+    and stack into one (H, W, 3) uint16 RGB image.
+
+    Planes may differ slightly in size; all are cropped to the common (min H,
+    min W). Returns linear RGB in [0, 65535]."""
+    planes = [plane_r, plane_g, plane_b]
+    if len(white_levels) != 3:
+        raise ValueError("white_levels must have 3 entries (R, G, B)")
+    h = min(p.shape[0] for p in planes)
+    w = min(p.shape[1] for p in planes)
+    out = np.empty((h, w, 3), dtype=np.uint16)
+    for i, (plane, wl) in enumerate(zip(planes, white_levels)):
+        cropped = plane[:h, :w].astype(np.float32)
+        scale = 65535.0 / wl if wl and wl > 0 else 1.0
+        out[..., i] = np.clip(cropped * scale, 0, 65535).astype(np.uint16)
+    return out
+
+
+def _decode_native_halfsize(path: str):
+    """Decode one RAW to a camera-native, half-size (2x2-binned, no-demosaic)
+    array. Returns (rgb, color_desc, white_level). rgb is (H, W, num_colors)
+    with unmixed sensor channels; libraw subtracts the black level during
+    postprocess. Raises on a non-Bayer-RGB sensor."""
+    import rawpy
+
+    with rawpy.imread(path) as raw:
+        white_level = float(raw.white_level)
+        num_colors = int(getattr(raw, "num_colors", 0) or 0)
+        color_desc = getattr(raw, "color_desc", b"")
+        pattern = getattr(raw, "raw_pattern", None)
+
+        if num_colors != 3:
+            raise ValueError(
+                f"3-way merge requires a 3-colour Bayer sensor; "
+                f"{os.path.basename(path)} reports {num_colors} colours "
+                f"(monochrome or 4-colour).")
+        if pattern is not None and tuple(np.asarray(pattern).shape) != (2, 2):
+            raise ValueError(
+                f"3-way merge requires a 2x2 Bayer mosaic; "
+                f"{os.path.basename(path)} is non-Bayer (e.g. X-Trans).")
+        # Raises if color_desc is not an R/G/B permutation.
+        bayer_channel_indices(color_desc)
+
+        rgb = raw.postprocess(
+            output_bps=16,
+            no_auto_bright=True,
+            gamma=(1, 1),                                  # linear
+            user_flip=0,
+            demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,  # inert w/ half_size
+            half_size=True,            # 2x2 bin == the no-demosaic extraction
+            use_camera_wb=False,
+            use_auto_wb=False,
+            output_color=rawpy.ColorSpace.raw,   # camera-native: no 3x3 matrix
+            no_auto_scale=True,        # absolute sensor values; we scale manually
+            adjust_maximum_thr=0.0,
+            four_color_rgb=False,
+        )
+    return rgb, color_desc, white_level
+
+
+def merge_raw_channels(sources: Sequence[str]) -> Tuple[np.ndarray, Tuple[int, int]]:
+    """Merge a (red, green, blue) triplet of RAW files into one (H, W, 3) uint16
+    linear-RGB image at half-sensor resolution, taking only each frame's own
+    colour channel with no demosaicing.
+
+    Returns (merged_rgb, full_size=(H, W)). Raises ValueError on a non-Bayer
+    sensor or a decode failure (the caller surfaces it)."""
+    if len(sources) != MERGE_GROUP_SIZE:
+        raise ValueError(f"merge_raw_channels needs exactly {MERGE_GROUP_SIZE} "
+                         f"sources, got {len(sources)}")
+    for p in sources:
+        if not os.path.exists(p):
+            raise ValueError(f"3-way merge source missing: {p}")
+
+    planes: List[np.ndarray] = []
+    white_levels: List[float] = []
+    for frame_pos, path in enumerate(sources):       # 0=red, 1=green, 2=blue
+        rgb, color_desc, white_level = _decode_native_halfsize(path)
+        r_idx, g_idx, b_idx = bayer_channel_indices(color_desc)
+        channel_idx = (r_idx, g_idx, b_idx)[frame_pos]
+        if rgb.ndim != 3 or channel_idx >= rgb.shape[2]:
+            raise ValueError(
+                f"unexpected decode shape {getattr(rgb, 'shape', None)} for "
+                f"{os.path.basename(path)}")
+        planes.append(rgb[..., channel_idx])
+        white_levels.append(white_level)
+
+    merged = combine_channels(planes[0], planes[1], planes[2], white_levels)
+    return merged, (merged.shape[0], merged.shape[1])

--- a/src/core/export_estimator.py
+++ b/src/core/export_estimator.py
@@ -28,6 +28,15 @@ def get_original_dims(ccr_img):
     if dims:
         return dims
 
+    # Merged (trichrome) images have no single backing file — file_path is one
+    # full-sensor source RAW, ~2x the half-size merged dims. Never probe it;
+    # fall back to the in-memory preview size. See spec/three-way-rgb-merge.md.
+    if getattr(ccr_img, "is_merged", False):
+        if ccr_img.resized_raw is not None:
+            dims = (ccr_img.resized_raw.shape[0], ccr_img.resized_raw.shape[1])
+            ccr_img.original_full_size = dims
+        return dims
+
     file_path = ccr_img.file_path
     ext = os.path.splitext(file_path)[1].lower()
     if ext == ".fff":

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -186,6 +186,9 @@ class MainWindow(QMainWindow):
         # first batch decodes in the right mode (see spec/positive-mode.md).
         positive_mode = self._settings.value("import/positive_mode", False, type=bool)
         ccr_backend.positive_mode = positive_mode
+        # Restore the global 3-way RGB merge toggle too (affects the next import).
+        ccr_backend.rgb_merge_mode = self._settings.value(
+            "import/rgb_merge_mode", False, type=bool)
         # Reflect the restored mode in the toolbar/slider gating right away
         # (no images yet, but the negative-only actions should already grey out).
         self.image_preview._update_unconvert_action_state()
@@ -585,6 +588,24 @@ class MainWindow(QMainWindow):
             if checked else "Positive mode off — film-negative tools restored.",
             duration=4000)
 
+    # --- 3-way RGB merge mode (global, persistent) ------------------------
+    def on_rgb_merge_mode_toggled(self, checked: bool):
+        """Flip the global 3-way RGB merge flag and persist it. Unlike Positive
+        mode this does NOT re-process loaded images — it only affects the NEXT
+        import (every 3 RAWs, sorted by filename, merged into one).
+        See spec/three-way-rgb-merge.md."""
+        ccr_backend.rgb_merge_mode = bool(checked)
+        self._settings.setValue("import/rgb_merge_mode", bool(checked))
+        if checked:
+            msg = ("3-way RGB merge on — your next import merges every 3 RAWs "
+                   "(R,G,B by filename).")
+            if ccr_backend.positive_mode:
+                msg += (" Positive mode is on; merged frames are negatives — "
+                        "turn Positive off to invert them.")
+        else:
+            msg = "3-way RGB merge off."
+        self.sliders_panel.set_temporary_hint(msg, duration=5000)
+
     def show_activation_dialog(self):
         QMessageBox.information(
             self,
@@ -653,6 +674,13 @@ class MainWindow(QMainWindow):
         """Called when the loader thread finishes. Nulls the references so isRunning() is never called on a deleted C++ object."""
         self._loader_thread = None
         self._loader_worker = None
+        # Surface a 3-way merge rejection recorded by the backend loader (covers
+        # the Open Folder path and decode-time non-Bayer rejections). Read once,
+        # then clear so it can't reappear on a later, unrelated load.
+        err = getattr(ccr_backend, "last_merge_error", None)
+        if err:
+            ccr_backend.last_merge_error = None
+            QMessageBox.warning(self, "3-way RGB merge", err)
 
     def _stop_loader_if_running(self):
         """Cancel and join any in-progress loader thread."""
@@ -703,6 +731,15 @@ class MainWindow(QMainWindow):
                 )
             
             if valid_files:
+                # 3-way RGB merge: validate the selection up front (multiple of
+                # 3, all RAW) so the user gets immediate feedback before any load.
+                if ccr_backend.rgb_merge_mode:
+                    from core import ccr_merge
+                    ok, err = ccr_merge.validate_merge_inputs(
+                        ccr_merge.sort_for_merge(valid_files))
+                    if not ok:
+                        QMessageBox.warning(self, "3-way RGB merge", err)
+                        return
                 self._stop_loader_if_running()
                 self.thumbnail_list.show_loading_dialog()
                 self._loader_thread = QThread()

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -150,6 +150,24 @@ class SettingsDialog(QDialog):
             "same toggle is on the thumbnail panel."))
         lay.addWidget(grp2)
 
+        # --- Trichrome (3-way RGB-light) capture ----------------------- #
+        grp3 = QGroupBox("Trichrome capture")
+        g3 = QVBoxLayout(grp3)
+        g3.setSpacing(theme.GAP_ROW)
+        self._cb_rgb_merge = QCheckBox(
+            "3-way RGB merge (combine red/green/blue-light exposures)")
+        self._cb_rgb_merge.toggled.connect(self._on_rgb_merge)
+        g3.addWidget(self._cb_rgb_merge)
+        g3.addWidget(self._muted(
+            "Shoot a static scene three times under pure red, then green, then "
+            "blue light. On your NEXT import, every 3 RAWs (sorted by filename) "
+            "are merged into one colour image — each frame contributes only its "
+            "own channel, with no demosaicing — then converted as a negative. "
+            "RAW (Bayer) only; the selected count must be a multiple of 3. "
+            "Applies to the next import only; merged-image edits are not saved "
+            "between sessions."))
+        lay.addWidget(grp3)
+
         lay.addStretch(1)
         return page
 
@@ -176,6 +194,11 @@ class SettingsDialog(QDialog):
         if bool(checked) == bool(ccr_backend.positive_mode):
             return                                   # programmatic sync, not a user toggle
         self._mw.on_positive_mode_toggled(bool(checked))
+
+    def _on_rgb_merge(self, checked: bool):
+        if bool(checked) == bool(ccr_backend.rgb_merge_mode):
+            return                                   # programmatic sync, not a user toggle
+        self._mw.on_rgb_merge_mode_toggled(bool(checked))
 
     def refresh_color_management(self):
         """Reflect the live active profile, the library list, and Positive mode."""
@@ -205,3 +228,7 @@ class SettingsDialog(QDialog):
         self._cb_positive.blockSignals(True)
         self._cb_positive.setChecked(bool(ccr_backend.positive_mode))
         self._cb_positive.blockSignals(False)
+
+        self._cb_rgb_merge.blockSignals(True)
+        self._cb_rgb_merge.setChecked(bool(ccr_backend.rgb_merge_mode))
+        self._cb_rgb_merge.blockSignals(False)

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -270,6 +270,10 @@ class _StubMW(QWidget):
         self.calls.append(("positive", bool(c)))
         ccr_backend.positive_mode = bool(c)
 
+    def on_rgb_merge_mode_toggled(self, c):
+        self.calls.append(("rgb_merge", bool(c)))
+        ccr_backend.rgb_merge_mode = bool(c)
+
 
 def _dialog():
     from widgets.settings_dialog import SettingsDialog
@@ -313,6 +317,21 @@ class TestSettingsDialog:
         d = _dialog()
         d._cb_positive.setChecked(True)
         assert ("positive", True) in d._mw.calls
+
+    def test_rgb_merge_checkbox_toggles_backend(self):
+        ccr_backend.rgb_merge_mode = False
+        d = _dialog()
+        d._cb_rgb_merge.setChecked(True)
+        assert ("rgb_merge", True) in d._mw.calls
+        assert ccr_backend.rgb_merge_mode is True
+
+    def test_rgb_merge_checkbox_reflects_backend_on_refresh(self):
+        ccr_backend.rgb_merge_mode = True
+        d = _dialog()                       # refresh runs in __init__
+        assert d._cb_rgb_merge.isChecked() is True
+        ccr_backend.rgb_merge_mode = False
+        d.refresh_color_management()
+        assert d._cb_rgb_merge.isChecked() is False
 
 
 class TestCameraProfileLibrary:

--- a/tests/test_three_way_merge.py
+++ b/tests/test_three_way_merge.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Tests for 3-way RGB-light merge (trichrome capture).
+
+Covers the pure, rawpy-free core: input validation (multiple-of-3, RAW-only),
+filename sorting + triplet grouping, the color_desc -> channel-index mapping,
+and the channel-combine maths (correct frame->channel selection, per-frame
+white-level scaling, size-mismatch cropping, output contract).
+
+merge_raw_channels itself (the only rawpy-touching function) and slice/duplicate
+of merged images need a real aligned trichrome triplet, which the repo does not
+ship (example_raw/ has only 2 unrelated ARWs) — see spec/three-way-rgb-merge.md.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core import ccr_merge  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# is_raw_path / RAW_EXTENSIONS
+# --------------------------------------------------------------------------- #
+def test_is_raw_path_accepts_every_raw_extension():
+    for ext in ccr_merge.RAW_EXTENSIONS:
+        assert ccr_merge.is_raw_path(f"C:/shots/frame{ext}")
+        assert ccr_merge.is_raw_path(f"/shots/frame{ext.upper()}")  # case-insensitive
+
+
+def test_is_raw_path_rejects_non_raw_and_fff_and_heic():
+    for ext in (".jpg", ".jpeg", ".png", ".tif", ".tiff", ".fff", ".heic", ".heif"):
+        assert not ccr_merge.is_raw_path(f"frame{ext}"), ext
+
+
+# --------------------------------------------------------------------------- #
+# validate_merge_inputs
+# --------------------------------------------------------------------------- #
+def test_validate_empty_is_invalid():
+    ok, msg = ccr_merge.validate_merge_inputs([])
+    assert not ok and msg
+
+
+def test_validate_three_and_six_raw_are_valid():
+    ok3, _ = ccr_merge.validate_merge_inputs(["a.arw", "b.arw", "c.arw"])
+    ok6, _ = ccr_merge.validate_merge_inputs([f"{n}.nef" for n in range(6)])
+    assert ok3 and ok6
+
+
+def test_validate_count_not_multiple_of_three_reports_the_count():
+    ok, msg = ccr_merge.validate_merge_inputs(["a.arw", "b.arw", "c.arw", "d.arw"])
+    assert not ok
+    assert "4" in msg                       # the offending count appears
+
+
+def test_validate_non_raw_present_lists_the_file():
+    ok, msg = ccr_merge.validate_merge_inputs(["r.arw", "g.arw", "still.jpg"])
+    assert not ok
+    assert "still.jpg" in msg               # the non-RAW file is named
+
+
+# --------------------------------------------------------------------------- #
+# sort_for_merge / group_into_triplets
+# --------------------------------------------------------------------------- #
+def test_sort_for_merge_by_basename_ignoring_directory_and_case():
+    paths = ["z/B.arw", "a/c.ARW", "m/a.arw"]
+    assert [os.path.basename(p) for p in ccr_merge.sort_for_merge(paths)] == \
+        ["a.arw", "B.arw", "c.ARW"]
+
+
+def test_sort_for_merge_is_stable_for_basename_collisions_across_dirs():
+    paths = ["b/img.arw", "a/img.arw"]
+    out = ccr_merge.sort_for_merge(paths)
+    # Deterministic: same basename -> ordered by the (normcased) full path.
+    assert out == ccr_merge.sort_for_merge(list(reversed(paths)))
+    assert [os.path.basename(p) for p in out] == ["img.arw", "img.arw"]
+
+
+def test_group_into_triplets_of_six():
+    paths = [f"f{n}.arw" for n in range(6)]
+    triplets = ccr_merge.group_into_triplets(paths)
+    assert triplets == [("f0.arw", "f1.arw", "f2.arw"),
+                        ("f3.arw", "f4.arw", "f5.arw")]
+
+
+def test_group_into_triplets_drops_trailing_remainder():
+    assert ccr_merge.group_into_triplets(["a", "b", "c", "d"]) == [("a", "b", "c")]
+
+
+# --------------------------------------------------------------------------- #
+# bayer_channel_indices
+# --------------------------------------------------------------------------- #
+def test_bayer_indices_canonical_rggb():
+    assert ccr_merge.bayer_channel_indices(b"RGBG") == (0, 1, 2)
+
+
+def test_bayer_indices_permuted_desc():
+    # BGGR: B at 0, G at 1, R at 3.
+    assert ccr_merge.bayer_channel_indices(b"BGGR") == (3, 1, 0)
+
+
+def test_bayer_indices_rejects_monochrome_and_non_rgb():
+    for desc in (b"G", b"GRAY", b"CYGM"):       # monochrome / 4-colour, no R/B
+        with pytest.raises(ValueError):
+            ccr_merge.bayer_channel_indices(desc)
+
+
+# --------------------------------------------------------------------------- #
+# combine_channels (the pure merge core)
+# --------------------------------------------------------------------------- #
+def _const_plane(h, w, value):
+    return np.full((h, w), value, dtype=np.float32)
+
+
+def test_combine_picks_correct_frame_and_channel():
+    # Each frame's chosen plane is a distinct constant; no scaling (wl=65535).
+    r = _const_plane(8, 6, 100)
+    g = _const_plane(8, 6, 200)
+    b = _const_plane(8, 6, 300)
+    out = ccr_merge.combine_channels(r, g, b, [65535, 65535, 65535])
+    assert out.shape == (8, 6, 3)
+    assert np.all(out[..., 0] == 100)        # R from the red frame's R-plane
+    assert np.all(out[..., 1] == 200)        # G from the green frame's G-plane
+    assert np.all(out[..., 2] == 300)        # B from the blue frame's B-plane
+
+
+def test_combine_applies_per_frame_white_level_scaling():
+    # white_level 32767 -> scale ~2x toward full range; 65535 -> unchanged.
+    r = _const_plane(4, 4, 100)
+    g = _const_plane(4, 4, 100)
+    b = _const_plane(4, 4, 100)
+    out = ccr_merge.combine_channels(r, g, b, [32767, 65535, 65535])
+    assert int(out[0, 0, 0]) == round(100 * 65535 / 32767)   # ~200
+    assert int(out[0, 0, 1]) == 100                          # unchanged
+    assert out[0, 0, 0] > out[0, 0, 1]
+
+
+def test_combine_clips_to_uint16_range():
+    r = _const_plane(2, 2, 60000)
+    out = ccr_merge.combine_channels(r, r, r, [30000, 65535, 65535])  # R overshoots
+    assert out.dtype == np.uint16
+    assert out[..., 0].max() == 65535        # clipped, no wrap-around
+
+
+def test_combine_crops_size_mismatch_to_common_min():
+    r = _const_plane(8, 6, 10)
+    g = _const_plane(8, 7, 20)               # one column wider
+    b = _const_plane(9, 6, 30)               # one row taller
+    out = ccr_merge.combine_channels(r, g, b, [65535, 65535, 65535])
+    assert out.shape == (8, 6, 3)            # common (min H, min W); no raise
+
+
+def test_combine_requires_three_white_levels():
+    p = _const_plane(2, 2, 1)
+    with pytest.raises(ValueError):
+        ccr_merge.combine_channels(p, p, p, [65535, 65535])


### PR DESCRIPTION
## 3-Way RGB-Light (Trichrome) Merge Mode

A capture/import mode for **trichrome photography**: shoot one static scene three
times under a single pure light each — **red, then green, then blue** — and
FreeCCR merges every consecutive triplet of RAWs into one full-colour image by
taking each frame's *own* channel and discarding the other two, **without
demosaicing**. The merged image then flows into the existing negative-inversion
pipeline unchanged.

Toggle on the **Settings → Color Management** tab (mirrors the Positive-mode
toggle).

### How it works
- **No demosaic:** each source RAW is decoded camera-native at half size
  (`rawpy half_size=True` collapses every 2×2 Bayer tile to one pixel — a pure
  bin, no interpolation; `output_color=raw`, no WB/matrix, so each output channel
  is an unmixed sensor colour). R-plane from frame 1, G from frame 2, B from
  frame 3; per-frame white-level scaling matching the existing decode.
- **Import:** when the toggle is on, the import sorts files by filename, requires
  a **multiple of 3**, groups into `(R,G,B)` triplets, and merges each in
  parallel. Bad count / non-RAW are rejected up front (Open Files) and
  defensively in the backend (Open Folder); non-Bayer sensors (X-Trans, mono,
  4-colour) are rejected at decode with a clear message.
- **Composes for free:** `read_image` dispatches to a re-merge, so export, zoom
  hi-res detail, Slice, and Duplicate all re-read from the three sources.
- **Session-only:** merged images are excluded from the per-file edit catalog on
  every serialization path (they'd otherwise corrupt a source RAW's record).

### Changes
- **New** `src/core/ccr_merge.py` — pure validation / sort / grouping /
  `color_desc`→channel mapping / channel-combine, plus the single rawpy decode
  with a Bayer-CFA guard.
- `ccr_image.py` — `is_merged`/`merge_sources` kwargs + `read_image` dispatch +
  `_read_merged`.
- `ccr_backend.py` — `rgb_merge_mode`/`last_merge_error`, parallel triplet
  loader, catalog-removal skip, `is_merged` threaded through Duplicate/Slice.
- `catalog.py` — skip merged images in `update_for_images`.
- `export_estimator.py` — don't probe a merged image's source as a full-sensor
  RAW.
- `settings_dialog.py` / `main_window.py` — the toggle, persistence
  (`import/rgb_merge_mode`), startup restore, hints, and error surfacing.

### Process
Spec authored and **refined after two adversarial review rounds** (a design
critique that caught a catalog-corruption blocker + the Duplicate/Slice
silent-wrong-export issue + Bayer/extension robustness, and an implementation
review that found only minor polish items, all fixed). See
`spec/three-way-rgb-merge.md`.

### Tests
- `tests/test_three_way_merge.py` — 18 pure-function tests (validation messages,
  sorting/grouping stability, `color_desc` mapping, channel selection,
  white-level scaling, size-mismatch crop, output contract).
- `tests/test_settings_dialog.py` — toggle round-trip + backend-sync.
- Visually verified the Settings → Color Management page renders the new group.

`merge_raw_channels` and slice/duplicate-of-merged need an aligned trichrome
triplet, which the repo doesn't ship (a follow-up could add a synthetic fixture).

No new failures vs the pre-existing `exposure_base` test-stub gaps / known flaky
native crash.

### Notes / known limitations
- Half-sensor resolution is inherent to no-demosaic channel extraction (that
  binned size *is* the merged image's full resolution).
- Merged-image edits are not persisted across sessions (re-import re-merges).
- Intended for negatives; if Positive mode is on, a hint reminds the user to turn
  it off (merged frames are negatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
