### PR TITLE
feat(exposure): photographic EV Exposure slider under Gain (OpenEnlarge algo)

### DIFF
--- a/spec/exposure-slider.md
+++ b/spec/exposure-slider.md
@@ -1,0 +1,172 @@
+# Exposure slider (photographic EV), under Gain
+
+## Goals
+
+- Add a new **Exposure** slider directly **under the existing Gain slider**, implementing
+  OpenEnlarge's exposure algorithm: a **photographic, per-stop, linear-light gain**
+  (`×2^EV`) applied in scene-linear space, black-anchored, before the tone/contrast curve.
+- One slider unit behaves like a fraction of a photographic stop; the control covers a
+  wide ±5 EV range (matching OpenEnlarge's `exposure: EV stops (−5..5)`), so it is the
+  *primary* brightness mover while the existing Gain stays the *fine* trim.
+- Headroom-safe: in the working space the multiply runs **un-clamped before the window
+  clamp**, so +EV that pushes detail above display-white lands in recoverable highlight
+  headroom (and is itself recoverable by lowering EV), exactly like Gain/White Point.
+- CPU and GPU byte-identical (rides the same shared pre-stages the Gain control uses).
+
+## Non-goals
+
+- No change to the existing **Gain** slider (`exposure` param, `1/(1−v/300)`), nor to
+  Auto Gain / auto-exposure-base, which keep riding the Gain stage. Exposure is an
+  independent, orthogonal control that stacks multiplicatively.
+- Not a port of OpenEnlarge's *filmic* exposure arm (`2^(0.14·EV)` scaling the
+  normalised **log-density** `t`). That arm is coupled to OpenEnlarge's logistic filmic
+  curve and its density working domain, neither of which FreeCCR has. FreeCCR's working
+  buffer is **linear display light**, so the faithful linear-light `×2^EV` (OpenEnlarge's
+  `FAITHFUL_EXPO_K = 1.0`, "one EV ≈ one photographic stop") is the correct, native port.
+- No new tone curve, no density round-trip (`L = 10^d − 1`): OpenEnlarge needs that only
+  because it stores density; FreeCCR already stores linear, so a plain multiply *is* the
+  black-anchored linear-light exposure.
+- Not applied to positive mode differently — it is a generic slider available like the
+  rest; nothing special-cases it (unlike Auto Gain, which is conversion-only).
+
+## Reference: OpenEnlarge's exposure algorithm
+
+From `crates/film-core/src/engine.rs`:
+
+- Filmic arm (`EXPO_K = 0.14`): `expo_gain = 2^(EXPO_K·EV)` multiplies the WB-neutralised
+  normalised log-density, pivoting at black.
+- **Faithful arm (`FAITHFUL_EXPO_K = 1.0`)**: exposure is *"a LINEAR-LIGHT gain on the
+  reconstructed scene, applied BEFORE the contrast curve — we treat the log-inverted
+  negative as a positive and 'expose' it like a TIFF. Black-anchored linear scene
+  `L = 10^d − 1` … gain ×2^EV … EV 0 is the identity."*
+
+The faithful arm is the one ported here. Its key invariants we preserve:
+- **EV 0 = identity** (gain = 1).
+- **Black-anchored** (a 0 scene value stays 0 at every EV — no black lift/colour cast).
+- **Pre-curve, linear-light** (it scales scene light, then the existing FreeCCR tone path
+  — contrast/brightness/curves — runs after, on the result).
+- **One EV ≈ one photographic stop.**
+
+## UX / interaction
+
+- New slider labelled **"Exposure"**, placed in `SlidersPanel` immediately after **Gain**
+  (between Gain and Brightness), styled like every other tone slider.
+- Raw range **[−100, +100]**, default **0** (integer `QSlider`, unitless display — the
+  same convention as Brightness/Contrast; Gain uses [−200, 200]). Internally
+  `EV = (v/100)·5`, i.e. each unit = 0.05 EV; the extremes are ±5 EV (`/32`…`×32`).
+- Resets to 0 with **Reset**; participates in **Compare**, **Sync to All** (in the existing
+  "Tone" group), copy/paste adjustments, and per-image catalog persistence — all
+  automatically, because it is just another key in the positional `ADJUSTMENT_KEYS`/
+  `self.sliders` zip and the generic adjustment dict.
+
+## Data model
+
+- New adjustment key: **`exposure_ev`** (distinct from the legacy `exposure` key, which
+  drives the *Gain* UI slider — the historical naming is unfortunate but locked; the new
+  key avoids any collision).
+- Default 0 ⇒ multiply 1.0 ⇒ exact identity. `s.get('exposure_ev', 0)` everywhere, so old
+  catalogs without the key load as 0 (fully backward compatible).
+- Lives only in the per-image adjustment dict — no new `CCRImage` field, no catalog schema
+  change (the dict is serialised whole).
+
+## Processing / math
+
+Constant + helper in `ccr_processor.py`:
+
+```
+EXPO_EV_MAX = 5.0   # EV magnitude at slider ±100 (matches OpenEnlarge ±5 EV)
+
+def _exposure_ev_gain(v):           # raw slider value → linear-light multiply
+    ev = float(np.clip(v, -100.0, 100.0)) / 100.0 * EXPO_EV_MAX
+    return float(2.0 ** ev)         # v=0 → 1.0 (identity); v=±20 → ×2 / ÷2 (±1 EV)
+```
+
+Applied as a black-anchored linear multiply `d *= 2^EV` in scene-linear light:
+
+- **Working space ON (default)** — inside `_apply_working_space_recovery` (the single
+  shared CPU+GPU pre-stage). De-window to linear `d`; apply WB, then White Point, then
+  the existing Gain multiply, then **`d *= _exposure_ev_gain(exposure_ev)` un-clamped**;
+  then the existing `clip(d,0,1)` window clamp. Because it is a multiply on the same
+  un-clamped linear `d`, it commutes with Gain/WP and recovers/relegates highlights to
+  headroom identically. CPU and GPU both route through this function ⇒ automatic parity.
+- **Working space OFF (legacy `FREECCR_WORKING_SPACE=0`)** —
+  - `adjust_image` (CPU): before the Gain block, `img = clip(img*m, 0, 65535)`.
+  - `adjust_image_opencl` (GPU): apply the same numpy `clip(img*m,0,65535)` after the WB
+    numpy step, then set `exposure_ev=0` so neither the kernel nor the CPU fallback
+    re-applies it (mirrors exactly how WB is consumed in numpy for parity). The kernel is
+    untouched.
+  - Identity holds: `clip(img/65535*m,0,1)*65535 == clip(img*m,0,65535)`, so the CPU and
+    GPU non-ws forms are byte-identical, and `m=1` is an exact no-op.
+
+Ordering note: Exposure and Gain are both linear multiplies and commute in the un-clamped
+ws path; in the clamped non-ws path Exposure is applied just before Gain. Either way EV 0
+is an exact identity and the EV-0 look is unchanged.
+
+### Interaction with Auto Gain / auto-exposure-base
+
+Unchanged and orthogonal. Auto Gain (`ag`) and auto-exposure-base (`eb`) are computed from
+the *base* pixels and ride the **Gain** value (`s['exposure'] + eb_eff + ag`); they are
+invariant to the sliders, including Exposure. The realised output is
+`base × gain_stage(exposure+eb+ag) × 2^EV`. If Auto Gain seats the highlight at 99.8% and
+the user dials +1 EV, highlights intentionally brighten by a stop — the expected,
+predictable behaviour. No Auto-Gain code changes.
+
+## Integration points (files)
+
+1. `src/core/ccr_processor.py`
+   - Add `EXPO_EV_MAX` + `_exposure_ev_gain`.
+   - `_apply_working_space_recovery(... , exposure_ev=0.0)`: un-clamped multiply pre-clamp.
+   - `adjust_image(... , exposure_ev=0.0)`: ws branch passes it to the recovery (then
+     zeroes it); non-ws branch applies the clamped multiply before Gain.
+   - `adjust_image_opencl(... , exposure_ev=0.0)`: ws branch passes to recovery; non-ws
+     branch applies the numpy multiply, zeroes it, and threads `exposure_ev` through both
+     CPU-fallback `adjust_image(...)` calls.
+   - New param added at the **end** of both signatures (after `ws_windowed`) so no existing
+     positional caller shifts.
+2. `src/widgets/sliders_panel.py`
+   - `ADJUSTMENT_KEYS`: insert `"exposure_ev"` right after `"exposure"`.
+   - `slider_labels`: insert `"Exposure"` after `"Gain"` (kept in sync though vestigial).
+   - Create `self.exposure_ev_slider_layout = self.create_slider("Exposure")` right after
+     the Gain slider and add it to `scroll_layout` directly under the Gain row.
+   - `SYNC_GROUPS` "tone" tuple: add `"exposure_ev"`.
+3. `src/core/ccr_image.py`
+   - Both `adjust_image_opencl(...)` call sites (`apply_adjustments` and `_adjust_for_area`)
+     pass `exposure_ev=s.get('exposure_ev', 0)`.
+
+## Test plan (`tests/test_exposure_slider.py`, pure-numpy, headless)
+
+- `test_constants`: `EXPO_EV_MAX == 5.0`; `_exposure_ev_gain(0) == 1.0`;
+  `_exposure_ev_gain(20) ≈ 2.0`; `_exposure_ev_gain(-20) ≈ 0.5`; `±100 → ×32 / ÷32`.
+- `test_identity_is_byte_noop_ws`: a windowed base through `adjust_image` with
+  `exposure_ev=0` equals the same with the arg omitted (exact).
+- `test_plus_one_ev_doubles_linear_ws`: a mid-grey windowed base (well inside headroom)
+  at `exposure_ev=+20` ≈ doubles the de-windowed linear value vs EV 0.
+- `test_black_is_anchored`: a pure-black base stays 0 at any EV (no lift).
+- `test_headroom_recoverable_ws`: a base whose highlight is in headroom, pushed by +EV
+  then pulled back by the equal −EV, round-trips (no hard clip lost) — contrast Gain's
+  same property.
+- `test_plus_ev_clips_to_white_when_no_headroom`: +EV on near-white in-range content
+  saturates toward 65535 (expected exposure behaviour).
+- `test_cpu_gpu_parity` (skip if no OpenCL): `adjust_image` vs `adjust_image_opencl` at a
+  few EV values, ws on and off, max abs diff ≤ 1.
+- `test_nonws_matches_ws_midtone`: non-ws and ws paths place a mid-grey at the same EV
+  multiply (within quantization).
+- `test_compose_with_gain`: Exposure and Gain together ≈ product of the two multiplies on
+  an in-headroom midtone (commute, un-clamped ws path).
+- `test_slider_wiring`: `SlidersPanel.ADJUSTMENT_KEYS` has `"exposure_ev"` immediately
+  after `"exposure"`, and `len(ADJUSTMENT_KEYS)` lines up with the created slider count.
+
+## Refinement (resolved before implementation)
+
+- **Which OpenEnlarge arm** → faithful linear-light `×2^EV` (rationale above); the filmic
+  log-density arm is out of scope and architecturally inapplicable.
+- **Units on the UI** → unitless raw [−100,100] like sibling sliders (no float/EV label;
+  `create_slider` has no value-scaling), mapped internally to ±5 EV. Keeps the panel
+  visually uniform; documented mapping in code.
+- **Range** → ±5 EV to match OpenEnlarge's stated `exposure (−5..5)`.
+- **Order vs Gain** → Exposure is the wide primary mover (±5 EV), Gain the fine trim
+  (±0.74 stop); placing Exposure under Gain matches the request and the coarse/fine split.
+- **Param name** → `exposure_ev` (the legacy `exposure` key is the Gain slider; do not
+  reuse).
+- **Parity strategy** → ride the shared `_apply_working_space_recovery` (ws) and a numpy
+  pre-multiply consumed before the kernel (non-ws), mirroring the WB pattern.

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -874,6 +874,9 @@ class CCRImage:
                      band_settings=(s if any(s.get(k, 0)
                                              for k in BAND_ADJUSTMENT_KEYS)
                                     else None),
