### PR TITLE
feat(histogram): self-painting widget with percentile-clipped vertical scale

### DIFF
--- a/spec/density-bwpoint-toggle.md
+++ b/spec/density-bwpoint-toggle.md
@@ -6,9 +6,12 @@ When the user converts a negative by sampling **both** a clear (film-base) point
 and a dense (exposed) point — the *two-point B/W* path — do the inversion in
 **optical-density (log) space** instead of the legacy linear-in-transmittance
 stretch. Expose a **"Density inversion"** checkbox in Settings → Color
-Management → *Negative conversion*. It is **opt-in (default OFF)**: the legacy
-linear stretch remains the out-of-box behaviour, because a faithful log inversion
-renders darker (it needs a brightness/curve lift) and re-expands shadow noise —
+Management → *Negative conversion*. It now **defaults ON** (was opt-in/OFF): with
+the windowed working space, linear two-point keeps almost no highlight headroom
+(~0.15 stops) whereas density keeps ~2 stops, so density is the better default.
+See spec/working-space-headroom.md. Historically it was opt-in because a faithful
+log inversion renders darker (it needs a brightness/curve lift) and re-expands
+shadow noise —
 so density is offered as a deliberate choice, not the default.
 
 ### Why (the science)

--- a/spec/working-space-headroom.md
+++ b/spec/working-space-headroom.md
@@ -1,0 +1,247 @@
+# Spec: Working Space with Headroom (windowed base buffer)
+
+Status: IMPLEMENTING v1 (default-slope + two-point landed; reference deferred)
+Owner: FreeCCR
+Feature branch: `feature/working-space-headroom`
+
+## 0. Implementation status
+
+Landed (gated behind `FREECCR_WORKING_SPACE`, byte-identical when off):
+- Window helpers `encode_window` / `_apply_working_space_recovery` and the
+  `WS_B`/`WS_W` geometry (10-bit window, `FREECCR_WS_BITS` / `FREECCR_WS_LO`).
+- **Default-slope** and **two-point (density + linear)** inversions emit a
+  windowed base; `apply_bwpoint_normalization` replay matches.
+- Gain/Exposure recovery + window clamp shared by the CPU and GPU adjust paths
+  (numpy pre-stage → kernel never sees headroom, so GPU/CPU parity is free).
+- `apply_adjustments` identity fast-path de-windows; per-image `_ws_windowed`
+  flag propagated through convert / slice / slice-reset / duplicate / catalog
+  reload; auto-exposure and the WB neutral picker de-window their samples.
+- Tests: `tests/test_working_space.py` (+ legacy tests pinned to full-range).
+
+Deferred to a follow-up commit on this branch:
+- **Reference-frame** mode still emits a full-range base (its saturation/shadow
+  look is baked into the inversion and clips at `[0,1]`; lifting that look into
+  the look-domain is the prerequisite). It is explicitly flagged non-windowed,
+  so it renders exactly as today.
+- §5.1 float32 export base (currently export uses the uint16 windowed base, i.e.
+  10-bit precision in the window — fine for 8-bit/JPEG, slightly soft for a
+  16-bit TIFF master).
+
+## 1. Summary
+
+Today the negative inversion maps the converted image to the **full** 16-bit
+range and hard-clips everything above display white (and below display black).
+Any highlight denser than the inversion's ceiling is lost permanently before the
+user ever touches a slider (see the highlight-clipping analysis of the
+black-point-only mode).
+
+This feature introduces a **working space with headroom**: the inverted "base"
+buffer reserves a narrow **display window** inside the 16-bit container and keeps
+out-of-window data instead of clipping it. Display and export render only the
+window; the over/under-range data is invisible but **recoverable** by moving the
+Gain / Exposure / White-point sliders, which operate on the un-clipped data
+*before* the window clamp.
+
+Concretely: the visible range is a **10-bit window** (`W − B = 1024` codes)
+placed low in the 16-bit container, giving **~6 stops of highlight headroom**
+above white plus a small shadow margin below black. Cached preview/zoom bases
+stay `uint16` (the existing currency; 10-bit is visually lossless on the 8-bit
+display). The **export base is computed in float32** so 16-bit masters carry no
+quantization from the narrow window.
+
+## 2. Goals / Non-goals
+
+### Goals
+- The inversion stops hard-clipping at display white; over/under-range data is
+  preserved in the base buffer as headroom.
+- The **White Point** slider recovers headroom (wide-range, stops-based across the
+  full ~6 stops); Gain/Exposure fine-tunes on top.
+- Display and export render **only the window**; data outside it is disregarded
+  at the render boundary (clamp to `[0,1]` after recovery).
+- **ON by default** on a normal launch (`FREECCR_WORKING_SPACE=0` forces legacy).
+  A neutral edit (White Point = 0) looks the same as legacy — only 10-bit-quantized
+  in the window; forced-off is bit-for-bit identical.
+- Applies to **all conversion modes** (default-slope, two-point, reference);
+  un-converted positive-mode scans are unaffected (stay full-range).
+- Resolution independent: preview, hi-res zoom, and export agree (the replay
+  path produces the same windowed base).
+- Auto-exposure places the highlight target **into headroom** instead of
+  clipping the top of the image.
+
+### Non-goals
+- No log/density container encoding in v1 (linear window only; logged as a future
+  option for uniform per-stop precision in uint16).
+- No new UI controls beyond an optional histogram/headroom indicator (§7).
+- No change to the look/order of the *look-domain* operators (brightness,
+  contrast, highlights/shadows, saturation, curves, bands).
+- No scene-linear color management rewrite — this is a range/headroom remap only.
+
+## 3. The window model
+
+### 3.1 Encoding
+
+A display value `d` (0.0 = display black, 1.0 = display white, may exceed `[0,1]`)
+maps linearly to a container code:
+
+```
+span = 1 + WS_LO + WS_HI          # display units across the whole container
+B    = round(WS_LO / span * 65535)        # code for d = 0
+W    = round((1 + WS_LO) / span * 65535)  # code for d = 1
+
+encode_window(d) -> u16:  clip(round(B + d * (W - B)), 0, 65535)
+decode_window(code) -> d: (code - B) / (W - B)
+```
+
+`WS_LO` / `WS_HI` are the shadow / highlight headroom in display units. The
+window width `W − B = 65535 / span` fixes the visible precision; the highlight
+headroom in stops is `≈ log2(span − WS_LO) ≈ 16 − window_bits`.
+
+### 3.2 Recommended constants (10-bit window, ~6 stops highlight)
+
+| Symbol | Value | Meaning |
+|---|---|---|
+| `WS_LO` | 0.5 | shadow margin (display units below black) |
+| `window_bits` | 10 | visible precision → `W − B = 1024` |
+| `span` | 64.0 | `65535 / 1024` |
+| `WS_HI` | 62.5 | `span − 1 − WS_LO` |
+| `B` | 512 | code for display-black |
+| `W` | 1536 | code for display-white |
+
+Result: visible range `[512, 1536]` (1024 codes, 10-bit); highlight headroom
+`(1536, 65535]` = display `(1.0, 63.5]` ≈ **+5.99 stops**; shadow margin
+`[0, 512)` = display `[−0.5, 0)`.
+
+The window sits low in the container by design — almost all codes are highlight
+headroom. The linear encoding therefore lavishes precision on recovered
+highlights (codes are uniform per display-unit, so upper stops get many codes):
+recovery is always smooth; only the neutral window is 10-bit, which is lossless
+for the 8-bit display.
+
+### 3.3 Tunables (env, FreeCCR `FREECCR_*` convention)
+
+- `FREECCR_WORKING_SPACE` — unset/`0` = legacy full-range, bit-identical. Set =
+  enable windowed working space.
+- `FREECCR_WS_BITS` — window precision (default 10).
+- `FREECCR_WS_LO` — shadow margin in display units (default 0.5).
+
+`B`/`W` are derived from these once at module load.
+
+## 4. Pipeline: two domains split by one clamp
+
+The adjustment chain (`adjust_image` CPU + the OpenCL kernel) is divided at a new
+window clamp. Input arrives as windowed `uint16` (cached preview/zoom) or float
+`d` (export); either way the kernel works in float `d`.
+
+1. **De-window (entry):** `d = decode_window(code)` (skip if input already float
+   `d`). `d` may be `< 0` or `> 1`.
+2. **Recovery domain — operate on un-clamped `d` (in `_apply_working_space_recovery`):**
+   - **White Point — the wide-range recovery (primary).** Stops-based across the
+     FULL headroom: `d *= 2^(_WS_HEADROOM_STOPS · wp/100)`, so `WP=-100` maps the
+     container ceiling exactly to white (recovers everything), `WP=0` is neutral.
+     This is the control that actually reaches the headroom — a linear `/300` gain
+     (below) only spans ~0.74 of the ~6 stops, which is why an early build appeared
+     to "not recover." Consumed here and zeroed before the look chain (so the
+     look-domain B/W remap doesn't re-apply it).
+   - Gain / Exposure: `d /= (1 − clip(exposure,−200,200)/300)` un-clamped — the
+     existing linear gain (±~0.74 stops), kept for fine tone control on top.
+3. **Window clamp:** `d = clip(d, 0, 1)` — enter the display window. Everything
+   outside is now disregarded.
+4. **Look domain — unchanged math, on `[0,1]`:** temperature/tint, brightness
+   (`pow`), highlights/shadows (`x³(1−x)` bumps), contrast (S-curve), channel
+   R/G/B, saturation, sub-saturation, curves, bands. These are defined on
+   `[0,1]`; keeping them after the clamp means **no change to their math**.
+   (temp/tint moves to after the clamp — its luminance tone-mask assumes `[0,1]`.)
+5. **Output tail — unchanged:** `clip(0,1) · 65535 → uint16` (export) or `· 255 →
+   uint8` (display). Output is full-range, so display (`/257`) and the export
+   writers need **no change**.
+
+### 4.1 Identity fast-path (critical)
+
+`apply_adjustments` currently returns the base as-is when no sliders/bases are
+active (`ccr_image.py:839-842`). The base is now *windowed*, so that path must
+still **de-window → window-clamp → emit full-range** (steps 1, 3, 5). It is a
+single vectorized op; cheap, but mandatory or a neutral image renders dark/shifted.
+
+## 5. Integration points
+
+| Area | File / function | Change |
+|---|---|---|
+| Window helpers | `ccr_processor.py` (new) | `encode_window`, `decode_window`, `B`/`W`/constants from env |
+| Default-slope invert | `_default_slope_invert` (`:1000`) | Return float `d` (overshoot kept); drop `clip(...,1)` |
+| Two-point invert | `_twopoint_invert` (`:1061`) | Same — keep data above the dense point as headroom |
+| Reference normalize | `apply_reference_normalization` (`:1633`), `compute_reference_norm_params` | Same windowed/float output |
+| Preview convert | `ccr_normalize_with_bwpoint` (`:1111`), `ccr_normalize_with_reference` (`:613`) | Cache base via `encode_window` (uint16); **export path keeps float `d`** |
+| Replay (zoom) | `apply_bwpoint_normalization` (`:1660`), `render_hires_base` (`ccr_image.py:935`) | Emit identical windowed base or zoom won't match preview |
+| Adjust (CPU) | `adjust_image` (`:2131`) | De-window entry; move/un-clamp recovery group; insert window clamp; accept uint16-windowed or float `d` |
+| Adjust (GPU) | OpenCL kernel (`:~150-272`) | Mirror CPU exactly (parity required) |
+| Identity path | `apply_adjustments` (`:839`) | De-window+clamp even when no sliders (§4.1) |
+| Auto-exposure | `compute_auto_exposure_gain` (`:1034`) | Operate in `d`-space; thresholds (`WHITE_EXCLUDE_FRACTION`) redefined in `d`; place target into headroom; stale "rolls off" docstrings corrected |
+| Analysis consumers | histogram, Auto-WB picker, any sampler of the converted buffer | De-window before measuring. Raw-scan pickers (B/W point) unaffected |
+| Cache invalidation | conversion + adjustment signatures (`_hires_signature`, `adj_sig`) | Add a working-space version constant so pre-change caches don't render wrong |
+
+### 5.1 Export float path
+
+Export is one-shot and uncached, so the export base is produced as float `d`
+(no `encode_window` quantization). `adjust_image` detects float32 input → uses it
+as `d` directly (de-window is identity). 16-bit TIFF masters thus carry full
+precision regardless of `window_bits`.
+
+## 6. Math notes / correctness
+
+- **Neutral identity:** with the feature off, `encode_window`/`decode_window` and
+  the recovery/clamp restructure are bypassed → byte-identical to today. Guard
+  with a golden-image test.
+- **GPU/CPU parity:** the kernel and numpy path must remain bit-compatible after
+  the restructure; this is the highest-risk regression.
+- **Recovery direction:** `exposure < 0` → denominator `> 1` → `d` shrinks →
+  highlight overshoot drops below 1.0 (recovered). `exposure > 0` lifts content
+  toward/over white (headroom now absorbs it instead of clipping).
+- **Reorder of White/Black-point and temp/tint** changes results for non-neutral
+  edits under the new mode only; documented and gated.
+
+## 7. UX (optional, recommended)
+
+- Histogram of the **windowed** (de-windowed `d`, clamped) data, plus a
+  **headroom indicator** showing how much data sits above white / below black so
+  the user knows recovery is available. Natural surface for the new capability.
+
+## 8. Migration / gating
+
+- `FREECCR_WORKING_SPACE` is **ON by default** on a normal launch; set it to `0`
+  (or `false`/`off`) to force legacy full-range behavior.
+- A working-space version constant participates in conversion/adjustment
+  signatures so caches and catalog-replayed conversions from before the change
+  are invalidated rather than rendered with the wrong decode.
+- Catalog: the persisted base (if any) is keyed by the version; conversion is
+  re-derived from `conversion_inputs` on load, so no on-disk migration needed.
+
+## 9. Test plan
+
+- **Golden identity:** feature off → bit-identical output vs `main` across a
+  fixture set (all three conversion modes).
+- **Round-trip encode:** `decode_window(encode_window(d)) ≈ d` within 1/1024 for
+  `d ∈ [−WS_LO, span−WS_LO]`.
+- **Headroom preserved:** a synthetic negative with highlights above the ceiling
+  → after inversion, codes exist above `W`; before this change they were pinned
+  at 65535.
+- **Recovery:** push `exposure` negative → previously-clipped highlights regain
+  distinct, monotonic detail (no flat 65535 plateau).
+- **GPU == CPU:** kernel vs numpy max abs diff within tolerance on the fixture
+  set, feature on.
+- **Resolution agreement:** preview vs `render_hires_base` vs export produce
+  matching tone at the same crop (windowed base replay + float export agree
+  within quantization).
+- **Auto-exposure:** high-key fixture no longer hard-clips the top 2%; the top
+  lands in headroom.
+- **Identity fast-path:** image with zero sliders renders correctly (not dark/
+  shifted) with the feature on.
+
+## 10. Open questions (resolve in REFINE pass)
+
+- Exact `d`-space thresholds for `compute_auto_exposure_gain`
+  (`WHITE_EXCLUDE_FRACTION`, percentile target) under headroom.
+- Whether per-channel R/G/B gain/blackpoint join the recovery group or stay in
+  the look domain (v1: stay in look domain, clamped).
+- Whether the optional recovery-domain safety clamp `[−WS_LO, span−WS_LO]` is
+  needed or noise is tolerable.
+- Histogram/headroom indicator: ship in v1 or defer.

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -434,6 +434,7 @@ def _replay_conversion(img, ci) -> None:
     elif mode == "ref_params":
         img.resized_raw = apply_reference_normalization(
             img.resized_raw, ci["p_lo"], ci["p_hi"], ci["od"])
+        img._ws_windowed = False   # reference path is full-range, not windowed
     elif mode == "bw":
         saved_fine = img.fine_rotation_angle
         img.fine_rotation_angle = ci.get("fine_rot", 0)

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -404,11 +404,11 @@ class CCRBackend:
             return preview
         return None
 
-    def get_histogram_image_by_index(self, idx: int) -> Optional[CCRImage]:
+    def get_histogram_data_by_index(self, idx: int):
+        """Raw per-channel histogram counts (np.ndarray (3, 256), R/G/B) for the
+        image at ``idx``, or None. HistogramWidget turns these into the plot."""
         if idx is not None and 0 <= idx < len(self.images):
-            image = self.images[idx]
-            histogram_image = image.histogram_image if image.histogram_image is not None else None
-            return histogram_image
+            return self.images[idx].histogram_data
         return None
     
     def set_adjustment_by_index(self, idx: int, adjustment: dict):

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -4,7 +4,7 @@ from core.ccr_image import CCRImage
 from core.ccr_processor import (ccr_normalize_with_reference, ccr_normalize_with_bwpoint,
                                 ccr_normalize_with_refparams, ccr_export_positive,
                                 auto_fine_angle, auto_frame,
-                                auto_frame_v2, log_bwpoint_slopes)
+                                auto_frame_v2, log_bwpoint_slopes, _ws_enabled)
 import os
 import glob
 import concurrent.futures
