### PR TITLE
fix(crop): Reset + Done clears the committed crop; clamp rotate knob to ±45°

### DIFF
--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -2815,6 +2815,11 @@ class ImagePreview(QWidget):
         angle = (angle + 180.0) % 360.0 - 180.0
         if abs(angle) < 0.75:
             angle = 0.0  # snap to straight
+        # The knob and the panel straighten slider are two-way synced and the
+        # slider only spans ±45°; clamp here so the knob can't drive the box past
+        # what the slider can represent (which would desync them and silently
+        # drop the excess rotation on the next slider nudge).
+        angle = max(-45.0, min(45.0, angle))
         self._pending_crop_angle = angle
         self._pending_crop_local = QRectF(box0)
 
@@ -3029,6 +3034,17 @@ class ImagePreview(QWidget):
                     cleared = new_crop is None
             else:
                 too_small = True
+        elif img_obj is not None and sel is None:
+            # Reset clears the pending box (Free ratio leaves no box). Confirming
+            # with no selection means "remove the crop", so Reset + Done actually
+            # restores the full frame instead of silently keeping the previously
+            # committed crop. A no-op when the image isn't cropped.
+            if img_obj.crop_rect is not None or getattr(img_obj, "crop_angle", 0.0):
+                img_obj.push_undo_state()
+                img_obj.crop_rect = None
+                img_obj.crop_angle = 0.0
+                applied = True
+                cleared = True
         self._exit_crop_mode()
         if applied and img_obj is not None:
             # The kept pixel region changed, so the histogram (computed over

--- a/tests/test_crop_panel.py
+++ b/tests/test_crop_panel.py
@@ -190,6 +190,19 @@ class TestCropHooks:
         ip.set_pending_straighten(3.5)
         assert ip._pending_crop_angle == pytest.approx(3.5)
 
+    def test_rotate_knob_clamped_to_straighten_range(self):
+        # The rotate knob must not drive the box past the ±45° straighten slider
+        # range, or the two desync and the extra rotation is silently lost.
+        ip, _h = _make_preview()
+        # box centered at (150,150); start straight up, drag to +90° raw.
+        drag = {"box0": QRectF(100, 100, 100, 100),
+                "start": QPointF(150, 50), "angle0": 0.0}
+        ip._drag_rotate_box(drag, QPointF(250, 150))
+        assert ip._pending_crop_angle == pytest.approx(45.0)   # clamped, not 90
+        # Same drag the other way clamps to -45.
+        ip._drag_rotate_box(drag, QPointF(50, 150))
+        assert ip._pending_crop_angle == pytest.approx(-45.0)
+
     def test_reset_pending_crop(self):
         ip, _h = _make_preview()
         ip.set_crop_panel(_RatioPanel(1.5))
@@ -251,6 +264,28 @@ class TestStraightenFoldIn:
         ip, img, _ok = self._entered(fine=300)
         ip.cancel_crop_mode()
         assert img.fine_rotation_angle == 300                 # untouched on cancel
+
+    def test_reset_then_confirm_clears_committed_crop(self):
+        # Regression: entering crop on a cropped image, clicking Reset (Free
+        # ratio -> pending box becomes None), then Done must actually clear the
+        # committed crop — not silently keep it.
+        ip, img, _ok = self._entered(fine=0, crop_rect=(0.1, 0.1, 0.9, 0.9))
+        assert ip._pending_crop_local is not None   # seeded from the committed crop
+        ip.reset_pending_crop()                     # user clicks Reset (Free)
+        assert ip._pending_crop_local is None
+        ip.confirm_crop()                           # user clicks Done
+        assert img.crop_rect is None                # crop actually removed
+        assert img.crop_angle == pytest.approx(0.0)
+        assert img.undo                             # one undo snapshot pushed
+
+    def test_confirm_no_box_on_uncropped_is_noop(self):
+        # Entering crop on an uncropped Free image and pressing Done with no box
+        # must not push a junk undo state or change anything.
+        ip, img, _ok = self._entered(fine=0)
+        assert ip._pending_crop_local is None
+        ip.confirm_crop()
+        assert img.crop_rect is None
+        assert not img.undo                          # no-op, no undo snapshot
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two crop-tool correctness fixes, surfaced by a review of the reported bug *"reset does not actually reset when cropping."*

### 1. Reset + Done did not clear a committed crop (the reported bug)

Entering crop mode on an already-cropped image, clicking **Reset** (with the default **Free** ratio, which leaves no pending box), then **Done** left the committed crop intact — the image stayed cropped.

`confirm_crop` guarded its entire commit block on `sel is not None`, so an empty pending selection was a no-op and `_exit_crop_mode` + `update_preview` re-rendered the still-present `crop_rect`.

**Fix:** added an `elif sel is None` branch that clears `crop_rect`/`crop_angle` (with an undo snapshot), mirroring the right-click `clear_crop` path. Guarded so it stays a no-op (no junk undo) on an uncropped image. Reset + **Esc** (cancel) still preserves the original crop.

### 2. Rotate knob could exceed the ±45° straighten range

`_drag_rotate_box` normalized the angle to ±180° but never clamped it to the ±45° range of its two-way-synced panel straighten slider. Dragging the knob past 45° pinned the slider at 45° and silently dropped the excess rotation on the next slider nudge (desync + data loss on the pending angle).

**Fix:** clamp the knob angle to ±45° to match the slider. `update_crop_drag` already re-syncs the panel afterward.

## Tests

Added 4 regression tests in `tests/test_crop_panel.py`:
- `test_reset_then_confirm_clears_committed_crop`
- `test_confirm_no_box_on_uncropped_is_noop` (guards against a junk undo)
- `test_rotate_knob_clamped_to_straighten_range` (both directions)

Full crop suite passes (99 tests across `test_crop_panel`, `test_crop_overlay`, `test_crop_hires`, `test_crop_aspect`, `test_histogram_crop`, `test_sub_saturation_crop_undo`).

## Not changed (noted for a separate decision)

- **Locked-ratio Reset re-seeds a centered box instead of clearing** — intentional per the `_on_reset` comment and covered by an existing test; clearing under a lock is still reachable via right-click clear or switching to Free.
- **Immediate Done on an auto-seeded box commits an unintended crop + undo** — entangled with the intentional seed-on-entry feature; suppressing it risks the "enter → Done applies the seeded ratio" flow.
- **Straighten slider is live but inert when no box exists** (Free + uncropped) — low-severity UX gap; the proper fix is a behavior addition beyond this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