+                     # Exposure (photographic ±5 EV, ×2^EV) — independent of Auto
+                     # Gain / eb (which ride the Gain stage above); stacks on top.
+                     exposure_ev=s.get('exposure_ev', 0),
                      # Windowed working-space base → de-window + Gain/Exposure
                      # recovery happens inside the adjustment call.
                      ws_windowed=self._ws_windowed)
@@ -927,7 +930,8 @@ class CCRImage:
                      sub_saturation=s.get('sub_saturation', 0),
                      band_settings=(s if any(s.get(k, 0)
                                              for k in BAND_ADJUSTMENT_KEYS)
-                                    else None))
+                                    else None),
+                     exposure_ev=s.get('exposure_ev', 0))
         curves = s.get('curves')
         if curves:
             adjusted = apply_curves(adjusted, curves)

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -1042,6 +1042,25 @@ def encode_window(d: np.ndarray) -> np.ndarray:
     return code.astype(np.uint16)
 
 
+# --- Exposure (photographic EV), spec/exposure-slider.md ---------------------
+# A second, wide brightness control under the Gain slider, ported from
+# OpenEnlarge's faithful exposure arm (FAITHFUL_EXPO_K = 1.0): a black-anchored
+# LINEAR-LIGHT gain `×2^EV` applied in scene-linear light before the tone curve
+# ("one EV ≈ one photographic stop"). Distinct from the legacy `exposure` param,
+# which drives the *Gain* slider (`1/(1−v/300)`). The raw slider value v ∈
+# [−100,100] maps to EV = (v/100)·EXPO_EV_MAX, so ±100 = ±5 EV (×32 / ÷32) and
+# v=0 is an exact identity (gain 1.0). Applied un-clamped in the working space so
+# +EV lands in highlight headroom (recoverable by lowering EV), like Gain.
+EXPO_EV_MAX = 5.0          # EV magnitude at slider ±100 (matches OpenEnlarge ±5 EV)
+
+
+def _exposure_ev_gain(v: float) -> float:
+    """Raw Exposure-slider value [−100,100] → linear-light multiply 2^EV.
+    v=0 → 1.0 (identity); v=±20 → ×2 / ÷2 (±1 EV); v=±100 → ×32 / ÷32 (±5 EV)."""
+    ev = float(np.clip(v, -100.0, 100.0)) / 100.0 * EXPO_EV_MAX
+    return float(2.0 ** ev)
+
+
 _WB_TEMP_STRENGTH = 0.40   # full-slider R/B scale: s = (slider/100)*0.40 (matches
                            #   the previous tone-aware WB midtone strength)
 _WB_TINT_STRENGTH = 0.26   # = 0.18 * skin(0.45): the previous tint midtone strength