@@ -50,9 +50,11 @@ class CCRBackend:
         # Two-point B/W conversion mode: True recovers optical density (log
         # space), False uses the legacy linear transmittance stretch. The choice
         # is baked per image into conversion_inputs["density"]; this holds the
-        # default for NEW conversions. Density is OPT-IN (default off). Global,
-        # persisted by MainWindow. See spec/density-bwpoint-toggle.md.
-        self.density_bwpoint: bool = False
+        # default for NEW conversions. Default ON — linear two-point has almost no
+        # highlight headroom (~0.15 stops) in the working space, whereas density
+        # keeps ~2 stops. Global, persisted by MainWindow. See
+        # spec/density-bwpoint-toggle.md and spec/working-space-headroom.md.
+        self.density_bwpoint: bool = True
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area
         # Global input ICC profile (one app-wide setting; applied to every
@@ -1388,6 +1390,9 @@ class CCRBackend:
                 # (zoom/export), not decode the red RAW alone.
                 is_merged=getattr(img, "is_merged", False),
                 merge_sources=getattr(img, "merge_sources", None),
+                # preloaded_img is a copy of the (possibly windowed) base — set
+                # the flag before the ctor's first preview render.
+                ws_windowed=getattr(img, "_ws_windowed", False),
             )
             dup.reference_frame = img.reference_frame
             dup.conversion_inputs = (dict(img.conversion_inputs)
@@ -1578,6 +1583,10 @@ class CCRBackend:
                     # and exported file match the merged preview.
                     is_merged=getattr(img_obj, "is_merged", False),
                     merge_sources=getattr(img_obj, "merge_sources", None),
+                    # The crop above replays the parent's conversion, so the
+                    # child's base is windowed iff the parent's was — set before
+                    # the ctor's first preview render so it de-windows.
+                    ws_windowed=getattr(img_obj, "_ws_windowed", False),
                 )
                 child.conversion_inputs = child_ci
                 # Slices descend from the parent's loaded content — carry its
@@ -1735,6 +1744,7 @@ class CCRBackend:
             parent.resized_raw = apply_reference_normalization(
                 parent.resized_raw, *norm_params)
             parent.converted = True
+            parent._ws_windowed = False   # reference path is full-range
             parent.conversion_inputs = {
                 "mode": "ref_params", "p_lo": norm_params[0],
                 "p_hi": norm_params[1], "od": norm_params[2]}
@@ -1742,6 +1752,7 @@ class CCRBackend:
             parent.resized_raw = apply_bwpoint_normalization(
                 parent.resized_raw, *bw_points, density=bw_density)
             parent.converted = True
+            parent._ws_windowed = _ws_enabled()   # bw base is windowed when enabled
             parent.conversion_inputs = {"mode": "bw", "bw": bw_points,
                                         "fine_rot": 0, "density": bw_density}
         parent.tint_balance_factor = template.tint_balance_factor

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -12,7 +12,7 @@ from PySide6.QtGui import QImage, QPixmap  # or from PySide6.QtGui import QImage
 from core.ccr_processor import (adjust_image, adjust_image_opencl,
                                 BAND_ADJUSTMENT_KEYS, apply_curves,
                                 apply_area_layers, apply_crop_to_image,
-                                apply_dust_removal)
+                                apply_dust_removal, _apply_working_space_recovery)
 from core import color_management
 from ui import theme
 
@@ -55,6 +55,7 @@ class CCRImage:
         areas: Optional[List[Dict[str, Any]]] = None,
         is_merged: bool = False,
         merge_sources: Optional[list] = None,
+        ws_windowed: bool = False,
         ):
         # Normalize file path to handle Unicode characters properly
         self.file_path = os.path.normpath(file_path)
@@ -153,6 +154,12 @@ class CCRImage:
         # Non-destructive auto-exposure (default-slope mode), in ch_input_gain
         # units → applied as a uniform gain. See spec/auto-exposure-default-slope.md.
         self.exposure_base: float = 0.0
