### PR TITLE
feat(merge): crosstalk-free Bayer extraction + monochrome sensor support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,12 @@ jobs:
           body: |
             ## What's New
 
+            **v0.8.1**
+            - **3-way RGB merge — monochrome sensors:** trichrome capture now supports monochrome (no-CFA) cameras, the ideal trichrome sensor — each frame is a full-resolution grayscale that becomes one channel, at full sensor resolution.
+            - **3-way RGB merge — crosstalk-free Bayer:** Bayer frames now read the raw sensor mosaic directly and take only the wanted colour's photosites (R/B single site, green = average of its two green sites), never mixing in the other colours — instead of the previous quad-binning decode.
+
             **v0.8.0**
-            - **3-way RGB merge (trichrome capture):** new toggle on Settings → Color Management. Shoot a static scene three times under pure red, then green, then blue light; on import, every 3 RAWs (sorted by filename) merge into one colour image — each frame contributes only its own channel, with no demosaicing — then convert as a negative. Bayer RAW only; the selected count must be a multiple of 3.
+            - **3-way RGB merge (trichrome capture):** new toggle on Settings → Color Management. Shoot a static scene three times under pure red, then green, then blue light; on import, every 3 RAWs (sorted by filename) merge into one colour image — each frame contributes only its own channel, with no demosaicing — then convert as a negative.
 
             ## Install
 
@@ -153,8 +157,12 @@ jobs:
           body: |
             ## What's New
 
+            **v0.8.1**
+            - **3-way RGB merge — monochrome sensors:** trichrome capture now supports monochrome (no-CFA) cameras, the ideal trichrome sensor — each frame is a full-resolution grayscale that becomes one channel, at full sensor resolution.
+            - **3-way RGB merge — crosstalk-free Bayer:** Bayer frames now read the raw sensor mosaic directly and take only the wanted colour's photosites (R/B single site, green = average of its two green sites), never mixing in the other colours — instead of the previous quad-binning decode.
+
             **v0.8.0**
-            - **3-way RGB merge (trichrome capture):** new toggle on Settings → Color Management. Shoot a static scene three times under pure red, then green, then blue light; on import, every 3 RAWs (sorted by filename) merge into one colour image — each frame contributes only its own channel, with no demosaicing — then convert as a negative. Bayer RAW only; the selected count must be a multiple of 3.
+            - **3-way RGB merge (trichrome capture):** new toggle on Settings → Color Management. Shoot a static scene three times under pure red, then green, then blue light; on import, every 3 RAWs (sorted by filename) merge into one colour image — each frame contributes only its own channel, with no demosaicing — then convert as a negative.
 
             ## Install
 

--- a/spec/three-way-rgb-merge.md
+++ b/spec/three-way-rgb-merge.md
@@ -44,14 +44,19 @@ the existing Positive-mode toggle.
   crop, sliders, dust) are **not saved between sessions**. A first-merge hint
   states this. (Follow-up: key the catalog on a composite of the 3 source
   signatures.)
-- **Bayer (RGGB) sensors only.** "Do not demosaic / take one channel" is a 2×2
-  Bayer-CFA concept. X-Trans (Fujifilm `.raf`), monochrome, and 4-colour
-  (CYGM/RGBE) sensors are rejected at decode time with a clear message.
+- **Bayer (RGGB) and monochrome sensors.** "Do not demosaic / take one channel"
+  applies to a 2×2 Bayer CFA (collapse each tile → one pixel) and, even more
+  naturally, to a monochrome sensor (no CFA at all — the whole grayscale frame is
+  that light's channel, full resolution). X-Trans (Fujifilm `.raf`) and 4-colour
+  (CYGM/RGBE) sensors are rejected at decode time with a clear message. All three
+  frames of a triplet must be the same sensor type.
 - **Non-RAW inputs are not supported.** Validated by extension up front and by a
-  Bayer-CFA guard at decode.
-- **No full-sensor-resolution output.** A no-demosaic channel extraction is
-  inherently a 2×2-binned, half-sensor-resolution image. That binned size *is*
-  the merged image's full resolution.
+  sensor-type guard at decode.
+- **Resolution is sensor-native.** A Bayer merge is inherently a 2×2-binned,
+  half-sensor-resolution image (that binned size *is* its full resolution); a
+  monochrome merge is **full sensor resolution** (no binning needed). For a
+  monochrome merge, `preview`/zoom decodes may run at half size for speed, but
+  export delivers full sensor resolution.
 - The mode is global; no per-image override. No change to the non-merge flow when
   the toggle is OFF.
 - **Positive mode is assumed OFF for merge.** Trichrome frames are negatives; the
@@ -103,10 +108,12 @@ muted text):
   - **Invalid count** (not a multiple of 3): *"3-way RGB merge needs a multiple of
     3 images (got N). Select 3 frames per shot: red, green, blue."* — nothing
     loads.
-  - **Non-RAW present**: *"3-way RGB merge requires RAW (Bayer) files. These are
-    not supported RAW: …"* — nothing loads.
-  - **Non-Bayer RAW** (X-Trans/mono/4-colour, only detectable at decode): the
-    triplet is rejected at decode; the import reports it via `last_merge_error`.
+  - **Non-RAW present**: *"3-way RGB merge requires RAW files. These are not
+    supported RAW: …"* — nothing loads.
+  - **Unsupported sensor** (X-Trans / 4-colour, or a triplet mixing monochrome
+    and Bayer — only detectable at decode): the triplet is rejected at decode;
+    the import reports it via `last_merge_error`. (Monochrome and Bayer are both
+    supported; only X-Trans/4-colour and mixed-type triplets are rejected.)
 
 ### Error surfacing across both entry points
 
