### PR TITLE
feat(tools): add colour-fidelity evaluation tools (color_eval + scan_color_eval)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ win_installer
 activation-server
 dmg_temp
 
+# local test scans / RAWs + profiles (large binaries, never commit)
+example_raw/
+
 # qt-testing skill: offscreen widget screenshots
 scratch/

--- a/tools/color_eval/README.md
+++ b/tools/color_eval/README.md
@@ -1,0 +1,98 @@
+# color_eval — general image colour-fidelity evaluator
+
+A standalone tool that measures how faithfully one or more **finished images**
+reproduce a colour reference, and writes a graphic + text report (Markdown **and
+PDF**) of four CIELab drift curves. **No application coupling** — depends on
+`numpy`, `opencv-python`, and `matplotlib`, plus `markdown-pdf` (+ `linkify-it-py`)
+for the PDF export. Read-only.
+
+It replaces the FreeCCR-specific `scan_color_eval` for the general case: it takes
+already-converted images (JPG/PNG/TIFF/…), not RAW negatives, and does no
+decoding/inversion of its own.
+
+## What it measures
+
+Every image is compared to a reference in CIELab. Per pixel (gold mode) or per
+patch (chart mode) it computes **hue** (`atan2(b*,a*)`), **saturation** (`Cab`),
+and **value** (`L*`), and the **drift** (image − reference) of each. The report
+contains four cross-plots, split by which data is meaningful for each:
+
+| plot | x | y | data used |
+|---|---|---|---|
+| hue-vs-hue | reference hue | Δhue | **colour patches** (grey has no hue) |
+| hue-vs-saturation | reference hue | Δsaturation | **colour patches** |
+| value-vs-hue | reference L* | Δhue | **grey ramp** (neutral-axis cast vs brightness) |
+| value-vs-value | reference L* | Δvalue | **grey ramp** (tone accuracy) |
+
+"Colour patches" = the 18 chromatic ColorChecker patches (or chromatic pixels in
+gold mode); "grey ramp" = the 6 neutral patches (or near-neutral pixels), which
+span brightness and reveal any tint on the neutral axis. Hue axes carry a CIELab
+hue colour strip so you can read a drift against its actual colour. (Note: hue on
+near-neutral greys is inherently noisy — value-vs-hue shows cast *direction*,
+value-vs-value is the stable tone metric.)
+
+## Reference (target) — two modes
+
+- **`--target chart`** — an in-frame **X-Rite/Calibrite ColorChecker Classic 24**
+  is the reference (absolute accuracy → ΔE-style drift). Locate the chart **once**
+  (interactive 4-corner picker, or `--chart-corners`); the **same location is
+  reused for every image**, so a multi-image run only asks once.
+- **`--target GOLD_IMAGE`** — one image is the gold standard; every other image is
+  **registered** to it (ORB + homography) and compared per pixel.
+
+The baked chart reference is the X-Rite *"November 2014 edition and newer"* chart,
+measured on an i1Pro 2 (M0), stored as CIELab (D50) and adapted to the chosen
+`--ref-illuminant` (`D50`/`D55`/`D65`; D65 = daylight, the default).
+
+## Usage
+
+```bash
+python color_eval.py IMAGE [IMAGE ...] --target chart          # in-frame chart
+python color_eval.py IMAGE [IMAGE ...] --target reference.jpg  # gold image
+```
+
+`IMAGE` may be files, folders, or globs. The 4-corner chart picker needs a display
+(**mouse-wheel zoom**, centred on the cursor, + live 24-patch overlay to verify
+orientation before you accept: click 1 = dark-skin corner, 2 = far end of that top
+row, 3 = opposite/bottom corner, 4 = white-patch corner; it handles tilt / rotation
+/ mirror and small hand-held charts). Headless: pass
+`--chart-corners x0,y0,x1,y1,x2,y2,x3,y3` (fractions, order TL, TR, BR, BL).
+
+Options: `--ref-illuminant D50|D55|D65`, `--chart-grid 6x4`, `--chart-image N`
+(which image to locate the chart on), `--long <px>`, `--no-gui`, `--out DIR`.
+
+## Outputs
+
+By default the report is written **next to the first image**, in a folder named
+`<first-image-name>_color_report/` (override with `--out`). It contains:
+
+- `drift.png` — the four drift curves, all images overlaid. In chart mode each
+  data point's **patch number is labelled under the x-axis**.
+- `report.md` — overall fidelity table + per-hue-band and per-brightness drift
+  tables, with the graphic embedded. In chart mode it also embeds the three
+  swatch-check grids below.
+- `report.pdf` — `report.md` rendered to PDF via the `markdown-pdf` package (A4
+  landscape). Images are embedded at **native resolution** (crisp when zoomed) and
+  the file is deflate-optimised (~0.4 MB). Needs `pip install markdown-pdf
+  linkify-it-py`; if missing, the PDF is skipped with a hint and the rest of the
+  report is still written. No pandoc/LaTeX/wkhtmltopdf needed.
+- **chart-check grids** (chart mode) — reference swatch row on top, each image's
+  sampled patches below (column = patch #):
+  - `chart_check.png` — sampled colours **as-is** (confirms mapping + raw drift).
+  - `chart_check_hue.png` — sampled at the reference **L\*** (lightness matched) →
+    hue + chroma difference.
+  - `chart_check_purehue.png` — sampled at the reference **L\* and chroma** →
+    **pure hue** difference.
+- `overall.csv`, `drift_per_hue_band.csv`, `drift_vs_value_greyramp.csv` — machine-readable.
+- `chart_per_patch.csv` (chart mode) — per-patch Δhue/Δsat/Δvalue for each image.
+- `registration_overlays.jpg` (gold mode) — checkerboard of gold vs each aligned
+  image; the scene should be seamless across the squares (validates alignment).
+
+## Notes
+
+- Images are read with OpenCV (BGR); all colour math is in CIELab, so the reference
+  and the measured patches are handled in the same space.
+- Chart mode assumes a ColorChecker Classic 24 (6 wide × 4 tall, dark-skin patch at
+  corner 1). Replace `COLORCHECKER24_LAB_D50` / `--chart-grid` for a different chart.
+- Hue is unstable at low chroma; hue stats are chroma-weighted and thresholded.
+- Gold mode assumes the images are the **same scene** (so they can be registered).

--- a/tools/color_eval/color_eval.py
+++ b/tools/color_eval/color_eval.py
@@ -1,0 +1,706 @@
+#!/usr/bin/env python3
+"""
+color_eval.py — general image colour-fidelity evaluator (standalone).
+
+Reads one or more FINISHED images (JPG/PNG/TIFF/…) and reports how each reproduces
+a colour reference, as five CIELab drift curves (hue/saturation/value drift cross-
+tabbed against hue and value), in graphic + text form.
+
+Reference (target) — two modes:
+  --target chart          an in-frame X-Rite/Calibrite ColorChecker Classic 24.
+                          Locate it ONCE (4-corner picker, or --chart-corners); the
+                          SAME location is reused for every image.
+  --target GOLD_IMAGE     one image is the gold standard; the others are registered
+                          to it and compared per pixel.
+
+No app coupling: depends only on numpy, opencv-python, matplotlib. Read-only.
+
+Examples:
+  python color_eval.py shot1.jpg shot2.jpg --target chart
+  python color_eval.py folder_of_jpgs --target chart --ref-illuminant D65
+  python color_eval.py a.jpg b.jpg c.jpg --target reference.jpg
+"""
+import argparse
+import csv
+import glob
+import math
+import os
+import sys
+
+import numpy as np
+import cv2
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+IMG_EXTS = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp", ".webp"}
+HUE_BANDS = [("R", 0, 30), ("O", 30, 60), ("Y", 60, 90), ("G", 90, 165),
+             ("C", 165, 195), ("B", 195, 255), ("P", 255, 315), ("M", 315, 360)]
+LBINS = [(0, 20), (20, 35), (35, 50), (50, 65), (65, 80), (80, 100)]
+REF_ILLUMINANTS = ("D50", "D55", "D65")
+
+GREY_MAX = 6.0   # CIELab chroma below this = neutral/grey (the ColorChecker grey ramp / neutral pixels)
+# The four drift cross-plots: (key, x-source, y-source, select, circular-y, xlabel, ylabel, title).
+# select: "colored" = chromatic patches/pixels only (the hue circle); "grey" = the neutral ramp only.
+# Hue-axis plots use the colour patches (grey has no meaningful hue); value-axis plots use the grey
+# ramp (it spans brightness and is the neutral-axis tone/cast reference).
+DRIFTS = [
+    ("hue_vs_hue",   "hue", "dH", "colored", True,  "hue (deg)", "hue drift (deg)",  "hue-vs-hue drift (colour patches)"),
+    ("value_vs_hue", "val", "dH", "grey",    True,  "L*",        "hue drift (deg)",  "value-vs-hue drift (grey ramp)"),
+    ("hue_vs_sat",   "hue", "dS", "colored", False, "hue (deg)", "sat drift (Cab)",  "hue-vs-saturation drift (colour patches)"),
+    ("value_vs_val", "val", "dV", "grey",    False, "L*",        "value drift (L*)", "value-vs-value drift (grey ramp)"),
+]
+MAXPIX = 200000
+
+# ColorChecker Classic 24 REFERENCE — X-Rite "November 2014 edition and newer",
+# measured on an i1Pro 2 (M0). CIELab (D50, 2deg), row-major (dark-skin first).
+COLORCHECKER24_LAB_D50 = [
+    (37.54, 14.37, 14.92), (64.66, 19.27, 17.50), (49.32, -3.82, -22.54),
+    (43.46, -12.74, 22.72), (54.94, 9.61, -24.79), (70.48, -32.26, -0.37),
+    (62.73, 35.83, 56.50), (39.43, 10.75, -45.17), (50.57, 48.64, 16.67),
+    (30.10, 22.54, -20.87), (71.77, -24.13, 58.19), (71.51, 18.24, 67.37),
+    (28.37, 15.42, -49.80), (54.38, -39.72, 32.27), (42.43, 51.05, 28.62),
+    (81.80, 2.67, 80.41), (50.63, 51.28, -14.12), (49.57, -29.71, -28.32),
+    (95.19, -1.03, 2.93), (81.29, -0.57, 0.44), (66.89, -0.75, -0.06),
+    (50.76, -0.13, 0.14), (35.63, -0.46, -0.48), (20.64, 0.07, -0.46),
+]
+_WHITES = {"D50": (0.96422, 1.0, 0.82521), "D55": (0.95682, 1.0, 0.92149), "D65": (0.95047, 1.0, 1.08883)}
+_M_BRADFORD = np.array([[0.8951, 0.2664, -0.1614], [-0.7502, 1.7135, 0.0367], [0.0389, -0.0685, 1.0296]])
+_M_XYZ2SRGB = np.array([[3.2404542, -1.5371385, -0.4985314],
+                        [-0.9692660, 1.8760108, 0.0415560], [0.0556434, -0.2040259, 1.0572252]])
+_HUE_GRAD = None
+
+
+# ----------------------------------------------------------------------------- reference / colour
+def _cat_bradford(src, dst):
+    s = _M_BRADFORD @ np.asarray(src, float)
+    d = _M_BRADFORD @ np.asarray(dst, float)
+    return np.linalg.inv(_M_BRADFORD) @ np.diag(d / s) @ _M_BRADFORD
+
+
+def _lab_to_xyz(lab, white):
+    lab = np.asarray(lab, float)
+    L, a, b = lab[:, 0], lab[:, 1], lab[:, 2]
+    fy = (L + 16) / 116; fx = fy + a / 500; fz = fy - b / 200
+    eps, kappa = 216 / 24389, 24389 / 27
+
+    def finv(f):
+        f3 = f ** 3
+        return np.where(f3 > eps, f3, (116 * f - 16) / kappa)
+    xr = finv(fx)
+    yr = np.where(L > kappa * eps, ((L + 16) / 116) ** 3, L / kappa)
+    zr = finv(fz)
+    return np.stack([xr * white[0], yr * white[1], zr * white[2]], 1)
+
+
+def reference_srgb(illuminant="D65"):
+    """ColorChecker reference sRGB under a chosen adopted white (Bradford D50->white)."""
+    xyz = _lab_to_xyz(COLORCHECKER24_LAB_D50, _WHITES["D50"]) @ _cat_bradford(_WHITES["D50"], _WHITES[illuminant]).T
+    lin = np.clip(xyz @ _M_XYZ2SRGB.T, 0, 1)
+    srgb = np.where(lin <= 0.0031308, 12.92 * lin, 1.055 * np.power(lin, 1 / 2.4) - 0.055)
+    return [tuple(int(x) for x in row) for row in np.clip(np.rint(srgb * 255), 0, 255).astype(int)]
+
+
+def lab_hsv(bgr):
+    """L*(value), Cab(saturation), hue(deg) maps from a BGR uint8 image."""
+    L = cv2.cvtColor(bgr, cv2.COLOR_BGR2Lab).astype(np.float32)
+    a, b = L[..., 1] - 128.0, L[..., 2] - 128.0
+    return L[..., 0] * 100 / 255.0, np.hypot(a, b), np.degrees(np.arctan2(b, a)) % 360
+
+
+def lab_hsv_srgb(rgb_tuples):
+    arr = np.array(rgb_tuples, np.uint8).reshape(-1, 1, 3)[:, :, ::-1]     # RGB -> BGR
+    L = cv2.cvtColor(arr, cv2.COLOR_BGR2Lab).astype(np.float32).reshape(-1, 3)
+    a, b = L[:, 1] - 128.0, L[:, 2] - 128.0
+    return L[:, 0] * 100 / 255.0, np.hypot(a, b), np.degrees(np.arctan2(b, a)) % 360
+
+
+def _lab_to_bgr(L, C, H):
+    """Reconstruct a BGR swatch from L*/chroma/hue (for the visual chart check)."""
+    a, b = C * np.cos(np.radians(H)), C * np.sin(np.radians(H))
+    lab = np.stack([np.clip(L * 255 / 100, 0, 255), np.clip(a + 128, 0, 255),
+                    np.clip(b + 128, 0, 255)], -1).astype(np.uint8).reshape(-1, 1, 3)
+    return cv2.cvtColor(lab, cv2.COLOR_Lab2BGR).reshape(-1, 3)
+
+
+def cdiff(h2, h1):
+    return (h2 - h1 + 180) % 360 - 180
+
+
+def wmean(v, w, circular):
+    if np.size(w) == 0 or w.sum() < 1e-6:
+        return float("nan")
+    if circular:
+        r = np.radians(v)
+        return math.degrees(math.atan2((w * np.sin(r)).sum(), (w * np.cos(r)).sum()))
+    return float(np.average(v, weights=w))
+
+
+def _hue_gradient(n=360, L8=180, C=55):
+    deg = np.arange(n)
+    lab = np.zeros((1, n, 3), np.uint8)
+    lab[0, :, 0] = L8
+    lab[0, :, 1] = np.clip(128 + C * np.cos(np.radians(deg)), 0, 255).astype(np.uint8)
+    lab[0, :, 2] = np.clip(128 + C * np.sin(np.radians(deg)), 0, 255).astype(np.uint8)
+    return (cv2.cvtColor(lab, cv2.COLOR_Lab2BGR)[:, :, ::-1].astype(np.float32) / 255.0)
+
+
+# ----------------------------------------------------------------------------- chart geometry
+def parse_corners(s):
+    if s is None:
+        return None
+    v = [float(x) for x in s.split(",")]
+    if len(v) != 8:
+        raise argparse.ArgumentTypeError("chart-corners = x0,y0,x1,y1,x2,y2,x3,y3 (TL,TR,BR,BL fractions)")
+    return [(v[0], v[1]), (v[2], v[3]), (v[4], v[5]), (v[6], v[7])]
+
+
+def _grid_centers(quad_px, cols, rows):
+    unit = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], np.float32)
+    H = cv2.getPerspectiveTransform(unit, np.asarray(quad_px, np.float32))
+    uv = np.array([[[(c + 0.5) / cols, (r + 0.5) / rows]] for r in range(rows) for c in range(cols)], np.float32)
+    return cv2.perspectiveTransform(uv, H).reshape(-1, 2)
+
+
+def sample_chart_quad(bgr, corners_frac, cols, rows, patch=0.45):
+    """Sample cols*rows patches from the 4 chart corners (fractions, [TL,TR,BR,BL]).
+    Perspective-correct -> tilt/rotation/mirror/perspective all handled; corner ORDER
+    fixes orientation (corner 1 = patch#1 / dark-skin). Returns L*,C,hue arrays."""
+    h, w = bgr.shape[:2]
+    quad = [(x * w, y * h) for x, y in corners_frac]
+    unit = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], np.float32)
+    H = cv2.getPerspectiveTransform(unit, np.asarray(quad, np.float32))
+    ctrs = _grid_centers(quad, cols, rows)
+    out = []
+    for i, (cx, cy) in enumerate(ctrs):
+        r, c = divmod(i, cols)
+        off = cv2.perspectiveTransform(
+            np.array([[[(c + 0.5 + patch * 0.5) / cols, (r + 0.5 + patch * 0.5) / rows]]], np.float32), H)[0, 0]
+        rad = max(2, int(0.7 * math.hypot(off[0] - cx, off[1] - cy)))
+        x0, x1 = max(0, int(cx - rad)), min(w, int(cx + rad))
+        y0, y1 = max(0, int(cy - rad)), min(h, int(cy + rad))
+        p = bgr[y0:y1, x0:x1]
+        if p.size == 0:
+            out.append((np.nan, np.nan, np.nan)); continue
+        med = np.median(p.reshape(-1, 3), axis=0).astype(np.uint8).reshape(1, 1, 3)
+        lab = cv2.cvtColor(med, cv2.COLOR_BGR2Lab).astype(np.float32).reshape(3)
+        a, b = lab[1] - 128.0, lab[2] - 128.0
+        out.append((lab[0] * 100 / 255.0, math.hypot(a, b), math.degrees(math.atan2(b, a)) % 360))
+    arr = np.array(out)
+    return arr[:, 0], arr[:, 1], arr[:, 2]
+
+
+def pick_chart_quad(bgr, cols, rows):
+    """4-corner ColorChecker picker with MOUSE-WHEEL ZOOM (centered on the cursor) and
+    a live 24-patch grid overlay. Click corners IN ORDER: 1=patch#1 (dark-skin) corner,
+    2=far end of that top row, 3=opposite/bottom corner, 4=white-patch corner. Robust
+    to tilt/rotation/mirror. Shown at native resolution unless it exceeds 1080p.
+    Keys: r=reset, Enter=confirm, Esc=cancel. Returns 4 corner fractions [TL,TR,BR,BL]."""
+    h, w = bgr.shape[:2]
+    s = min(1.0, 1920.0 / w, 1080.0 / h)          # full resolution unless it exceeds 1080p
+    base = cv2.resize(bgr, (int(w * s), int(h * s))) if s < 1 else bgr.copy()
+    dh, dw = base.shape[:2]
+    pts = []                                       # corner points in BASE-image coords
+    view = {"z": 1.0, "cx": dw / 2.0, "cy": dh / 2.0}   # zoom + view centre (base coords)
+    win = "Chart corners  1=dark-skin 2=top-end 3=bottom 4=white | wheel=zoom  r=reset  Enter=ok  Esc=cancel"
+
+    def w2b(x, y):                                 # window pixel -> base coords
+        return (view["cx"] + (x - dw / 2.0) / view["z"], view["cy"] + (y - dh / 2.0) / view["z"])
+
+    def clamp():
+        hw, hh = (dw / view["z"]) / 2.0, (dh / view["z"]) / 2.0
+        view["cx"] = min(max(view["cx"], hw), dw - hw)
+        view["cy"] = min(max(view["cy"], hh), dh - hh)
+
+    def on_mouse(ev, x, y, flags, param):
+        if ev == cv2.EVENT_MOUSEWHEEL:
+            try:
+                delta = cv2.getMouseWheelDelta(flags)          # not in all cv2 builds
+            except Exception:
+                delta = (flags >> 16) & 0xFFFF                 # high word = wheel delta...
+                if delta >= 0x8000:
+                    delta -= 0x10000                           # ...as a signed short
+            bx, by = w2b(x, y)                      # keep this base point under the cursor
+            view["z"] = float(np.clip(view["z"] * (1.25 if delta > 0 else 0.8), 1.0, 16.0))
+            view["cx"], view["cy"] = bx - (x - dw / 2.0) / view["z"], by - (y - dh / 2.0) / view["z"]
+            clamp()
+        elif ev == cv2.EVENT_LBUTTONDOWN and len(pts) < 4:
+            pts.append(w2b(x, y))
+    cv2.namedWindow(win, cv2.WINDOW_AUTOSIZE)
+    cv2.setMouseCallback(win, on_mouse)
+    labels = {0: "1", cols - 1: str(cols), cols * rows - cols: str(cols * rows - cols + 1), cols * rows - 1: str(cols * rows)}
+    while True:
+        z, cx, cy = view["z"], view["cx"], view["cy"]
+        M = np.array([[z, 0, dw / 2.0 - z * cx], [0, z, dh / 2.0 - z * cy]], np.float32)
+        img = cv2.warpAffine(base, M, (dw, dh))
+
+        def b2w(p):                                # base coords -> window pixel
+            return (int(z * (p[0] - cx) + dw / 2.0), int(z * (p[1] - cy) + dh / 2.0))
+        for i, p in enumerate(pts):
+            wp = b2w(p)
+            cv2.circle(img, wp, 5, (0, 0, 255), -1)
+            cv2.putText(img, str(i + 1), (wp[0] + 6, wp[1] - 6), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 255), 2)
+        if len(pts) >= 2:
+            cv2.polylines(img, [np.array([b2w(p) for p in pts], np.int32)], len(pts) == 4, (0, 255, 255), 1)
+        if len(pts) == 4:
+            for j, c in enumerate(_grid_centers(pts, cols, rows)):
+                wc = b2w(c)
+                cv2.circle(img, wc, 3, (0, 255, 0), -1)
+                if j in labels:
+                    cv2.putText(img, labels[j], (wc[0] + 3, wc[1] - 3), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
+        cv2.putText(img, f"corner {len(pts)}/4   zoom {z:.1f}x   (wheel to zoom)", (6, dh - 10),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
+        cv2.imshow(win, img)
+        k = cv2.waitKey(20) & 0xFF
+        if k == ord('r'):
+            pts.clear(); view.update(z=1.0, cx=dw / 2.0, cy=dh / 2.0)
+        elif k in (13, 10) and len(pts) == 4:
+            break
+        elif k == 27:
+            cv2.destroyWindow(win); raise RuntimeError("chart pick cancelled")
+    cv2.destroyWindow(win)
+    return [(p[0] / dw, p[1] / dh) for p in pts]
+
+
+# ----------------------------------------------------------------------------- registration (gold mode)
+def register(var_bgr, gold_bgr):
+    g1 = cv2.cvtColor(gold_bgr, cv2.COLOR_BGR2GRAY)
+    g2 = cv2.cvtColor(var_bgr, cv2.COLOR_BGR2GRAY)
+    orb = cv2.ORB_create(6000)
+    k1, d1 = orb.detectAndCompute(g1, None)
+    k2, d2 = orb.detectAndCompute(g2, None)
+    if d1 is None or d2 is None:
+        return None
+    good = [m for m, n in cv2.BFMatcher(cv2.NORM_HAMMING).knnMatch(d2, d1, k=2) if m.distance < 0.75 * n.distance]
+    if len(good) < 12:
+        return None
+    sp = np.float32([k2[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+    dp = np.float32([k1[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+    H, _ = cv2.findHomography(sp, dp, cv2.RANSAC, 3.0)
+    if H is None:
+        return None
+    th, tw = gold_bgr.shape[:2]
+    warp = cv2.warpPerspective(var_bgr, H, (tw, th))
+    vm = cv2.erode(cv2.warpPerspective(np.ones(var_bgr.shape[:2], np.uint8), H, (tw, th)),
+                   np.ones((7, 7), np.uint8)).astype(bool)
+    gw = cv2.cvtColor(warp, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    gt = g1.astype(np.float32)
+    a, b = gt[vm] - gt[vm].mean(), gw[vm] - gw[vm].mean()
+    ncc = float((a * b).sum() / (np.sqrt((a * a).sum() * (b * b).sum()) + 1e-9))
+    return warp, vm, ncc
+
+
+def _checker(a, b, mask, n=14):
+    h, w = a.shape[:2]; bs = max(h, w) // n; o = a.copy()
+    for y in range(0, h, bs):
+        for x in range(0, w, bs):
+            if ((x // bs) + (y // bs)) % 2 == 1:
+                o[y:y + bs, x:x + bs] = b[y:y + bs, x:x + bs]
+    o[~mask] = (o[~mask] * 0.3).astype(np.uint8)
+    return o
+
+
+# ----------------------------------------------------------------------------- drift
+def drift_arrays(tL, tC, tH, vL, vC, vH, sel):
+    idx = np.flatnonzero(sel)
+    if idx.size > MAXPIX:
+        idx = idx[:: max(1, idx.size // MAXPIX)]
+    return dict(val=tL.ravel()[idx], sat=tC.ravel()[idx], hue=tH.ravel()[idx],
+                dV=(vL - tL).ravel()[idx], dS=(vC - tC).ravel()[idx], dH=cdiff(vH, tH).ravel()[idx])
+
+
+def _csel(r):
+    """Chroma used to split colour vs grey. In chart mode this is the ILLUMINANT-
+    INDEPENDENT D50 chroma ('csel'), so the 6 neutral patches stay classed as grey
+    even when --ref-illuminant renders the reference warm. Gold mode: pixel chroma."""
+    return r["csel"] if "csel" in r else r["sat"]
+
+
+def _sel(r, select, chroma_thr):
+    """Boolean mask selecting colour patches/pixels, the grey ramp, or all."""
+    c = _csel(r)
+    if select == "colored":
+        return c > chroma_thr
+    if select == "grey":
+        return c < GREY_MAX
+    return np.ones(np.shape(c), bool)
+
+
+def binned_curve(r, drift, chroma_thr):
+    _, xsrc, ysrc, select, circ, _, _, _ = drift
+    if np.size(r["hue"]) == 0:
+        return None
+    x, y = r[xsrc], r[ysrc]
+    sel = np.isfinite(x) & np.isfinite(y) & _sel(r, select, chroma_thr)
+    w = r["sat"][sel] if select == "colored" else np.ones(int(sel.sum()))   # sat-weight colours; grey uniform
+    x, y = x[sel], y[sel]
+    if xsrc == "hue":
+        xs, width = np.arange(0, 360, 10), 10
+    else:
+        xs, width = np.arange(2.5, 100, 5), 5
+    ys = []
+    for xb in xs:
+        m = (x >= xb - (0 if xsrc == "hue" else width / 2)) & (x < xb + (width if xsrc == "hue" else width / 2))
+        ys.append(wmean(y[m], w[m], circ) if m.sum() > 40 else np.nan)
+    return xs, np.array(ys)
+
+
+# ----------------------------------------------------------------------------- io helpers
+def collect_images(patterns):
+    out = []
+    for p in patterns:
+        if os.path.isdir(p):
+            out += sorted(f for f in glob.glob(os.path.join(p, "*")) if os.path.splitext(f)[1].lower() in IMG_EXTS)
+        elif any(ch in p for ch in "*?["):
+            out += sorted(glob.glob(p))
+        else:
+            out.append(p)
+    return [p for p in out if os.path.splitext(p)[1].lower() in IMG_EXTS and os.path.isfile(p)]
+
+
+def load_bgr(path, long_edge):
+    img = cv2.imread(path, cv2.IMREAD_COLOR)
+    if img is None:
+        raise ValueError(f"cannot read image: {path}")
+    h, w = img.shape[:2]
+    s = long_edge / max(h, w)
+    return cv2.resize(img, (max(1, int(w * s)), max(1, int(h * s))), interpolation=cv2.INTER_AREA) if s < 1 else img
+
+
+# ----------------------------------------------------------------------------- modes
+def run_chart(paths, args):
+    cols, rows = (int(x) for x in args.chart_grid.lower().split("x"))
+    imgs = {p: load_bgr(p, args.long) for p in paths}
+    if args.chart_corners:
+        quad = args.chart_corners
+    elif args.no_gui:
+        sys.exit("chart mode needs --chart-corners or a display")
+    else:
+        pick_on = paths[min(args.chart_image, len(paths) - 1)]
+        print(f"Locate the ColorChecker on '{os.path.basename(pick_on)}' — this location is reused for ALL images.")
+        full = cv2.imread(pick_on, cv2.IMREAD_COLOR)      # native resolution for precise clicking
+        quad = pick_chart_quad(full if full is not None else imgs[pick_on], cols, rows)
+    refL, refC, refH = lab_hsv_srgb(reference_srgb(args.ref_illuminant))
+    base = np.array(COLORCHECKER24_LAB_D50, float)
+    csel = np.hypot(base[:, 1], base[:, 2])           # D50 chroma -> illuminant-independent grey/colour split
+    ref_bgr = np.array(reference_srgb(args.ref_illuminant), np.uint8)[:, ::-1]   # RGB -> BGR reference swatches
+    print(f"Reference: X-Rite ColorChecker24 (post-Nov2014), adopted white {args.ref_illuminant}\n")
+    pool, measured = {}, {}
+    for p in paths:
+        name = os.path.basename(p)
+        mL, mC, mH = sample_chart_quad(imgs[p], quad, cols, rows)
+        measured[name] = (mL, mC, mH)                 # sampled L*,C,hue per patch (for the visual checks)
+        pool[name] = dict(val=refL, sat=refC, hue=refH, dV=mL - refL, dS=mC - refC, dH=cdiff(mH, refH), csel=csel)
+        good = (refC > 10) & np.isfinite(pool[name]["dH"])
+        print(f"  {name:30s} mean|Δhue|={np.nanmean(np.abs(pool[name]['dH'][good])):5.1f}  "
+              f"mean|Δsat|={np.nanmean(np.abs(pool[name]['dS'])):5.1f}  mean|ΔL|={np.nanmean(np.abs(pool[name]['dV'])):5.1f}")
+    _write_chart_check(measured, ref_bgr, refL, refC, args.out)
+    write_outputs(pool, list(pool.keys()), args, mode="chart")
+
+
+def run_gold(paths, args):
+    gold_path = os.path.abspath(args.target)
+    gold = load_bgr(gold_path, args.long)
+    gL, gC, gH = lab_hsv(gold)
+    eval_paths = [p for p in paths if os.path.abspath(p) != gold_path]
+    if not eval_paths:
+        sys.exit("no images to evaluate (all match the gold image)")
+    print(f"Gold standard: {os.path.basename(gold_path)}  ({len(eval_paths)} image(s) to compare)\n")
+    pool, overlays = {}, []
+    for p in eval_paths:
+        name = os.path.basename(p)
+        var = load_bgr(p, args.long)
+        r = register(var, gold)
+        if r is None:
+            print(f"  {name:30s} REGISTRATION FAILED (different scene?)"); continue
+        warp, vm, ncc = r
+        print(f"  {name:30s} NCC={ncc:.3f}" + ("  <- weak, excluded" if ncc < 0.6 else ""))
+        if ncc < 0.6:
+            continue
+        overlays.append((name, _checker(gold, warp, vm)))
+        vL, vC, vH = lab_hsv(warp)
+        pool[name] = drift_arrays(gL, gC, gH, vL, vC, vH, vm & (gL > 3) & (gL < 99))
+    write_outputs(pool, list(pool.keys()), args, mode="pixel", overlays=overlays)
+
+
+# ----------------------------------------------------------------------------- outputs
+def _overall(r):
+    """hue & saturation drift on the COLOUR patches; value drift (bias + |ΔL|) on the GREY ramp."""
+    c = _csel(r)
+    col = (c > 8) & np.isfinite(r["dH"])
+    grey = c < GREY_MAX
+    return (float(np.average(np.abs(r["dH"][col]), weights=r["sat"][col])) if col.sum() else float("nan"),
+            float(np.nanmean(np.abs(r["dS"][col]))) if col.sum() else float("nan"),
+            float(np.nanmean(r["dV"][grey])) if grey.sum() else float("nan"),
+            float(np.nanmean(np.abs(r["dV"][grey]))) if grey.sum() else float("nan"))
+
+
+def _hue_band_val(r, lo, hi, ysrc, circ, chroma, min_n):
+    """Colour-patch metric per hue band (chroma-weighted)."""
+    sel = (r["hue"] >= lo) & (r["hue"] < hi) & (_csel(r) > chroma) & np.isfinite(r[ysrc])
+    return wmean(r[ysrc][sel], _csel(r)[sel], circ) if sel.sum() >= min_n else float("nan")
+
+
+def _lbin_val(r, lo, hi, ysrc, circ, select, chroma, min_n):
+    """Metric per L* bin over the selected patches/pixels ('grey' or 'colored')."""
+    sel = (r["val"] >= lo) & (r["val"] < hi) & np.isfinite(r[ysrc]) & _sel(r, select, chroma)
+    w = r["sat"][sel] if select == "colored" else np.ones(int(sel.sum()))
+    return wmean(r[ysrc][sel], w, circ) if sel.sum() >= min_n else float("nan")
+
+
+def write_outputs(pool, keys, args, mode, overlays=None):
+    keys = [k for k in keys if k in pool and np.size(pool[k]["hue"])]
+    if not keys:
+        print("no results to write"); return
+    out = args.out
+    chr_thr = args.chroma if mode == "pixel" else 8.0
+    mn = 1 if mode == "chart" else 20
+    with open(os.path.join(out, "overall.csv"), "w", newline="") as fh:
+        w = csv.writer(fh); w.writerow(["image", "mean_abs_hue_drift_deg", "mean_abs_sat_drift", "value_bias_L", "mean_abs_value_drift_L"])
+        for k in keys:
+            w.writerow([k] + [f"{x:.2f}" for x in _overall(pool[k])])
+    with open(os.path.join(out, "drift_per_hue_band.csv"), "w", newline="") as fh:
+        w = csv.writer(fh); w.writerow(["band"] + [f"{k} dHue" for k in keys] + [f"{k} dSat" for k in keys])
+        for bn, lo, hi in HUE_BANDS:
+            w.writerow([bn] + [f"{_hue_band_val(pool[k], lo, hi, 'dH', True, chr_thr, mn):.1f}" for k in keys]
+                       + [f"{_hue_band_val(pool[k], lo, hi, 'dS', False, chr_thr, mn):.1f}" for k in keys])
+    with open(os.path.join(out, "drift_vs_value_greyramp.csv"), "w", newline="") as fh:
+        w = csv.writer(fh); w.writerow(["L_low", "L_high"] + [f"{k} dHue" for k in keys] + [f"{k} dVal" for k in keys])
+        for lo, hi in LBINS:
+            w.writerow([lo, hi]
+                       + [f"{_lbin_val(pool[k], lo, hi, 'dH', True, 'grey', 0, mn):.1f}" for k in keys]
+                       + [f"{_lbin_val(pool[k], lo, hi, 'dV', False, 'grey', 0, mn):.1f}" for k in keys])
+    if mode == "chart":
+        with open(os.path.join(out, "chart_per_patch.csv"), "w", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(["patch", "ref_L", "ref_C", "ref_hue"] + [f"{k} dHue" for k in keys] + [f"{k} dSat" for k in keys] + [f"{k} dVal" for k in keys])
+            ref = pool[keys[0]]
+            for i in range(np.size(ref["hue"])):
+                w.writerow([i + 1, f"{ref['val'][i]:.1f}", f"{ref['sat'][i]:.1f}", f"{ref['hue'][i]:.1f}"]
+                           + [f"{pool[k]['dH'][i]:.1f}" for k in keys]
+                           + [f"{pool[k]['dS'][i]:.1f}" for k in keys]
+                           + [f"{pool[k]['dV'][i]:.1f}" for k in keys])
+    _plot(keys, pool, out, chr_thr, mode)
+    if overlays:
+        H = max(o.shape[0] for _, o in overlays)
+        tiles = []
+        for name, o in overlays:
+            cv2.rectangle(o, (0, 0), (o.shape[1], 20), (0, 0, 0), -1)
+            cv2.putText(o, name, (4, 15), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 255), 1)
+            tiles.append(cv2.copyMakeBorder(o, 0, H - o.shape[0], 0, 6, cv2.BORDER_CONSTANT, value=(50, 50, 50)))
+        cv2.imwrite(os.path.join(out, "registration_overlays.jpg"), np.hstack(tiles), [cv2.IMWRITE_JPEG_QUALITY, 90])
+    _report_md(pool, keys, args, out, mode, mn, chr_thr)
+    _write_pdf(out)
+    print("\nOverall (mean|Δhue|deg, mean|Δsat|, ΔL bias, mean|ΔL|):")
+    for k in keys:
+        o = _overall(pool[k]); print(f"  {k:30s} hue={o[0]:5.1f}  sat={o[1]:5.1f}  Lbias={o[2]:+5.1f}  |L|={o[3]:5.1f}")
+    print(f"\nDone. Outputs in: {out}")
+
+
+def _plot(keys, pool, out, chr_thr, mode):
+    global _HUE_GRAD
+    if _HUE_GRAD is None:
+        _HUE_GRAD = _hue_gradient()
+    colors = plt.cm.tab10(np.linspace(0, 1, 10))
+    ncol = 2                                          # 2x2 landscape: left col = hue-axis, right = value-axis
+    nrow = -(-len(DRIFTS) // ncol)
+    fig, axes = plt.subplots(nrow, ncol, figsize=(8 * ncol, 4.6 * nrow))
+    ax = np.atleast_1d(axes).ravel()
+    for i, drift in enumerate(DRIFTS):
+        _, xsrc, ysrc, select, circ, xlab, ylab, title = drift
+        for ki, k in enumerate(keys):
+            col = colors[ki % 10]
+            r = pool[k]
+            if mode == "chart":
+                sel = np.isfinite(r[xsrc]) & np.isfinite(r[ysrc]) & _sel(r, select, 8)
+                xv, yv = r[xsrc][sel], r[ysrc][sel]
+                o = np.argsort(xv)
+                ax[i].plot(xv[o], yv[o], "-o", ms=4, color=col, label=k)
+            else:
+                cur = binned_curve(r, drift, chr_thr)
+                if cur is None:
+                    continue
+                xs, ys = cur
+                ax[i].plot(xs, ys, "-o", ms=3, color=col, label=k)
+        ax[i].axhline(0, color="k", lw=.6); ax[i].set_title(title); ax[i].set_ylabel(ylab)
+        ax[i].legend(fontsize=7); ax[i].grid(alpha=.3)
+        if mode == "chart" and keys:                  # patch numbers under the x-axis (chart mode)
+            r0 = pool[keys[0]]
+            xref = np.asarray(r0[xsrc], float)
+            m = _sel(r0, select, 8) & np.isfinite(xref)
+            tr = ax[i].get_xaxis_transform()
+            py = -0.05 if xsrc == "hue" else -0.13     # hue: above the strip; value: below the L* ticks
+            for xv, num in zip(xref[m], (np.arange(xref.size) + 1)[m]):
+                ax[i].text(xv, py, str(int(num)), transform=tr, ha="center", va="top",
+                           fontsize=6.5, color="0.35", clip_on=False)
+        if xsrc == "hue":
+            ax[i].set_xlim(0, 360); ax[i].set_xticklabels([]); ax[i].set_xlabel("")
+            cax = ax[i].inset_axes([0, -0.17, 1, 0.06])
+            cax.imshow(_HUE_GRAD, aspect="auto", extent=[0, 360, 0, 1])
+            cax.set_yticks([]); cax.set_xlim(0, 360); cax.set_xticks(range(0, 361, 30))
+            cax.tick_params(labelsize=8); cax.set_xlabel(xlab)
+        else:
+            ax[i].set_xlabel(xlab)
+    for j in range(len(DRIFTS), len(ax)):             # hide any unused cell
+        ax[j].axis("off")
+    plt.subplots_adjust(hspace=0.62, wspace=0.16, top=0.95, bottom=0.11, left=0.06, right=0.98)
+    plt.savefig(os.path.join(out, "drift.png"), dpi=200); plt.close()
+
+
+def _report_md(pool, keys, args, out, mode, mn, chr_thr):
+    tgt = "in-frame ColorChecker (absolute)" if mode == "chart" else f"gold image `{os.path.basename(args.target)}`"
+    lines = ["# Colour-fidelity report", "",
+             f"- Images: {len(keys)}", f"- Target: {tgt}",
+             (f"- Chart reference: X-Rite CC24 (post-Nov2014), adopted white {args.ref_illuminant}" if mode == "chart" else ""),
+             "", "Drift = image − reference in CIELab (hue=atan2(b,a)°, saturation=Cab, value=L*).", "",
+             "## Overall fidelity (lower = closer to reference)", "",
+             "| image | mean \\|Δhue\\| ° | mean \\|Δsat\\| | ΔL bias | mean \\|ΔL\\| |", "|---|---|---|---|---|"]
+    for k in keys:
+        o = _overall(pool[k])
+        lines.append(f"| {k} | {o[0]:.1f} | {o[1]:.1f} | {o[2]:+.1f} | {o[3]:.1f} |")
+    lines += ["", "![drift](drift.png)", "",
+              "### hue drift per colour band (deg)", "",
+              "| band | " + " | ".join(keys) + " |", "|" + "---|" * (len(keys) + 1)]
+    for bn, lo, hi in HUE_BANDS:
+        lines.append(f"| {bn} | " + " | ".join(f"{_hue_band_val(pool[k], lo, hi, 'dH', True, chr_thr, mn):.1f}" for k in keys) + " |")
+    lines += ["", "### grey-ramp drift vs brightness L* (Δhue° / ΔL)", "",
+              "| L* | " + " | ".join(keys) + " |", "|" + "---|" * (len(keys) + 1)]
+    for lo, hi in LBINS:
+        cell = [f"{_lbin_val(pool[k], lo, hi, 'dH', True, 'grey', 0, mn):+.1f}/"
+                f"{_lbin_val(pool[k], lo, hi, 'dV', False, 'grey', 0, mn):+.1f}" for k in keys]
+        lines.append(f"| {lo}-{hi} | " + " | ".join(cell) + " |")
+    if mode == "chart":
+        lines += ["", "## Chart swatch checks", "",
+                  "Reference swatches on the top row; each image's sampled patches below (column = patch #).", "",
+                  "**1. Sampled colours (as-is)** — confirms the chart is mapped correctly and shows the raw drift:", "",
+                  "![sampled](chart_check.png)", "",
+                  "**2. Lightness matched (hue + chroma)** — sampled swatches at the reference L*, so lightness "
+                  "differences are removed and hue/chroma shifts stand out:", "",
+                  "![hue and chroma](chart_check_hue.png)", "",
+                  "**3. Lightness + saturation matched (pure hue)** — sampled swatches at the reference L* and "
+                  "chroma, so only the hue difference remains:", "",
+                  "![pure hue](chart_check_purehue.png)", ""]
+    with open(os.path.join(out, "report.md"), "w", encoding="utf-8") as fh:
+        fh.write("\n".join(x for x in lines if x is not None))
+
+
+def _render_check(ref_bgr, rows, out, fname, note, cw=110, ch=150):
+    """Draw: header (patch #/name) + REFERENCE swatch row + one SAMPLED row per image.
+    Column i is patch i+1, so identities line up column-by-column. Green-family names
+    are highlighted green. cw/ch = swatch column width / row height (big + tall so the
+    swatches read large in the PDF, which fits the wide grid to the page width)."""
+    SHORT = ["dk", "ls", "sky", "fol", "bf", "bg", "or", "pb", "mr", "pu", "yg", "oy",
+             "bl", "GRN", "rd", "ye", "mg", "cy", "wh", "n8", "n6", "n5", "n3", "bk"]
+    keys = list(rows.keys()); n = len(ref_bgr)
+    L, HDR, FOOT = 150, 60, 34
+    W, H = L + n * cw, HDR + (1 + len(keys)) * ch + FOOT
+    img = np.full((H, W, 3), 30, np.uint8)
+    F = cv2.FONT_HERSHEY_SIMPLEX
+    for i in range(n):
+        cx = L + i * cw + cw // 2
+        cv2.putText(img, str(i + 1), (cx - (14 if i >= 9 else 7), 26), F, 0.7, (255, 255, 255), 2)
+        grn = SHORT[i] in ("fol", "bg", "yg", "GRN")
+        cv2.putText(img, SHORT[i], (cx - 20, 50), F, 0.55, (0, 230, 0) if grn else (185, 185, 185), 1)
+    y = HDR
+    cv2.putText(img, "REFERENCE", (8, y + ch // 2), F, 0.6, (0, 255, 255), 2)
+    for i in range(n):
+        img[y:y + ch, L + i * cw:L + (i + 1) * cw] = ref_bgr[i]
+    for ri, k in enumerate(keys):
+        y = HDR + (ri + 1) * ch
+        cv2.putText(img, k[:16], (8, y + ch // 2), F, 0.55, (255, 255, 255), 1)
+        for i in range(n):
+            img[y:y + ch, L + i * cw:L + (i + 1) * cw] = rows[k][i]
+    cv2.putText(img, note, (8, H - 10), F, 0.6, (200, 200, 200), 2)
+    cv2.imwrite(os.path.join(out, fname), img)
+
+
+def _write_chart_check(measured_lch, ref_bgr, refL, refC, out):
+    """Three swatch grids (reference row on top, sampled rows below, col = patch#):
+      chart_check.png          sampled colours as-is (L*, chroma, hue all measured)
+      chart_check_hue.png      L* set to reference (lightness matched)  -> hue + chroma difference
+      chart_check_purehue.png  L* AND chroma set to reference           -> PURE hue difference"""
+    full = {k: _lab_to_bgr(mL, mC, mH) for k, (mL, mC, mH) in measured_lch.items()}
+    huec = {k: _lab_to_bgr(refL, mC, mH) for k, (mL, mC, mH) in measured_lch.items()}
+    hueo = {k: _lab_to_bgr(refL, refC, mH) for k, (mL, mC, mH) in measured_lch.items()}
+    _render_check(ref_bgr, full, out, "chart_check.png",
+                  "sampled colours as-is (col = patch#). top row = reference. green family in green.")
+    _render_check(ref_bgr, huec, out, "chart_check_hue.png",
+                  "sampled at the reference L* (lightness matched) -> hue + chroma difference.")
+    _render_check(ref_bgr, hueo, out, "chart_check_purehue.png",
+                  "sampled at the reference L* AND chroma -> PURE hue difference (lightness + saturation matched).")
+
+
+def _write_pdf(out):
+    """Render report.md -> report.pdf with the markdown-pdf package. It embeds the
+    PNGs at their native resolution (no re-rasterising), so images stay crisp/zoomable.
+    Uses A4 landscape so the wide plot/swatch grids get more width. Skipped with a
+    hint if the package is missing."""
+    try:
+        from markdown_pdf import MarkdownPdf, Section
+    except ImportError:
+        print("  report.pdf skipped - run `pip install markdown-pdf linkify-it-py` to enable PDF export")
+        return
+    try:
+        import re
+        text = open(os.path.join(out, "report.md"), encoding="utf-8").read()
+        pdf = MarkdownPdf(toc_level=2, mode="gfm-like", optimize=True)   # deflate images: 22MB -> 0.4MB, same res
+        # Give the drift plot and each wide swatch grid its own page/section, else
+        # PyMuPDF shrinks an image to whatever vertical space is left after the tables.
+        before, dsep, after = text.partition("![drift](drift.png)")
+        secs = [before]                                          # title + overall table
+        if dsep:
+            secs.append("## Drift curves\n\n" + dsep)           # the drift plot, alone -> full page
+            head, sep, tail = after.partition("## Chart swatch checks")
+            secs.append(head)                                   # drift tables
+            if sep:
+                parts = re.split(r"(?=\*\*\d+\. )", sep + tail)  # [heading+intro, cap1+img1, cap2+img2, ...]
+                if len(parts) > 1:
+                    parts[1] = parts[0] + parts[1]; parts = parts[1:]   # fold intro onto first grid's page
+                secs += parts
+        else:
+            secs = [text]
+        for s in secs:
+            if s.strip():
+                pdf.add_section(Section(s, root=out, paper_size="A4-L"))
+        pdf.meta["title"] = "Colour-fidelity report"
+        pdf.save(os.path.join(out, "report.pdf"))
+    except Exception as e:                             # never let a PDF hiccup kill the report
+        print(f"  report.pdf skipped - {type(e).__name__}: {e}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="General image colour-fidelity evaluator (chart or gold-image reference)")
+    ap.add_argument("images", nargs="+", help="image files, folders, or globs (JPG/PNG/TIFF/…)")
+    ap.add_argument("--target", required=True, help="'chart' (in-frame ColorChecker) or a path to a gold-standard image")
+    ap.add_argument("--chart-corners", type=parse_corners, default=None,
+                    help="(chart) 4 corner fractions x0,y0,..,x3,y3 in order TL(dark-skin),TR,BR,BL(white)")
+    ap.add_argument("--chart-grid", default="6x4")
+    ap.add_argument("--chart-image", type=int, default=0, help="(chart) index of the image to locate the chart on")
+    ap.add_argument("--ref-illuminant", default="D65", choices=REF_ILLUMINANTS,
+                    help="(chart) adopted white for the reference; D65 = daylight (default)")
+    ap.add_argument("--long", type=int, default=1500, help="analysis long-edge px")
+    ap.add_argument("--chroma", type=float, default=12.0, help="min CIELab chroma for a hue to count (gold mode)")
+    ap.add_argument("--no-gui", action="store_true", help="never open the picker (chart mode needs --chart-corners)")
+    ap.add_argument("--out", default=None,
+                    help="output folder (default: '<first-image>_color_report' next to the image)")
+    args = ap.parse_args()
+
+    paths = collect_images(args.images)
+    if not paths:
+        sys.exit("no readable images found")
+    if args.out is None:
+        first = os.path.abspath(paths[0])
+        stem = os.path.splitext(os.path.basename(first))[0]
+        args.out = os.path.join(os.path.dirname(first), f"{stem}_color_report")
+    os.makedirs(args.out, exist_ok=True)
+    print(f"{len(paths)} image(s); target={args.target}\nOutput folder: {args.out}")
+    if args.target == "chart":
+        run_chart(paths, args)
+    else:
+        if not os.path.isfile(args.target):
+            sys.exit(f"gold image not found: {args.target}")
+        run_gold(paths, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/scan_color_eval/README.md
+++ b/tools/scan_color_eval/README.md
@@ -1,0 +1,214 @@
+# Film-scan colour-fidelity evaluation — standard procedure
+
+A repeatable method (and CLI tool, `scan_color_eval.py`) for answering: **how
+faithfully does each capture method — light source × camera profile — reproduce
+colour after negative conversion?** It quantifies, per pixel or per colour-chart
+patch, the **hue / saturation / value drift** of every capture against a chosen
+reference, and reports it as graphics and text.
+
+This document is the procedure we followed; the tool automates it.
+
+---
+
+## 1. What it measures
+
+After converting each negative to a positive, every capture is compared to a
+**reference** in CIELab. For each pixel (or chart patch):
+
+- **hue** = `atan2(b*, a*)` (degrees)
+- **saturation** = `Cab` = `hypot(a*, b*)` (chroma)
+- **value** = `L*`
+
+and the **drift** = `variant − reference` for each. The report contains the five
+cross-plots the analysis is built around:
+
+| plot | x-axis | y-axis |
+|---|---|---|
+| hue-vs-hue drift | reference hue | Δhue |
+| value-vs-hue drift | reference L* | Δhue |
+| hue-vs-saturation drift | reference hue | Δsaturation |
+| value-vs-saturation drift | reference L* | Δsaturation |
+| value-vs-value drift | reference L* | Δvalue (tone transfer) |
+
+The **value-vs-hue** and **value-vs-saturation** curves are the "what happens in
+the shadows" views — a hue/sat drift that depends on brightness is a tone-dependent
+cast (e.g. magenta shadows).
+
+---
+
+## 2. Capture setup & data layout
+
+Per **light source**, shoot:
+
+1. **A film-lead shot** containing BOTH:
+   - the **unexposed film base** (the orange C-41 mask, Dmin) — becomes the **black** point,
+   - an **exposed/dense film base** patch (Dmax) — becomes the **white** point.
+   The tool reads `black`/`white` rectangles from this shot. **All film-lead shots
+   must share framing** so one pair of rectangles serves every light source.
+2. **The test negatives** — the same scenes shot under each light source.
+   (Optionally, include a **Calibrite ColorChecker** in-frame for absolute accuracy.)
+
+Lay the files out as a ROOT folder whose **subfolders are named by light source**:
+
+```
+ROOT/
+  trichrome/      DSC..R,G,B triplets — 1st triplet = lead, rest = tests   (auto RGB-merge)
+  neutral/        lead.ARW, test1.ARW, test2.ARW, ...
+  white/          lead.ARW, test1.ARW, test2.ARW, ...
+```
+
+- Files are **sorted by filename**; the **first** image (or first R,G,B triplet) is
+  the lead, the rest are tests. Test *i* must be the same scene across folders.
+- A subfolder whose name contains **`trichrome`** is loaded in **3-way RGB-merge
+  mode** automatically (each consecutive R,G,B triplet → one camera-native frame).
+
+---
+
+## 3. Conversion & profiles
+
+The negative is inverted with the **two-point (bwpoint)** method from FreeCCR's
+`ccr_processor._twopoint_invert`:
+
+- **black point** = median of the unexposed-base rect (clear, high scan value → black)
+- **white point** = median of the exposed-base rect (dense, low scan value → white)
+
+Each non-trichrome light source is decoded under each **profile**:
+
+- **none** — camera-native (`output_color=raw`, `no_auto_scale`, `×65535/white_level`)
+- **matrix** — libraw `output_color=Adobe` (the in-app "Camera Matrix")
+- **dcp** — camera-native + `dcp_profile.apply_dcp(profile, as_shot_wb=raw.camera_whitebalance)`
+
+Trichrome is camera-native by construction (no matrix), so it carries only `none`.
+
+---
+
+## 4. Reference (target) — two modes
+
+- **Source-as-truth** (`--target <folder>`, default `trichrome`): one light source is
+  the reference. Every other capture is **registered** to it (ORB + RANSAC homography,
+  validated by NCC; pixels excluded if NCC < 0.6) and compared per pixel.
+- **Chart-as-truth** (`--target chart`): an in-frame **ColorChecker Classic (24)** is
+  the reference. Locate it once with `--chart-rect` (same location for all light
+  sources); the tool samples the 6×4 patches and compares to the **baked-in X-Rite
+  reference** — the *"November 2014 edition and newer"* chart, measured on an i1Pro 2
+  (M0), stored as CIELab (D50) in `COLORCHECKER24_LAB_D50` and derived to sRGB
+  (Bradford D50→D65) for the comparison. This gives **absolute** accuracy (ΔE +
+  drifts), not just similarity to trichrome.
+
+---
+
+## 5. Procedure (what the tool does)
+
+1. Enumerate light-source subfolders; split each into lead + tests.
+2. From each lead, sample the black/white points (same rects for all).
+3. Convert lead + tests per profile via two-point inversion → sRGB positives.
+4. Build the reference (trichrome positive, or the chart's known values).
+5. **Source mode:** register each variant to the reference, validate NCC.
+   **Chart mode:** sample the chart patches directly (no registration needed).
+6. Compute per-pixel/per-patch hue/sat/value drift; aggregate (chroma-weighted,
+   circular mean for hue) into the five cross-plots, pooled over all test images.
+7. Emit graphics + text + CSVs.
+
+---
+
+## 6. Usage
+
+```bash
+# from the repo root
+python tools/scan_color_eval/scan_color_eval.py --root <ROOT> [options]
+```
+
+Interactive geometry (recommended): **omit** `--black/--white` (and `--chart-rect`)
+and the tool **pops up the lead image** — drag a box for the unexposed base, then the
+exposed base (then the chart). Needs a display.
+
+Headless / scripted: pass rectangles as `x0,y0,x1,y1` **fractions** of the frame.
+
+```bash
+# source-as-truth (trichrome), all profiles, with a DCP
+python tools/scan_color_eval/scan_color_eval.py \
+  --root /path/ROOT --target trichrome \
+  --black 0.55,0.35,0.70,0.65 --white 0.32,0.50,0.44,0.72 \
+  --profiles none,matrix,dcp --dcp /path/profile.dcp
+
+# absolute accuracy against an in-frame ColorChecker in the first test image
+python tools/scan_color_eval/scan_color_eval.py \
+  --root /path/ROOT --target chart --chart-rect 0.10,0.60,0.45,0.95 \
+  --black ... --white ... --profiles none,matrix,dcp --dcp /path/profile.dcp
+```
+
+Key options: `--target` (folder name | `chart`), `--profiles`, `--dcp`,
+`--density` (log bwpoint vs default affine), `--chart-from test:N|lead`,
+`--chart-grid 6x4`, `--ref-illuminant D50|D55|D65`, `--no-gui`, `--out`.
+
+**Reference illuminant (`--ref-illuminant`, chart mode).** The X-Rite reference is
+measured under **D50**. `--ref-illuminant` Bradford-adapts it to the chosen adopted
+white before comparison: **D65** (default) = the chart adapted to daylight, giving a
+neutral reference — correct for a daylight (≈D65) shot that the conversion
+white-balances; **D50/D55** leave the reference progressively warmer, to match a
+lower-temperature adopted white or a conversion that is not fully balanced to
+daylight. Note: if the conversion white-balances *perfectly* to the capture light,
+the reference illuminant washes out and D65 is right — so use D50/D55 mainly as a
+diagnostic (pick the one that minimises the neutral-patch ΔE) if the shot is
+under-corrected.
+
+---
+
+## 7. Outputs (graphic + text)
+
+Written to `<ROOT>/scan_color_eval_out/` (or `--out`):
+
+- `drift_<light>.png` — the five drift curves per light source, profiles overlaid.
+- `report.md` — text report: overall fidelity table + per-hue-band and
+  per-brightness drift tables (Δhue/Δsat/Δvalue), with the graphics embedded.
+- `overall.csv`, `drift_per_hue_band.csv`, `drift_vs_value.csv` — machine-readable.
+- `registration_overlays.jpg` (source mode) — checkerboard of reference vs each
+  aligned variant; **validate that the scene is seamless across squares**.
+- `chart_*` outputs in chart mode (per-patch + summary, ΔE).
+
+---
+
+## 8. Findings from the reference run (Kodak C-41, this dataset)
+
+Run on `20260626ScanTestv2` (trichrome = truth; neutral & white light; none/matrix/dcp;
+3 test scenes, registration NCC 0.99). These are dataset-specific but illustrative:
+
+- **Overall similarity to the no-matrix trichrome truth:** `none` is closest
+  (neutral 6.1° / white 8.9° mean |Δhue|), then `dcp`, then `matrix`. Note this is
+  partly **by construction** — trichrome-truth has no colour matrix, so the no-matrix
+  `none` decode shares its colour science. "Closest to trichrome" ≠ "most accurate";
+  use **chart mode** to judge absolute accuracy.
+- **DCP is a better-behaved profile than the libraw Camera Matrix** — smaller drift
+  in both lights, and far gentler on blue/cyan (B band: dcp ≈ −3…−13° vs matrix
+  ≈ −9…−21°).
+- **The matrix/DCP correct warm hues** (R/O off by +20…+40° in `none`, pulled toward
+  0) **but distort cool hues** — the inherent trade of a camera matrix on a negative.
+- **Light source governs the shadow (tone-dependent) drift:** under **neutral**
+  light all profiles are tone-stable (±~7° across L*); under **white** light matrix
+  and dcp develop a **strong shadow→highlight hue crossover** (+12…+25° in shadows →
+  −8…−10° in highlights). `none` stays flat. This is consistent with a **spectral
+  mismatch** between the white light and the profile's calibration illuminant — so
+  shoot under the light the profile was made for, or use no profile.
+
+---
+
+## 9. Assumptions & caveats
+
+- All film-lead shots (and the chart, in chart mode) share framing — one set of
+  rectangles is reused for every light source.
+- The orange unexposed base reads as R,G high / B ≈ half — the tool/operator should
+  confirm that signature when placing the black-point box.
+- Chart mode assumes a **ColorChecker Classic 24** (6 wide × 4 tall, dark-skin patch
+  top-left, upright). The baked reference is the **X-Rite post-Nov-2014** measured
+  CIELab (`COLORCHECKER24_LAB_D50`); replace it (and `--chart-grid`) for a different
+  chart/edition, ideally with your own chart's measured values.
+- Hue is unstable at low chroma; hue stats are chroma-weighted and thresholded.
+  Saturation/value drifts use all pixels. The magenta/cyan bands (few pixels, hue
+  wrap) are the noisiest — trust R/O/Y/G/B and the brightness curves most.
+- "none-is-closest" in source mode is **similarity**, not absolute accuracy.
+
+## Dependencies
+
+Runs against the FreeCCR repo (`src/core` for decode/merge/invert/DCP) plus
+`rawpy`, `opencv-python` (ORB + HighGUI for the picker), `numpy`, `matplotlib`.
+Read-only — it never writes to the RAWs or the application.

--- a/tools/scan_color_eval/scan_color_eval.py
+++ b/tools/scan_color_eval/scan_color_eval.py
@@ -1,0 +1,824 @@
+#!/usr/bin/env python3
+"""
+scan_color_eval.py — Film-scan colour-fidelity evaluator.
+
+Measures how faithfully each capture method (LIGHT SOURCE x CAMERA PROFILE)
+reproduces a colour reference, after a two-point (bwpoint) negative conversion.
+Reports five CIELab drift curves (graphic + text): hue/saturation/value drift
+cross-tabbed against hue and value. See README.md for the full procedure.
+
+Geometry you provide ONCE (assumed identical for every light source):
+  * BLACK / WHITE bwpoint sample rects, read from each light's film-lead shot:
+      BLACK = unexposed film base (orange mask, Dmin)  -> black
+      WHITE = exposed  film base (dense,       Dmax)   -> white
+  * (chart mode) the ColorChecker bounding box.
+  Provide them on the CLI (--black/--white/--chart-rect, fractions) OR omit them
+  to open an interactive picker (drag a box; needs a display).
+
+ROOT: a folder whose SUBFOLDERS are named by light source. In each subfolder:
+  file 1 (sorted)     = film-lead shot (bwpoint sample)
+  files 2..N (sorted) = test negatives (same scenes across folders)
+  A subfolder named 'trichrome' is auto-loaded in RGB-merge mode.
+
+TARGET (reference):
+  --target <foldername>  a light source is the truth (relative; others registered)
+  --target chart         an in-frame Calibrite ColorChecker (ABSOLUTE accuracy)
+
+Profiles: none (camera-native) | matrix (libraw Adobe) | dcp (apply_dcp + as-shot WB).
+Read-only. Outputs PNGs + CSVs + report.md to <root>/scan_color_eval_out (or --out).
+"""
+import argparse
+import csv
+import glob
+import math
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
+os.environ.setdefault("FREECCR_WORKING_SPACE", "0")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.join(REPO, "src"))
+sys.path.insert(0, REPO)
+
+import numpy as np
+import cv2
+import rawpy
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from core.ccr_merge import RAW_EXTENSIONS, sort_for_merge, group_into_triplets, merge_raw_channels
+from core.ccr_processor import _twopoint_invert
+
+HUE_BANDS = [("R", 0, 30), ("O", 30, 60), ("Y", 60, 90), ("G", 90, 165),
+             ("C", 165, 195), ("B", 195, 255), ("P", 255, 315), ("M", 315, 360)]
+LBINS = [(0, 20), (20, 35), (35, 50), (50, 65), (65, 80), (80, 100)]
+PROFILE_COLORS = {"none": "#888888", "matrix": "#d62728", "dcp": "#2ca02c"}
+MAXPIX = 200000  # per variant per test (subsample to bound memory)
+
+# ColorChecker Classic 24 REFERENCE — X-Rite "November 2014 edition and newer",
+# measured on an i1Pro 2 (MeasurementCondition M0). CIELab (D50, 2deg), row-major
+# (dark-skin patch first). This is the authoritative baked-in reference; the sRGB
+# table used by chart mode is DERIVED from it (Lab D50 -> Bradford D50/D65 -> sRGB),
+# so absolute-accuracy comparisons use the real chart values, not an approximation.
+COLORCHECKER24_LAB_D50 = [
+    (37.54, 14.37, 14.92), (64.66, 19.27, 17.50), (49.32, -3.82, -22.54),
+    (43.46, -12.74, 22.72), (54.94, 9.61, -24.79), (70.48, -32.26, -0.37),
+    (62.73, 35.83, 56.50), (39.43, 10.75, -45.17), (50.57, 48.64, 16.67),
+    (30.10, 22.54, -20.87), (71.77, -24.13, 58.19), (71.51, 18.24, 67.37),
+    (28.37, 15.42, -49.80), (54.38, -39.72, 32.27), (42.43, 51.05, 28.62),
+    (81.80, 2.67, 80.41), (50.63, 51.28, -14.12), (49.57, -29.71, -28.32),
+    (95.19, -1.03, 2.93), (81.29, -0.57, 0.44), (66.89, -0.75, -0.06),
+    (50.76, -0.13, 0.14), (35.63, -0.46, -0.48), (20.64, 0.07, -0.46),
+]
+
+
+REF_ILLUMINANTS = ("D50", "D55", "D65")
+_WHITES = {"D50": (0.96422, 1.0, 0.82521),           # CIE 2-deg white points (XYZ, Y=1)
+           "D55": (0.95682, 1.0, 0.92149),
+           "D65": (0.95047, 1.0, 1.08883)}
+_M_BRADFORD = np.array([[0.8951, 0.2664, -0.1614],
+                        [-0.7502, 1.7135, 0.0367],
+                        [0.0389, -0.0685, 1.0296]])
+_M_XYZ2SRGB = np.array([[3.2404542, -1.5371385, -0.4985314],
+                        [-0.9692660, 1.8760108, 0.0415560],
+                        [0.0556434, -0.2040259, 1.0572252]])  # XYZ(D65) -> linear sRGB
+
+
+def _cat_bradford(src, dst):
+    s = _M_BRADFORD @ np.asarray(src, float)
+    d = _M_BRADFORD @ np.asarray(dst, float)
+    return np.linalg.inv(_M_BRADFORD) @ np.diag(d / s) @ _M_BRADFORD
+
+
+def _lab_to_xyz(lab, white):
+    lab = np.asarray(lab, float)
+    L, a, b = lab[:, 0], lab[:, 1], lab[:, 2]
+    fy = (L + 16) / 116; fx = fy + a / 500; fz = fy - b / 200
+    eps, kappa = 216 / 24389, 24389 / 27
+
+    def finv(f):
+        f3 = f ** 3
+        return np.where(f3 > eps, f3, (116 * f - 16) / kappa)
+    xr = finv(fx)
+    yr = np.where(L > kappa * eps, ((L + 16) / 116) ** 3, L / kappa)
+    zr = finv(fz)
+    return np.stack([xr * white[0], yr * white[1], zr * white[2]], 1)
+
+
+def reference_srgb(illuminant="D65"):
+    """ColorChecker reference sRGB under a chosen ADOPTED WHITE. The measured chart
+    Lab is D50; we Bradford-adapt D50 -> `illuminant`, then encode with the (D65)
+    sRGB matrix. D65 = the chart adapted to daylight/display-neutral (matches a
+    white-balanced daylight shot; the sensible default). D50/D55 leave the reference
+    progressively WARMER, to match a lower-temperature adopted white or a conversion
+    that is not fully white-balanced to daylight."""
+    xyz = _lab_to_xyz(COLORCHECKER24_LAB_D50, _WHITES["D50"]) @ _cat_bradford(_WHITES["D50"], _WHITES[illuminant]).T
+    lin = np.clip(xyz @ _M_XYZ2SRGB.T, 0, 1)
+    srgb = np.where(lin <= 0.0031308, 12.92 * lin, 1.055 * np.power(lin, 1 / 2.4) - 0.055)
+    return [tuple(int(x) for x in row) for row in np.clip(np.rint(srgb * 255), 0, 255).astype(int)]
+
+
+COLORCHECKER_CLASSIC24_SRGB = reference_srgb("D65")   # default reference (daylight)
+
+def _hue_gradient(n=360, L8=180, C=55):
+    """A 1xN sRGB strip of the CIELab hue circle (0..360 deg) at fixed L*,chroma,
+    so the hue axis can be annotated with its actual colours. Out-of-gamut hues
+    clip; that is fine for a reference swatch."""
+    deg = np.arange(n)
+    lab = np.zeros((1, n, 3), np.uint8)
+    lab[0, :, 0] = L8
+    lab[0, :, 1] = np.clip(128 + C * np.cos(np.radians(deg)), 0, 255).astype(np.uint8)
+    lab[0, :, 2] = np.clip(128 + C * np.sin(np.radians(deg)), 0, 255).astype(np.uint8)
+    bgr = cv2.cvtColor(lab, cv2.COLOR_Lab2BGR)
+    return (bgr[:, :, ::-1].astype(np.float32) / 255.0)   # (1, n, 3) RGB
+
+
+_HUE_GRAD = None  # lazily built (needs cv2)
+
+
+# The five drift cross-plots: (key, x-source, y-source, chromatic-only, circular-y, xlabel, ylabel, title)
+DRIFTS = [
+    ("hue_vs_hue",   "hue", "dH", True,  True,  "hue (deg)", "hue drift (deg)",  "hue-vs-hue drift"),
+    ("value_vs_hue", "val", "dH", True,  True,  "L*",        "hue drift (deg)",  "value-vs-hue drift"),
+    ("hue_vs_sat",   "hue", "dS", True,  False, "hue (deg)", "sat drift (Cab)",  "hue-vs-saturation drift"),
+    ("value_vs_sat", "val", "dS", False, False, "L*",        "sat drift (Cab)",  "value-vs-saturation drift"),
+    ("value_vs_val", "val", "dV", False, False, "L*",        "value drift (L*)", "value-vs-value drift"),
+]
+
+
+# ----------------------------------------------------------------------------- decode
+def _post(path, matrix):
+    with rawpy.imread(path) as raw:
+        wl = raw.white_level
+        wb = np.asarray(raw.camera_whitebalance[:3], float)
+        rgb = raw.postprocess(
+            output_bps=16, no_auto_bright=True, gamma=(1, 1), user_flip=0,
+            demosaic_algorithm=rawpy.DemosaicAlgorithm.AHD, half_size=True,
+            use_camera_wb=False, use_auto_wb=False,
+            output_color=(rawpy.ColorSpace.Adobe if matrix else rawpy.ColorSpace.raw),
+            no_auto_scale=(not matrix), adjust_maximum_thr=0.0, four_color_rgb=False
+        ).astype(np.float32)
+    if (not matrix) and 0 < wl < 65535:
+        rgb = np.clip(rgb * (65535.0 / wl), 0, 65535)
+    return rgb, wb
+
+
+def decode(path, profile, dcp_obj, cache):
+    key = (path, profile)
+    if key in cache:
+        return cache[key]
+    if profile == "matrix":
+        out = _post(path, True)[0]
+    elif profile == "dcp":
+        from core.dcp_profile import apply_dcp
+        nat, wb = _post(path, False)
+        out = apply_dcp(dcp_obj, np.clip(nat, 0, 65535).astype(np.uint16), as_shot_wb=wb).astype(np.float32)
+    else:
+        out = _post(path, False)[0]
+    cache[key] = out
+    return out
+
+
+def decode_merge(paths, cache):
+    key = ("merge",) + tuple(paths)
+    if key in cache:
+        return cache[key]
+    cache[key] = merge_raw_channels(paths, preview=True)[0].astype(np.float32)
+    return cache[key]
+
+
+# ----------------------------------------------------------------------------- convert
+def sample_points(lead_rgb, black_rect, white_rect):
+    h, w = lead_rgb.shape[:2]
+
+    def med(rc):
+        x0, y0, x1, y1 = int(rc[0] * w), int(rc[1] * h), int(rc[2] * w), int(rc[3] * h)
+        return np.median(lead_rgb[y0:y1, x0:x1].reshape(-1, 3), axis=0)
+    return med(black_rect), med(white_rect)
+
+
+def to_srgb8(pos_rgb, long_edge):
+    """RGB positive (uint16) -> 8-bit sRGB in **BGR** order. The decode/_twopoint_invert
+    chain is RGB; everything downstream (cv2 imshow/imwrite, cvtColor BGR2Lab, the
+    chart sampler) is cv2/BGR — so we convert here. Missing this swaps R<->B and a
+    correct warm positive renders/measures as cyan."""
+    x = np.clip(pos_rgb / 65535.0, 0, 1)
+    v = cv2.cvtColor((np.power(x, 1 / 2.2) * 255).astype(np.uint8), cv2.COLOR_RGB2BGR)
+    h, w = v.shape[:2]
+    s = long_edge / max(h, w)
+    return cv2.resize(v, (max(1, int(w * s)), max(1, int(h * s))), interpolation=cv2.INTER_AREA)
+
+
+# ----------------------------------------------------------------------------- registration
+def register(var_bgr, truth_bgr):
+    g1 = cv2.cvtColor(truth_bgr, cv2.COLOR_BGR2GRAY)
+    g2 = cv2.cvtColor(var_bgr, cv2.COLOR_BGR2GRAY)
+    orb = cv2.ORB_create(6000)
+    k1, d1 = orb.detectAndCompute(g1, None)
+    k2, d2 = orb.detectAndCompute(g2, None)
+    if d1 is None or d2 is None:
+        return None
+    good = [m for m, n in cv2.BFMatcher(cv2.NORM_HAMMING).knnMatch(d2, d1, k=2)
+            if m.distance < 0.75 * n.distance]
+    if len(good) < 12:
+        return None
+    sp = np.float32([k2[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+    dp = np.float32([k1[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+    H, _ = cv2.findHomography(sp, dp, cv2.RANSAC, 3.0)
+    if H is None:
+        return None
+    th, tw = truth_bgr.shape[:2]
+    warp = cv2.warpPerspective(var_bgr, H, (tw, th))
+    vm = cv2.erode(cv2.warpPerspective(np.ones(var_bgr.shape[:2], np.uint8), H, (tw, th)),
+                   np.ones((7, 7), np.uint8)).astype(bool)
+    gw = cv2.cvtColor(warp, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    gt = g1.astype(np.float32)
+    a, b = gt[vm] - gt[vm].mean(), gw[vm] - gw[vm].mean()
+    ncc = float((a * b).sum() / (np.sqrt((a * a).sum() * (b * b).sum()) + 1e-9))
+    return warp, vm, ncc
+
+
+# ----------------------------------------------------------------------------- colour (CIELab: hue/sat/value)
+def lab_hsv(bgr):
+    """Return L* (value), Cab (chroma=saturation), hue(deg) maps from an sRGB BGR image."""
+    L = cv2.cvtColor(bgr, cv2.COLOR_BGR2Lab).astype(np.float32)
+    Ls = L[..., 0] * 100 / 255.0
+    a = L[..., 1] - 128.0
+    b = L[..., 2] - 128.0
+    return Ls, np.hypot(a, b), np.degrees(np.arctan2(b, a)) % 360
+
+
+def lab_hsv_srgb(rgb_tuples):
+    arr = np.array(rgb_tuples, np.uint8).reshape(-1, 1, 3)[:, :, ::-1]
+    L = cv2.cvtColor(arr, cv2.COLOR_BGR2Lab).astype(np.float32).reshape(-1, 3)
+    a, b = L[:, 1] - 128.0, L[:, 2] - 128.0
+    return L[:, 0] * 100 / 255.0, np.hypot(a, b), np.degrees(np.arctan2(b, a)) % 360
+
+
+def cdiff(h2, h1):
+    return (h2 - h1 + 180) % 360 - 180
+
+
+def wmean(deg_or_lin, w, circular):
+    if np.size(w) == 0 or w.sum() < 1e-6:
+        return float("nan")
+    if circular:
+        r = np.radians(deg_or_lin)
+        return math.degrees(math.atan2((w * np.sin(r)).sum(), (w * np.cos(r)).sum()))
+    return float(np.average(deg_or_lin, weights=w))
+
+
+# ----------------------------------------------------------------------------- enumeration / GUI
+def list_raws(folder):
+    files = [p for p in glob.glob(os.path.join(folder, "*"))
+             if os.path.splitext(p)[1].lower() in RAW_EXTENSIONS and os.path.isfile(p)]
+    return sort_for_merge(files)
+
+
+def folder_lead_tests(folder, is_merge):
+    files = list_raws(folder)
+    if is_merge:
+        groups = group_into_triplets(files)
+        return (groups[0], groups[1:]) if len(groups) >= 2 else (None, [])
+    return (files[0], files[1:]) if len(files) >= 2 else (None, [])
+
+
+def parse_rect(s):
+    if s is None:
+        return None
+    v = [float(x) for x in s.split(",")]
+    if len(v) != 4:
+        raise argparse.ArgumentTypeError("rect must be x0,y0,x1,y1 fractions")
+    return tuple(v)
+
+
+def parse_corners(s):
+    if s is None:
+        return None
+    v = [float(x) for x in s.split(",")]
+    if len(v) != 8:
+        raise argparse.ArgumentTypeError("chart-corners = x0,y0,x1,y1,x2,y2,x3,y3 (TL,TR,BR,BL fractions)")
+    return [(v[0], v[1]), (v[2], v[3]), (v[4], v[5]), (v[6], v[7])]
+
+
+def is_merge_folder(name, merge_set):
+    return "trichrome" in name.lower() or name in merge_set
+
+
+def pick_rect(srgb_bgr, title):
+    """Open a window; user drags a box. Returns (x0,y0,x1,y1) fractions. Needs a display."""
+    h, w = srgb_bgr.shape[:2]
+    s = 1000.0 / max(h, w)
+    disp = cv2.resize(srgb_bgr, (int(w * s), int(h * s))) if s < 1 else srgb_bgr.copy()
+    dh, dw = disp.shape[:2]
+    x, y, ww, hh = cv2.selectROI(title, disp, showCrosshair=True, fromCenter=False)
+    cv2.destroyWindow(title)
+    if ww == 0 or hh == 0:
+        raise RuntimeError(f"no region selected for {title}")
+    return (x / dw, y / dh, (x + ww) / dw, (y + hh) / dh)
+
+
+# ----------------------------------------------------------------------------- chart sampling
+def _grid_centers(quad_px, cols, rows):
+    """24 patch-centre pixels from 4 chart-corner pixels ordered [TL,TR,BR,BL]
+    (perspective homography from a unit grid -> handles tilt/rotation/perspective)."""
+    unit = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], np.float32)
+    H = cv2.getPerspectiveTransform(unit, np.asarray(quad_px, np.float32))
+    uv = np.array([[[(c + 0.5) / cols, (r + 0.5) / rows]] for r in range(rows) for c in range(cols)], np.float32)
+    return cv2.perspectiveTransform(uv, H).reshape(-1, 2)
+
+
+def sample_chart_quad(srgb_bgr, corners_frac, cols, rows, patch=0.45):
+    """Sample cols*rows patches from the 4 chart corners (fractions, [TL,TR,BR,BL]).
+    Perspective-correct, so tilt/rotation/mirror/perspective are all handled; the
+    corner ORDER fixes orientation (corner 1 = patch#1 / dark-skin). Returns L*,C,hue."""
+    h, w = srgb_bgr.shape[:2]
+    quad = [(x * w, y * h) for x, y in corners_frac]
+    unit = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], np.float32)
+    H = cv2.getPerspectiveTransform(unit, np.asarray(quad, np.float32))
+    ctrs = _grid_centers(quad, cols, rows)
+    out = []
+    for i, (cx, cy) in enumerate(ctrs):
+        r, c = divmod(i, cols)
+        off = cv2.perspectiveTransform(
+            np.array([[[(c + 0.5 + patch * 0.5) / cols, (r + 0.5 + patch * 0.5) / rows]]], np.float32), H)[0, 0]
+        rad = max(2, int(0.7 * math.hypot(off[0] - cx, off[1] - cy)))
+        x0, x1 = max(0, int(cx - rad)), min(w, int(cx + rad))
+        y0, y1 = max(0, int(cy - rad)), min(h, int(cy + rad))
+        p = srgb_bgr[y0:y1, x0:x1]
+        if p.size == 0:
+            out.append((np.nan, np.nan, np.nan)); continue
+        med = np.median(p.reshape(-1, 3), axis=0).astype(np.uint8).reshape(1, 1, 3)
+        lab = cv2.cvtColor(med, cv2.COLOR_BGR2Lab).astype(np.float32).reshape(3)
+        a, b = lab[1] - 128.0, lab[2] - 128.0
+        out.append((lab[0] * 100 / 255.0, math.hypot(a, b), math.degrees(math.atan2(b, a)) % 360))
+    arr = np.array(out)
+    return arr[:, 0], arr[:, 1], arr[:, 2]   # L, C, hue
+
+
+def pick_chart_quad(srgb_bgr, cols, rows):
+    """Interactive 4-corner ColorChecker picker: magnifier for precise clicks on a
+    small/hand-held chart, and a live grid overlay to verify orientation. Click the
+    corners IN ORDER — 1: patch#1 (dark-skin) corner, 2: far end of that top row
+    (patch#%d), 3: opposite/bottom corner (patch#%d), 4: patch#%d (white) corner.
+    Robust to tilt / rotation / mirror. Keys: r=reset, Enter=confirm, Esc=cancel.
+    Returns 4 corner fractions [TL,TR,BR,BL].""" % (cols, cols * rows, cols * rows - cols + 1)
+    h, w = srgb_bgr.shape[:2]
+    s = min(1.0, 1500.0 / max(h, w))
+    base = cv2.resize(srgb_bgr, (int(w * s), int(h * s))) if s < 1 else srgb_bgr.copy()
+    dh, dw = base.shape[:2]
+    pts, st = [], {"m": (0, 0)}
+    win = "Chart corners: 1=dark-skin 2=top-end 3=bottom 4=white | r reset  Enter ok  Esc cancel"
+
+    def on_mouse(ev, x, y, flags, param):
+        st["m"] = (x, y)
+        if ev == cv2.EVENT_LBUTTONDOWN and len(pts) < 4:
+            pts.append((x, y))
+    cv2.namedWindow(win, cv2.WINDOW_AUTOSIZE)
+    cv2.setMouseCallback(win, on_mouse)
+    labels = {0: "1", cols - 1: str(cols), cols * rows - cols: str(cols * rows - cols + 1), cols * rows - 1: str(cols * rows)}
+    while True:
+        img = base.copy()
+        for i, (px, py) in enumerate(pts):
+            cv2.circle(img, (px, py), 5, (0, 0, 255), -1)
+            cv2.putText(img, str(i + 1), (px + 6, py - 6), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 255), 2)
+        if len(pts) >= 2:
+            cv2.polylines(img, [np.array(pts, np.int32)], len(pts) == 4, (0, 255, 255), 1)
+        if len(pts) == 4:
+            for j, (cx, cy) in enumerate(_grid_centers(pts, cols, rows)):
+                cv2.circle(img, (int(cx), int(cy)), 3, (0, 255, 0), -1)
+                if j in labels:
+                    cv2.putText(img, labels[j], (int(cx) + 3, int(cy) - 3), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
+        mx, my = st["m"]                                   # magnifier
+        if 0 <= mx < dw and 0 <= my < dh:
+            R, Z = 34, 6
+            x0, y0 = max(0, mx - R), max(0, my - R)
+            crop = base[y0:y0 + 2 * R, x0:x0 + 2 * R]
+            if crop.size:
+                mag = cv2.resize(crop, (crop.shape[1] * Z, crop.shape[0] * Z), interpolation=cv2.INTER_NEAREST)
+                cv2.drawMarker(mag, (mag.shape[1] // 2, mag.shape[0] // 2), (0, 0, 255), cv2.MARKER_CROSS, 18, 1)
+                mh, mw = mag.shape[:2]
+                img[2:2 + mh, dw - mw - 2:dw - 2] = mag
+        cv2.putText(img, f"corner {len(pts)}/4", (6, dh - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
+        cv2.imshow(win, img)
+        k = cv2.waitKey(20) & 0xFF
+        if k == ord('r'):
+            pts.clear()
+        elif k in (13, 10) and len(pts) == 4:
+            break
+        elif k == 27:
+            cv2.destroyWindow(win); raise RuntimeError("chart pick cancelled")
+    cv2.destroyWindow(win)
+    return [(px / dw, py / dh) for px, py in pts]
+
+
+# ----------------------------------------------------------------------------- drift collection
+def drift_arrays(tL, tC, tH, vL, vC, vH, sel):
+    """Subsampled per-pixel drift record on a boolean selection."""
+    idx = np.flatnonzero(sel)
+    if idx.size > MAXPIX:
+        idx = idx[:: max(1, idx.size // MAXPIX)]
+    return dict(val=tL.ravel()[idx], sat=tC.ravel()[idx], hue=tH.ravel()[idx],
+                dV=(vL - tL).ravel()[idx], dS=(vC - tC).ravel()[idx], dH=cdiff(vH, tH).ravel()[idx])
+
+
+def empty_pool():
+    return dict(val=[], sat=[], hue=[], dV=[], dS=[], dH=[])
+
+
+def add_pool(pool, rec):
+    for k in pool:
+        pool[k].append(rec[k])
+
+
+def finalize(pool):
+    return {k: (np.concatenate(v) if v else np.array([])) for k, v in pool.items()}
+
+
+def binned_curve(r, drift, chroma_thr):
+    _, xsrc, ysrc, chromatic, circ, _, _, _ = drift
+    if r["hue"].size == 0:
+        return None
+    x = r[xsrc]; y = r[ysrc]
+    sel = np.isfinite(x) & np.isfinite(y)
+    if chromatic:
+        sel &= r["sat"] > chroma_thr
+    w = np.where(chromatic, r["sat"], 1.0)[sel] if chromatic else np.ones(sel.sum())
+    x, y = x[sel], y[sel]
+    if xsrc == "hue":
+        xs = np.arange(0, 360, 10); width = 10
+    else:
+        xs = np.arange(2.5, 100, 5); width = 5
+    ys = []
+    for xb in xs:
+        m = (x >= xb - (0 if xsrc == "hue" else width / 2)) & (x < xb + (width if xsrc == "hue" else width / 2))
+        ys.append(wmean(y[m], w[m], circ) if m.sum() > 40 else np.nan)
+    return xs, np.array(ys)
+
+
+# ----------------------------------------------------------------------------- main
+def main():
+    ap = argparse.ArgumentParser(description="Film-scan colour-fidelity evaluator")
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--target", default="trichrome", help="a subfolder name, or 'chart'")
+    ap.add_argument("--merge", default="", help="extra folder names to RGB-merge ('trichrome' auto-detected)")
+    ap.add_argument("--black", type=parse_rect, default=None, help="unexposed-base rect x0,y0,x1,y1 (omit -> picker)")
+    ap.add_argument("--white", type=parse_rect, default=None, help="exposed-base rect x0,y0,x1,y1 (omit -> picker)")
+    ap.add_argument("--profiles", default="none,matrix,dcp")
+    ap.add_argument("--dcp", default=None)
+    ap.add_argument("--density", action="store_true")
+    ap.add_argument("--long", type=int, default=1500)
+    ap.add_argument("--chroma", type=float, default=12.0)
+    ap.add_argument("--chart-rect", type=parse_rect, default=None,
+                    help="(chart) axis-aligned box (legacy; use --chart-corners or the picker for tilted charts)")
+    ap.add_argument("--chart-corners", type=parse_corners, default=None,
+                    help="(chart) 4 corner fractions x0,y0,..,x3,y3 in order TL(dark-skin),TR,BR,BL(white)")
+    ap.add_argument("--chart-grid", default="6x4")
+    ap.add_argument("--chart-from", default="test:0", help="'test:N' or 'lead'")
+    ap.add_argument("--ref-illuminant", default="D65", choices=REF_ILLUMINANTS,
+                    help="(--target chart) adopted white for the reference; D65 = daylight (default)")
+    ap.add_argument("--no-gui", action="store_true", help="never open the picker (error if a rect is missing)")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    root = os.path.abspath(args.root)
+    out = args.out or os.path.join(root, "scan_color_eval_out")
+    os.makedirs(out, exist_ok=True)
+    merge_set = {m.strip() for m in args.merge.split(",") if m.strip()}
+    profiles = [p.strip() for p in args.profiles.split(",") if p.strip()]
+    dcp_obj = None
+    if "dcp" in profiles:
+        if not args.dcp or not os.path.exists(args.dcp):
+            print("WARNING: 'dcp' requested but --dcp missing; dropping dcp.")
+            profiles = [p for p in profiles if p != "dcp"]
+        else:
+            from core.dcp_profile import parse_dcp
+            dcp_obj = parse_dcp(args.dcp)
+    subfolders = sorted(d for d in os.listdir(root)
+                        if os.path.isdir(os.path.join(root, d)) and list_raws(os.path.join(root, d)))
+    if not subfolders:
+        sys.exit(f"no light-source subfolders with RAWs under {root}")
+    cache = {}
+
+    def convert_image(folder, src, profile):
+        is_m = is_merge_folder(folder, merge_set)
+        lead, _ = folder_lead_tests(os.path.join(root, folder), is_m)
+        if is_m:
+            bk, wt = sample_points(decode_merge(lead, cache), args.black, args.white)
+            pos = _twopoint_invert(decode_merge(src, cache), bk, wt, args.density)
+        else:
+            bk, wt = sample_points(decode(lead, profile, dcp_obj, cache), args.black, args.white)
+            pos = _twopoint_invert(decode(src, profile, dcp_obj, cache), bk, wt, args.density)
+        return to_srgb8(pos, args.long)
+
+    def folder_profiles(folder):
+        return ["none"] if is_merge_folder(folder, merge_set) else profiles
+
+    # ---- resolve geometry (CLI or interactive picker) ----
+    _resolve_geometry(args, root, subfolders, merge_set, profiles, dcp_obj, cache)
+
+    print(f"Root: {root}\nSubfolders: {subfolders}\nTarget: {args.target}  "
+          f"black={args.black} white={args.white} density={args.density}")
+    if args.target == "chart":
+        run_chart_mode(args, root, subfolders, merge_set, convert_image, folder_profiles, out)
+    else:
+        run_source_mode(args, root, subfolders, merge_set, convert_image, folder_profiles, out)
+    print(f"\nDone. Outputs in: {out}")
+
+
+def _resolve_geometry(args, root, subfolders, merge_set, profiles, dcp_obj, cache):
+    # Chart geometry -> a 4-corner quad. Explicit corners/rect apply to ALL lights;
+    # otherwise it is picked PER light in run_chart_mode (hand-held -> location varies).
+    args.chart_quad = None
+    if args.target == "chart":
+        if args.chart_corners:
+            args.chart_quad = args.chart_corners
+        elif args.chart_rect:
+            x0, y0, x1, y1 = args.chart_rect
+            args.chart_quad = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+    if args.black is not None and args.white is not None:
+        return
+    if args.no_gui:
+        sys.exit("missing --black/--white and --no-gui set. Provide them as x0,y0,x1,y1 fractions.")
+    pick_folder = next((f for f in subfolders if not is_merge_folder(f, merge_set)), subfolders[0])
+    is_m = is_merge_folder(pick_folder, merge_set)
+    lead, _ = folder_lead_tests(os.path.join(root, pick_folder), is_m)
+    p0 = profiles[0] if profiles else "none"
+    lead_disp = to_srgb8(decode_merge(lead, cache) if is_m else decode(lead, p0, dcp_obj, cache), args.long)
+    if args.black is None:
+        print("PICKER: drag the UNEXPOSED film-base region -> BLACK point. Enter/Space to confirm.")
+        args.black = pick_rect(lead_disp, "BLACK = unexposed base - drag box")
+    if args.white is None:
+        print("PICKER: drag the EXPOSED (dense) film-base region -> WHITE point.")
+        args.white = pick_rect(lead_disp, "WHITE = exposed dense base - drag box")
+    print(f"Picked black={tuple(round(v,3) for v in args.black)} white={tuple(round(v,3) for v in args.white)}")
+
+
+# ----------------------------------------------------------------------------- mode: source-as-truth
+def run_source_mode(args, root, subfolders, merge_set, convert_image, folder_profiles, out):
+    if args.target not in subfolders:
+        sys.exit(f"target '{args.target}' not in {subfolders}")
+    tlead, ttests = folder_lead_tests(os.path.join(root, args.target), is_merge_folder(args.target, merge_set))
+    if tlead is None:
+        sys.exit(f"target '{args.target}' lacks lead + tests")
+    n_tests = len(ttests)
+    variants = [(f, p) for f in subfolders if f != args.target for p in folder_profiles(f)]
+    pool = {f"{f} {p}": empty_pool() for f, p in variants}
+    overlays = []
+    for ti in range(n_tests):
+        truth = convert_image(args.target, ttests[ti], "none")
+        tL, tC, tH = lab_hsv(truth)
+        print(f"\n[test {ti + 1}/{n_tests}] NCC vs truth:")
+        for f, p in variants:
+            lead, tests = folder_lead_tests(os.path.join(root, f), is_merge_folder(f, merge_set))
+            if lead is None or ti >= len(tests):
+                continue
+            try:
+                var = convert_image(f, tests[ti], p)
+            except Exception as e:
+                print(f"  {f} {p}: convert FAILED {e}"); continue
+            r = register(var, truth)
+            if r is None:
+                print(f"  {f} {p}: REG FAILED"); continue
+            warp, vm, ncc = r
+            print(f"  {f:14s} {p:6s}: NCC={ncc:.3f}" + ("  <-weak,excl" if ncc < 0.6 else ""))
+            if ncc < 0.6:
+                continue
+            if ti == 0:
+                overlays.append((f"{f} {p}", _checker(truth, warp, vm)))
+            vL, vC, vH = lab_hsv(warp)
+            sel = vm & (tL > 3) & (tL < 99)
+            add_pool(pool[f"{f} {p}"], drift_arrays(tL, tC, tH, vL, vC, vH, sel))
+    pool = {k: finalize(v) for k, v in pool.items()}
+    pool = {k: v for k, v in pool.items() if v["hue"].size}
+    _write_outputs(pool, list(pool.keys()), args, out, overlays, mode="pixel")
+
+
+# ----------------------------------------------------------------------------- mode: chart-as-truth
+def run_chart_mode(args, root, subfolders, merge_set, convert_image, folder_profiles, out):
+    cols, rows = (int(x) for x in args.chart_grid.lower().split("x"))
+    refL, refC, refH = lab_hsv_srgb(reference_srgb(args.ref_illuminant))
+    print(f"  chart reference: X-Rite CC24 (post-Nov2014), adopted white {args.ref_illuminant}")
+    kind, idx = (args.chart_from.split(":") + ["0"])[:2]
+    idx = int(idx)
+
+    def chart_src(f):
+        lead, tests = folder_lead_tests(os.path.join(root, f), is_merge_folder(f, merge_set))
+        if lead is None:
+            return None
+        return lead if kind == "lead" else (tests[idx] if idx < len(tests) else None)
+
+    # Resolve the chart quad PER light (hand-held -> different location/tilt each shot).
+    quads = {}
+    for f in subfolders:
+        src = chart_src(f)
+        if src is None:
+            continue
+        if args.chart_quad is not None:               # explicit corners/rect -> shared
+            quads[f] = args.chart_quad
+            continue
+        if args.no_gui:
+            sys.exit("chart mode needs a display to pick the chart, or pass --chart-corners.")
+        fp = folder_profiles(f)[0]
+        try:
+            srgb = convert_image(f, src, fp)
+        except Exception as e:
+            print(f"  {f}: convert FAILED {e}"); continue
+        print(f"PICK the ColorChecker in '{f}' (converted positive) — click 4 corners.")
+        quads[f] = pick_chart_quad(srgb, cols, rows)
+
+    variants = [(f, p) for f in subfolders if f in quads for p in folder_profiles(f)]
+    pool = {}
+    for f, p in variants:
+        src = chart_src(f)
+        try:
+            srgb = convert_image(f, src, p)
+        except Exception as e:
+            print(f"  {f} {p}: convert FAILED {e}"); continue
+        mL, mC, mH = sample_chart_quad(srgb, quads[f], cols, rows)
+        rec = dict(val=refL, sat=refC, hue=refH, dV=mL - refL, dS=mC - refC, dH=cdiff(mH, refH))
+        pool[f"{f} {p}"] = {k: np.asarray(v, float) for k, v in rec.items()}
+        good = (refC > 10) & np.isfinite(rec["dH"])
+        print(f"  {f:14s} {p:6s}: mean|Δhue|={np.nanmean(np.abs(rec['dH'][good])):5.1f}  "
+              f"mean|Δsat|={np.nanmean(np.abs(rec['dS'])):5.1f}  mean|ΔL|={np.nanmean(np.abs(rec['dV'])):5.1f}")
+    _write_outputs(pool, list(pool.keys()), args, out, [], mode="chart")
+
+
+# ----------------------------------------------------------------------------- outputs
+def _checker(a, b, mask, n=14):
+    h, w = a.shape[:2]; bs = max(h, w) // n; o = a.copy()
+    for y in range(0, h, bs):
+        for x in range(0, w, bs):
+            if ((x // bs) + (y // bs)) % 2 == 1:
+                o[y:y + bs, x:x + bs] = b[y:y + bs, x:x + bs]
+    o[~mask] = (o[~mask] * 0.3).astype(np.uint8)
+    return o
+
+
+def _overall(r):
+    g = (r["sat"] > 8) & np.isfinite(r["dH"])
+    return (float(np.average(np.abs(r["dH"][g]), weights=r["sat"][g])) if g.sum() else float("nan"),
+            float(np.nanmean(np.abs(r["dS"]))), float(np.nanmean(r["dV"])), float(np.nanmean(np.abs(r["dV"]))))
+
+
+def _hue_band_val(r, lo, hi, ysrc, circ, chroma, min_n=20):
+    sel = (r["hue"] >= lo) & (r["hue"] < hi) & (r["sat"] > chroma) & np.isfinite(r[ysrc])
+    return wmean(r[ysrc][sel], r["sat"][sel], circ) if sel.sum() >= min_n else float("nan")
+
+
+def _lbin_val(r, lo, hi, ysrc, circ, chroma, min_n=20):
+    sel = (r["val"] >= lo) & (r["val"] < hi) & np.isfinite(r[ysrc])
+    if circ or chroma:
+        sel &= r["sat"] > chroma
+        w = r["sat"][sel]
+    else:
+        w = np.ones(int(sel.sum()))
+    return wmean(r[ysrc][sel], w, circ) if sel.sum() >= min_n else float("nan")
+
+
+def _write_outputs(pool, keys, args, out, overlays, mode):
+    if not keys:
+        print("no results to write"); return
+    chr_thr = args.chroma if mode == "pixel" else 8.0
+    mn = 1 if mode == "chart" else 20          # min samples per bin (24 patches vs millions of px)
+    # ---- overall CSV ----
+    with open(os.path.join(out, "overall.csv"), "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["light_profile", "mean_abs_hue_drift_deg", "mean_abs_sat_drift", "value_bias_L", "mean_abs_value_drift_L"])
+        for k in keys:
+            o = _overall(pool[k]); w.writerow([k] + [f"{x:.2f}" for x in o])
+    # ---- per-hue-band CSV (hue & sat drift) ----
+    with open(os.path.join(out, "drift_per_hue_band.csv"), "w", newline="") as fh:
+        w = csv.writer(fh); w.writerow(["band"] + [f"{k} dHue" for k in keys] + [f"{k} dSat" for k in keys])
+        for bn, lo, hi in HUE_BANDS:
+            w.writerow([bn] + [f"{_hue_band_val(pool[k], lo, hi, 'dH', True, chr_thr, mn):.1f}" for k in keys]
+                       + [f"{_hue_band_val(pool[k], lo, hi, 'dS', False, chr_thr, mn):.1f}" for k in keys])
+    # ---- per-L-bin CSV (hue, sat, value drift) ----
+    with open(os.path.join(out, "drift_vs_value.csv"), "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["L_low", "L_high"] + [f"{k} dHue" for k in keys] + [f"{k} dSat" for k in keys] + [f"{k} dVal" for k in keys])
+        for lo, hi in LBINS:
+            w.writerow([lo, hi]
+                       + [f"{_lbin_val(pool[k], lo, hi, 'dH', True, chr_thr, mn):.1f}" for k in keys]
+                       + [f"{_lbin_val(pool[k], lo, hi, 'dS', False, 0, mn):.1f}" for k in keys]
+                       + [f"{_lbin_val(pool[k], lo, hi, 'dV', False, 0, mn):.1f}" for k in keys])
+    # ---- chart per-patch CSV (the most useful absolute-accuracy table) ----
+    if mode == "chart":
+        with open(os.path.join(out, "chart_per_patch.csv"), "w", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(["patch", "ref_L", "ref_C", "ref_hue"]
+                       + [f"{k} dHue" for k in keys] + [f"{k} dSat" for k in keys] + [f"{k} dVal" for k in keys])
+            ref = pool[keys[0]]
+            for i in range(ref["hue"].size):
+                w.writerow([i + 1, f"{ref['val'][i]:.1f}", f"{ref['sat'][i]:.1f}", f"{ref['hue'][i]:.1f}"]
+                           + [f"{pool[k]['dH'][i]:.1f}" for k in keys]
+                           + [f"{pool[k]['dS'][i]:.1f}" for k in keys]
+                           + [f"{pool[k]['dV'][i]:.1f}" for k in keys])
+    # ---- graphic: per light source, 5 drift panels ----
+    lights = []
+    for k in keys:
+        f = k.rsplit(" ", 1)[0]
+        if f not in lights:
+            lights.append(f)
+    pngs = []
+    for f in lights:
+        ks = [k for k in keys if k.rsplit(" ", 1)[0] == f]
+        png = _plot_drifts(f, ks, pool, out, chr_thr, mode)
+        pngs.append((f, png))
+    if overlays:
+        H = max(o.shape[0] for _, o in overlays)
+        tiles = []
+        for name, o in overlays:
+            cv2.rectangle(o, (0, 0), (o.shape[1], 20), (0, 0, 0), -1)
+            cv2.putText(o, name, (4, 15), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 255), 1)
+            tiles.append(cv2.copyMakeBorder(o, 0, H - o.shape[0], 0, 6, cv2.BORDER_CONSTANT, value=(50, 50, 50)))
+        cv2.imwrite(os.path.join(out, "registration_overlays.jpg"), np.hstack(tiles), [cv2.IMWRITE_JPEG_QUALITY, 90])
+    # ---- text report ----
+    _write_report_md(pool, keys, lights, args, out, mode, pngs, chr_thr, mn)
+    print("\nOverall (mean|Δhue|deg, mean|Δsat|Cab, ΔL bias, mean|ΔL|):")
+    for k in keys:
+        o = _overall(pool[k]); print(f"  {k:22s} hue={o[0]:5.1f}  sat={o[1]:5.1f}  Lbias={o[2]:+5.1f}  |L|={o[3]:5.1f}")
+
+
+def _plot_drifts(light, keys, pool, out, chr_thr, mode="pixel"):
+    global _HUE_GRAD
+    if _HUE_GRAD is None:
+        _HUE_GRAD = _hue_gradient()
+    fig, ax = plt.subplots(len(DRIFTS), 1, figsize=(11, 3.5 * len(DRIFTS)))
+    for i, drift in enumerate(DRIFTS):
+        key, xsrc, ysrc, chromatic, circ, xlab, ylab, title = drift
+        for k in keys:
+            prof = k.rsplit(" ", 1)[1]
+            if mode == "chart":                       # 24 patches -> scatter the raw points
+                r = pool[k]
+                sel = np.isfinite(r[xsrc]) & np.isfinite(r[ysrc])
+                if chromatic:
+                    sel &= r["sat"] > 8
+                xv, yv = r[xsrc][sel], r[ysrc][sel]
+                o = np.argsort(xv)
+                ax[i].plot(xv[o], yv[o], "-o", ms=5, color=PROFILE_COLORS.get(prof), label=prof)
+            else:
+                cur = binned_curve(pool[k], drift, chr_thr)
+                if cur is None:
+                    continue
+                xs, ys = cur
+                ax[i].plot(xs, ys, "-o", ms=3, color=PROFILE_COLORS.get(prof), label=prof)
+        ax[i].axhline(0, color="k", lw=.6)
+        ax[i].set_title(f"{light} — {title}"); ax[i].set_ylabel(ylab)
+        ax[i].legend(fontsize=8); ax[i].grid(alpha=.3)
+        if xsrc == "hue":
+            # colour the hue axis: a CIELab hue strip sits ON TOP of the degree numbers.
+            ax[i].set_xlim(0, 360)
+            ax[i].set_xticklabels([]); ax[i].set_xlabel("")
+            cax = ax[i].inset_axes([0, -0.17, 1, 0.06])
+            cax.imshow(_HUE_GRAD, aspect="auto", extent=[0, 360, 0, 1])
+            cax.set_yticks([]); cax.set_xlim(0, 360)
+            cax.set_xticks(range(0, 361, 30)); cax.tick_params(labelsize=8)
+            cax.set_xlabel(xlab)
+        else:
+            ax[i].set_xlabel(xlab)
+    plt.subplots_adjust(hspace=0.6, top=0.97, bottom=0.04, left=0.08, right=0.97)
+    path = os.path.join(out, f"drift_{light.replace(' ', '_')}.png")
+    plt.savefig(path, dpi=105); plt.close()
+    return os.path.basename(path)
+
+
+def _write_report_md(pool, keys, lights, args, out, mode, pngs, chr_thr, min_n=20):
+    lines = ["# Scan colour-fidelity report", "",
+             f"- Root: `{args.root}`", f"- Target: `{args.target}` ({'absolute chart' if mode == 'chart' else 'source-as-truth'})",
+             f"- bwpoint: black={args.black} white={args.white} density={args.density}",
+             f"- Profiles: {args.profiles}", "",
+             "Drift = variant − reference, in CIELab (hue=atan2(b,a) deg, saturation=Cab chroma, value=L*).", ""]
+    lines += ["## Overall fidelity (lower = closer to reference)", "",
+              "| light · profile | mean \\|Δhue\\| ° | mean \\|Δsat\\| | ΔL bias | mean \\|ΔL\\| |",
+              "|---|---|---|---|---|"]
+    for k in keys:
+        o = _overall(pool[k])
+        lines.append(f"| {k} | {o[0]:.1f} | {o[1]:.1f} | {o[2]:+.1f} | {o[3]:.1f} |")
+    lines.append("")
+    for f in lights:
+        ks = [k for k in keys if k.rsplit(" ", 1)[0] == f]
+        profs = [k.rsplit(" ", 1)[1] for k in ks]
+        lines += [f"## {f}", "", f"![{f}](drift_{f.replace(' ', '_')}.png)", "",
+                  "### hue drift per colour band (deg)", "",
+                  "| band | " + " | ".join(profs) + " |", "|" + "---|" * (len(profs) + 1)]
+        for bn, lo, hi in HUE_BANDS:
+            lines.append(f"| {bn} | " + " | ".join(f"{_hue_band_val(pool[k], lo, hi, 'dH', True, chr_thr, min_n):.1f}" for k in ks) + " |")
+        lines += ["", "### drift vs brightness L* (Δhue° / Δsat / ΔL)", "",
+                  "| L* | " + " | ".join(profs) + " |", "|" + "---|" * (len(profs) + 1)]
+        for lo, hi in LBINS:
+            cell = []
+            for k in ks:
+                dh = _lbin_val(pool[k], lo, hi, "dH", True, chr_thr, min_n)
+                ds = _lbin_val(pool[k], lo, hi, "dS", False, 0, min_n)
+                dv = _lbin_val(pool[k], lo, hi, "dV", False, 0, min_n)
+                cell.append(f"{dh:+.1f}/{ds:+.1f}/{dv:+.1f}")
+            lines.append(f"| {lo}-{hi} | " + " | ".join(cell) + " |")
+        lines.append("")
+    with open(os.path.join(out, "report.md"), "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds two read-only colour-fidelity evaluation tools under `tools/`.

### `color_eval` — standalone, general-purpose
Measures how faithfully finished images reproduce colour, in CIELab. Depends only on numpy/opencv/matplotlib plus `markdown-pdf` (+ `linkify-it-py`) for the PDF export.

- Two reference modes: in-frame **ColorChecker 24** (baked X-Rite post-Nov-2014 reference, D50/D55/D65 Bradford adaptation) or a **gold-standard image** (ORB + homography registration).
- Four drift cross-plots (2×2 landscape): hue-vs-hue & hue-vs-sat (colour patches), value-vs-hue & value-vs-value (grey ramp), with a CIELab hue colour strip and per-patch numbers.
- Mouse-wheel-zoom 4-corner chart picker (robust to tilt / rotation / mirror, small hand-held charts).
- Three per-patch swatch-check grids: sampled as-is / lightness-matched (hue+chroma) / pure-hue.
- Markdown **and PDF** report (images embedded at native resolution, deflate-optimised), plus CSVs.

### `scan_color_eval` — FreeCCR-coupled procedure tool
RAW decode, two-point bwpoint inversion, trichrome merge, DCP — for comparing light source × camera profile after negative conversion.

Also ignores local `example_raw/` test scans.

## Test plan
- Validated on synthetic ColorChecker images: accurate image → ~0.5° mean hue drift; +red / +green casts render as the expected drift.
- Chart mapping verified via the swatch-check grids (reference vs sampled align per patch); D50/D55/D65 grey-ramp selection verified illuminant-independent.
- PDF verified: 6 pages, tables render, images embedded at native resolution, ~0.5 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