+        # True when the current converted base is a WINDOWED working-space buffer
+        # (highlight headroom preserved); apply_adjustments de-windows it. Set by
+        # the conversion that produced the base, or passed in for a preloaded
+        # converted base (slice/duplicate) so the first preview render at the end
+        # of __init__ de-windows correctly. See spec/working-space-headroom.md.
+        self._ws_windowed: bool = ws_windowed
         self.histogram_image = None
         self.original_full_size: Optional[tuple[int, int]] = None  # (height, width) of the full-res source, set by read_image
 
@@ -219,6 +226,7 @@ class CCRImage:
         # decode goes straight to user adjustments (no darkening / shadow crush).
         self.brightness_base = 0 if self._positive_mode_active() else -8
         self.exposure_base = 0.0    # Clear auto-exposure when reverting to original scan
+        self._ws_windowed = False   # raw scan is full-range, not a windowed base
         self.conversion_inputs = None
         img = self.read_image(self.file_path, max_long_side=1080)
         if img is None:
@@ -763,9 +771,16 @@ class CCRImage:
         hist_img_f = np.full((hist_height, hist_width, 3),
                              float(theme.Paint.HIST_BG[0]), dtype=np.float32)
 
-        # Find the global max value across all channels for adaptive scaling
-        max_val = max([hist[c].mean() for c in hist]) * 6
-        scale = max(max_val, 0.1)  # prevent division by zero / too-flat lines
+        # Scale to the tallest CONTENT bin, excluding the hard-clip bins 0 and 255.
+        # The old scale (hist.mean()*6) was a constant (= total_pixels/256 * 6,
+        # independent of the distribution), so any clip spike ≥~2.3% of pixels
+        # saturated the plot at full height while real content was squished to ~40%
+        # — and a saturated clip "line" can't shrink as highlights are recovered,
+        # making recovery look broken. Excluding the extremes lets content fill the
+        # height and reflect recovery; the clip bins still draw (an honest clip
+        # indicator) but shrink once clipping falls below the content peak.
+        content_max = max(float(hist[c][1:255].max()) for c in hist)
+        scale = max(content_max, 0.1)  # prevent division by zero / too-flat lines
 
         rows = np.arange(hist_height, dtype=np.int32)[:, None]  # (150, 1)
         masks = []
@@ -776,6 +791,14 @@ class CCRImage:
                                    theme.Paint.HIST_B)):
             h_scaled = np.clip((hist[channel] / scale) * (hist_height - 1),
                                0, hist_height - 1)
+            # Don't draw the hard-clip bins (0, 255) as bars: a concentrated clip
+            # pile is always the tallest single bin, so a bar histogram would draw
+            # it as a full-height line that can't shrink as highlights are recovered
+            # (the reported "vertical line where it clipped"). Excluding them lets
+            # the in-range content — which DOES visibly redistribute on recovery —
+            # own the plot. Clipping still reads from content piling near the edges.
+            h_scaled[0] = 0.0
+            h_scaled[-1] = 0.0
             col_tops = hist_height - h_scaled.astype(np.int32)  # (256,)
             mask = rows >= col_tops[None, :]                    # (150, 256) bool
             masks.append(mask)
@@ -837,15 +860,20 @@ class CCRImage:
                  else areas_override)
         has_areas = bool(areas) and any(a.get("enabled") for a in areas)
         if not s and cb == 0 and tb == 0 and bb == 0 and eb == 0 and not has_areas:
-            # No slider/base/area adjustments — but Black & White still has to
-            # map the image to a single luminance channel.
+            # No slider/base/area adjustments. A windowed working-space base still
+            # has to be de-windowed + window-clamped to a normal full-range image
+            # before display/export (the base itself is not directly renderable).
+            if self._ws_windowed:
+                image = _apply_working_space_recovery(image, 0.0)
+            # Black & White still has to map the image to a single luminance channel.
             return self._to_grayscale(image) if profile == "bw" else image
         adjusted = adjust_image_opencl(image,
                      s.get('temperature', 0) + tb,
                      s.get('tint', 0),
-                     # Auto-exposure (default-slope mode) rides the TONE-AWARE
-                     # exposure as a non-destructive base (UI slider stays 0):
-                     # highlights roll off instead of hard-clipping, midtones lift.
+                     # Auto-exposure (default-slope mode) rides the Gain/Exposure
+                     # stage as a non-destructive base (UI slider stays 0). With the
+                     # working space ON it is applied un-clamped before the window
+                     # clamp, so the lifted top lands in highlight headroom.
                      s.get('exposure', 0) + eb,
                      # Brightness slider is half-strength per click; the
                      # always-on base offset (bb) keeps full weight so the
@@ -875,7 +903,10 @@ class CCRImage:
                      # CPU fallback); None keeps the inactive case free.
                      band_settings=(s if any(s.get(k, 0)
                                              for k in BAND_ADJUSTMENT_KEYS)
-                                    else None))
+                                    else None),
+                     # Windowed working-space base → de-window + Gain/Exposure
+                     # recovery happens inside the adjustment call.
+                     ws_windowed=self._ws_windowed)
         # Tone curves run after the slider pass, in RGB, before any B&W
         # luminance collapse (Photoshop-like). No-op for identity curves.
         curves = s.get('curves')

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -14,7 +14,6 @@ from core.ccr_processor import (adjust_image, adjust_image_opencl,
                                 apply_area_layers, apply_crop_to_image,
                                 apply_dust_removal, _apply_working_space_recovery)
 from core import color_management
-from ui import theme
 
 # Import optional libraries with fallbacks
 try:
@@ -160,7 +159,7 @@ class CCRImage:
         # converted base (slice/duplicate) so the first preview render at the end
         # of __init__ de-windows correctly. See spec/working-space-headroom.md.
         self._ws_windowed: bool = ws_windowed
-        self.histogram_image = None
+        self.histogram_data = None   # raw per-channel counts (3, 256) R/G/B, or None
         self.original_full_size: Optional[tuple[int, int]] = None  # (height, width) of the full-res source, set by read_image
 
         self.info = self.get_camera_and_lens_for_lensfun(self.file_path)  # Extract camera and lens info for lensfun
@@ -750,67 +749,23 @@ class CCRImage:
         preview_img = self.resize_image_to_max_pixel(display_img, preview_size)
         qimage = self.generate_qimage_from_np_array_8(to_8bit(preview_img))
         self.resized_preview = QPixmap.fromImage(qimage)
-        # Calculate histogram for the 8-bit preview (RGB). When a crop is set,
-        # the histogram is computed over only the kept (cropped) region so it
-        # matches what the canvas shows. Same normalized-rect + angle contract
-        # as the display/export crop path; apply_crop_to_image returns the
-        # input unchanged when crop_rect is None.
-        hist = {}
+        # Compute the per-channel histogram over the 8-bit preview (RGB). When a
+        # crop is set, it's computed over only the kept (cropped) region so it
+        # matches what the canvas shows. Same normalized-rect + angle contract as
+        # the display/export crop path; apply_crop_to_image returns the input
+        # unchanged when crop_rect is None.
+        #
+        # We store only the raw counts here (shape (3, 256), R/G/B order). All
+        # presentation — the percentile-clipped vertical scale, smoothing,
+        # filled curves and clip markers — lives in HistogramWidget, which paints
+        # at the widget's real resolution. See widgets/histogram_widget.py.
         preview_img_8bit = to_8bit(preview_img)
         hist_source = apply_crop_to_image(
             preview_img_8bit, self.crop_rect, getattr(self, "crop_angle", 0.0) or 0.0)
-        for i, color in enumerate(['r', 'g', 'b']):
-            hist[color] = cv2.calcHist([hist_source], [i], None, [256], [0, 256]).flatten()
-
-        # Generate a histogram image (RGB channels overlaid). Fully vectorized:
-        # the previous per-column cv2.addWeighted loop took ~55 ms per call
-        # (every load AND every slider tick); this renders in ~2 ms.
-        hist_height = 150
-        hist_width = 256
-        alpha = 0.33  # transparency for histogram curves
-        hist_img_f = np.full((hist_height, hist_width, 3),
-                             float(theme.Paint.HIST_BG[0]), dtype=np.float32)
-
-        # Scale to the tallest CONTENT bin, excluding the hard-clip bins 0 and 255.
-        # The old scale (hist.mean()*6) was a constant (= total_pixels/256 * 6,
-        # independent of the distribution), so any clip spike ≥~2.3% of pixels
-        # saturated the plot at full height while real content was squished to ~40%
-        # — and a saturated clip "line" can't shrink as highlights are recovered,
-        # making recovery look broken. Excluding the extremes lets content fill the
-        # height and reflect recovery; the clip bins still draw (an honest clip
-        # indicator) but shrink once clipping falls below the content peak.
-        content_max = max(float(hist[c][1:255].max()) for c in hist)
-        scale = max(content_max, 0.1)  # prevent division by zero / too-flat lines
-
-        rows = np.arange(hist_height, dtype=np.int32)[:, None]  # (150, 1)
-        masks = []
-        # RGB order: hist_img is rendered via QImage Format_RGB888, not cv2.imshow,
-        # so colors must be RGB — (255,0,0) draws the R-data curve in red.
-        for channel, color in zip(('r', 'g', 'b'),
-                                  (theme.Paint.HIST_R, theme.Paint.HIST_G,
-                                   theme.Paint.HIST_B)):
-            h_scaled = np.clip((hist[channel] / scale) * (hist_height - 1),
-                               0, hist_height - 1)
-            # Don't draw the hard-clip bins (0, 255) as bars: a concentrated clip
-            # pile is always the tallest single bin, so a bar histogram would draw
-            # it as a full-height line that can't shrink as highlights are recovered
-            # (the reported "vertical line where it clipped"). Excluding them lets
-            # the in-range content — which DOES visibly redistribute on recovery —
-            # own the plot. Clipping still reads from content piling near the edges.
-            h_scaled[0] = 0.0
-            h_scaled[-1] = 0.0
-            col_tops = hist_height - h_scaled.astype(np.int32)  # (256,)
-            mask = rows >= col_tops[None, :]                    # (150, 256) bool
-            masks.append(mask)
-            hist_img_f[mask] = (hist_img_f[mask] * (1.0 - alpha)
-                                + np.array(color, dtype=np.float32) * alpha)
-
-        hist_img = hist_img_f.astype(np.uint8)
-        # Where all three channels overlap, set to white
-        hist_img[masks[0] & masks[1] & masks[2]] = theme.Paint.HIST_PEAK
-        hist_img = np.ascontiguousarray(hist_img)
-
-        self.histogram_image = QPixmap.fromImage(self.generate_qimage_from_np_array_8(hist_img))
+        counts = np.empty((3, 256), dtype=np.float32)
+        for i in range(3):   # 0=R, 1=G, 2=B
+            counts[i] = cv2.calcHist([hist_source], [i], None, [256], [0, 256]).flatten()
+        self.histogram_data = counts
 
     def generate_qimage_from_np_array_8(self, thumb_img_8):
         h, w, ch = thumb_img_8.shape

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -837,6 +837,10 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,water_mark=True,jpg_
     gc.collect()
     # --- End of brightness normalization ---
 