@@ -1069,7 +1088,8 @@ def _white_balance_gains(kelvin_shift: float, tint_shift: float,
 def _apply_working_space_recovery(img16: np.ndarray, exposure: float,
                                   white_point: float = 0.0,
                                   kelvin_shift: float = 0.0, tint_shift: float = 0.0,
-                                  tint_balance_factor: float = 1.0) -> np.ndarray:
+                                  tint_balance_factor: float = 1.0,
+                                  exposure_ev: float = 0.0) -> np.ndarray:
     """De-window a windowed base, apply the highlight-recovery controls UN-clamped
     (so headroom can be pulled back below white), then clamp to the display window
     and return a normal full-range [0,65535] positive for the look chain. This
@@ -1081,8 +1101,10 @@ def _apply_working_space_recovery(img16: np.ndarray, exposure: float,
         WP=-100 maps the container ceiling exactly to white (recovers everything),
         WP=0 neutral, WP>0 pushes highlights up. Perceptual feel: typical blown
         highlights come back within the first chunk of negative travel.
-      Gain/Exposure — the existing linear `1/(1−v/300)` gain (±~0.74 stops), kept
-        for fine tone control on top of the White Point recovery."""
+      Gain — the existing linear `1/(1−v/300)` gain (±~0.74 stops), kept for fine
+        tone control on top of the White Point recovery.
+      Exposure — `exposure_ev`, the photographic ±5 EV `×2^EV` linear-light gain
+        (spec/exposure-slider.md). Also un-clamped here, so +EV lands in headroom."""
     d = img16.astype(np.float32)
     d -= np.float32(WS_B)
     d *= np.float32(_WS_INV_WIDTH)
@@ -1103,6 +1125,10 @@ def _apply_working_space_recovery(img16: np.ndarray, exposure: float,
     if exposure != 0.0:
         white_val = 1.0 - np.clip(exposure, -200.0, 200.0) / 300.0
         d *= np.float32(1.0 / white_val)        # un-clamped: recovers overshoot
+    if exposure_ev != 0.0:
+        # Exposure (photographic EV): black-anchored linear-light ×2^EV, un-clamped
+        # alongside Gain so +EV lands in highlight headroom (recoverable by -EV).
+        d *= np.float32(_exposure_ev_gain(exposure_ev))
     np.clip(d, 0.0, 1.0, out=d)                  # window clamp: enter display range
     d *= np.float32(65535.0)
     return d.astype(np.uint16)
@@ -2351,6 +2377,7 @@ def adjust_image(
     sub_saturation: float = 0.0,
     band_settings: dict = None,
     ws_windowed: bool = False,
+    exposure_ev: float = 0.0,
 ) -> np.ndarray:
     """
     Apply temperature, tint, exposure, brightness, blackpoint, whitepoint, highlights, shadows,
