### PR TITLE
feat(profile): default camera profile to None (bare RAW)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,9 @@ jobs:
           body: |
             ## What's New
 
+            **v0.9.1**
+            - **Camera profile defaults to None:** new installs now decode RAWs in bare camera-native space (no colour matrix) by default, instead of Camera Matrix (Adobe RGB). Pick Camera Matrix or an ICC/DCP profile from the “Camera profile” dropdown for a matrixed/profiled look; existing selections are unchanged.
+
             **v0.9.0**
             - **Auto gain (on by default):** the brightest highlights are placed at the top of the working range automatically, without moving the Gain slider — the top 0.1% of the in-range highlights are set to 99.8% of full. Pixels outside the sampled clear/dense film range are ignored, and it applies to film conversions only. Turn it off in **Settings → General**.
             - **White balance now uses highlight headroom:** Temperature/Tint are applied in the scene-linear working space *before* the highlight clamp, so warming or cooling a channel lands in recoverable headroom instead of clipping — and cooling can pull blown highlights back down into range.
@@ -165,6 +168,9 @@ jobs:
           # The body is static, so refresh "## What's New" for each release.
           body: |
             ## What's New
+
+            **v0.9.1**
+            - **Camera profile defaults to None:** new installs now decode RAWs in bare camera-native space (no colour matrix) by default, instead of Camera Matrix (Adobe RGB). Pick Camera Matrix or an ICC/DCP profile from the “Camera profile” dropdown for a matrixed/profiled look; existing selections are unchanged.
 
             **v0.9.0**
             - **Auto gain (on by default):** the brightest highlights are placed at the top of the working range automatically, without moving the Gain slider — the top 0.1% of the in-range highlights are set to 99.8% of full. Pixels outside the sampled clear/dense film range are ignored, and it applies to film conversions only. Turn it off in **Settings → General**.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -213,8 +213,9 @@ class MainWindow(QMainWindow):
 
         # Restore the active camera-profile selection (applied to every decode).
         # Done before any images load so the first batch picks it up. A fresh
-        # install / a vanished profile file defaults to Camera Matrix (the prior
-        # Adobe RGB + auto-scale out-of-box look). "none" = explicit bare-RAW.
+        # install / a vanished or unreadable profile defaults to None (bare
+        # camera-native RAW). Camera Matrix (Adobe RGB + auto-scale) and ICC/DCP
+        # profiles are opt-in; "none" is the explicit bare-RAW selection.
         CM = ccr_backend.CAMERA_MATRIX
         saved = self._settings.value("import/active_profile_path", "", type=str)
 
@@ -224,8 +225,8 @@ class MainWindow(QMainWindow):
                 self._settings.setValue("import/active_profile_path",
                                         sel if sel else "none")
             except Exception:
-                ccr_backend.set_active_profile(CM)
-                self._settings.setValue("import/active_profile_path", CM)
+                ccr_backend.set_active_profile(None)
+                self._settings.setValue("import/active_profile_path", "none")
 
         if saved == "none":
             ccr_backend.set_active_profile(None)
@@ -236,7 +237,7 @@ class MainWindow(QMainWindow):
         else:
             legacy = (self._settings.value("import/input_icc_path", "", type=str)
                       or self._settings.value("import/input_dcp_path", "", type=str))
-            _restore(legacy if (legacy and os.path.exists(legacy)) else CM)
+            _restore(legacy if (legacy and os.path.exists(legacy)) else None)
         self.thumbnail_list.refresh_profile_combo()
         self._refresh_profile_ui()
 

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -286,10 +286,12 @@ def _dialog():
 
 
 class TestSettingsDialog:
-    def test_has_color_management_category(self):
+    def test_has_categories(self):
         d = _dialog()
         names = [d._sidebar.item(i).text() for i in range(d._sidebar.count())]
-        assert names == ["Color Management"]
+        assert names == ["General", "Color Management"]
+        # The General tab carries the Auto gain toggle (spec/auto-gain.md).
+        assert hasattr(d, "_cb_auto_gain")
 
     def test_no_disable_checkbox(self):
         # The disable checkbox is gone — "None" in the picker replaces it.


### PR DESCRIPTION
Changes the out-of-box camera-profile default from **Camera Matrix (Adobe RGB)** to **None (bare camera-native RAW)**.

### What changes
- A **fresh install** (or a saved profile file that has vanished / fails to load) now activates **None** — `output_color=raw`, no colour matrix — instead of Camera Matrix.
- Camera Matrix and ICC/DCP profiles become **opt-in** via the "Camera profile" dropdown.
- **Existing selections are preserved**: a saved Camera Matrix, a saved profile file, and the legacy ICC/DCP migration all still restore as before. Only the *default* (and the corrupt-profile fallback) changes. The backend already inits `active_profile_path=None`; only `main_window`'s startup restore changed.

### Also in this PR
- **Test fix**: `test_settings_dialog` asserted a single "Color Management" category, but the Settings dialog gained a **General** tab in v0.9.0 (with Auto gain). Updated to `["General", "Color Management"]` and added a check that the Auto gain toggle exists.
- **Release notes**: added the **v0.9.1** "What's New" entry to both release jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