+    # Reference-frame conversion does not (yet) use the windowed working space —
+    # its base is full-range, so clear the flag (handles a bw→ref re-convert).
+    ccr_image._ws_windowed = False
+
     # --- apply user adjustments --- only when outputting
     step_start = time.time()
     if output_path is not None:  # this is for processing
@@ -997,6 +1001,76 @@ DEFAULT_DENSITY_GAMMA = 1.0
 _DENSITY_FLOOR = 1.0
 
 
+# --- Working space with headroom (spec/working-space-headroom.md) ---
+# The inverted "base" buffer reserves a narrow DISPLAY WINDOW inside the 16-bit
+# container and keeps out-of-window data as recoverable headroom instead of
+# hard-clipping at white. Display/export render only the window; the White Point
+# slider recovers headroom (it runs un-clamped, BEFORE the window clamp). ON by
+# default on a normal launch; set FREECCR_WORKING_SPACE=0 to force legacy full-range
+# (byte-identical to before). A neutral conversion looks the same either way (only
+# 10-bit-quantized in the window); the difference is recoverable headroom.
+def _ws_enabled() -> bool:
+    return os.environ.get("FREECCR_WORKING_SPACE", "1").strip().lower() not in (
+        "0", "false", "no", "off", "")
+
+
+# Window geometry: a `_WS_BITS`-wide window (default 10-bit = 1024 codes) placed
+# low in the container, leaving `_WS_LO` display units of shadow margin below
+# black and the remainder (~6 stops at 10-bit) as highlight headroom above white.
+_WS_BITS = int(os.environ.get("FREECCR_WS_BITS", "10"))
+_WS_LO = float(os.environ.get("FREECCR_WS_LO", "0.5"))
+_WS_WIDTH = float(1 << _WS_BITS)                   # window width in codes (1024)
+WS_B = _WS_LO * _WS_WIDTH                           # code for display-black (d=0)
+WS_W = (1.0 + _WS_LO) * _WS_WIDTH                   # code for display-white (d=1)
+_WS_INV_WIDTH = 1.0 / (WS_W - WS_B)                 # == 1/_WS_WIDTH
+# Highlight headroom, in stops, between display-white and the container ceiling
+# (~6 at the 10-bit default). The White Point recovery slider spans exactly this
+# range, so WP=-100 maps the ceiling back to white (recovers ALL headroom).
+_WS_HEADROOM_STOPS = float(np.log2((65535.0 - WS_B) / (WS_W - WS_B)))
+
+
+def encode_window(d: np.ndarray) -> np.ndarray:
+    """Map display values `d` (0=black, 1=white, may overshoot either end) into
+    windowed uint16 container codes, clamped to [0,65535]. Only data beyond the
+    container (≈+6 stops / −0.5 below black at the 10-bit default) is discarded;
+    everything between white and the container top survives as recoverable
+    headroom. `d` may be modified in place."""
+    code = d
+    code *= np.float32(WS_W - WS_B)
+    code += np.float32(WS_B)
+    np.clip(code, 0.0, 65535.0, out=code)
+    return code.astype(np.uint16)
+
+
+def _apply_working_space_recovery(img16: np.ndarray, exposure: float,
+                                  white_point: float = 0.0) -> np.ndarray:
+    """De-window a windowed base, apply the highlight-recovery controls UN-clamped
+    (so headroom can be pulled back below white), then clamp to the display window
+    and return a normal full-range [0,65535] positive for the look chain. This
+    single numpy pre-stage is shared by the CPU and GPU adjustment paths, so
+    GPU/CPU parity is automatic — the kernel never sees headroom.
+
+    Two recovery controls, both neutral at 0 (so a neutral edit is byte-identical):
+      White Point — the WIDE-range recovery, stops-based across the FULL headroom:
+        WP=-100 maps the container ceiling exactly to white (recovers everything),
+        WP=0 neutral, WP>0 pushes highlights up. Perceptual feel: typical blown
+        highlights come back within the first chunk of negative travel.
+      Gain/Exposure — the existing linear `1/(1−v/300)` gain (±~0.74 stops), kept
+        for fine tone control on top of the White Point recovery."""
+    d = img16.astype(np.float32)
+    d -= np.float32(WS_B)
+    d *= np.float32(_WS_INV_WIDTH)
+    if white_point != 0.0:
+        wp = float(np.clip(white_point, -100.0, 100.0))
+        d *= np.float32(2.0 ** (_WS_HEADROOM_STOPS * wp / 100.0))   # un-clamped
+    if exposure != 0.0:
+        white_val = 1.0 - np.clip(exposure, -200.0, 200.0) / 300.0
+        d *= np.float32(1.0 / white_val)        # un-clamped: recovers overshoot
+    np.clip(d, 0.0, 1.0, out=d)                  # window clamp: enter display range
+    d *= np.float32(65535.0)
+    return d.astype(np.uint16)
+
+
 def _default_slope_invert(img_f: np.ndarray, black_point_bgr) -> np.ndarray:
     """Density-space inversion for the black-point-only mode, using the baked
     scalar DEFAULT_DENSITY_SLOPE. `img_f` is a float32 (H,W,3) BGR array.
@@ -1015,6 +1089,11 @@ def _default_slope_invert(img_f: np.ndarray, black_point_bgr) -> np.ndarray:
         np.maximum(ch, 0.0, out=ch)                      # clamp (img brighter than base)
         out[..., c] = ch
     out *= np.float32(DEFAULT_DENSITY_SLOPE)             # single scalar = contrast
+    if _ws_enabled():
+        # Keep highlight overshoot (density above the 1/SLOPE ceiling) as headroom.
+        if DEFAULT_DENSITY_GAMMA != 1.0:
+            np.power(out, np.float32(1.0 / DEFAULT_DENSITY_GAMMA), out=out)
+        return encode_window(out)
     np.clip(out, 0.0, 1.0, out=out)
     if DEFAULT_DENSITY_GAMMA != 1.0:
         np.power(out, np.float32(1.0 / DEFAULT_DENSITY_GAMMA), out=out)
@@ -1031,19 +1110,28 @@ EXPOSURE_BASE_MIN = -100.0          # exposure-base clamp (-2 EV nominal)
 EXPOSURE_BASE_MAX = 100.0           # exposure-base clamp (+2 EV nominal)
 
 
-def compute_auto_exposure_gain(img_bgr: np.ndarray) -> float:
-    """Auto-exposure for default-slope mode: return the EXPOSURE-base value (in
-    exposure-slider units, where 2^(x/50) is the nominal stop multiplier) that
+def compute_auto_exposure_gain(img_bgr: np.ndarray, ws_windowed: bool = False) -> float:
+    """Auto-exposure for default-slope mode: return the EXPOSURE-base value that
     would place the (film-holder-excluded) AUTO_EXPOSURE_PERCENTILE luminance at
     AUTO_EXPOSURE_TARGET of full scale.
 
-    The value is applied through the TONE-AWARE exposure (not a uniform gain), so
-    the boost mainly lifts midtones while highlights roll off near white instead
-    of hard-clipping — i.e. this is the nominal target; the top compresses
-    gracefully toward it. Pure-white pixels (luminance >= WHITE_EXCLUDE_FRACTION·
-    65535) are the film holder / clear surround and are excluded so they don't
-    peg the estimate. Returns 0.0 when there isn't enough non-white content."""
-    img = img_bgr.astype(np.float32, copy=False)
+    The value rides the Gain/Exposure stage (a uniform `1/(1−v/300)` gain). With
+    the working space ON it is applied UN-clamped before the window clamp (see
+    _apply_working_space_recovery), so the lifted top lands in highlight headroom
+    instead of hard-clipping. Pure-white pixels (luminance >= WHITE_EXCLUDE_FRACTION·
+    65535 in display scale) are the film holder / clear surround and are excluded
+    so they don't peg the estimate. Returns 0.0 when there isn't enough non-white
+    content. When `ws_windowed`, `img_bgr` is a windowed base, so it is decoded to
+    the display [0,65535] scale (clamped) first so the percentile target matches
+    the legacy full-range behaviour."""
+    if ws_windowed:
+        img = img_bgr.astype(np.float32)
+        img -= np.float32(WS_B)
+        img *= np.float32(_WS_INV_WIDTH)
+        np.clip(img, 0.0, 1.0, out=img)
+        img *= np.float32(65535.0)
+    else:
+        img = img_bgr.astype(np.float32, copy=False)
     # BGR → luminance.
     lum = 0.114 * img[..., 0] + 0.587 * img[..., 1] + 0.299 * img[..., 2]
     keep = lum < (WHITE_EXCLUDE_FRACTION * 65535.0)
@@ -1078,6 +1166,35 @@ def _twopoint_invert(img_f: np.ndarray, black_point_bgr, white_point_bgr,
       (img − dense)/(base − dense), then a linear 65535−x invert. Bit-identical
       to the prior two-point behaviour. See spec/density-bwpoint-toggle.md.
     """
+    ws = _ws_enabled()
+    if ws:
+        # Working-space path: build the per-channel DISPLAY positive `d` (0=clear,
+        # 1=dense) WITHOUT clipping the top, so density beyond the sampled dense
+        # point survives as headroom, then encode into the window.
+        d = np.empty_like(img_f)
+        for c in range(3):
+            base = max(float(black_point_bgr[c]), 1.0)
+            dense = max(float(white_point_bgr[c]), 1.0)
+            if density:
+                dmax = float(np.log10(base / dense)) if base > dense else 0.0
+                if dmax <= 1e-6:                        # no usable density range
+                    d[..., c] = 0.0
+                    continue
+                ch = np.maximum(img_f[..., c], _DENSITY_FLOOR)
+                np.divide(base, ch, out=ch)
+                np.log10(ch, out=ch)
+                np.divide(ch, dmax, out=ch)             # clear→0, dense→1 (overshoot kept)
+                d[..., c] = ch
+            else:
+                denom = base - dense
+                if abs(denom) < 1.0:
+                    d[..., c] = 1.0                      # degenerate → white (matches legacy)
+                    continue
+                # positive d = 1 − transmittance-stretch (overshoot kept)
+                t = (img_f[..., c] - dense) / denom
+                np.subtract(1.0, t, out=d[..., c])
+        return encode_window(d)
+
     norm = np.empty_like(img_f)
     for c in range(3):
         base = max(float(black_point_bgr[c]), 1.0)     # clear / film base (HIGH)