@@ -2361,15 +2388,20 @@ def adjust_image(
     ws_windowed: when True, img16 is a windowed working-space base — de-window it,
     apply the Gain/Exposure recovery un-clamped, clamp to the display window, and
     consume exposure here (the rest of the chain runs on a normal full-range image).
+    exposure_ev: photographic Exposure slider [-100,100] -> ×2^EV linear-light gain
+    (spec/exposure-slider.md); consumed in the ws pre-stage, or applied here (clamped)
+    for the legacy non-windowed path.
     Returns a 16-bit image.
     """
     if ws_windowed:
         img16 = _apply_working_space_recovery(img16, exposure, whitepoint,
-                                              kelvin_shift, tint_shift, tint_balance_factor)
+                                              kelvin_shift, tint_shift, tint_balance_factor,
+                                              exposure_ev)
         exposure = 0.0       # consumed by the recovery pre-stage
         whitepoint = 0.0     # White Point is the headroom-recovery control here
         kelvin_shift = 0.0   # White Balance consumed (flat per-channel gain, pre-clamp)
         tint_shift = 0.0
+        exposure_ev = 0.0    # Exposure consumed (un-clamped, headroom-safe)
     img = img16.astype(np.float32)
 
     # White balance - flat per-channel gain (spec/working-space-white-balance.md).
@@ -2391,6 +2423,14 @@ def adjust_image(
     contrast_scale = 1.0 + (contrast / 100.0)      # 0.0 to 2.0
     saturation_scale = 1.0 + (saturation / 100.0)  # 0.0 to 2.0
 
+
+    # Exposure (photographic EV) — legacy non-windowed path (the ws path consumed
+    # it above, un-clamped). Black-anchored linear-light ×2^EV, clamped to [0,1].
+    # clip(img/65535*m,0,1)*65535 == clip(img*m,0,65535), matching the GPU numpy
+    # pre-multiply for byte-identical CPU/GPU parity.
+    if exposure_ev != 0.0:
+        m = _exposure_ev_gain(exposure_ev)
+        img = np.clip(img * np.float32(m), 0.0, 65535.0)
 
     # Gain — shares Channel Levels "Master Gain"'s /300 curve: a uniform linear
     # gain out = in / (1 - v/300), hard-clipped to [0,1] (v=200 -> 3x, v=100 ->
@@ -2804,6 +2844,7 @@ def adjust_image_opencl(
     sub_saturation: float = 0.0,
     band_settings: dict = None,
     ws_windowed: bool = False,
+    exposure_ev: float = 0.0,
 ) -> np.ndarray:
     """
     GPU-accelerated (OpenCL) version of adjust_image.
@@ -2818,12 +2859,14 @@ def adjust_image_opencl(
     # never sees headroom.
     if ws_windowed:
         img16 = _apply_working_space_recovery(img16, exposure, whitepoint,
-                                              kelvin_shift, tint_shift, tint_balance_factor)
+                                              kelvin_shift, tint_shift, tint_balance_factor,
+                                              exposure_ev)
         exposure = 0.0
         whitepoint = 0.0
         ws_windowed = False
         kelvin_shift = 0.0
         tint_shift = 0.0
+        exposure_ev = 0.0
 
     # White balance - flat per-channel gain done in numpy so the kernel (and the
     # CPU fallback) never apply WB -> automatic CPU/GPU parity. ws consumed above.
@@ -2835,6 +2878,15 @@ def adjust_image_opencl(
         img16[..., 2] *= np.float32(_gb)
         kelvin_shift = 0.0
         tint_shift = 0.0
+
+    # Exposure (photographic EV) — legacy non-windowed path. Done in numpy (like
+    # WB) so the kernel and CPU fallback never re-apply it -> exact CPU/GPU parity.
+    # clip(img*m,0,65535) matches adjust_image's clamped form. ws consumed above.
+    if exposure_ev != 0.0:
+        img16 = np.asarray(img16, dtype=np.float32)
+        np.multiply(img16, np.float32(_exposure_ev_gain(exposure_ev)), out=img16)
+        np.clip(img16, 0.0, 65535.0, out=img16)
+        exposure_ev = 0.0
 
     # Spatial band feathering is a CPU post-blur the per-pixel kernel can't
     # do, so run the whole adjustment on the CPU when it is active (keeps the
@@ -2852,7 +2904,8 @@ def adjust_image_opencl(
                           ch_g_shift, ch_g_gain, ch_g_blackpoint,
                           ch_b_shift, ch_b_gain, ch_b_blackpoint,
                           sub_saturation=sub_saturation,
-                          band_settings=band_settings)
+                          band_settings=band_settings,
+                          exposure_ev=exposure_ev)  # already consumed above (0); kept explicit
 
     try:
       # Serialize GPU submissions: the hi-res zoom worker may run this
@@ -2918,7 +2971,8 @@ def adjust_image_opencl(
                           ch_g_shift, ch_g_gain, ch_g_blackpoint,
                           ch_b_shift, ch_b_gain, ch_b_blackpoint,
                           sub_saturation=sub_saturation,
-                          band_settings=band_settings)
+                          band_settings=band_settings,
+                          exposure_ev=exposure_ev)  # already consumed above (0); kept explicit
 
 
 

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -19,7 +19,7 @@ SYNC_GROUPS = [
     ("profile", "Color Profile (Color / B&W)", ()),
     ("wb", "White Balance / Tint", ("temperature", "tint")),
     ("tone", "Tone (gain, brightness, contrast, ...)",
-     ("exposure", "brightness", "highlights", "white_point",
+     ("exposure", "exposure_ev", "brightness", "highlights", "white_point",
       "shadows", "black_point", "contrast")),
     ("sat", "Saturation", ("saturation", "sub_saturation")),
     ("crop", "Crop", ()),
@@ -245,9 +245,9 @@ class SlidersPanel(QWidget):
     # Order must match the create_slider() call order exactly — the two
     # lists are zipped positionally.
     ADJUSTMENT_KEYS = [
-        "temperature", "tint", "exposure", "brightness", "highlights",
-        "white_point", "shadows", "black_point", "contrast", "saturation",
-        "sub_saturation",
+        "temperature", "tint", "exposure", "exposure_ev", "brightness",
+        "highlights", "white_point", "shadows", "black_point", "contrast",
+        "saturation", "sub_saturation",
         # Per-channel levels controls (collapsible section)
         "ch_input_gain", "ch_master_shift", "ch_master_gain",
         "ch_r_shift", "ch_r_gain", "ch_r_blackpoint",
@@ -338,7 +338,7 @@ class SlidersPanel(QWidget):
         layout.addWidget(scroll_area, 1)  # stretch=1: fills remaining height
 
         self.slider_labels = [
-            "Temperature", "Tint", "Gain", "Brightness",
+            "Temperature", "Tint", "Gain", "Exposure", "Brightness",
             "Highlights", "White Point", "Shadows", "Black Point", "Contrast", "Saturation",
             "Subtracted Sat"
         ]
@@ -474,6 +474,10 @@ class SlidersPanel(QWidget):
         self.tint_slider_layout = self.create_slider(
             "Tint", gradient=theme.TINT_GRADIENT)
         self.exposure_slider_layout = self.create_slider("Gain", min_value=-200, max_value=200)
+        # Exposure — photographic EV under Gain (spec/exposure-slider.md). Raw
+        # [-100,100] maps to ±5 EV (×2^EV linear-light gain). Created right after
+        # Gain so it stays positionally aligned with ADJUSTMENT_KEYS["exposure_ev"].
+        self.exposure_ev_slider_layout = self.create_slider("Exposure")
         self.brightness_slider_layout = self.create_slider("Brightness")
         self.highlights_slider_layout = self.create_slider("Highlights")
         self.white_point_slider_layout = self.create_slider("White Point")
@@ -487,6 +491,7 @@ class SlidersPanel(QWidget):
         scroll_layout.addLayout(self.temperature_slider_layout)
         scroll_layout.addLayout(self.tint_slider_layout)
         scroll_layout.addLayout(self.exposure_slider_layout)
+        scroll_layout.addLayout(self.exposure_ev_slider_layout)
         scroll_layout.addLayout(self.brightness_slider_layout)
         scroll_layout.addLayout(self.highlights_slider_layout)
         scroll_layout.addLayout(self.white_point_slider_layout)

--- a/tests/test_exposure_slider.py
+++ b/tests/test_exposure_slider.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests for the Exposure slider (spec/exposure-slider.md).
+
+Exposure is a second, wide brightness control under Gain, ported from
+OpenEnlarge's faithful exposure arm: a black-anchored LINEAR-LIGHT gain `×2^EV`
+applied in scene-linear light before the tone curve. The raw slider value
+v ∈ [-100,100] maps to EV = (v/100)·5, so ±100 = ±5 EV and v=0 is an exact
+identity. In the working space it runs un-clamped (pre window-clamp), so +EV
+lands in recoverable highlight headroom. Pure numpy core, runs headless.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.ccr_processor import (  # noqa: E402
+    adjust_image, adjust_image_opencl, encode_window,
+    _exposure_ev_gain, EXPO_EV_MAX, OPENCL_AVAILABLE,
+)
+
+
+def _ws_base(d):
+    """Windowed base from a display array `d` (overshoot beyond 1 is kept as
+    headroom up to the container ceiling)."""
+    return encode_window(np.asarray(d, dtype=np.float32).copy())
+
+
+# --- the EV → multiply mapping -------------------------------------------
+
+def test_constants():
+    assert EXPO_EV_MAX == 5.0
+    assert _exposure_ev_gain(0) == 1.0                     # exact identity
+    assert _exposure_ev_gain(20) == pytest.approx(2.0)     # +1 EV
+    assert _exposure_ev_gain(-20) == pytest.approx(0.5)    # -1 EV
+    assert _exposure_ev_gain(100) == pytest.approx(32.0)   # +5 EV
+    assert _exposure_ev_gain(-100) == pytest.approx(1.0 / 32.0)
+    # clamps beyond ±100
+    assert _exposure_ev_gain(500) == pytest.approx(32.0)
+    assert _exposure_ev_gain(-500) == pytest.approx(1.0 / 32.0)
+
+
+# --- working-space (default) path ----------------------------------------
+
+def test_identity_is_byte_noop_ws():
+    """exposure_ev=0 is byte-identical to omitting it (the multiply branch is
+    skipped entirely)."""
+    base = _ws_base(np.full((16, 16, 3), 0.4))
+    a = adjust_image(base, ws_windowed=True)
+    b = adjust_image(base, exposure_ev=0.0, ws_windowed=True)
+    assert np.array_equal(a, b)
+
+
+def test_plus_one_ev_doubles_linear_ws():
+    """A mid-grey base well inside headroom: +1 EV (slider +20) ≈ doubles the
+    de-windowed linear output vs EV 0."""
+    base = _ws_base(np.full((16, 16, 3), 0.25))            # 0.25 is window-exact
+    ev0 = adjust_image(base, exposure_ev=0.0, ws_windowed=True).astype(np.float32)
+    ev1 = adjust_image(base, exposure_ev=20.0, ws_windowed=True).astype(np.float32)
+    assert ev1.mean() / ev0.mean() == pytest.approx(2.0, rel=0.01)
+
+
+def test_black_is_anchored():
+    """Pure black stays 0 at any EV (black-anchored, no lift / colour cast)."""
+    base = _ws_base(np.zeros((16, 16, 3)))
+    for v in (-100.0, -50.0, 50.0, 100.0):
+        out = adjust_image(base, exposure_ev=v, ws_windowed=True)
+        assert int(out.max()) == 0
+
+
+def test_headroom_recoverable_ws():
+    """A highlight stored in headroom (d=1.5, above display white) clips to white
+    at EV 0 but is pulled back below white by -1 EV — headroom is recoverable,
+    exactly like the Gain control."""
+    base = _ws_base(np.full((16, 16, 3), 1.5))             # 1.5 stored in headroom
+    ev0 = adjust_image(base, exposure_ev=0.0, ws_windowed=True).astype(np.float32)
+    evm = adjust_image(base, exposure_ev=-20.0, ws_windowed=True).astype(np.float32)
+    assert ev0.mean() == pytest.approx(65535.0, rel=1e-3)  # clipped to white
+    assert evm.mean() < ev0.mean()                          # recovered
+    assert evm.mean() / 65535.0 == pytest.approx(0.75, rel=0.02)  # 1.5 × 0.5
+
+
+def test_plus_ev_clips_to_white_when_no_headroom():
+    """+EV on near-white in-range content saturates toward white (expected)."""
+    base = _ws_base(np.full((16, 16, 3), 0.9))
+    out = adjust_image(base, exposure_ev=20.0, ws_windowed=True).astype(np.float32)
+    assert out.mean() == pytest.approx(65535.0, rel=1e-3)
+
+
+def test_compose_with_gain_commutes_ws():
+    """Exposure and Gain are both linear multiplies on the un-clamped working
+    buffer, so adding +1 EV on top of any Gain multiplies the output by ≈2."""
+    base = _ws_base(np.full((16, 16, 3), 0.125))           # leaves headroom
+    gain_only = adjust_image(base, exposure=60.0, ws_windowed=True).astype(np.float32)
+    gain_ev = adjust_image(base, exposure=60.0, exposure_ev=20.0,
+                           ws_windowed=True).astype(np.float32)
+    assert gain_ev.mean() / gain_only.mean() == pytest.approx(2.0, rel=0.01)
+
+
+# --- legacy non-windowed path --------------------------------------------
+
+def test_nonws_plus_one_ev_doubles():
+    """Without the working space the base is full-range; +1 EV doubles a midtone
+    (clamped at white)."""
+    img = np.full((16, 16, 3), int(0.25 * 65535), dtype=np.uint16)
+    ev0 = adjust_image(img, exposure_ev=0.0, ws_windowed=False).astype(np.float32)
+    ev1 = adjust_image(img, exposure_ev=20.0, ws_windowed=False).astype(np.float32)
+    assert ev1.mean() / ev0.mean() == pytest.approx(2.0, rel=0.01)
+
+
+def test_nonws_matches_ws_midtone():
+    """ws and non-ws paths place an in-range midtone at the same EV multiply."""
+    d = 0.25
+    ws = adjust_image(_ws_base(np.full((16, 16, 3), d)), exposure_ev=20.0,
+                      ws_windowed=True).astype(np.float32)
+    full = adjust_image(np.full((16, 16, 3), int(d * 65535), dtype=np.uint16),
+                        exposure_ev=20.0, ws_windowed=False).astype(np.float32)
+    assert ws.mean() / 65535.0 == pytest.approx(0.5, rel=0.01)
+    assert full.mean() / 65535.0 == pytest.approx(0.5, rel=0.01)
+
+
+# --- CPU / GPU parity -----------------------------------------------------
+
+@pytest.mark.skipif(not OPENCL_AVAILABLE, reason="OpenCL not available")
+@pytest.mark.parametrize("ws", [True, False])
+@pytest.mark.parametrize("v", [30.0, -30.0])
+def test_cpu_gpu_parity(ws, v):
+    """The Exposure multiply rides shared numpy pre-stages (the recovery in ws
+    mode, a pre-kernel multiply otherwise), so CPU and GPU stay byte-identical."""
+    rng = np.random.default_rng(1)
+    d = rng.uniform(0.05, 0.8, size=(48, 48, 3)).astype(np.float32)
+    src = _ws_base(d) if ws else (d * 65535.0).astype(np.uint16)
+    cpu = adjust_image(src, exposure_ev=v, ws_windowed=ws).astype(np.int32)
+    gpu = adjust_image_opencl(src, exposure_ev=v, ws_windowed=ws).astype(np.int32)
+    assert np.abs(cpu - gpu).max() <= 1
+
+
+# --- UI wiring ------------------------------------------------------------
+
+def test_slider_wiring():
+    """exposure_ev is positioned right after exposure in ADJUSTMENT_KEYS, lives
+    in the Tone sync group, and the created-slider count matches the key count."""
+    from PySide6.QtWidgets import QApplication
+    from widgets.sliders_panel import SlidersPanel, SYNC_GROUPS
+
+    keys = SlidersPanel.ADJUSTMENT_KEYS
+    assert "exposure_ev" in keys
+    assert keys.index("exposure_ev") == keys.index("exposure") + 1
+
+    tone = dict((gid, members) for gid, _label, members in SYNC_GROUPS)["tone"]
+    assert "exposure_ev" in tone
+
+    _app = QApplication.instance() or QApplication(sys.argv[:1])
+    panel = SlidersPanel()
+    # Every adjustment key must have a matching slider (strict positional zip).
+    assert len(panel.sliders) == len(panel.adjustment_keys)
+    ev_idx = panel.adjustment_keys.index("exposure_ev")
+    sl = panel.sliders[ev_idx]
+    assert (sl.minimum(), sl.maximum()) == (-100, 100)
+    assert sl.value() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Adds a new **Exposure** slider directly **under the existing Gain slider**, porting OpenEnlarge's exposure algorithm: a **photographic, per-stop, linear-light gain** (`×2^EV`) applied in scene-linear light, black-anchored, before the tone curve — "one EV ≈ one photographic stop".

- New **`exposure_ev`** adjustment key (distinct from the legacy `exposure` key, which drives the *Gain* slider — the historical naming is unfortunate but locked).
- Raw slider `[−100, +100]` → `EV = (v/100)·5`, so ±100 = ±5 EV (`×32` … `÷32`), matching OpenEnlarge's `exposure (−5..5)`. **`v=0` is an exact identity.**
- Exposure is the **wide primary mover** (±5 EV); the existing Gain stays the **fine trim** (±0.74 stop). Both are linear multiplies and **commute**.

## Which OpenEnlarge arm, and why

OpenEnlarge has two exposure arms (`crates/film-core/src/engine.rs`):
- *Filmic* (`EXPO_K = 0.14`): scales the normalised **log-density** `t`, coupled to its logistic filmic curve.
- **Faithful** (`FAITHFUL_EXPO_K = 1.0`): *"a LINEAR-LIGHT gain on the reconstructed scene, applied BEFORE the contrast curve … black-anchored linear scene `L = 10^d − 1` … gain ×2^EV … EV 0 is the identity."*

FreeCCR's working buffer is **linear display light** (not log-density), so the **faithful linear-light `×2^EV`** is the correct, native port — a plain multiply *is* the black-anchored linear-light exposure. The filmic log-density arm is out of scope (architecturally inapplicable; FreeCCR has no logistic filmic curve or density working domain).

## Where it's applied (headroom-safe, CPU/GPU parity)

- **Working space ON (default):** un-clamped multiply inside the shared `_apply_working_space_recovery` pre-stage (alongside Gain/White Point), before the window clamp — so **+EV lands in recoverable highlight headroom** and is itself recoverable by −EV. Both CPU and GPU route through this function ⇒ automatic byte-parity.
- **Working space OFF (legacy `FREECCR_WORKING_SPACE=0`):** the same numpy `clip(img*m, 0, 65535)` before the Gain stage (CPU) / before the kernel (GPU, consumed in numpy like WB). `clip(img/65535*m,0,1)*65535 == clip(img*m,0,65535)`, so the two paths are byte-identical and `m=1` is an exact no-op.

## Interaction with Auto Gain / auto-exposure-base

**Unchanged and orthogonal.** Auto Gain (`ag`) and auto-exposure-base (`eb`) are computed from the *base* pixels and ride the **Gain** stage; they're invariant to the sliders, including Exposure. Output = `base × gain_stage(exposure+eb+ag) × 2^EV`. Dialing +1 EV after Auto Gain seats the highlight intentionally brightens by a stop — the expected behaviour. No Auto-Gain code changes.

## Files

- `src/core/ccr_processor.py` — `EXPO_EV_MAX` + `_exposure_ev_gain`; threaded through `_apply_working_space_recovery`, `adjust_image`, `adjust_image_opencl` (new param added at the **end** of both signatures so no positional caller shifts).
- `src/widgets/sliders_panel.py` — `"exposure_ev"` after `"exposure"` in `ADJUSTMENT_KEYS`; "Exposure" slider created under Gain; added to the Tone sync group + label list.
- `src/core/ccr_image.py` — both `adjust_image_opencl` call sites pass `exposure_ev=s.get('exposure_ev', 0)`.
- `spec/exposure-slider.md` — full spec (goals/non-goals, math, integration, test plan, resolved refinements).
- `tests/test_exposure_slider.py` — 14 tests.

It rides the generic adjustment dict, so Reset / Compare / **Sync to All** (Tone group) / copy-paste / catalog persistence all work automatically. Old catalogs without the key load as `0` (backward compatible).

## Tests

`tests/test_exposure_slider.py` — **14 passing** (EV→multiply mapping, ws identity byte-noop, +1 EV doubles linear, black-anchor, headroom recovery, +EV white clip, Gain commute, non-ws parity with ws, **CPU/GPU parity** ws on+off, UI wiring). Full focused run: **131 passed**; the only failures in adjacent suites are the **pre-existing `exposure_base` fixture failures** (ccr_image.py:813, confirmed identical on clean `main` via `git stash`) — unrelated to this change. Both positive-mode identity contracts still pass.

> Note: release-notes "What's New" in `release.yml` intentionally untouched — no version bump requested; update on the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