@@ -160,9 +167,12 @@ if max_long_side:
 return rgb
 ```
 
-`preview` is accepted but ignored: the merge's native resolution **is**
-half-sensor (the 2×2 bin is the no-demosaic step); there is no cheaper/higher
-decode. Size control is purely via `max_long_side`.
+`preview` is forwarded to `merge_raw_channels`: for **Bayer** it is irrelevant
+(the 2×2 bin is already the only resolution); for **monochrome** it lets the
+decode run at half size for a fast preview/zoom tile. `merge_raw_channels` always
+returns the *canonical full* size (full sensor for monochrome, binned for Bayer)
+so `original_full_size` is correct even when a monochrome preview array is
+half-sensor; `max_long_side` then does the final downsize.
 
 Because the dispatch lives inside `read_image`, **export, zoom hi-res replay,
 slicing, and duplication all compose for free** — each re-reads through
@@ -195,20 +205,27 @@ Merged images must never enter the per-file catalog. Guard **every** path:
 
 ## Processing / Maths
 
-### Why half resolution and "no demosaic"
+### "No demosaic" for the two sensor kinds
 
-A Bayer sensor records one colour per photosite in a 2×2 tile (RGGB). A normal
-decode *demosaics* — interpolates the two missing colours at every site. The
-requirement is the opposite: take only the photosites that natively measured the
-wanted colour, discard the rest, do not interpolate. The clean way is to collapse
-each 2×2 CFA tile to one output pixel: `R = R-site`, `G = mean(two G-sites)`,
-`B = B-site`. That is exactly rawpy/libraw `half_size=True` — a pure bin, **no
-interpolation**. The result is a half-width × half-height RGB image, which is the
-merged frame's full resolution.
+**Bayer.** A Bayer sensor records one colour per photosite in a 2×2 tile (RGGB).
+A normal decode *demosaics* — interpolates the two missing colours at every site.
+The requirement is the opposite: take only the photosites that natively measured
+the wanted colour, discard the rest, do not interpolate. The clean way is to
+collapse each 2×2 CFA tile to one output pixel: `R = R-site`,
+`G = mean(two G-sites)`, `B = B-site`. That is exactly rawpy/libraw
+`half_size=True` — a pure bin, **no interpolation** — yielding a half-width ×
+half-height RGB image, which is the Bayer merge's full resolution.
+
+**Monochrome.** A monochrome sensor has no CFA, so there is nothing to demosaic:
+every photosite measured the (single) light's intensity. The whole grayscale
+frame **is** that frame's channel, at **full sensor resolution**. This is in fact
+the ideal trichrome sensor — no wasted photosites, no resolution loss.
 
 ### Per-frame native decode
 
-For each source RAW, decode in **camera-native colour with no channel mixing**:
+For each source RAW, decode in **camera-native colour with no channel mixing**.
+The only differences between the two sensor kinds are `half_size` and (for
+monochrome) which channel to take:
 
 ```python
 raw.postprocess(
@@ -217,7 +234,8 @@ raw.postprocess(
     gamma=(1, 1),                 # linear
     user_flip=0,
     demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,  # inert under half_size
-    half_size=True,               # 2×2 bin == the no-demosaic channel extraction
+    half_size=True,               # Bayer: 2×2 bin == the no-demosaic extraction
+                                  # Monochrome: half_size=preview (full for export)
     use_camera_wb=False,          # no WB scaling
     use_auto_wb=False,
     output_color=rawpy.ColorSpace.raw,   # camera-native: NO 3×3 matrix → no mixing
@@ -227,26 +245,38 @@ raw.postprocess(
 )
 ```
 
-Verified empirically on `example_raw/DSC07096.ARW`: this yields a byte-identical
-2×2 bin to a manual black-subtracted bin — unmixed, no interpolation; `LINEAR`
-vs `AHD` are identical under `half_size` (the bin, not the algorithm, is what
-avoids interpolation). libraw subtracts the black level during postprocess
-(per-channel min = 0 with `no_auto_scale=True`), so we **do not** black-subtract
-again. The purity guarantee rests on `half_size` + `output_color=raw`, not on the
-demosaic algorithm.
+- **Bayer:** `half_size=True`; pick the frame's colour channel
+  (`rgb[..., channel_idx]`, index from `color_desc`).
+- **Monochrome:** `half_size=preview` (full sensor for export, half for fast
+  previews/zoom); the channel **is** the grayscale plane (`rgb` if 2-D, else
+  `rgb[..., 0]` — the channels are equal).
 
-### Bayer guard (decode-time)
+Verified empirically on `example_raw/DSC07096.ARW` (Bayer): this yields a
+byte-identical 2×2 bin to a manual black-subtracted bin — unmixed, no
+interpolation; `LINEAR` vs `AHD` are identical under `half_size`. libraw subtracts
+the black level during postprocess (per-channel min = 0 with `no_auto_scale=True`),
+so we **do not** black-subtract again. The purity guarantee rests on the bin (or
+the absence of a CFA) + `output_color=raw`, not on the demosaic algorithm.
+(Monochrome cannot be CI-verified here — the repo ships no monochrome RAW — so the
+decode mirrors `read_image`'s existing monochrome path plus the Bayer path's
+absolute-value scaling.)
 
-After `rawpy.imread`, require a 2×2 RGB Bayer mosaic, else raise a clear error
-(surfaced via `last_merge_error`):
+### Sensor-type guard (decode-time)
 
-- `raw.num_colors == 3`,
-- `raw.color_desc` contains exactly the letters `R`, `G`, `B` (a permutation like
-  `RGBG`), and
-- `raw.raw_pattern` has shape `(2, 2)`.
+After `rawpy.imread`, classify the sensor and reject the unsupported kinds, with a
+clear error surfaced via `last_merge_error`:
 
-Rejects X-Trans (`.raf`, 6×6), monochrome (`num_colors == 1`), and 4-colour
-sensors with a message naming the offending file and reason.
+- **Monochrome** (accepted): `num_colors == 1`, a grey `color_desc`
+  (`b'G'`/`b'GRAY'`/`b'GREY'`), or a `b'RGBG'` desc whose CFA pattern is all one
+  index — mirrors `read_image`'s monochrome detection.
+- **Bayer** (accepted): `num_colors == 3`, `color_desc` a permutation containing
+  `R`,`G`,`B`, and `raw_pattern` shape `(2, 2)`.
+- **Rejected:** X-Trans (`.raf`, 6×6) and 4-colour (CYGM/RGBE) sensors, with a
+  message naming the file and reason.
+
+All three frames of a triplet must be the **same** type (`merge_raw_channels`
+raises if a triplet mixes monochrome and Bayer — they have different
+resolutions).
 
 ### Channel selection by `color_desc` (not hardcoded indices)
 
@@ -300,15 +330,19 @@ def group_into_triplets(sorted_paths) -> list[tuple[str, str, str]]
 def validate_merge_inputs(paths) -> tuple[bool, Optional[str]]
         # (ok, error). Checks: non-empty, len % 3 == 0, all is_raw_path.
 def bayer_channel_indices(color_desc) -> tuple[int, int, int]   # pure
+def is_monochrome_sensor(num_colors, color_desc, raw_pattern=None) -> bool  # pure
 def combine_channels(plane_r, plane_g, plane_b, white_levels) -> np.ndarray  # pure
         # crop to common (min H, min W); scale each by 65535/wl; clip; stack -> uint16
-def merge_raw_channels(sources) -> tuple[np.ndarray, tuple[int, int]]
-        # decode 3 RAWs native half-size, Bayer-guard, pick planes via
-        # bayer_channel_indices, combine_channels; returns (merged, (H, W)).
+def merge_raw_channels(sources, preview=False) -> tuple[np.ndarray, tuple[int, int]]
+        # decode 3 RAWs camera-native (Bayer half-size 2x2 bin / monochrome
+        # full-size), sensor-type guard, take each frame's channel, combine;
+        # returns (merged, full_size). preview only affects monochrome.
 ```
 
-`merge_raw_channels` is the only rawpy-touching function; everything else is pure
-and unit-tested.
+`merge_raw_channels` is the only rawpy-touching function; everything else
+(`is_raw_path`, `sort_for_merge`, `group_into_triplets`, `validate_merge_inputs`,
+`bayer_channel_indices`, `is_monochrome_sensor`, `combine_channels`) is pure and
+unit-tested.
 
 ## Integration Points
 
@@ -354,12 +388,16 @@ triplet order stable.
 
 - **Count not a multiple of 3** → rejected, nothing loads (both entry points).
 - **Non-RAW file present** → rejected up front with the offending names.
-- **Non-Bayer RAW** (X-Trans/mono/4-colour) → rejected at decode via the Bayer
-  guard; reported through `last_merge_error`.
+- **Monochrome RAW** → supported: decoded full-sensor, the grayscale frame is the
+  channel (no demosaic needed).
+- **Unsupported sensor** (X-Trans / 4-colour) → rejected at decode via the
+  sensor-type guard; reported through `last_merge_error`.
+- **Mixed-type triplet** (monochrome + Bayer) → rejected at decode (different
+  resolutions would silently misalign); reported through `last_merge_error`.
 - **A source fails to decode** → `merge_raw_channels` raises; the pool task
   catches, records `last_merge_error`, skips that triplet; others still load.
-- **Differing frame dimensions** in a triplet → `combine_channels` crops to the
-  common min H/W.
+- **Differing frame dimensions** within one sensor type → `combine_channels`
+  crops to the common min H/W.
 - **Duplicate of a merged image** → carries `is_merged`/`merge_sources`; initial
   preview reuses the copied `resized_raw`, and zoom/export re-merge correctly.
 - **Slice of a merged image** → children carry `is_merged`/`merge_sources`; the
@@ -428,3 +466,15 @@ dialog. `load_images_from_folder`'s diagnostic failure count is computed in
 triplet units when merge mode is on. The per-worker `last_merge_error` is a
 single last-writer-wins slot (accepted: the message is deliberately generic and
 the set of loaded images is deterministic regardless).
+
+Round 4 (monochrome support): added monochrome sensors as a first-class merge
+input (full-sensor resolution, no CFA — the grayscale frame is the channel). The
+Bayer-only guard became a sensor-type classifier (`is_monochrome_sensor`); the
+decode branches on it (`_decode_frame_plane`), with `merge_raw_channels(preview)`
+running monochrome decodes at half size for fast previews while always reporting
+the canonical full size so `original_full_size` stays correct. Mixed-type
+triplets are rejected. Reviewed for the full → preview/export → slice/duplicate
+resolution round-trip; the only items found were a stale `export_estimator`
+comment (fixed) and the mixed-type guard (added). The monochrome rawpy decode
+itself is not CI-verifiable here (no monochrome RAW in the repo); it mirrors
+`read_image`'s existing monochrome path plus the Bayer absolute-value scaling.

--- a/spec/three-way-rgb-merge.md
+++ b/spec/three-way-rgb-merge.md
@@ -209,57 +209,50 @@ Merged images must never enter the per-file catalog. Guard **every** path:
 
 **Bayer.** A Bayer sensor records one colour per photosite in a 2×2 tile (RGGB).
 A normal decode *demosaics* — interpolates the two missing colours at every site.
-The requirement is the opposite: take only the photosites that natively measured
-the wanted colour, discard the rest, do not interpolate. The clean way is to
-collapse each 2×2 CFA tile to one output pixel: `R = R-site`,
-`G = mean(two G-sites)`, `B = B-site`. That is exactly rawpy/libraw
-`half_size=True` — a pure bin, **no interpolation** — yielding a half-width ×
-half-height RGB image, which is the Bayer merge's full resolution.
+The requirement is the opposite: take **only** the photosites that natively
+measured the wanted colour, with **no inter-channel crosstalk at all**. We read
+the RAW Bayer mosaic directly (`raw.raw_image_visible` + `raw.raw_colors_visible`)
+and phase-slice out a single colour's sites — `mosaic[dy::2, dx::2]`, where
+`(dy, dx)` is that colour's position in the 2×2 tile (read from the actual
+`colors` at the visible origin, so it is offset-safe). One site per quad, **no
+averaging, no quad-merge, no demosaic, and no libraw colour pipeline whatsoever.**
+The black pedestal is subtracted manually (`raw_image` carries it). This yields a
+half-width × half-height plane (one site per quad = the Bayer merge's full
+resolution).
+
+> `half_size=True` is the quick, lower-rigor alternative: it bins each quad to
+> `R = R-site, G = mean(two G-sites), B = B-site`. It is interpolation-free, but
+> it *mixes the quad* (averages the two greens, and runs the libraw postprocess),
+> so it is **deliberately not used**. For the green channel we take only **one**
+> of the two green sites (taking both would be an average == a merge).
 
 **Monochrome.** A monochrome sensor has no CFA, so there is nothing to demosaic:
 every photosite measured the (single) light's intensity. The whole grayscale
 frame **is** that frame's channel, at **full sensor resolution**. This is in fact
 the ideal trichrome sensor — no wasted photosites, no resolution loss.
 
-### Per-frame native decode
+### Per-frame extraction
 
-For each source RAW, decode in **camera-native colour with no channel mixing**.
-The only differences between the two sensor kinds are `half_size` and (for
-monochrome) which channel to take:
+- **Bayer:** read the raw mosaic, pick the frame's CFA colour index from
+  `color_desc` (`bayer_channel_indices`), and `extract_cfa_plane(mosaic, colors,
+  target)` returns just that colour's sites. Subtract `black_level_per_channel[
+  target]`. No `raw.postprocess` at all.
+- **Monochrome:** `raw.postprocess(half_size=preview, output_color=raw,
+  gamma=(1,1), no_auto_bright=True, no_auto_scale=True, use_camera_wb=False)`;
+  the channel **is** the grayscale plane (`rgb` if 2-D, else `rgb[..., 0]` — the
+  channels are equal). `preview` gives a fast half-size decode; the full sensor
+  size is still reported as the canonical resolution.
 
-```python
-raw.postprocess(
-    output_bps=16,
-    no_auto_bright=True,
-    gamma=(1, 1),                 # linear
-    user_flip=0,
-    demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,  # inert under half_size
-    half_size=True,               # Bayer: 2×2 bin == the no-demosaic extraction
-                                  # Monochrome: half_size=preview (full for export)
-    use_camera_wb=False,          # no WB scaling
-    use_auto_wb=False,
-    output_color=rawpy.ColorSpace.raw,   # camera-native: NO 3×3 matrix → no mixing
-    no_auto_scale=True,           # absolute sensor values; we scale manually
-    adjust_maximum_thr=0.0,
-    four_color_rgb=False,
-)
-```
+Either way the plane is scaled by `65535/white_level` in `combine_channels`
+(matching `read_image`'s black-subtracted negative decode).
 
-- **Bayer:** `half_size=True`; pick the frame's colour channel
-  (`rgb[..., channel_idx]`, index from `color_desc`).
-- **Monochrome:** `half_size=preview` (full sensor for export, half for fast
-  previews/zoom); the channel **is** the grayscale plane (`rgb` if 2-D, else
-  `rgb[..., 0]` — the channels are equal).
-
-Verified empirically on `example_raw/DSC07096.ARW` (Bayer): this yields a
-byte-identical 2×2 bin to a manual black-subtracted bin — unmixed, no
-interpolation; `LINEAR` vs `AHD` are identical under `half_size`. libraw subtracts
-the black level during postprocess (per-channel min = 0 with `no_auto_scale=True`),
-so we **do not** black-subtract again. The purity guarantee rests on the bin (or
-the absence of a CFA) + `output_color=raw`, not on the demosaic algorithm.
-(Monochrome cannot be CI-verified here — the repo ships no monochrome RAW — so the
-decode mirrors `read_image`'s existing monochrome path plus the Bayer path's
-absolute-value scaling.)
+Verified on `example_raw/DSC07096.ARW` (Bayer): the direct-mosaic R and B planes
+are **byte-identical** (max abs diff 0) to libraw's own `half_size`+`output_color=
+raw` single-site read — proving the phase + black-level handling is correct — while
+the green plane differs (one site vs libraw's two-green average), which is exactly
+the merge being eliminated. (Monochrome cannot be CI-verified here — the repo
+ships no monochrome RAW — so its decode mirrors `read_image`'s existing monochrome
+path.)
 
 ### Sensor-type guard (decode-time)
 
@@ -331,6 +324,8 @@ def validate_merge_inputs(paths) -> tuple[bool, Optional[str]]
         # (ok, error). Checks: non-empty, len % 3 == 0, all is_raw_path.
 def bayer_channel_indices(color_desc) -> tuple[int, int, int]   # pure
 def is_monochrome_sensor(num_colors, color_desc, raw_pattern=None) -> bool  # pure
+def extract_cfa_plane(mosaic, colors, target_index) -> np.ndarray  # pure
+        # phase-slice one CFA colour's sites from the raw mosaic; no merge
 def combine_channels(plane_r, plane_g, plane_b, white_levels) -> np.ndarray  # pure
         # crop to common (min H, min W); scale each by 65535/wl; clip; stack -> uint16
 def merge_raw_channels(sources, preview=False) -> tuple[np.ndarray, tuple[int, int]]
@@ -341,8 +336,8 @@ def merge_raw_channels(sources, preview=False) -> tuple[np.ndarray, tuple[int, i
 
 `merge_raw_channels` is the only rawpy-touching function; everything else
 (`is_raw_path`, `sort_for_merge`, `group_into_triplets`, `validate_merge_inputs`,
-`bayer_channel_indices`, `is_monochrome_sensor`, `combine_channels`) is pure and
-unit-tested.
+`bayer_channel_indices`, `is_monochrome_sensor`, `extract_cfa_plane`,
+`combine_channels`) is pure and unit-tested.
 
 ## Integration Points
 
@@ -478,3 +473,12 @@ resolution round-trip; the only items found were a stale `export_estimator`
 comment (fixed) and the mixed-type guard (added). The monochrome rawpy decode
 itself is not CI-verifiable here (no monochrome RAW in the repo); it mirrors
 `read_image`'s existing monochrome path plus the Bayer absolute-value scaling.
+
+Round 5 (crosstalk-free Bayer): replaced the Bayer `half_size=True` decode with a
+direct raw-mosaic read (`extract_cfa_plane`) that pulls only the wanted colour's
+photosites — one site per quad, no green averaging, no quad-merge, no libraw
+colour pipeline — eliminating inter-channel crosstalk. Validated on the example
+ARW: R and B planes are byte-identical to libraw's single-site read, green now
+uses one site (the eliminated average). `half_size` is documented as the
+lower-rigor alternative and no longer used for Bayer; monochrome still uses
+`postprocess` (no CFA, so no crosstalk to remove).

--- a/spec/three-way-rgb-merge.md
+++ b/spec/three-way-rgb-merge.md
@@ -210,21 +210,22 @@ Merged images must never enter the per-file catalog. Guard **every** path:
 **Bayer.** A Bayer sensor records one colour per photosite in a 2×2 tile (RGGB).
 A normal decode *demosaics* — interpolates the two missing colours at every site.
 The requirement is the opposite: take **only** the photosites that natively
-measured the wanted colour, with **no inter-channel crosstalk at all**. We read
-the RAW Bayer mosaic directly (`raw.raw_image_visible` + `raw.raw_colors_visible`)
-and phase-slice out a single colour's sites — `mosaic[dy::2, dx::2]`, where
-`(dy, dx)` is that colour's position in the 2×2 tile (read from the actual
-`colors` at the visible origin, so it is offset-safe). One site per quad, **no
-averaging, no quad-merge, no demosaic, and no libraw colour pipeline whatsoever.**
-The black pedestal is subtracted manually (`raw_image` carries it). This yields a
-half-width × half-height plane (one site per quad = the Bayer merge's full
-resolution).
+measured the wanted colour, **never mixing in the other colours** (zero
+inter-channel crosstalk). We read the RAW Bayer mosaic directly
+(`raw.raw_image_visible` + `raw.raw_colors_visible`) and phase-slice out a single
+colour's sites — `mosaic[dy::2, dx::2]`, where `(dy, dx)` is that colour's
+position in the 2×2 tile (read from the actual `colors` at the visible origin, so
+it is offset-safe). **No demosaic and no libraw colour pipeline whatsoever.** R
+and B have one site per quad → that bare site; **green has two sites per quad,
+which are averaged** (both are green, so this is not crosstalk, and it preserves
+the green SNR). The black pedestal is subtracted per site manually (`raw_image`
+carries it). This yields a half-width × half-height plane (one site per quad = the
+Bayer merge's full resolution).
 
-> `half_size=True` is the quick, lower-rigor alternative: it bins each quad to
-> `R = R-site, G = mean(two G-sites), B = B-site`. It is interpolation-free, but
-> it *mixes the quad* (averages the two greens, and runs the libraw postprocess),
-> so it is **deliberately not used**. For the green channel we take only **one**
-> of the two green sites (taking both would be an average == a merge).
+> `half_size=True` gives a numerically similar result (it bins each quad to
+> `R = R-site, G = mean(two G-sites), B = B-site`), but it goes through libraw's
+> postprocess pipeline. Reading the mosaic directly keeps full control and
+> guarantees no hidden colour operation, which is why it is used instead.
 
 **Monochrome.** A monochrome sensor has no CFA, so there is nothing to demosaic:
 every photosite measured the (single) light's intensity. The whole grayscale
@@ -233,10 +234,13 @@ the ideal trichrome sensor — no wasted photosites, no resolution loss.
 
 ### Per-frame extraction
 
-- **Bayer:** read the raw mosaic, pick the frame's CFA colour index from
-  `color_desc` (`bayer_channel_indices`), and `extract_cfa_plane(mosaic, colors,
-  target)` returns just that colour's sites. Subtract `black_level_per_channel[
-  target]`. No `raw.postprocess` at all.
+- **Bayer:** read the raw mosaic; `extract_cfa_channel(mosaic, colors,
+  color_desc, letter, black_levels)` returns that colour's plane — the single
+  site for R/B, the per-site-black-subtracted **average of the two sites for
+  green** — matching contributing sites by CFA letter (so it works whether the
+  two greens share one colour index or use indices 1 and 3). No `raw.postprocess`
+  at all. (`bayer_channel_indices` is still the guard that rejects a non-R/G/B
+  `color_desc`.)
 - **Monochrome:** `raw.postprocess(half_size=preview, output_color=raw,
   gamma=(1,1), no_auto_bright=True, no_auto_scale=True, use_camera_wb=False)`;
   the channel **is** the grayscale plane (`rgb` if 2-D, else `rgb[..., 0]` — the
@@ -246,13 +250,14 @@ the ideal trichrome sensor — no wasted photosites, no resolution loss.
 Either way the plane is scaled by `65535/white_level` in `combine_channels`
 (matching `read_image`'s black-subtracted negative decode).
 
-Verified on `example_raw/DSC07096.ARW` (Bayer): the direct-mosaic R and B planes
-are **byte-identical** (max abs diff 0) to libraw's own `half_size`+`output_color=
-raw` single-site read — proving the phase + black-level handling is correct — while
-the green plane differs (one site vs libraw's two-green average), which is exactly
-the merge being eliminated. (Monochrome cannot be CI-verified here — the repo
-ships no monochrome RAW — so its decode mirrors `read_image`'s existing monochrome
-path.)
+Verified on `example_raw/DSC07096.ARW` (Bayer) against libraw's own
+`half_size`+`output_color=raw` read: R and B are **byte-identical** (max abs diff
+0), and green matches the two-green average to within float-vs-integer **rounding**
+(max abs diff 6 / 65535 ≈ 0.01% of pixels) — confirming the phase, black-level,
+and green-average handling. The direct read reaches the same values as `half_size`
+without going through libraw's postprocess. (Monochrome cannot be CI-verified
+here — the repo ships no monochrome RAW — so its decode mirrors `read_image`'s
+existing monochrome path.)
 
 ### Sensor-type guard (decode-time)
 
@@ -324,8 +329,9 @@ def validate_merge_inputs(paths) -> tuple[bool, Optional[str]]
         # (ok, error). Checks: non-empty, len % 3 == 0, all is_raw_path.
 def bayer_channel_indices(color_desc) -> tuple[int, int, int]   # pure
 def is_monochrome_sensor(num_colors, color_desc, raw_pattern=None) -> bool  # pure
-def extract_cfa_plane(mosaic, colors, target_index) -> np.ndarray  # pure
-        # phase-slice one CFA colour's sites from the raw mosaic; no merge
+def extract_cfa_channel(mosaic, colors, color_desc, letter, black_levels=None) -> np.ndarray
+        # pure: one CFA colour's plane from the raw mosaic — single site for R/B,
+        # per-site-black-subtracted average of the two sites for green
 def combine_channels(plane_r, plane_g, plane_b, white_levels) -> np.ndarray  # pure
         # crop to common (min H, min W); scale each by 65535/wl; clip; stack -> uint16
 def merge_raw_channels(sources, preview=False) -> tuple[np.ndarray, tuple[int, int]]
@@ -336,7 +342,7 @@ def merge_raw_channels(sources, preview=False) -> tuple[np.ndarray, tuple[int, i
 
 `merge_raw_channels` is the only rawpy-touching function; everything else
 (`is_raw_path`, `sort_for_merge`, `group_into_triplets`, `validate_merge_inputs`,
-`bayer_channel_indices`, `is_monochrome_sensor`, `extract_cfa_plane`,
+`bayer_channel_indices`, `is_monochrome_sensor`, `extract_cfa_channel`,
 `combine_channels`) is pure and unit-tested.
 
 ## Integration Points
@@ -475,10 +481,16 @@ itself is not CI-verifiable here (no monochrome RAW in the repo); it mirrors
 `read_image`'s existing monochrome path plus the Bayer absolute-value scaling.
 
 Round 5 (crosstalk-free Bayer): replaced the Bayer `half_size=True` decode with a
-direct raw-mosaic read (`extract_cfa_plane`) that pulls only the wanted colour's
-photosites — one site per quad, no green averaging, no quad-merge, no libraw
-colour pipeline — eliminating inter-channel crosstalk. Validated on the example
-ARW: R and B planes are byte-identical to libraw's single-site read, green now
-uses one site (the eliminated average). `half_size` is documented as the
-lower-rigor alternative and no longer used for Bayer; monochrome still uses
-`postprocess` (no CFA, so no crosstalk to remove).
+direct raw-mosaic read (`extract_cfa_channel`) that pulls only the wanted colour's
+photosites — no demosaic, no libraw colour pipeline, never mixing the other
+colours — eliminating inter-channel crosstalk. R/B use their single site; green
+**averages its two same-colour sites** (not crosstalk — both green — and it keeps
+the green SNR). Per-site black subtraction. Validated on the example ARW: R and B
+are byte-identical to libraw's single-site read and green matches the two-green
+average within rounding. `half_size` (numerically similar, but via libraw's
+postprocess) is no longer used for Bayer; monochrome still uses `postprocess` (no
+CFA, so no crosstalk to remove).
+
+(During review the green channel was first implemented as a single site — strict
+"no merge" — then changed per request to the two-green average, since averaging
+two same-colour sites is not crosstalk and preserves green resolution/SNR.)

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -417,11 +417,14 @@ class CCRImage:
                      max_long_side: Optional[int] = None) -> Optional[np.ndarray]:
         """Decode a 3-way RGB-merged image from its source RAWs. Mirrors the tail
         of read_image's RAW branch (slice ops, full-size capture, optional
-        downsize) so export / zoom / slice all compose. `preview` is accepted but
-        ignored: the merge's native resolution IS half-sensor (the 2x2 bin is the
-        no-demosaic step); size is controlled purely by max_long_side."""
+        downsize) so export / zoom / slice all compose. The merge's native
+        resolution is sensor-native: half-sensor for Bayer (the 2x2 bin is the
+        no-demosaic step), full-sensor for monochrome (no CFA). `preview` only
+        speeds up a monochrome decode (half size); full_decode_size always
+        reports the canonical full resolution, and max_long_side does the rest."""
         from core import ccr_merge
-        rgb, full_decode_size = ccr_merge.merge_raw_channels(self.merge_sources)
+        rgb, full_decode_size = ccr_merge.merge_raw_channels(self.merge_sources,
+                                                             preview=preview)
         # Sliced merged children read only their region of the source.
         rgb = self._apply_source_ops(rgb)
         self.original_full_size = self._ops_full_size(full_decode_size)

--- a/src/core/ccr_merge.py
+++ b/src/core/ccr_merge.py
@@ -6,12 +6,22 @@ red, then green, then blue — and every consecutive triplet of source RAWs is
 merged into one full-colour image by taking each frame's OWN colour channel and
 discarding the other two, WITHOUT demosaicing.
 
-"No demosaic" means: collapse each 2x2 Bayer (RGGB) tile to one output pixel
-(R = R-site, G = mean of the two G-sites, B = B-site) — a pure bin, no
-interpolation. That is exactly what libraw/rawpy `half_size=True` does, so the
-merged frame is half-sensor resolution (which IS its full resolution). Decoding
-in camera-native colour (`output_color=raw`, no white balance) keeps each output
-channel an unmixed sensor colour, so picking a single channel is faithful.
+Two sensor kinds are supported:
+
+* **Bayer (RGGB)** — "no demosaic" means collapse each 2x2 CFA tile to one
+  output pixel (R = R-site, G = mean of the two G-sites, B = B-site): a pure bin,
+  no interpolation. That is exactly what libraw/rawpy `half_size=True` does, so a
+  Bayer merge is half-sensor resolution (which IS its full resolution). Decoding
+  camera-native (`output_color=raw`, no white balance) keeps each output channel
+  an unmixed sensor colour, so picking a single channel is faithful.
+
+* **Monochrome** — no CFA at all, so there is nothing to demosaic: every
+  photosite measured the (single) light's intensity. The whole grayscale frame
+  IS that frame's channel, at FULL sensor resolution. A monochrome sensor is in
+  fact the ideal trichrome sensor (no wasted photosites, full resolution).
+
+Either way each frame contributes exactly one channel (R from the red-light
+frame, G from green, B from blue), scaled to 16-bit by 65535/white_level.
 
 This module is split so everything except `merge_raw_channels` is pure and
 unit-testable without rawpy/Qt. See spec/three-way-rgb-merge.md.
@@ -61,8 +71,8 @@ def validate_merge_inputs(paths: Sequence[str]) -> Tuple[bool, Optional[str]]:
     """Pre-decode validation for a merge import. Returns (ok, error_message).
 
     Checks, in order: non-empty, every file is a supported RAW, count is a
-    multiple of 3. The Bayer-CFA check can only happen at decode time (see
-    merge_raw_channels), so it is NOT done here."""
+    multiple of 3. The sensor check (Bayer vs monochrome vs unsupported) can only
+    happen at decode time (see merge_raw_channels), so it is NOT done here."""
     if not paths:
         return False, "No files selected for 3-way RGB merge."
     non_raw = [p for p in paths if not is_raw_path(p)]
@@ -70,7 +80,7 @@ def validate_merge_inputs(paths: Sequence[str]) -> Tuple[bool, Optional[str]]:
         shown = "\n".join(os.path.basename(p) for p in non_raw[:8])
         if len(non_raw) > 8:
             shown += f"\n… and {len(non_raw) - 8} more"
-        return False, ("3-way RGB merge requires RAW (Bayer) files. "
+        return False, ("3-way RGB merge requires RAW files. "
                        f"These are not supported RAW:\n\n{shown}")
     if len(paths) % MERGE_GROUP_SIZE != 0:
         return False, ("3-way RGB merge needs a multiple of 3 images "
@@ -119,30 +129,84 @@ def combine_channels(plane_r: np.ndarray, plane_g: np.ndarray, plane_b: np.ndarr
     return out
 
 
-def _decode_native_halfsize(path: str):
-    """Decode one RAW to a camera-native, half-size (2x2-binned, no-demosaic)
-    array. Returns (rgb, color_desc, white_level). rgb is (H, W, num_colors)
-    with unmixed sensor channels; libraw subtracts the black level during
-    postprocess. Raises on a non-Bayer-RGB sensor."""
+def _desc_bytes(color_desc) -> bytes:
+    if isinstance(color_desc, (bytes, bytearray)):
+        return bytes(color_desc)
+    return str(color_desc).encode("ascii", "ignore")
+
+
+def is_monochrome_sensor(num_colors, color_desc, raw_pattern=None) -> bool:
+    """Whether a RAW comes from a monochrome (no-CFA) sensor. Mirrors
+    read_image's detection (ccr_image.py): num_colors == 1, a grey color_desc,
+    or an RGBG desc whose CFA pattern is all one colour index. Pure (takes the
+    rawpy primitives, not a raw object), so it is unit-testable."""
+    if num_colors == 1:
+        return True
+    cd = _desc_bytes(color_desc)
+    if cd in (b"G", b"GRAY", b"GREY"):
+        return True
+    if cd == b"RGBG" and raw_pattern is not None:
+        try:
+            if int(np.asarray(raw_pattern).max()) == 0:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
+    """Decode one source RAW and return (plane_2d, white_level, is_mono,
+    sensor_full) for the single colour this frame contributes (frame_pos
+    0=R/1=G/2=B). libraw subtracts the black level during postprocess.
+
+    * Monochrome: no CFA — the whole grayscale frame IS the channel, at FULL
+      sensor resolution (nothing to demosaic). `preview` may decode at half size
+      for a fast preview/zoom tile, but the canonical full resolution reported is
+      always the full sensor.
+    * Bayer (RGGB): half-size 2x2 bin (the no-demosaic extraction), camera-native
+      (no matrix), then pick the frame's colour channel via color_desc. The
+      binned size IS the Bayer merge's full resolution (`preview` is irrelevant).
+
+    Raises ValueError on an unsupported sensor (X-Trans, 4-colour)."""
     import rawpy
 
     with rawpy.imread(path) as raw:
         white_level = float(raw.white_level)
+        sensor_full = (int(raw.sizes.height), int(raw.sizes.width))
         num_colors = int(getattr(raw, "num_colors", 0) or 0)
         color_desc = getattr(raw, "color_desc", b"")
         pattern = getattr(raw, "raw_pattern", None)
 
+        if is_monochrome_sensor(num_colors, color_desc, pattern):
+            rgb = raw.postprocess(
+                output_bps=16,
+                no_auto_bright=True,
+                gamma=(1, 1),                                  # linear
+                user_flip=0,
+                demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,
+                half_size=preview,         # full res unless a fast preview decode
+                use_camera_wb=False,
+                use_auto_wb=False,
+                output_color=rawpy.ColorSpace.raw,
+                no_auto_scale=True,        # absolute sensor values; scale manually
+                adjust_maximum_thr=0.0,
+                four_color_rgb=False,
+            )
+            plane = rgb if rgb.ndim == 2 else rgb[..., 0]   # channels are equal
+            return np.ascontiguousarray(plane), white_level, True, sensor_full
+
+        # Bayer (RGGB): require a 3-colour 2x2 R/G/B mosaic.
         if num_colors != 3:
             raise ValueError(
-                f"3-way merge requires a 3-colour Bayer sensor; "
+                f"3-way merge requires a Bayer (RGGB) or monochrome sensor; "
                 f"{os.path.basename(path)} reports {num_colors} colours "
-                f"(monochrome or 4-colour).")
+                f"(e.g. 4-colour CYGM/RGBE).")
         if pattern is not None and tuple(np.asarray(pattern).shape) != (2, 2):
             raise ValueError(
-                f"3-way merge requires a 2x2 Bayer mosaic; "
-                f"{os.path.basename(path)} is non-Bayer (e.g. X-Trans).")
-        # Raises if color_desc is not an R/G/B permutation.
-        bayer_channel_indices(color_desc)
+                f"3-way merge requires a 2x2 Bayer mosaic or a monochrome "
+                f"sensor; {os.path.basename(path)} is non-Bayer (e.g. X-Trans).")
+        r_idx, g_idx, b_idx = bayer_channel_indices(color_desc)  # raises if not RGB
+        channel_idx = (r_idx, g_idx, b_idx)[frame_pos]
 
         rgb = raw.postprocess(
             output_bps=16,
@@ -158,15 +222,23 @@ def _decode_native_halfsize(path: str):
             adjust_maximum_thr=0.0,
             four_color_rgb=False,
         )
-    return rgb, color_desc, white_level
+        if rgb.ndim != 3 or channel_idx >= rgb.shape[2]:
+            raise ValueError(
+                f"unexpected decode shape {getattr(rgb, 'shape', None)} for "
+                f"{os.path.basename(path)}")
+        return np.ascontiguousarray(rgb[..., channel_idx]), white_level, False, sensor_full
 
 
-def merge_raw_channels(sources: Sequence[str]) -> Tuple[np.ndarray, Tuple[int, int]]:
+def merge_raw_channels(sources: Sequence[str],
+                       preview: bool = False) -> Tuple[np.ndarray, Tuple[int, int]]:
     """Merge a (red, green, blue) triplet of RAW files into one (H, W, 3) uint16
-    linear-RGB image at half-sensor resolution, taking only each frame's own
-    colour channel with no demosaicing.
+    linear-RGB image, taking only each frame's own colour channel with no
+    demosaicing. Bayer → half-sensor resolution (2x2 bin); monochrome → full
+    sensor resolution (no CFA). `preview` lets a monochrome decode run at half
+    size for fast preview/zoom (Bayer ignores it).
 
-    Returns (merged_rgb, full_size=(H, W)). Raises ValueError on a non-Bayer
+    Returns (merged_rgb, full_size=(H, W)) where full_size is the merged image's
+    canonical FULL (export) resolution. Raises ValueError on an unsupported
     sensor or a decode failure (the caller surfaces it)."""
     if len(sources) != MERGE_GROUP_SIZE:
         raise ValueError(f"merge_raw_channels needs exactly {MERGE_GROUP_SIZE} "
@@ -177,16 +249,27 @@ def merge_raw_channels(sources: Sequence[str]) -> Tuple[np.ndarray, Tuple[int, i
 
     planes: List[np.ndarray] = []
     white_levels: List[float] = []
+    monos: List[bool] = []
+    sensor_full: Optional[Tuple[int, int]] = None
     for frame_pos, path in enumerate(sources):       # 0=red, 1=green, 2=blue
-        rgb, color_desc, white_level = _decode_native_halfsize(path)
-        r_idx, g_idx, b_idx = bayer_channel_indices(color_desc)
-        channel_idx = (r_idx, g_idx, b_idx)[frame_pos]
-        if rgb.ndim != 3 or channel_idx >= rgb.shape[2]:
-            raise ValueError(
-                f"unexpected decode shape {getattr(rgb, 'shape', None)} for "
-                f"{os.path.basename(path)}")
-        planes.append(rgb[..., channel_idx])
+        plane, white_level, mono, sfull = _decode_frame_plane(path, frame_pos, preview)
+        planes.append(plane)
         white_levels.append(white_level)
+        monos.append(mono)
+        if sensor_full is None:
+            sensor_full = sfull
+
+    # All three frames must be the same sensor type — mixing a monochrome
+    # (full-res) frame with Bayer (half-res) ones would silently min-crop into a
+    # misaligned merge. A real trichrome set is always one body, so reject.
+    any_mono = any(monos)
+    if any_mono and not all(monos):
+        raise ValueError("3-way merge sources must all be the same sensor type "
+                         "(all Bayer, or all monochrome).")
 
     merged = combine_channels(planes[0], planes[1], planes[2], white_levels)
-    return merged, (merged.shape[0], merged.shape[1])
+    # Canonical FULL (export) resolution: full sensor for monochrome (the merge
+    # is full-res; a preview decode may have produced a smaller `merged`), the
+    # 2x2-binned size for Bayer (its only resolution).
+    full_size = sensor_full if any_mono else (merged.shape[0], merged.shape[1])
+    return merged, full_size

--- a/src/core/ccr_merge.py
+++ b/src/core/ccr_merge.py
@@ -8,12 +8,15 @@ discarding the other two, WITHOUT demosaicing.
 
 Two sensor kinds are supported:
 
-* **Bayer (RGGB)** — "no demosaic" means collapse each 2x2 CFA tile to one
-  output pixel (R = R-site, G = mean of the two G-sites, B = B-site): a pure bin,
-  no interpolation. That is exactly what libraw/rawpy `half_size=True` does, so a
-  Bayer merge is half-sensor resolution (which IS its full resolution). Decoding
-  camera-native (`output_color=raw`, no white balance) keeps each output channel
-  an unmixed sensor colour, so picking a single channel is faithful.
+* **Bayer (RGGB)** — read the RAW Bayer mosaic directly and take ONLY the
+  wanted colour's photosites: one site per 2x2 quad, with NO averaging, NO
+  quad-merge, NO demosaic, and NO libraw colour pipeline. This eliminates
+  inter-channel crosstalk entirely (we never touch the other three sites of the
+  quad — not even to average the two greens, of which only one is used). A Bayer
+  merge is therefore half-sensor resolution (one site per quad = its full
+  resolution). NB: `half_size=True` would be the quick, lower-rigor alternative
+  (it bins the quad, averaging the greens), but it mixes the four sites, so it is
+  deliberately NOT used here.
 
 * **Monochrome** — no CFA at all, so there is nothing to demosaic: every
   photosite measured the (single) light's intensity. The whole grayscale frame
@@ -154,18 +157,44 @@ def is_monochrome_sensor(num_colors, color_desc, raw_pattern=None) -> bool:
     return False
 
 
+def extract_cfa_plane(mosaic: np.ndarray, colors: np.ndarray,
+                      target_index: int) -> np.ndarray:
+    """From a raw Bayer mosaic (2-D sensor read-out) and its per-pixel CFA colour
+    indices, return the half-resolution plane of ONLY the photosites whose colour
+    == target_index — by phase-slicing the 2x2 lattice, NOT by binning/averaging.
+
+    This is the crosstalk-free extraction: no quad merge, no green averaging, no
+    demosaic, no colour matrix — just the bare sites of one colour, exactly as the
+    sensor measured them. The colour's phase within the tile is read from the
+    actual `colors` at the visible origin (offset-safe), and the CFA is periodic
+    with period 2, so `mosaic[dy::2, dx::2]` is precisely that colour's sites.
+    Pure (numpy in/out), so it is unit-testable without rawpy."""
+    eff = np.asarray(colors)[:2, :2]
+    pos = np.argwhere(eff == target_index)
+    if pos.size == 0:
+        raise ValueError(f"CFA colour index {target_index} not present in the "
+                         f"2x2 tile {eff.tolist()}")
+    dy, dx = int(pos[0][0]), int(pos[0][1])
+    return np.asarray(mosaic)[dy::2, dx::2]
+
+
 def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
     """Decode one source RAW and return (plane_2d, white_level, is_mono,
     sensor_full) for the single colour this frame contributes (frame_pos
-    0=R/1=G/2=B). libraw subtracts the black level during postprocess.
+    0=R/1=G/2=B).
 
+    * Bayer (RGGB): read the RAW Bayer mosaic directly (`raw.raw_image_visible`)
+      and take ONLY this frame's colour photosites — one site per 2x2 quad, no
+      averaging, no quad-merge, no demosaic, no libraw colour pipeline — so there
+      is zero inter-channel crosstalk. The black pedestal is subtracted manually
+      (raw_image carries it). Half-sensor resolution (one site per quad) is the
+      Bayer merge's full resolution; `preview` is irrelevant (the read is already
+      cheap). For the green channel only one of the two green sites is used
+      (taking both would average == merge, which we avoid).
     * Monochrome: no CFA — the whole grayscale frame IS the channel, at FULL
-      sensor resolution (nothing to demosaic). `preview` may decode at half size
-      for a fast preview/zoom tile, but the canonical full resolution reported is
-      always the full sensor.
-    * Bayer (RGGB): half-size 2x2 bin (the no-demosaic extraction), camera-native
-      (no matrix), then pick the frame's colour channel via color_desc. The
-      binned size IS the Bayer merge's full resolution (`preview` is irrelevant).
+      sensor resolution (nothing to demosaic, no quad to mix). `preview` may
+      decode at half size for a fast preview/zoom tile, but the canonical full
+      resolution reported is always the full sensor.
 
     Raises ValueError on an unsupported sensor (X-Trans, 4-colour)."""
     import rawpy
@@ -206,27 +235,21 @@ def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
                 f"3-way merge requires a 2x2 Bayer mosaic or a monochrome "
                 f"sensor; {os.path.basename(path)} is non-Bayer (e.g. X-Trans).")
         r_idx, g_idx, b_idx = bayer_channel_indices(color_desc)  # raises if not RGB
-        channel_idx = (r_idx, g_idx, b_idx)[frame_pos]
+        target = (r_idx, g_idx, b_idx)[frame_pos]               # CFA colour index
 
-        rgb = raw.postprocess(
-            output_bps=16,
-            no_auto_bright=True,
-            gamma=(1, 1),                                  # linear
-            user_flip=0,
-            demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,  # inert w/ half_size
-            half_size=True,            # 2x2 bin == the no-demosaic extraction
-            use_camera_wb=False,
-            use_auto_wb=False,
-            output_color=rawpy.ColorSpace.raw,   # camera-native: no 3x3 matrix
-            no_auto_scale=True,        # absolute sensor values; we scale manually
-            adjust_maximum_thr=0.0,
-            four_color_rgb=False,
-        )
-        if rgb.ndim != 3 or channel_idx >= rgb.shape[2]:
-            raise ValueError(
-                f"unexpected decode shape {getattr(rgb, 'shape', None)} for "
-                f"{os.path.basename(path)}")
-        return np.ascontiguousarray(rgb[..., channel_idx]), white_level, False, sensor_full
+        # Read the RAW mosaic and pull only this colour's sites — no merge.
+        mosaic = np.asarray(raw.raw_image_visible)
+        colors = np.asarray(raw.raw_colors_visible)
+        plane = extract_cfa_plane(mosaic, colors, target).astype(np.float32)
+        # Subtract this colour's black pedestal (raw_image carries it); combine
+        # then scales by 65535/white_level, matching read_image's negative decode.
+        try:
+            black = float(raw.black_level_per_channel[target])
+        except Exception:
+            black = 0.0
+        plane = np.clip(plane - black, 0, None)
+        return (np.ascontiguousarray(plane), white_level, False,
+                (plane.shape[0], plane.shape[1]))
 
 
 def merge_raw_channels(sources: Sequence[str],

--- a/src/core/ccr_merge.py
+++ b/src/core/ccr_merge.py
@@ -9,14 +9,14 @@ discarding the other two, WITHOUT demosaicing.
 Two sensor kinds are supported:
 
 * **Bayer (RGGB)** — read the RAW Bayer mosaic directly and take ONLY the
-  wanted colour's photosites: one site per 2x2 quad, with NO averaging, NO
-  quad-merge, NO demosaic, and NO libraw colour pipeline. This eliminates
-  inter-channel crosstalk entirely (we never touch the other three sites of the
-  quad — not even to average the two greens, of which only one is used). A Bayer
-  merge is therefore half-sensor resolution (one site per quad = its full
-  resolution). NB: `half_size=True` would be the quick, lower-rigor alternative
-  (it bins the quad, averaging the greens), but it mixes the four sites, so it is
-  deliberately NOT used here.
+  wanted colour's photosites, with NO demosaic and NO libraw colour pipeline, and
+  never mixing in the OTHER colours — so there is zero inter-channel crosstalk.
+  R and B use their single site per quad; green averages its two same-colour sites
+  (not crosstalk — both are green — and it preserves the green SNR). A Bayer merge
+  is half-sensor resolution (one site per quad = its full resolution). NB: libraw
+  `half_size=True` gives a numerically similar result, but it goes through the
+  postprocess pipeline; reading the mosaic directly keeps full control and
+  guarantees no hidden colour operation.
 
 * **Monochrome** — no CFA at all, so there is nothing to demosaic: every
   photosite measured the (single) light's intensity. The whole grayscale frame
@@ -157,25 +157,42 @@ def is_monochrome_sensor(num_colors, color_desc, raw_pattern=None) -> bool:
     return False
 
 
-def extract_cfa_plane(mosaic: np.ndarray, colors: np.ndarray,
-                      target_index: int) -> np.ndarray:
+def extract_cfa_channel(mosaic: np.ndarray, colors: np.ndarray, color_desc,
+                        letter: str, black_levels=None) -> np.ndarray:
     """From a raw Bayer mosaic (2-D sensor read-out) and its per-pixel CFA colour
-    indices, return the half-resolution plane of ONLY the photosites whose colour
-    == target_index — by phase-slicing the 2x2 lattice, NOT by binning/averaging.
+    indices, return the half-resolution plane for ONE colour `letter` (R/G/B) by
+    phase-slicing the 2x2 lattice — NO demosaic, NO colour matrix, and NO mixing
+    with the OTHER colours, so there is zero inter-channel crosstalk.
 
-    This is the crosstalk-free extraction: no quad merge, no green averaging, no
-    demosaic, no colour matrix — just the bare sites of one colour, exactly as the
-    sensor measured them. The colour's phase within the tile is read from the
-    actual `colors` at the visible origin (offset-safe), and the CFA is periodic
-    with period 2, so `mosaic[dy::2, dx::2]` is precisely that colour's sites.
-    Pure (numpy in/out), so it is unit-testable without rawpy."""
+    R and B have a single site per quad → that bare site. Green has two sites per
+    quad (same colour, not crosstalk) → their per-site-black-subtracted AVERAGE,
+    which keeps the green SNR. Each contributing site is matched by its CFA letter
+    via `color_desc` (so it works whether the two greens share one colour index or
+    use indices 1 and 3), located by its phase in the tile read from the actual
+    `colors` at the visible origin (offset-safe; the CFA is period-2 so
+    `mosaic[dy::2, dx::2]` is exactly that phase's sites), and black-subtracted by
+    its own colour index when `black_levels` is given. Pure — unit-testable
+    without rawpy."""
     eff = np.asarray(colors)[:2, :2]
-    pos = np.argwhere(eff == target_index)
-    if pos.size == 0:
-        raise ValueError(f"CFA colour index {target_index} not present in the "
-                         f"2x2 tile {eff.tolist()}")
-    dy, dx = int(pos[0][0]), int(pos[0][1])
-    return np.asarray(mosaic)[dy::2, dx::2]
+    desc = _desc_bytes(color_desc).decode("ascii", "ignore").upper()
+    letter = letter.upper()
+    phases = [(dy, dx, int(eff[dy, dx]))
+              for dy in range(eff.shape[0]) for dx in range(eff.shape[1])
+              if 0 <= int(eff[dy, dx]) < len(desc) and desc[int(eff[dy, dx])] == letter]
+    if not phases:
+        raise ValueError(f"CFA colour {letter!r} not present in the 2x2 tile "
+                         f"{eff.tolist()} (color_desc {desc!r})")
+    m = np.asarray(mosaic)
+    subs = [m[dy::2, dx::2].astype(np.float32) for dy, dx, _ in phases]
+    h = min(s.shape[0] for s in subs)
+    w = min(s.shape[1] for s in subs)
+    acc = np.zeros((h, w), dtype=np.float32)
+    for (dy, dx, idx), s in zip(phases, subs):
+        black = 0.0
+        if black_levels is not None and idx < len(black_levels):
+            black = float(black_levels[idx])
+        acc += s[:h, :w] - black
+    return acc / len(phases)            # 1 site for R/B; average of 2 for green
 
 
 def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
@@ -184,13 +201,13 @@ def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
     0=R/1=G/2=B).
 
     * Bayer (RGGB): read the RAW Bayer mosaic directly (`raw.raw_image_visible`)
-      and take ONLY this frame's colour photosites — one site per 2x2 quad, no
-      averaging, no quad-merge, no demosaic, no libraw colour pipeline — so there
-      is zero inter-channel crosstalk. The black pedestal is subtracted manually
-      (raw_image carries it). Half-sensor resolution (one site per quad) is the
-      Bayer merge's full resolution; `preview` is irrelevant (the read is already
-      cheap). For the green channel only one of the two green sites is used
-      (taking both would average == merge, which we avoid).
+      and take ONLY this frame's colour photosites — no demosaic, no libraw
+      colour pipeline, and never mixing in the OTHER colours, so there is zero
+      inter-channel crosstalk. R/B use their single site per quad; green averages
+      its two same-colour sites (not crosstalk — both are green — and it keeps the
+      green SNR). The black pedestal is subtracted per site manually (raw_image
+      carries it). Half-sensor resolution (one site per quad) is the Bayer merge's
+      full resolution; `preview` is irrelevant (the read is already cheap).
     * Monochrome: no CFA — the whole grayscale frame IS the channel, at FULL
       sensor resolution (nothing to demosaic, no quad to mix). `preview` may
       decode at half size for a fast preview/zoom tile, but the canonical full
@@ -234,20 +251,21 @@ def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
             raise ValueError(
                 f"3-way merge requires a 2x2 Bayer mosaic or a monochrome "
                 f"sensor; {os.path.basename(path)} is non-Bayer (e.g. X-Trans).")
-        r_idx, g_idx, b_idx = bayer_channel_indices(color_desc)  # raises if not RGB
-        target = (r_idx, g_idx, b_idx)[frame_pos]               # CFA colour index
+        bayer_channel_indices(color_desc)        # guard: raises if not R/G/B
+        letter = "RGB"[frame_pos]                 # this frame's colour
 
-        # Read the RAW mosaic and pull only this colour's sites — no merge.
+        # Read the RAW mosaic and pull only this colour's sites (R/B single,
+        # green = average of its two sites) with per-site black subtraction;
+        # combine then scales 65535/white_level, matching read_image's decode.
         mosaic = np.asarray(raw.raw_image_visible)
         colors = np.asarray(raw.raw_colors_visible)
-        plane = extract_cfa_plane(mosaic, colors, target).astype(np.float32)
-        # Subtract this colour's black pedestal (raw_image carries it); combine
-        # then scales by 65535/white_level, matching read_image's negative decode.
         try:
-            black = float(raw.black_level_per_channel[target])
+            black_levels = list(raw.black_level_per_channel)
         except Exception:
-            black = 0.0
-        plane = np.clip(plane - black, 0, None)
+            black_levels = None
+        plane = extract_cfa_channel(mosaic, colors, color_desc, letter,
+                                    black_levels=black_levels)
+        plane = np.clip(plane, 0, None)
         return (np.ascontiguousarray(plane), white_level, False,
                 (plane.shape[0], plane.shape[1]))
 

--- a/src/core/export_estimator.py
+++ b/src/core/export_estimator.py
@@ -29,8 +29,10 @@ def get_original_dims(ccr_img):
         return dims
 
     # Merged (trichrome) images have no single backing file — file_path is one
-    # full-sensor source RAW, ~2x the half-size merged dims. Never probe it;
-    # fall back to the in-memory preview size. See spec/three-way-rgb-merge.md.
+    # source RAW whose dimensions don't match the merged image (a Bayer merge is
+    # half-sensor; a monochrome merge is full-sensor but still derived from 3
+    # files). Never probe it; fall back to the in-memory preview size.
+    # See spec/three-way-rgb-merge.md.
     if getattr(ccr_img, "is_merged", False):
         if ccr_img.resized_raw is not None:
             dims = (ccr_img.resized_raw.shape[0], ccr_img.resized_raw.shape[1])

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -163,7 +163,8 @@ class SettingsDialog(QDialog):
             "blue light. On your NEXT import, every 3 RAWs (sorted by filename) "
             "are merged into one colour image — each frame contributes only its "
             "own channel, with no demosaicing — then converted as a negative. "
-            "RAW (Bayer) only; the selected count must be a multiple of 3. "
+            "RAW only (Bayer or monochrome); the selected count must be a "
+            "multiple of 3. "
             "Applies to the next import only; merged-image edits are not saved "
             "between sessions."))
         lay.addWidget(grp3)

--- a/tests/test_three_way_merge.py
+++ b/tests/test_three_way_merge.py
@@ -135,55 +135,69 @@ def test_bayer_is_not_monochrome():
 
 
 # --------------------------------------------------------------------------- #
-# extract_cfa_plane (crosstalk-free single-channel extraction from the mosaic)
+# extract_cfa_channel (crosstalk-free per-colour extraction from the mosaic)
 # --------------------------------------------------------------------------- #
 def _ramp(n=4):
     # value = row*10 + col, so each site's origin is identifiable
-    return np.array([[i * 10 + j for j in range(n)] for i in range(n)])
+    return np.array([[i * 10 + j for j in range(n)] for i in range(n)], dtype=np.float32)
 
 
-def test_extract_cfa_plane_rggb_each_colour_is_its_own_site():
-    # RGGB tile: index 0=R@(0,0), 1=G@(0,1), 3=G2@(1,0), 2=B@(1,1)
+# RGGB tile: index 0=R@(0,0), 1=G@(0,1), 3=G2@(1,0), 2=B@(1,1); desc 'RGBG'.
+_RGGB_COLORS = np.array([[0, 1, 0, 1],
+                         [3, 2, 3, 2],
+                         [0, 1, 0, 1],
+                         [3, 2, 3, 2]])
+
+
+def test_extract_channel_red_and_blue_are_single_site():
+    m = _ramp(4)
+    r = ccr_merge.extract_cfa_channel(m, _RGGB_COLORS, b"RGBG", "R")
+    b = ccr_merge.extract_cfa_channel(m, _RGGB_COLORS, b"RGBG", "B")
+    assert r.tolist() == [[0, 2], [20, 22]]      # R@(0,0)
+    assert b.tolist() == [[11, 13], [31, 33]]    # B@(1,1)
+
+
+def test_extract_channel_green_averages_the_two_green_sites():
+    m = _ramp(4)
+    g = ccr_merge.extract_cfa_channel(m, _RGGB_COLORS, b"RGBG", "G")
+    # green sites: (0,1)->[[1,3],[21,23]] and (1,0)->[[10,12],[30,32]]; averaged
+    assert np.allclose(g, [[5.5, 7.5], [25.5, 27.5]])
+
+
+def test_extract_channel_green_average_when_both_greens_share_one_index():
+    # Some cameras map both greens to index 1 (color_desc 'RGB', 3 colours).
     colors = np.array([[0, 1, 0, 1],
-                       [3, 2, 3, 2],
+                       [1, 2, 1, 2],
                        [0, 1, 0, 1],
-                       [3, 2, 3, 2]])
-    mosaic = _ramp(4)
-    assert ccr_merge.extract_cfa_plane(mosaic, colors, 0).tolist() == [[0, 2], [20, 22]]   # R
-    assert ccr_merge.extract_cfa_plane(mosaic, colors, 2).tolist() == [[11, 13], [31, 33]]  # B
-    assert ccr_merge.extract_cfa_plane(mosaic, colors, 1).tolist() == [[1, 3], [21, 23]]    # G
+                       [1, 2, 1, 2]])
+    m = _ramp(4)
+    g = ccr_merge.extract_cfa_channel(m, colors, b"RGB", "G")
+    # green index-1 phases (0,1) and (1,0) averaged — same result as RGGB above
+    assert np.allclose(g, [[5.5, 7.5], [25.5, 27.5]])
 
 
-def test_extract_cfa_plane_does_not_merge_the_two_greens():
-    # The two green sub-lattices (index 1 and 3) are DISTINCT — proves we take
-    # one green site, never an average/merge of both.
-    colors = np.array([[0, 1, 0, 1],
-                       [3, 2, 3, 2],
-                       [0, 1, 0, 1],
-                       [3, 2, 3, 2]])
-    mosaic = _ramp(4)
-    g1 = ccr_merge.extract_cfa_plane(mosaic, colors, 1)
-    g2 = ccr_merge.extract_cfa_plane(mosaic, colors, 3)
-    assert g1.tolist() == [[1, 3], [21, 23]]
-    assert g2.tolist() == [[10, 12], [30, 32]]
-    assert g1.tolist() != g2.tolist()
+def test_extract_channel_subtracts_black_per_index():
+    m = _ramp(4)
+    r = ccr_merge.extract_cfa_channel(m, _RGGB_COLORS, b"RGBG", "R",
+                                      black_levels=[100, 200, 300, 200])
+    assert r.tolist() == [[0 - 100, 2 - 100], [20 - 100, 22 - 100]]
 
 
-def test_extract_cfa_plane_follows_actual_phase_not_assumed_origin():
-    # A shifted CFA phase (R no longer at (0,0)): extraction must use the real
-    # per-pixel colours, not a hardcoded origin.
+def test_extract_channel_follows_actual_phase():
+    # Shifted CFA phase: R no longer at (0,0).
     colors = np.array([[1, 0, 1, 0],
                        [2, 3, 2, 3],
                        [1, 0, 1, 0],
                        [2, 3, 2, 3]])
-    mosaic = _ramp(4)
-    assert ccr_merge.extract_cfa_plane(mosaic, colors, 0).tolist() == [[1, 3], [21, 23]]  # R@(0,1)
+    m = _ramp(4)
+    r = ccr_merge.extract_cfa_channel(m, colors, b"RGBG", "R")
+    assert r.tolist() == [[1, 3], [21, 23]]      # R@(0,1)
 
 
-def test_extract_cfa_plane_missing_colour_raises():
-    colors = np.array([[0, 1], [1, 0]])   # no index 2 in the tile
+def test_extract_channel_missing_colour_raises():
+    colors = np.array([[0, 1], [1, 0]])          # only R/G in the tile, no B
     with pytest.raises(ValueError):
-        ccr_merge.extract_cfa_plane(np.zeros((2, 2)), colors, 2)
+        ccr_merge.extract_cfa_channel(np.zeros((2, 2)), colors, b"RGBG", "B")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_three_way_merge.py
+++ b/tests/test_three_way_merge.py
@@ -135,6 +135,58 @@ def test_bayer_is_not_monochrome():
 
 
 # --------------------------------------------------------------------------- #
+# extract_cfa_plane (crosstalk-free single-channel extraction from the mosaic)
+# --------------------------------------------------------------------------- #
+def _ramp(n=4):
+    # value = row*10 + col, so each site's origin is identifiable
+    return np.array([[i * 10 + j for j in range(n)] for i in range(n)])
+
+
+def test_extract_cfa_plane_rggb_each_colour_is_its_own_site():
+    # RGGB tile: index 0=R@(0,0), 1=G@(0,1), 3=G2@(1,0), 2=B@(1,1)
+    colors = np.array([[0, 1, 0, 1],
+                       [3, 2, 3, 2],
+                       [0, 1, 0, 1],
+                       [3, 2, 3, 2]])
+    mosaic = _ramp(4)
+    assert ccr_merge.extract_cfa_plane(mosaic, colors, 0).tolist() == [[0, 2], [20, 22]]   # R
+    assert ccr_merge.extract_cfa_plane(mosaic, colors, 2).tolist() == [[11, 13], [31, 33]]  # B
+    assert ccr_merge.extract_cfa_plane(mosaic, colors, 1).tolist() == [[1, 3], [21, 23]]    # G
+
+
+def test_extract_cfa_plane_does_not_merge_the_two_greens():
+    # The two green sub-lattices (index 1 and 3) are DISTINCT — proves we take
+    # one green site, never an average/merge of both.
+    colors = np.array([[0, 1, 0, 1],
+                       [3, 2, 3, 2],
+                       [0, 1, 0, 1],
+                       [3, 2, 3, 2]])
+    mosaic = _ramp(4)
+    g1 = ccr_merge.extract_cfa_plane(mosaic, colors, 1)
+    g2 = ccr_merge.extract_cfa_plane(mosaic, colors, 3)
+    assert g1.tolist() == [[1, 3], [21, 23]]
+    assert g2.tolist() == [[10, 12], [30, 32]]
+    assert g1.tolist() != g2.tolist()
+
+
+def test_extract_cfa_plane_follows_actual_phase_not_assumed_origin():
+    # A shifted CFA phase (R no longer at (0,0)): extraction must use the real
+    # per-pixel colours, not a hardcoded origin.
+    colors = np.array([[1, 0, 1, 0],
+                       [2, 3, 2, 3],
+                       [1, 0, 1, 0],
+                       [2, 3, 2, 3]])
+    mosaic = _ramp(4)
+    assert ccr_merge.extract_cfa_plane(mosaic, colors, 0).tolist() == [[1, 3], [21, 23]]  # R@(0,1)
+
+
+def test_extract_cfa_plane_missing_colour_raises():
+    colors = np.array([[0, 1], [1, 0]])   # no index 2 in the tile
+    with pytest.raises(ValueError):
+        ccr_merge.extract_cfa_plane(np.zeros((2, 2)), colors, 2)
+
+
+# --------------------------------------------------------------------------- #
 # combine_channels (the pure merge core)
 # --------------------------------------------------------------------------- #
 def _const_plane(h, w, value):

--- a/tests/test_three_way_merge.py
+++ b/tests/test_three_way_merge.py
@@ -110,6 +110,31 @@ def test_bayer_indices_rejects_monochrome_and_non_rgb():
 
 
 # --------------------------------------------------------------------------- #
+# is_monochrome_sensor
+# --------------------------------------------------------------------------- #
+def test_monochrome_detected_by_num_colors():
+    assert ccr_merge.is_monochrome_sensor(1, b"RGBG") is True
+    assert ccr_merge.is_monochrome_sensor(1, b"G") is True
+
+
+def test_monochrome_detected_by_grey_desc():
+    for desc in (b"G", b"GRAY", b"GREY"):
+        assert ccr_merge.is_monochrome_sensor(3, desc) is True, desc
+
+
+def test_monochrome_detected_by_flat_rgbg_pattern():
+    flat = np.zeros((2, 2), dtype=np.int32)            # all one colour index
+    assert ccr_merge.is_monochrome_sensor(3, b"RGBG", flat) is True
+
+
+def test_bayer_is_not_monochrome():
+    normal = np.array([[0, 1], [3, 2]], dtype=np.int32)  # real RGGB pattern
+    assert ccr_merge.is_monochrome_sensor(3, b"RGBG", normal) is False
+    assert ccr_merge.is_monochrome_sensor(3, b"RGBG") is False   # no pattern given
+    assert ccr_merge.is_monochrome_sensor(4, b"RGBE") is False   # 4-colour, not mono
+
+
+# --------------------------------------------------------------------------- #
 # combine_channels (the pure merge core)
 # --------------------------------------------------------------------------- #
 def _const_plane(h, w, value):


### PR DESCRIPTION
Follow-up to #54. Two refinements to the merge decode, both about reading the
sensor more faithfully.

## 1. Crosstalk-free Bayer extraction (read raw mosaic, one site per quad)

The original Bayer path used `half_size=True`, which bins each 2×2 quad to
`R = R-site, G = mean(G1,G2), B = B-site`. That's interpolation-free, but it
**mixes the quad** (averages the two greens) and runs libraw's postprocess
pipeline. To eliminate inter-channel crosstalk we now **read the raw Bayer mosaic
directly and take only the wanted colour's photosites**:

- `extract_cfa_channel(mosaic, colors, color_desc, letter, black_levels)` —
  phase-slices a colour's sites out of `raw.raw_image_visible` using
  `raw.raw_colors_visible` (offset-safe — the phase is read from the actual
  colours at the visible origin). **No demosaic, no libraw colour pipeline, and
  the other colours are never mixed in.**
- **R and B** use their single site per quad. **Green averages its two
  same-colour sites** — that is *not* inter-channel crosstalk (both are green) and
  it preserves green resolution/SNR. Each contributing site is black-subtracted by
  its own colour index; `combine_channels` scales `65535/white_level` as before.
- Monochrome is unchanged (no CFA → no crosstalk to remove).

**Validation on `example_raw/DSC07096.ARW`** against libraw's own
`half_size`+`output_color=raw` read: **R and B are byte-identical** (max abs diff
= 0), and **green matches the two-green average within rounding** (max abs diff
6 / 65535 ≈ 0.01% of pixels). The direct read reaches the same values as
`half_size` without going through libraw's postprocess — full control, no hidden
colour op.

## 2. Monochrome sensor support

A monochrome (no-CFA) sensor is the **ideal** trichrome sensor: under each pure
light every photosite measures that colour, so each frame is a **full-resolution
grayscale that *is* that frame's channel** — nothing to demosaic, no binning.

- `is_monochrome_sensor(...)` — pure detector mirroring `read_image`'s detection.
- `_decode_frame_plane()` branches by sensor type; `merge_raw_channels(preview)`
  runs monochrome decodes at half size for fast previews but always reports the
  **canonical full size** so `original_full_size` stays correct.
- Rejects only **X-Trans / 4-colour** sensors and **mixed-type triplets**
  (mono + Bayer); both surface via `last_merge_error`.

### Resolution
| Sensor | No-demosaic mechanism | Merge resolution |
|---|---|---|
| Bayer (RGGB) | raw mosaic: R/B single site, green = 2-green average; no other colour mixed | half-sensor |
| Monochrome | none needed (no CFA) | full-sensor |

## Tests
- 28 pure unit tests pass: `extract_cfa_channel` (R/B single site / green
  averages its two sites / works when both greens share one index / per-index
  black subtraction / follows actual phase / missing-colour raises),
  `is_monochrome_sensor`, plus the existing validation/sort/group/mapping/combine
  tests.
- Bayer path validated end-to-end against the example ARWs (R/B byte-identical to
  libraw, green = two-green average within rounding; shape/dtype/range unchanged).

**Caveat:** the monochrome rawpy decode can't be CI-tested (no monochrome RAW in
the repo); it mirrors `read_image`'s existing monochrome decode. Worth a manual
check with a real monochrome triplet before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