@@ -1220,12 +1337,22 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
     ccr_image.contrast_base = 0
     ccr_image.temperature_base = 0
 
+    # Working space: the B/W-point inversions emit a WINDOWED base when enabled
+    # (highlight headroom preserved). Flag the image so apply_adjustments de-windows
+    # this base. False when the feature is off → legacy full-range, byte-identical.
+    ws = _ws_enabled()
+    ccr_image._ws_windowed = ws
+    if ws:
+        print(f"[working-space] windowed base: ~{_WS_HEADROOM_STOPS:.1f} stops "
+              f"highlight headroom — recover with White Point (drag negative)")
+
     # Auto-exposure (default-slope mode only): compute once from the preview and
     # store as a non-destructive uniform-gain base; export/zoom reuse it. With a
     # white point the two-point map already sets the cut, so force it to 0.
     if output_path is None:
         ccr_image.exposure_base = (
-            compute_auto_exposure_gain(rgb_result) if white_point_bgr is None else 0.0)
+            compute_auto_exposure_gain(rgb_result, ws_windowed=ws)
+            if white_point_bgr is None else 0.0)
 
     # --- User adjustments (export only) ---
     if output_path is not None:
@@ -1404,6 +1531,7 @@ def ccr_normalize_with_refparams(ccr_image, p_lo, p_hi, od_factors,
         raise ValueError("CCRImage: could not load image data for ref-params conversion")
 
     rgb_result = apply_reference_normalization(img, p_lo, p_hi, od_factors)
+    ccr_image._ws_windowed = False   # reference path is full-range, not windowed
 
     if output_path is None:
         print(f"TOTAL ref-params normalization time: {time.time() - total_start_time:.3f}s")
@@ -2155,6 +2283,7 @@ def adjust_image(
     ch_b_blackpoint: float = 0.0,
     sub_saturation: float = 0.0,
     band_settings: dict = None,
+    ws_windowed: bool = False,
 ) -> np.ndarray:
     """
     Apply temperature, tint, exposure, brightness, blackpoint, whitepoint, highlights, shadows,
@@ -2162,8 +2291,15 @@ def adjust_image(
     All input factors are in range [-100, 100], 0 = no change.
     band_settings optionally carries the per-color-band sliders
     (band_<color>_<param> keys), applied as the final step.
+    ws_windowed: when True, img16 is a windowed working-space base — de-window it,
+    apply the Gain/Exposure recovery un-clamped, clamp to the display window, and
+    consume exposure here (the rest of the chain runs on a normal full-range image).
     Returns a 16-bit image.
     """
+    if ws_windowed:
+        img16 = _apply_working_space_recovery(img16, exposure, whitepoint)
+        exposure = 0.0      # consumed by the recovery pre-stage
+        whitepoint = 0.0    # White Point is the headroom-recovery control here
     img = img16.astype(np.float32)
 
     # Map input factors from [-100, 100] to useful ranges
@@ -2693,12 +2829,24 @@ def adjust_image_opencl(
     ch_b_blackpoint: float = 0.0,
     sub_saturation: float = 0.0,
     band_settings: dict = None,
+    ws_windowed: bool = False,
 ) -> np.ndarray:
     """
     GPU-accelerated (OpenCL) version of adjust_image.
     Uses cached OpenCL context and compiled program for better performance.
     """
     global _opencl_cache
+
+    # Working space: do the de-window + Gain/Exposure recovery + window clamp in
+    # numpy here (cheap on the ≤1080px preview), then run the kernel on the
+    # resulting normal full-range image with exposure consumed. Sharing this
+    # pre-stage with the CPU path makes GPU/CPU parity automatic — the kernel
+    # never sees headroom.
+    if ws_windowed:
+        img16 = _apply_working_space_recovery(img16, exposure, whitepoint)
+        exposure = 0.0
+        whitepoint = 0.0
+        ws_windowed = False
 
     # Spatial band feathering is a CPU post-blur the per-pixel kernel can't
     # do, so run the whole adjustment on the CPU when it is active (keeps the

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -189,10 +189,11 @@ class MainWindow(QMainWindow):
         # Restore the global 3-way RGB merge toggle too (affects the next import).
         ccr_backend.rgb_merge_mode = self._settings.value(
             "import/rgb_merge_mode", False, type=bool)
-        # Restore the two-point B/W Density-inversion default (OFF — opt-in).
+        # Restore the two-point B/W Density-inversion default (ON — density keeps
+        # real highlight headroom in the working space; linear has ~0.15 stops).
         # New two-point conversions bake this; see spec/density-bwpoint-toggle.md.
         ccr_backend.density_bwpoint = self._settings.value(
-            "conversion/density_bwpoint", False, type=bool)
+            "conversion/density_bwpoint", True, type=bool)
         # Reflect the restored mode in the toolbar/slider gating right away
         # (no images yet, but the negative-only actions should already grey out).
         self.image_preview._update_unconvert_action_state()

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -100,12 +100,14 @@ class Paint:
     CURVE_NODE = "#f0f0f0"
     CURVE_NODE_OUTLINE = "#222222"
     CURVE_NODE_DISABLED = "#777777"
-    # Histogram (numpy-rendered) — kept as RGB tuples to match ccr_image.py.
+    # Histogram (widgets/histogram_widget.py paints it with QPainter). RGB
+    # tuples: the model stores raw counts, the widget builds QColors from these.
     HIST_BG = (42, 42, 42)            # == PANEL #2a2a2a (keep container in sync)
+    HIST_GRID = (255, 255, 255, 16)   # quarter-tone gridlines — faint over HIST_BG
     HIST_R = (230, 80, 80)
     HIST_G = (90, 200, 90)
     HIST_B = (100, 140, 235)
-    HIST_PEAK = (235, 235, 235)
+    HIST_PEAK = (235, 235, 235)       # where all channels overlap / clip-all wedge
 
 
 class Overlay:

--- a/src/widgets/histogram_widget.py
+++ b/src/widgets/histogram_widget.py
@@ -1,0 +1,216 @@
+"""FreeCCR histogram widget — antialiased, percentile-scaled RGB histogram.
+
+Replaces the old numpy-rasterised 256x150 pixmap (upscaled with smoothing, so it
+looked blocky) with a self-painting QWidget that draws at the widget's real
+resolution. Three improvements over the previous render:
+
+1. **Algorithm** — the model now stores raw per-channel counts (``histogram_data``,
+   shape ``(3, 256)`` in R, G, B order); all presentation lives here. Counts are
+   lightly smoothed for clean curves, but clip detection reads the raw extremes.
+
+2. **Robust clipped vertical scale** (the chosen "percentile clip") — the height
+   reference is a high percentile (``_PCTL``) of the *populated* in-range bins
+   (the pure-clip bins 0/255 are excluded), floored to a fraction of the tallest
+   bin. The top few percent — a blown-highlight pile or other dominant cluster —
+   then clip flat at the top instead of defining the scale and crushing every
+   other detail to the floor. Using only POPULATED bins keeps the percentile off
+   the empty floor; the floor term keeps a bimodal frame (whose mass is all in
+   two excluded piles) from amplifying a sparse survivor to full height. Known
+   residual: a very high-key frame whose lower tones are an almost perfectly flat
+   plateau under a broad bright region is compressed rather than filling the
+   height (the corner wedges still flag any actual clipping).
+
+3. **Look** — translucent per-channel fills are screen-blended (CompositionMode
+   Plus) so overlaps brighten naturally toward white, each topped by a crisp
+   antialiased stroke, over subtle quarter-tone gridlines. Shadow/highlight
+   clipping lights small colour-coded wedges in the bottom corners.
+
+Fed via :meth:`set_data` (a ``(3, 256)`` array or ``None`` to clear).
+"""
+
+import numpy as np
+from PySide6.QtCore import Qt, QPointF, QRectF
+from PySide6.QtGui import QPainter, QPen, QBrush, QColor, QPainterPath, QPolygonF
+from PySide6.QtWidgets import QWidget
+
+from ui import theme
+
+# Tuning ------------------------------------------------------------------
+_PCTL = 95.0          # height reference = this percentile of the POPULATED in-range
+                      #   bins; the top ~5% (a blown-highlight pile / dominant
+                      #   cluster) then clip flat instead of crushing the rest.
+_MIN_REF_FRAC = 0.05  # floor: reference >= this * the tallest in-range bin, so a
+                      #   near-empty survivor set (e.g. a bimodal frame whose mass
+                      #   is all in two excluded piles) can't amplify a sparse bin.
+_HEADROOM = 1.05      # tallest kept bin reaches ~95% height, not flush to the top
+_SMOOTH = np.array([1, 4, 6, 4, 1], dtype=np.float32)  # gentle binomial blur
+_FILL_ALPHA = 90      # 0-255, per-channel area fill (Plus-blended → overlaps glow)
+_LINE_ALPHA = 235     # crisp top stroke
+_LINE_W = 1.4
+_RADIUS = 10          # rounded background corners (matches panel chrome)
+_PAD = 6.0            # plot inset inside the rounded background
+_CLIP_THRESH = 0.0015   # fraction of pixels at an extreme to register as clipping
+_CLIP_SAT = 0.04        # clip fraction that maps to a fully-opaque corner wedge
+_CLIP_SIZE = 11.0       # corner wedge leg length in px
+
+
+class HistogramWidget(QWidget):
+    """Antialiased RGB histogram with a percentile-clipped vertical scale."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._data = None          # np.ndarray (3, 256) float32, R/G/B, or None
+        self.setMinimumHeight(120)
+        self.setAttribute(Qt.WA_OpaquePaintEvent, False)
+
+    # -- data ------------------------------------------------------------
+    def set_data(self, data):
+        """Set the raw per-channel counts (``(3, 256)`` array) or ``None``."""
+        if data is None:
+            self._data = None
+        else:
+            arr = np.asarray(data, dtype=np.float32)
+            self._data = arr if arr.shape == (3, 256) else None
+        self.update()
+
+    def clear_data(self):
+        self.set_data(None)
+
+    # -- paint -----------------------------------------------------------
+    def paintEvent(self, event):
+        p = QPainter(self)
+        p.setRenderHint(QPainter.Antialiasing, True)
+
+        # Rounded background; clip everything to it so fills/curves and the
+        # corner clip wedges stay inside the rounded chrome.
+        bg_rect = QRectF(self.rect()).adjusted(0.5, 0.5, -0.5, -0.5)
+        bg_path = QPainterPath()
+        bg_path.addRoundedRect(bg_rect, _RADIUS, _RADIUS)
+        p.fillPath(bg_path, QColor(*theme.Paint.HIST_BG))
+        p.setClipPath(bg_path)
+
+        plot = bg_rect.adjusted(_PAD, _PAD, -_PAD, -_PAD)
+        self._draw_grid(p, plot)
+
+        if self._data is not None and float(self._data.sum()) > 0.0:
+            self._draw_channels(p, plot)
+            self._draw_clip_markers(p, plot)
+
+        # Subtle defining border on top of everything.
+        p.setClipping(False)
+        p.setPen(QPen(QColor(theme.BORDER), 1))
+        p.setBrush(Qt.NoBrush)
+        p.drawPath(bg_path)
+        p.end()
+
+    # -- pieces ----------------------------------------------------------
+    def _draw_grid(self, p, plot):
+        grid = QColor(*theme.Paint.HIST_GRID)
+        p.setPen(QPen(grid, 1))
+        for k in range(1, 4):
+            gx = plot.left() + plot.width() * k / 4.0
+            gy = plot.top() + plot.height() * k / 4.0
+            p.drawLine(QPointF(gx, plot.top()), QPointF(gx, plot.bottom()))
+            p.drawLine(QPointF(plot.left(), gy), QPointF(plot.right(), gy))
+
+    def _scaled_heights(self):
+        """Return smoothed counts normalised to [0, 1] by a robust reference."""
+        data = self._data
+        k = _SMOOTH / _SMOOTH.sum()
+        # Drop the pure-clip bins (0, 255) BEFORE smoothing so a clipped pile
+        # neither draws a full-height spike at the plot edge nor bleeds into its
+        # neighbours; clipping is signalled separately by the corner wedges.
+        src = data.copy()
+        src[:, 0] = 0.0
+        src[:, 255] = 0.0
+        # Smooth (edge-padded so the blur doesn't pull edge bins toward zero) for
+        # clean curves.
+        sm = np.empty_like(data)
+        for c in range(3):
+            sm[c] = np.convolve(np.pad(src[c], 2, mode="edge"), k, mode="valid")
+        # Height reference: the _PCTL-th percentile of the POPULATED in-range bins
+        # (pure-clip bins 0/255 excluded). The top (100-_PCTL)% — a blown pile or
+        # other dominant cluster — clips flat at the top instead of defining the
+        # scale and crushing the rest. The floor keeps a bimodal frame (mass all
+        # in two excluded piles) from amplifying a sparse survivor to full height.
+        inrange = data[:, 1:255]
+        nz = inrange[inrange > 0]
+        ref = float(np.percentile(nz, _PCTL)) if nz.size else 1.0
+        ref = max(ref, _MIN_REF_FRAC * float(inrange.max()))
+        ref = max(ref * _HEADROOM, 1.0)
+        return np.clip(sm / ref, 0.0, 1.0)
+
+    def _draw_channels(self, p, plot):
+        heights = self._scaled_heights()
+        n = 256
+        xs = plot.left() + np.arange(n) * (plot.width() / (n - 1))
+        bottom = plot.bottom()
+        h = plot.height()
+
+        colors = (theme.Paint.HIST_R, theme.Paint.HIST_G, theme.Paint.HIST_B)
+        tops = []  # cache top polylines for the stroke pass
+
+        # Fill pass — additive so overlapping channels brighten toward white.
+        p.setPen(Qt.NoPen)
+        p.setCompositionMode(QPainter.CompositionMode_Plus)
+        for c in range(3):
+            ys = bottom - heights[c] * h
+            poly = [QPointF(float(xs[i]), float(ys[i])) for i in range(n)]
+            tops.append(poly)
+            area = QPolygonF([QPointF(plot.left(), bottom)] + poly
+                             + [QPointF(plot.right(), bottom)])
+            col = QColor(*colors[c]); col.setAlpha(_FILL_ALPHA)
+            p.setBrush(QBrush(col))
+            p.drawPolygon(area)
+
+        # Stroke pass — crisp coloured top edge over the glow.
+        p.setCompositionMode(QPainter.CompositionMode_SourceOver)
+        p.setBrush(Qt.NoBrush)
+        for c in range(3):
+            path = QPainterPath()
+            path.moveTo(tops[c][0])
+            for pt in tops[c][1:]:
+                path.lineTo(pt)
+            col = QColor(*colors[c]); col.setAlpha(_LINE_ALPHA)
+            p.setPen(QPen(col, _LINE_W))
+            p.drawPath(path)
+
+    def _draw_clip_markers(self, p, plot):
+        data = self._data
+        total = float(data[0].sum())
+        if total <= 0:
+            return
+        shadow = data[:, 0] / total      # per-channel fraction at pure black
+        highlight = data[:, 255] / total  # ... at pure white
+        self._corner_wedge(p, plot, shadow, left=True)
+        self._corner_wedge(p, plot, highlight, left=False)
+
+    def _corner_wedge(self, p, plot, frac, left):
+        on = frac > _CLIP_THRESH
+        if not on.any():
+            return
+        # Colour encodes which channels clip; all three → white.
+        if bool(on.all()):
+            col = QColor(*theme.Paint.HIST_PEAK)
+        else:
+            base = (theme.Paint.HIST_R, theme.Paint.HIST_G, theme.Paint.HIST_B)
+            rgb = [0, 0, 0]
+            for c in range(3):
+                if on[c]:
+                    for j in range(3):
+                        rgb[j] = min(255, rgb[j] + base[c][j])
+            col = QColor(*rgb)
+        amt = float(frac[on].max())
+        col.setAlpha(int(np.clip(amt / _CLIP_SAT, 0.45, 1.0) * 235))
+
+        s = _CLIP_SIZE
+        b = plot.bottom()
+        if left:
+            x = plot.left()
+            tri = QPolygonF([QPointF(x, b), QPointF(x + s, b), QPointF(x, b - s)])
+        else:
+            x = plot.right()
+            tri = QPolygonF([QPointF(x, b), QPointF(x - s, b), QPointF(x, b - s)])
+        p.setPen(Qt.NoPen)
+        p.setBrush(QBrush(col))
+        p.drawPolygon(tri)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1126,7 +1126,7 @@ class ImagePreview(QWidget):
             # Apply transformations which will handle fitting consistently
             # (it also redraws the crop/area overlay after the scene.clear()).
             self.apply_transformations()
-            histogram = ccr_backend.get_histogram_image_by_index(idx)
+            histogram = ccr_backend.get_histogram_data_by_index(idx)
             self.parent().parent().sliders_panel.set_histogram(histogram)
 
             # A confirmed crop magnifies the kept region even at the fitted

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -315,6 +315,12 @@ class GraphicsImageView(QGraphicsView):
         crop = data[max(0, y - rad):min(h, y + rad + 1),
                     max(0, x - rad):min(w, x + rad + 1), :]
         means = np.mean(crop.reshape(-1, 3), axis=0)
+        # A windowed working-space base is in container codes, not display values;
+        # de-window (+ window-clamp) the sample so the neutral pick matches the
+        # displayed positive (a no-op when the feature is off / base is full-range).
+        if getattr(img_obj, '_ws_windowed', False):
+            from core.ccr_processor import WS_B, WS_W
+            means = np.clip((means - WS_B) / (WS_W - WS_B), 0.0, 1.0) * 65535.0
 
         from core.ccr_processor import compute_neutral_temp_tint
         temp, tint = compute_neutral_temp_tint(

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -3,11 +3,12 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QSlider, QLabel, QHBoxLayou
                                 QPushButton, QDialog, QMessageBox, QScrollArea,
                                 QCheckBox, QComboBox)
 from PySide6.QtCore import Qt, QTimer, QThread, Signal, QRectF
-from PySide6.QtGui import (QPixmap, QKeySequence, QShortcut, QPainter, QColor,
+from PySide6.QtGui import (QKeySequence, QShortcut, QPainter, QColor,
                            QLinearGradient, QPen)
 from core.ccr_backend import ccr_backend
 from core.ccr_processor import COLOR_BANDS, BAND_PARAMS, BAND_ADJUSTMENT_KEYS
 from widgets.curve_editor import CurveEditor
+from widgets.histogram_widget import HistogramWidget
 from ui import theme
 import copy
 
@@ -311,19 +312,15 @@ class SlidersPanel(QWidget):
         layout.setSpacing(theme.GAP_ROW)
 
         # --- Histogram — fixed at top, outside scroll area ---
-        self.histogram_label = QLabel()
-        self.histogram_label.setFixedHeight(150)
-        self.histogram_label.setAlignment(Qt.AlignCenter)
-        self.histogram_label.setFrameShape(QFrame.NoFrame)
-        self.histogram_label.setText("")
-        self.histogram_label.setStyleSheet(
-            f"background-color: rgb({theme.Paint.HIST_BG[0]},{theme.Paint.HIST_BG[1]},{theme.Paint.HIST_BG[2]}); border: none; border-radius: 12px;"
-        )
+        # Self-painting widget (paints its own rounded background + curves at the
+        # widget's real resolution). See widgets/histogram_widget.py.
+        self.histogram = HistogramWidget()
+        self.histogram.setFixedHeight(150)
         # Inset to match the content below so it isn't flush against the panel's
         # right border (the scroll area below keeps its scrollbar at the edge).
         hist_row = QHBoxLayout()
         hist_row.setContentsMargins(theme.GAP_PANEL, theme.GAP_PANEL, theme.GAP_PANEL, 0)
-        hist_row.addWidget(self.histogram_label)
+        hist_row.addWidget(self.histogram)
         layout.addLayout(hist_row)
 
         # --- Scrollable middle section ---
@@ -672,21 +669,10 @@ class SlidersPanel(QWidget):
         self.paste_shortcut = QShortcut(QKeySequence.Paste, self)
         self.paste_shortcut.activated.connect(self.paste_adjustment_settings)
 
-    def set_histogram(self, pixmap: QPixmap):
-        """
-        Set the histogram image in the container.
-        """
-        if pixmap is not None:
-            self.histogram_label.setPixmap(pixmap.scaled(
-                self.histogram_label.width(),
-                self.histogram_label.height(),
-                Qt.KeepAspectRatio,
-                Qt.SmoothTransformation
-            ))
-            self.histogram_label.setText("")  # Remove placeholder text
-        else:
-            self.histogram_label.clear()
-            self.histogram_label.setText("")
+    def set_histogram(self, data):
+        """Feed the histogram widget raw per-channel counts ((3, 256) array) or
+        None to clear. The widget handles all scaling/painting."""
+        self.histogram.set_data(data)
 
     def create_slider(self, label_text, min_value=-100, max_value=100,
                       default_value=0, gradient=None):

--- a/tests/test_default_slope.py
+++ b/tests/test_default_slope.py
@@ -33,6 +33,14 @@ BASE_BGR = (11385.0, 14569.0, 7022.0)    # clear film base (high scan values)
 WHITE_BGR = (760.0, 420.0, 117.0)        # dense area (low scan values)
 
 
+@pytest.fixture(autouse=True)
+def _force_legacy_full_range(monkeypatch):
+    """These tests pin the LEGACY full-range inversion (base→0, dense→65535). The
+    windowed working space is ON by default now, so explicitly force it OFF here;
+    its behaviour is covered in test_working_space.py."""
+    monkeypatch.setenv("FREECCR_WORKING_SPACE", "0")
+
+
 def _img(pixels_bgr, dtype=np.uint16):
     """Build a (1, N, 3) image from a list of (B,G,R) tuples."""
     return np.array([pixels_bgr], dtype=dtype)

--- a/tests/test_density_bwpoint.py
+++ b/tests/test_density_bwpoint.py
@@ -30,6 +30,14 @@ BLACK = (4000.0, 4000.0, 4000.0)     # clear -> output black
 WHITE = (400.0, 400.0, 400.0)        # dense -> output white  (10x density range)
 
 
+@pytest.fixture(autouse=True)
+def _force_legacy_full_range(monkeypatch):
+    """These tests pin the LEGACY full-range inversion (clear→0, dense→65535). The
+    windowed working space is ON by default now, so explicitly force it OFF here;
+    its behaviour is covered in test_working_space.py."""
+    monkeypatch.setenv("FREECCR_WORKING_SPACE", "0")
+
+
 def _plane(value, h=4, w=4):
     return np.full((h, w, 3), value, dtype=np.float32)
 

--- a/tests/test_histogram_crop.py
+++ b/tests/test_histogram_crop.py
@@ -21,7 +21,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 import cv2  # noqa: E402
 from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout  # noqa: E402
-from PySide6.QtGui import QImage  # noqa: E402
 
 _app = QApplication.instance() or QApplication(sys.argv[:1])
 
@@ -49,8 +48,10 @@ def _half_image(h=40, w=60):
 
 
 def _hist_bytes(img):
-    qimg = img.histogram_image.toImage().convertToFormat(QImage.Format_RGB888)
-    return bytes(qimg.constBits())
+    # The histogram is now stored as raw per-channel counts ((3, 256) array);
+    # comparing those bytes tests the crop-aware computation directly (the
+    # presentation lives in HistogramWidget and is exercised separately).
+    return img.histogram_data.tobytes()
 
 
 class TestHistogramReflectsCrop:

--- a/tests/test_histogram_widget.py
+++ b/tests/test_histogram_widget.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Tests for widgets/histogram_widget.HistogramWidget.
+
+The widget owns all histogram presentation: the robust clipped vertical scale
+(the fix for "overexposed crushes everything"), smoothing, and the actual
+QPainter render. These exercise the scaling math directly and smoke-test the
+paint path headless via QWidget.grab().
+"""
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from widgets.histogram_widget import HistogramWidget  # noqa: E402
+
+
+def _widget(data=None):
+    w = HistogramWidget()
+    w.resize(320, 150)
+    if data is not None:
+        w.set_data(data)
+    return w
+
+
+def _gaussian(center, height, sigma=25.0):
+    x = np.arange(256, dtype=np.float32)
+    return height * np.exp(-((x - center) / sigma) ** 2)
+
+
+# --- set_data validation --------------------------------------------------
+
+def test_set_data_accepts_3x256():
+    w = _widget(np.ones((3, 256), dtype=np.float32))
+    assert w._data is not None and w._data.shape == (3, 256)
+
+
+def test_set_data_rejects_bad_shape():
+    w = _widget(np.ones((3, 255), dtype=np.float32))
+    assert w._data is None        # wrong shape → stored as None, paints empty
+
+
+def test_set_data_none_clears():
+    w = _widget(np.ones((3, 256), dtype=np.float32))
+    w.set_data(None)
+    assert w._data is None
+
+
+def _broad(weight, center, sigma):
+    """A broad tonal lobe normalised to hold `weight` fraction of N pixels."""
+    a = _gaussian(center, 1.0, sigma)
+    return a / a.sum() * weight
+
+
+# --- the scale fix: a dominant pile must NOT crush the rest ---------------
+
+def test_blown_pile_clips_but_content_is_not_crushed():
+    """The canonical complaint: a blown-highlight pile near white clips flat at
+    the top while the rest of the (broad) tonal content still fills the height —
+    not crushed to the floor as it was before."""
+    N = 800_000
+    scene = _broad(0.7, 110, 45) * N          # broad scene across the range
+    scene[250:256] += 0.30 * N / 6            # blown pile near white (6 bins)
+    h = _widget(np.tile(scene, (3, 1)))._scaled_heights()
+    assert h[:, 250:256].max() >= 0.999       # the pile clips flat at the top
+    assert h[0, 60:230].max() > 0.8           # scene fills the height (not crushed)
+
+
+def test_normal_distribution_reaches_near_top():
+    """With no dominant pile, the tallest bin reaches near full height (familiar
+    histogram) — the scale isn't needlessly compressing a clean image."""
+    data = np.tile(_gaussian(128, 5000.0), (3, 1)).astype(np.float32)
+    h = _widget(data)._scaled_heights()
+    assert 0.9 <= h.max() <= 1.0
+
+
+def test_spread_bright_region_does_not_crush_subject():
+    """A bright region spread over many tonal bins (a gradient sky / window) must
+    not crush a structured subject to the floor — the per-bin mass threshold of
+    the first cut failed this; the percentile reference keeps the subject visible
+    and clips the bright cluster."""
+    N = 800_000
+    subject = _broad(0.64, 120, 45) * N       # structured subject, midtones
+    subject[235:255] += 0.36 * N / 20         # bright region spread over 20 bins
+    h = _widget(np.tile(subject, (3, 1)))._scaled_heights()
+    assert h[0, 235:255].max() > 0.9          # bright cluster sits at the top
+    assert h[0, 60:200].max() > 0.35          # subject clearly visible, not floored
+
+
+def test_bimodal_transition_not_overamplified():
+    """Two dominant piles with a sparse transition between them: the piles clip,
+    but the near-empty transition must NOT be amplified to full height (the floor
+    term bounds it). Regression for the bimodal over-amplification finding."""
+    N = 800_000
+    a = np.zeros(256, dtype=np.float32)
+    a[18:23] += 0.45 * N / 5                  # dark pile
+    a[233:238] += 0.45 * N / 5                # bright pile
+    a[60:200] += 0.10 * N / 140               # sparse transition (0.07%/bin)
+    h = _widget(np.tile(a, (3, 1)))._scaled_heights()
+    assert h[0, 18:23].max() > 0.9 and h[0, 233:238].max() > 0.9   # piles at the top
+    assert h[0, 60:200].max() < 0.3           # transition stays subordinate
+
+
+def test_clip_pile_draws_no_full_height_edge_spike():
+    """A pile at the pure-clip bins (0/255) must not draw a full-height column at
+    the plot edge, nor bleed into its neighbours via smoothing — the bins are
+    zeroed before the blur, and clipping is shown by the corner wedges instead.
+    Regression for the reintroduced 'vertical line where it clipped'."""
+    bins = _gaussian(128, 4000.0)
+    bins[255] = 300_000.0                      # huge highlight-clip pile
+    bins[0] = 200_000.0                        # huge shadow-clip pile
+    h = _widget(np.tile(bins, (3, 1)))._scaled_heights()
+    assert h[0, 255] < 0.05 and h[0, 0] < 0.05         # no edge spike
+    assert h[0, 253] < 0.1 and h[0, 2] < 0.1           # no bleed into neighbours
+    assert h[0, 120:136].max() > 0.8                   # real content unaffected
+
+
+# --- paint smoke tests (headless) ----------------------------------------
+
+def test_paint_with_data_does_not_crash():
+    data = np.tile(_gaussian(128, 5000.0), (3, 1)).astype(np.float32)
+    pm = _widget(data).grab()
+    assert not pm.isNull()
+
+
+def test_paint_with_clipping_does_not_crash():
+    bins = _gaussian(128, 3000.0)
+    bins[0] = 80000.0       # shadow clip → bottom-left wedge
+    bins[255] = 80000.0     # highlight clip → bottom-right wedge
+    data = np.tile(bins, (3, 1)).astype(np.float32)
+    pm = _widget(data).grab()
+    assert not pm.isNull()
+
+
+def test_paint_empty_does_not_crash():
+    pm = _widget(None).grab()       # no data → background + grid only
+    assert not pm.isNull()
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_working_space.py
+++ b/tests/test_working_space.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Tests for the windowed working space with headroom
+(spec/working-space-headroom.md).
+
+When FREECCR_WORKING_SPACE is set, the negative inversion no longer hard-clips at
+display white: the converted "base" buffer reserves a narrow display WINDOW inside
+the 16-bit container (10-bit by default, codes [WS_B, WS_W]) and keeps over-range
+data as recoverable headroom. apply_adjustments de-windows the base, applies the
+Gain/Exposure recovery un-clamped (so blown highlights can be pulled back below
+white), then clamps to the window and emits a normal full-range positive.
+
+These exercise the pure-numpy core (no Qt), so they run headless. The feature is
+read from the env at call time via _ws_enabled(), so monkeypatch toggles it.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.ccr_processor import (  # noqa: E402
+    apply_bwpoint_normalization,
+    adjust_image,
+    encode_window,
+    _apply_working_space_recovery,
+    _ws_enabled,
+    WS_B, WS_W,
+    DEFAULT_DENSITY_SLOPE,
+)
+
+BASE_BGR = (10000.0, 10000.0, 10000.0)   # neutral clear base for clean density math
+
+
+def _img(pixels_bgr, dtype=np.uint16):
+    return np.array([pixels_bgr], dtype=dtype)
+
+
+@pytest.fixture
+def ws_on(monkeypatch):
+    monkeypatch.setenv("FREECCR_WORKING_SPACE", "1")
+    assert _ws_enabled()
+
+
+# --- window geometry / encode-decode -------------------------------------
+
+def test_window_constants_are_10bit_default():
+    # default 10-bit window, WS_LO=0.5 → B=512, W=1536, width=1024
+    assert WS_B == 512.0
+    assert WS_W == 1536.0
+    assert WS_W - WS_B == 1024.0
+
+
+def test_encode_decode_roundtrip():
+    d = np.linspace(-0.5, 63.0, 4096, dtype=np.float32)
+    code = encode_window(d.copy())
+    assert code.dtype == np.uint16
+    decoded = (code.astype(np.float32) - WS_B) / (WS_W - WS_B)
+    # within one window code (1/1024 in display units), ignoring container clamp
+    inside = (d >= -0.5) & (d <= 63.0)
+    assert np.max(np.abs(decoded[inside] - d[inside])) < (1.5 / 1024.0)
+
+
+def test_encode_anchors():
+    code = encode_window(np.array([0.0, 1.0], dtype=np.float32))
+    assert int(code[0]) == int(WS_B)     # display-black → B
+    assert int(code[1]) == int(WS_W)     # display-white → W
+
+
+# --- the toggle leaves legacy behaviour intact ---------------------------
+
+def test_off_base_maps_to_zero(monkeypatch):
+    """Feature OFF (FREECCR_WORKING_SPACE=0): a film-base pixel still inverts to
+    code 0 (legacy)."""
+    monkeypatch.setenv("FREECCR_WORKING_SPACE", "0")
+    assert not _ws_enabled()
+    out = apply_bwpoint_normalization(_img([tuple(map(round, BASE_BGR))]), BASE_BGR, None)
+    assert int(out[0, 0, 0]) < 3
+
+
+def test_on_base_maps_to_window_black(ws_on):
+    """Feature ON: a film-base pixel maps to WS_B, not 0 (windowed black)."""
+    out = apply_bwpoint_normalization(_img([tuple(map(round, BASE_BGR))]), BASE_BGR, None)
+    assert abs(int(out[0, 0, 0]) - int(WS_B)) <= 2
+
+
+# --- headroom is preserved instead of clipping ---------------------------
+
+def test_headroom_preserved_default_slope(ws_on):
+    """Highlights denser than the 1/slope ceiling clip to 65535 in legacy; with
+    the window they survive as distinct codes above WS_W (recoverable)."""
+    densities = (2.0, 3.0, 4.0)          # all above the 1/slope (=1.25) ceiling
+    px = [(BASE_BGR[0] / (10.0 ** d),) * 3 for d in densities]
+    out = apply_bwpoint_normalization(_img(px), BASE_BGR, None)[0, :, 0].astype(int)
+    assert all(c > WS_W for c in out)            # in headroom, not clipped to white
+    assert out[0] < out[1] < out[2]              # denser → higher code (distinct)
+    assert out[2] < 65535 or out[2] == 65535     # bounded by the container
+
+
+def test_headroom_preserved_twopoint_density(ws_on):
+    """Two-point density mode: a pixel denser than the sampled dense point exceeds
+    d=1 and is kept as headroom above WS_W rather than clipped."""
+    base = (10000.0,) * 3
+    dense = (1000.0,) * 3                 # dense point: d=1 at log10(10) = 1.0
+    denser = (100.0,) * 3                 # twice the density → d≈2 (headroom)
+    out = apply_bwpoint_normalization(_img([dense, denser]), base, dense,
+                                      density=True)[0].astype(int)
+    assert abs(out[0, 0] - int(WS_W)) <= 3       # dense point → display white (W)
+    assert out[1, 0] > WS_W                       # denser → headroom
+
+
+# --- recovery via the exposure/gain slider -------------------------------
+
+def test_de_window_no_recovery_clips_like_legacy(ws_on):
+    """De-window + window-clamp with no recovery reproduces the legacy clamped
+    positive (within 10-bit window quantization)."""
+    densities = (0.2, 0.6, 1.0)          # below / at the ceiling
+    px = [(BASE_BGR[0] / (10.0 ** d),) * 3 for d in densities]
+    win = apply_bwpoint_normalization(_img(px), BASE_BGR, None)
+    rendered = _apply_working_space_recovery(win, 0.0)[0, :, 0].astype(int)
+    legacy = [int(np.clip(DEFAULT_DENSITY_SLOPE * d, 0, 1) * 65535) for d in densities]
+    for r, l in zip(rendered, legacy):
+        assert abs(r - l) <= 80          # ~1 window code = 64 levels
+
+
+def test_recovery_pulls_back_blown_highlights(ws_on):
+    """Highlights that clip to white at zero gain become distinct, monotonic,
+    sub-white values once a darkening (negative) gain is applied."""
+    densities = (1.30, 1.40, 1.50)       # slope*d ∈ (1.0, 1.25): just over white
+    px = [(BASE_BGR[0] / (10.0 ** d),) * 3 for d in densities]
+    win = apply_bwpoint_normalization(_img(px), BASE_BGR, None)
+
+    flat = _apply_working_space_recovery(win, 0.0)[0, :, 0].astype(int)
+    assert np.all(flat == 65535)         # all blown to white at zero gain
+
+    rec = _apply_working_space_recovery(win, -200.0)[0, :, 0].astype(int)
+    assert rec.max() < 65535             # recovered below the clip
+    assert rec[0] < rec[1] < rec[2]      # distinct detail restored, monotonic
+
+
+# --- adjust_image honours the windowed base ------------------------------
+
+def test_adjust_image_dewindows_identity(ws_on):
+    """adjust_image with no sliders + ws_windowed == the de-window pre-stage."""
+    px = [(BASE_BGR[0] / (10.0 ** 0.5),) * 3]
+    win = apply_bwpoint_normalization(_img(px), BASE_BGR, None)
+    out = adjust_image(win, ws_windowed=True)
+    exp = _apply_working_space_recovery(win, 0.0)
+    np.testing.assert_array_equal(out, exp)
+
+
+def test_adjust_image_exposure_consumed_once(ws_on):
+    """The recovery exposure is consumed by the pre-stage: passing it via
+    adjust_image(ws_windowed=True) matches the recovery helper directly."""
+    densities = (1.30, 1.40, 1.50)
+    px = [(BASE_BGR[0] / (10.0 ** d),) * 3 for d in densities]
+    win = apply_bwpoint_normalization(_img(px), BASE_BGR, None)
+    out = adjust_image(win, exposure=-200.0, ws_windowed=True)[0, :, 0].astype(int)
+    exp = _apply_working_space_recovery(win, -200.0)[0, :, 0].astype(int)
+    np.testing.assert_array_equal(out, exp)
+
+
+# --- White Point: wide-range recovery across the FULL headroom ------------
+
+def test_white_point_recovers_full_headroom(ws_on):
+    """White Point (negative) reaches the WHOLE headroom — densities far past the
+    ceiling that Gain cannot touch come back as distinct, monotonic, sub-white
+    values. (High base so the density floor doesn't cap the test densities.)"""
+    base = (50000.0,) * 3
+    densities = (1.25, 1.5, 2.0, 3.0, 4.0)        # 1.25 = ceiling; rest are headroom
+    px = [(base[0] / (10.0 ** d),) * 3 for d in densities]
+    win = apply_bwpoint_normalization(_img(px), base, None)
+
+    flat = _apply_working_space_recovery(win, 0.0, 0.0)[0, :, 0].astype(int)
+    assert np.all(flat[1:] == 65535)              # all headroom blown at WP=0
+
+    rec = _apply_working_space_recovery(win, 0.0, -50.0)[0, :, 0].astype(int)
+    assert rec.max() < 65535                       # everything recovered below white
+    assert np.all(np.diff(rec) > 0)                # distinct + monotonic detail
+
+
+def test_white_point_neutral_at_zero(ws_on):
+    """WP=0 is byte-identical to a plain de-window (neutral edit unchanged)."""
+    px = [(BASE_BGR[0] / (10.0 ** d),) * 3 for d in (0.4, 1.0, 2.0)]
+    win = apply_bwpoint_normalization(_img(px), BASE_BGR, None)
+    np.testing.assert_array_equal(
+        _apply_working_space_recovery(win, 0.0, 0.0),
+        _apply_working_space_recovery(win, 0.0))
+
+
+def test_white_point_consumed_once_via_adjust(ws_on):
+    """White Point recovery is consumed by the pre-stage and not re-applied by the
+    look-domain B/W remap: adjust_image(whitepoint=...) == the recovery helper."""
+    base = (50000.0,) * 3
+    px = [(base[0] / (10.0 ** d),) * 3 for d in (1.5, 2.0, 3.0)]
+    win = apply_bwpoint_normalization(_img(px), base, None)
+    out = adjust_image(win, whitepoint=-50.0, ws_windowed=True)[0, :, 0].astype(int)
+    exp = _apply_working_space_recovery(win, 0.0, -50.0)[0, :, 0].astype(int)
+    np.testing.assert_array_equal(out, exp)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why

Refactors the histogram (requested: fix the algorithm, beautify the UI, make the vertical scale reasonable so an overexposed frame doesn't crush the rest of the detail to the floor).

Replaces the numpy-rasterised 256×150 pixmap (upscaled with smoothing → blocky) with a self-painting `HistogramWidget` that draws at the widget's real resolution, and splits model from presentation.

## Changes

- **Model stores raw counts only** — `CCRImage.histogram_data` (`(3,256)`, R/G/B). Data flow renamed: `get_histogram_data_by_index`, `set_histogram(data)`.
- **Robust clipped vertical scale** (the chosen "percentile clip") — reference = 95th percentile of the *populated* in-range bins, floored to a fraction of the tallest bin. A dominant pile (blown highlights / large flat region) clips flat at the top instead of defining the scale and crushing everything else. Chosen via an empirical bake-off (per-bin mass threshold and median-clip both failed realistic cases).
- **No edge spike on clipping** — pure-clip bins 0/255 are zeroed before smoothing, so a clipped pile draws no full-height column and doesn't bleed into neighbours; clipping is shown by colour-coded corner wedges.
- **Beautified** — antialiased filled curves with additive overlaps, subtle gridlines, rounded background, corner clip wedges.

## Behaviour notes

- The three channels share **one** vertical scale (Photoshop/Lightroom convention), so an imbalanced frame shows channels at different heights — confirmed as the desired behaviour.
- Known residual (documented in the widget): a very high-key frame whose lower tones are an almost perfectly flat plateau under a broad bright region is compressed rather than full-height; the corner wedges still flag any actual clipping.

## Tests

- New `tests/test_histogram_widget.py` (11): scale fix, clip-pile/edge-spike, bimodal, spread-bright, paint smoke tests.
- `tests/test_histogram_crop.py` updated to compare `histogram_data` directly.
- 57 relevant tests pass (widget + crop-data + adjacent suites). The SlidersPanel-constructing tests hit the pre-existing flaky native GC crash only when many share a process (pass in isolation).

## Review

Verified by an adversarial multi-agent review (3 lenses). The data-flow refactor was clean; all 5 confirmed findings (all in the scaling math) are fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012C4T6y6ciHgWs8vmQPKS2B
