### PR TITLE
feat(gamma): add hue-preserving (luminance) Gamma mode toggle

### DIFF
--- a/spec/gamma-luminance-mode.md
+++ b/spec/gamma-luminance-mode.md
@@ -1,0 +1,151 @@
+# Gamma: hue-preserving (luminance) mode
+
+## Goals
+
+- Add a global **checkbox in Settings → General** that switches how the **Gamma**
+  slider (see `spec/gamma-slider.md`) is applied:
+  - **Off (default): per-channel Gamma** — the current behavior. The composite
+    tone curve is applied independently to R, G, and B (`apply_curves` with an
+    `"rgb"` curve). Because the curve is non-linear, it distorts the R:G:B
+    ratios, so non-neutral colors shift hue/saturation. This is the standard,
+    filmic behavior of most tone tools and stays the default so existing edits
+    render identically.
+  - **On: luminance (hue-preserving) Gamma** — apply the *same* tone curve to a
+    single luminance value `L`, derive a scale factor `k = L' / L`, and multiply
+    all three channels by `k`. Uniform scaling leaves the RGB *direction*
+    (chromaticity) untouched, so **hue and HSV-saturation are preserved**; only
+    brightness changes. Equivalent to applying the Gamma curve in a "Luminosity"
+    blend.
+- The toggle is a **global, persisted display mode** (like **Auto gain**), not a
+  per-image setting: flipping it only re-renders — no re-conversion, no catalog
+  write.
+
+## Non-goals
+
+- **No change to the Curves editor.** This mode governs only the **Gamma**
+  slider. The manual Curves ("All"/per-channel) editor stays per-channel — a
+  hand-drawn curve is expected to behave per-channel, and per-channel Curves are
+  the whole point of that tool.
+- No change to the Gamma slider's UI, range, curve shape, or pipeline placement.
+  Only the *channel application* changes.
+- No new per-image state, no `SLIDER_DEFAULTS` entry, no undo interaction (it is
+  a global render mode, exactly like Auto gain).
+- Not a perceptual-hue guarantee. "Hue preserved" means constant RGB ratio
+  (HSV/HSL hue). It is *not* constant CIE-Lab/CAM hue (the Abney effect is not
+  corrected), and the guarantee holds only where **no channel clips** (see Math).
+
+## UX / interaction
+
+- Settings → **General** page gains a new group **"Gamma"** below the existing
+  **"Exposure"** (Auto gain) group:
+  - Checkbox: **"Hue-preserving Gamma (apply to luminance only)"**.
+  - Muted description: *"Apply the Gamma slider to luminance and scale the colour
+    channels together, so midtone adjustments don't shift hue or saturation. Off
+    (default) applies Gamma per channel — the standard look, which adds a little
+    saturation as it brightens/darkens. Highlights that would exceed white still
+    clip."*
+- **Staged**, like the other Settings toggles: changing the checkbox does nothing
+  until **Done**; Escape/close discards it. Seeded from the live backend on open
+  (`_init_toggles`), applied on Done (`_apply_pending`).
+- On apply, a temporary hint on the sliders panel:
+  *"Gamma: hue-preserving (luminance) mode."* / *"Gamma: per-channel mode."*
+
+## Data model
+
+- New global flag `CCRBackend.gamma_luminance: bool = False` (next to
+  `auto_gain`). Not serialized per image; not in `adjustment_settings`.
+- Persisted by MainWindow under QSettings key **`adjust/gamma_luminance`**
+  (default `False`), restored at startup next to `adjust/auto_gain`.
+
+## Processing / math
+
+The per-channel path is unchanged. The luminance path reuses the **identical**
+tone LUT so neutrals render bit-for-bit the same in both modes.
+
+```
+lut16  = _gamma_lut16(gamma)                 # 65536-entry uint16, built exactly
+                                             # as apply_curves builds the "rgb" LUT
+L      = 0.299*R + 0.587*G + 0.114*B         # Rec.601 luma (matches the weights
+                                             # already used elsewhere in the file)
+L'     = lut16[round(L)]                      # same tone curve, on luminance only
+k      = L' / max(L, 1.0)                      # floor the denominator at 1 count
+out    = clip(RGB * k, 0, 65535)              # uniform per-pixel scale, then clip
+```
+
+Key properties (each is a test):
+
+- **Neutrals are identical to per-channel.** For `R=G=B=v`: `L=v`,
+  `out = v · lut16[v]/v = lut16[v]` — exactly the per-channel result. So grays,
+  the black point, and the white point match between modes.
+- **Hue/chroma preserved (pre-clip).** All three channels are scaled by the same
+  `k`, so the R:G:B ratios (hence HSV hue and saturation) are unchanged wherever
+  `RGB·k` stays within `[0, 65535]`.
+- **Clipping is the documented exception.** A saturated near-white pixel with a
+  brightening Gamma can drive its top channel past white; the clip then breaks
+  the ratio and reintroduces a hue shift. This is inherent to any brighten-then-
+  clip and is called out in the UI copy.
+- **Division-by-zero guard.** The denominator is floored at 1 count. Pure black
+  (`L=0`) stays black (`L'=0 → out=0`); this avoids amplifying shadow chroma
+  noise the way an unclamped `L'/L` would.
+
+`_gamma_lut16(gamma)` factors out the LUT expansion already inlined in
+`apply_curves` (build the 256-point composite curve via
+`build_channel_lut(gamma_curve_points(gamma))`, then `np.interp` it up to a
+16-bit LUT), so both paths share one definition of the curve.
+
+### Pipeline placement
+
+Unchanged. Still applied in `apply_adjustments` / `_adjust_for_area` after the
+slider pass and before manual `curves`. Only the internal branch differs.
+
+## Integration points
+
+1. `src/core/ccr_processor.py`
+   - Add `luminance: bool = False` kwarg to `apply_gamma_curve`. When true and
+     `gamma != 0`, dispatch to a new `_apply_gamma_luminance(img16, gamma)`;
+     otherwise the existing `apply_curves({"rgb": ...})` path. Default `False`
+     keeps every current caller/test unchanged.
+   - Add `_gamma_lut16(gamma)` (shared LUT builder) and
+     `_apply_gamma_luminance(img16, gamma)` (the L·k scale above).
+2. `src/core/ccr_backend.py`
+   - Add `self.gamma_luminance: bool = False`.
+3. `src/core/ccr_image.py`
+   - Both `apply_gamma_curve` call sites pass
+     `luminance=ccr_backend.gamma_luminance`. The whole-image path already has a
+     deferred `ccr_backend` import in scope (the Auto-gain block); the area path
+     adds the same deferred import.
+4. `src/ui/main_window.py`
+   - Restore `ccr_backend.gamma_luminance` from `adjust/gamma_luminance` at init
+     (beside `adjust/auto_gain`).
+   - Add `on_gamma_mode_toggled(checked)`: set flag, persist, and re-render all
+     loaded images (`_release_hires`, `update_all_thumbnails`, `update_preview`)
+     with a hint — a copy of `on_auto_gain_toggled` (display-only; no reconvert,
+     no catalog write).
+5. `src/widgets/settings_dialog.py`
+   - New "Gamma" group + `self._cb_gamma_lum` checkbox on the General page.
+   - Add it to `_init_toggles` (seed from `ccr_backend.gamma_luminance`) and
+     `_apply_pending` (on change, call `on_gamma_mode_toggled`).
+
+## Test plan
+
+`tests/test_gamma_slider.py` (extend):
+- **Luminance identity at 0**: `apply_gamma_curve(img, 0, luminance=True)` returns
+  the input unchanged.
+- **Neutrals match per-channel**: for several grays and gammas,
+  `apply_gamma_curve(gray, g, luminance=True) == apply_gamma_curve(gray, g)`
+  (== `lut` value), incl. black→0 and white→65535.
+- **Hue/ratio preserved**: a non-clipping colored pixel (e.g. `(120,80,40)`-ish
+  in 16-bit) keeps its channel ratios after luminance-mode Gamma (within LUT
+  quantization), and equals `round(rgb · k)`.
+- **Per-channel *shifts* the ratio**: the same pixel through the default path
+  changes the ratio (documents the difference the feature addresses).
+- **Clipping caveat**: a bright saturated pixel with large `+gamma` clips its top
+  channel at 65535 in luminance mode (ratio no longer preserved) — asserted so
+  the limitation is pinned, not a surprise.
+
+`tests/test_settings_dialog.py` (extend):
+- The **General** page exposes `_cb_gamma_lum`; it seeds from
+  `ccr_backend.gamma_luminance`.
+- Toggling then **Done** calls `on_gamma_mode_toggled` and flips the backend flag;
+  closing without Done leaves it unchanged (staged/discard behavior, mirroring the
+  existing Auto-gain / Positive toggle tests).

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -60,6 +60,11 @@ class CCRBackend:
         # slider is never moved). Supersedes the legacy baked auto-exposure while
         # on. Global, persisted by MainWindow. See spec/auto-gain.md.
         self.auto_gain: bool = True
+        # Gamma slider application mode: False = per-channel (default filmic look,
+        # shifts hue), True = apply to luminance and scale RGB together
+        # (hue-preserving). Global display mode, persisted by MainWindow. See
+        # spec/gamma-luminance-mode.md.
+        self.gamma_luminance: bool = False
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area
         # Global input ICC profile (one app-wide setting; applied to every

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -881,10 +881,12 @@ class CCRImage:
         # Gamma slider: a center-point tone curve driven through the SAME
         # monotone-cubic path as the Curves editor (a single 'rgb' point moving
         # diagonally from center). Applied before the user's manual curves so the
-        # two compose predictably. No-op at 0.
+        # two compose predictably. No-op at 0. Per-channel by default; the global
+        # gamma_luminance flag switches it to hue-preserving (luminance) mode.
         gamma = s.get('gamma', 0)
         if gamma:
-            adjusted = apply_gamma_curve(adjusted, gamma)
+            adjusted = apply_gamma_curve(adjusted, gamma,
+                                         luminance=ccr_backend.gamma_luminance)
         # Tone curves run after the slider pass, in RGB, before any B&W
         # luminance collapse (Photoshop-like). No-op for identity curves.
         curves = s.get('curves')
@@ -938,7 +940,9 @@ class CCRImage:
                                     else None))
         gamma = s.get('gamma', 0)
         if gamma:
-            adjusted = apply_gamma_curve(adjusted, gamma)
+            from core.ccr_backend import ccr_backend
+            adjusted = apply_gamma_curve(adjusted, gamma,
+                                         luminance=ccr_backend.gamma_luminance)
         curves = s.get('curves')
         if curves:
             adjusted = apply_curves(adjusted, curves)

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3109,10 +3109,57 @@ def gamma_curve_points(gamma: float):
     return [[0.0, 0.0], [127.5 - offset, 127.5 + offset], [255.0, 255.0]]
 
 
-def apply_gamma_curve(img16: np.ndarray, gamma: float) -> np.ndarray:
-    """Apply the Gamma slider as a center-point tone curve. No-op at 0."""
+def _gamma_lut16(gamma: float) -> np.ndarray:
+    """Full 16-bit LUT (65536 -> uint16) for the Gamma tone curve, expanded the
+    same way apply_curves builds the composite 'rgb' LUT — including its 256-level
+    rounding (apply_curves composes through an identity per-channel ramp with
+    np.rint) — so a neutral pixel renders bit-for-bit identically in both the
+    per-channel and luminance paths."""
+    curve256 = np.rint(build_channel_lut(gamma_curve_points(gamma)))   # 256 levels
+    sample = np.arange(65536, dtype=np.float32)
+    src_idx = np.arange(256, dtype=np.float32) * (65535.0 / 255.0)
+    return np.interp(sample, src_idx,
+                     curve256 * (65535.0 / 255.0)).astype(np.uint16)
+
+
+# Rec.601 luma weights (R, G, B) — the same weights the saturation / shadow
+# stages in this module already use.
+_GAMMA_LUMA = np.array([0.299, 0.587, 0.114], dtype=np.float32)
+
+
+def _apply_gamma_luminance(img16: np.ndarray, gamma: float) -> np.ndarray:
+    """Hue-preserving Gamma: apply the tone curve to luminance only, then scale
+    the RGB channels by the ratio L'/L. Uniform scaling leaves chromaticity (hue
+    + HSV saturation) untouched except where a channel clips. Neutrals render
+    bit-for-bit identically to the per-channel path (out = L'/L * v = L' when
+    R=G=B=v). See spec/gamma-luminance-mode.md."""
+    lut16 = _gamma_lut16(gamma)
+    rgbf = img16.astype(np.float32)
+    lum = rgbf @ _GAMMA_LUMA                                       # (H, W)
+    idx = np.clip(np.rint(lum), 0, 65535).astype(np.uint16)
+    lum_out = lut16[idx].astype(np.float32)
+    # Floor the denominator at one count: pure black (lum==0 -> lum_out==0) stays
+    # black, and near-black pixels can't blow up k (which would amplify shadow
+    # chroma noise).
+    k = lum_out / np.maximum(lum, 1.0)
+    out = rgbf * k[..., np.newaxis]
+    # Round (not truncate) so a neutral pixel recovers lut16[v] exactly: for
+    # R=G=B=v, out = v * lut16[v] / v differs from lut16[v] only by float error.
+    return np.clip(np.rint(out), 0.0, 65535.0).astype(np.uint16)
+
+
+def apply_gamma_curve(img16: np.ndarray, gamma: float,
+                      luminance: bool = False) -> np.ndarray:
+    """Apply the Gamma slider as a center-point tone curve. No-op at 0.
+
+    luminance=False (default): apply the curve PER CHANNEL (via apply_curves) —
+    the standard filmic look, which shifts hue/saturation of non-neutral colours.
+    luminance=True: apply the curve to luminance and scale RGB together, so hue
+    and HSV saturation are preserved (except where a channel clips)."""
     if not gamma:
         return img16
+    if luminance:
+        return _apply_gamma_luminance(img16, gamma)
     return apply_curves(img16, {"rgb": gamma_curve_points(gamma)})
 
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -200,6 +200,11 @@ class MainWindow(QMainWindow):
         # spec/auto-gain.md.
         ccr_backend.auto_gain = self._settings.value(
             "adjust/auto_gain", True, type=bool)
+        # Restore the Gamma application mode (default OFF = per-channel). When on,
+        # the Gamma slider is applied to luminance and RGB is scaled together, so
+        # midtone moves don't shift hue. See spec/gamma-luminance-mode.md.
+        ccr_backend.gamma_luminance = self._settings.value(
+            "adjust/gamma_luminance", False, type=bool)
         # Reflect the restored mode in the toolbar/slider gating right away
         # (no images yet, but the negative-only actions should already grey out).
         self.image_preview._update_unconvert_action_state()
@@ -668,6 +673,31 @@ class MainWindow(QMainWindow):
             "Auto gain on — highlights auto-placed at the top of the window."
             if checked else
             "Auto gain off — the Gain slider alone controls exposure.",
+            duration=5000)
+
+    # --- Gamma application mode (global, persistent) ----------------------
+    def on_gamma_mode_toggled(self, checked: bool):
+        """Flip the global Gamma mode (per-channel vs hue-preserving luminance),
+        persist it, and re-render all loaded images. Gamma is a display-domain
+        tone op, so this only re-renders — no re-conversion, no catalog write.
+        Mirrors on_auto_gain_toggled. See spec/gamma-luminance-mode.md."""
+        ccr_backend.gamma_luminance = bool(checked)
+        self._settings.setValue("adjust/gamma_luminance", bool(checked))
+        if ccr_backend.images:
+            QApplication.setOverrideCursor(Qt.WaitCursor)
+            try:
+                # The mode is read live in apply_adjustments, so a plain re-render
+                # reflects it. Drop the zoom hi-res cache (it baked the old mode).
+                self.image_preview._release_hires(refresh=False)
+                self.thumbnail_list.update_all_thumbnails()
+                if self.image_preview.current_idx is not None:
+                    self.image_preview.update_preview(self.image_preview.current_idx)
+            finally:
+                QApplication.restoreOverrideCursor()
+        self.sliders_panel.set_temporary_hint(
+            "Gamma: hue-preserving (luminance) mode."
+            if checked else
+            "Gamma: per-channel mode (standard).",
             duration=5000)
 
     def show_activation_dialog(self):

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -108,6 +108,19 @@ class SettingsDialog(QDialog):
             "exposure with the Gain slider alone."))
         lay.addWidget(grp)
 
+        grp_gamma = QGroupBox("Gamma")
+        gg = QVBoxLayout(grp_gamma)
+        gg.setSpacing(theme.GAP_ROW)
+        self._cb_gamma_lum = QCheckBox("Hue-preserving Gamma (apply to luminance only)")
+        gg.addWidget(self._cb_gamma_lum)
+        gg.addWidget(self._muted(
+            "Apply the Gamma slider to luminance and scale the colour channels "
+            "together, so midtone adjustments don't shift hue or saturation. Off "
+            "(default) applies Gamma per channel — the standard look, which adds a "
+            "little saturation as it brightens/darkens. Highlights that would "
+            "exceed white still clip."))
+        lay.addWidget(grp_gamma)
+
         lay.addStretch(1)
         return page
 
@@ -240,7 +253,8 @@ class SettingsDialog(QDialog):
         for cb, val in ((self._cb_positive, ccr_backend.positive_mode),
                         (self._cb_rgb_merge, ccr_backend.rgb_merge_mode),
                         (self._cb_density, ccr_backend.density_bwpoint),
-                        (self._cb_auto_gain, ccr_backend.auto_gain)):
+                        (self._cb_auto_gain, ccr_backend.auto_gain),
+                        (self._cb_gamma_lum, ccr_backend.gamma_luminance)):
             cb.blockSignals(True)
             cb.setChecked(bool(val))
             cb.blockSignals(False)
@@ -258,6 +272,8 @@ class SettingsDialog(QDialog):
             self._mw.on_density_bwpoint_toggled(bool(self._cb_density.isChecked()))
         if bool(self._cb_auto_gain.isChecked()) != bool(ccr_backend.auto_gain):
             self._mw.on_auto_gain_toggled(bool(self._cb_auto_gain.isChecked()))
+        if bool(self._cb_gamma_lum.isChecked()) != bool(ccr_backend.gamma_luminance):
+            self._mw.on_gamma_mode_toggled(bool(self._cb_gamma_lum.isChecked()))
 
     def accept(self):
         """Done: commit the staged toggles, then close. (Escape/close → reject,

--- a/tests/test_gamma_slider.py
+++ b/tests/test_gamma_slider.py
@@ -102,3 +102,51 @@ def test_endpoints_pinned(g):
     """Pure black and pure white are invariant (the effect stays in the window)."""
     assert int(apply_gamma_curve(_solid(0), g)[0, 0, 0]) == 0
     assert int(apply_gamma_curve(_solid(65535), g)[0, 0, 0]) == 65535
+
+
+# --- luminance (hue-preserving) mode ---------------------------------------
+# apply_gamma_curve(..., luminance=True) applies the SAME tone curve to luminance
+# and scales RGB together, so chromaticity (hue + HSV saturation) is preserved
+# except where a channel clips. See spec/gamma-luminance-mode.md.
+
+_COLOR = np.array([[[20000, 12000, 6000]]], dtype=np.uint16)   # non-clipping warm
+
+
+def test_luminance_zero_is_identity():
+    img = np.linspace(0, 65535, 4 * 4 * 3).reshape(4, 4, 3).astype(np.uint16)
+    assert np.array_equal(apply_gamma_curve(img, 0, luminance=True), img)
+
+
+@pytest.mark.parametrize("g", [60, -60, 37, -100])
+@pytest.mark.parametrize("v255", [0, 1, 40, 128, 200, 255])
+def test_luminance_neutral_matches_per_channel(v255, g):
+    """Grays render bit-for-bit identically in both modes — toggling the mode
+    only changes non-neutral colours."""
+    gray = _solid(_to16(v255))
+    assert np.array_equal(apply_gamma_curve(gray, g, luminance=True),
+                          apply_gamma_curve(gray, g))
+
+
+@pytest.mark.parametrize("g", [60, -60])
+def test_luminance_preserves_channel_ratios(g):
+    """A non-clipping colour keeps its R:G:B ratios (uniform scale) — the point
+    of the feature."""
+    inp = _COLOR[0, 0].astype(float)
+    out = apply_gamma_curve(_COLOR, g, luminance=True)[0, 0].astype(float)
+    assert np.allclose(out / out.max(), inp / inp.max(), atol=0.01)
+
+
+def test_per_channel_shifts_channel_ratios():
+    """The default per-channel path DOES distort the ratios (this is the hue
+    shift the luminance mode avoids)."""
+    inp = _COLOR[0, 0].astype(float)
+    out = apply_gamma_curve(_COLOR, 60)[0, 0].astype(float)
+    assert not np.allclose(out / out.max(), inp / inp.max(), atol=0.01)
+
+
+def test_luminance_clips_bright_saturated_highlight():
+    """The hue guarantee holds only pre-clip: a bright saturated colour with a
+    strong +gamma scales its top channel past white, which clips."""
+    px = np.array([[[60000, 20000, 10000]]], dtype=np.uint16)
+    out = apply_gamma_curve(px, 100, luminance=True)[0, 0]
+    assert int(out[0]) == 65535

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -49,6 +49,7 @@ def _reset_profile_state():
         cm.set_camera_matrix_mode(False)
         ccr_backend.positive_mode = False
         ccr_backend.density_bwpoint = False        # product default: opt-in
+        ccr_backend.gamma_luminance = False        # product default: per-channel
         ccr_backend.active_profile_path = None
         ccr_backend.images = []
     _reset()
@@ -279,6 +280,14 @@ class _StubMW(QWidget):
         self.calls.append(("density", bool(c)))
         ccr_backend.density_bwpoint = bool(c)
 
+    def on_auto_gain_toggled(self, c):
+        self.calls.append(("auto_gain", bool(c)))
+        ccr_backend.auto_gain = bool(c)
+
+    def on_gamma_mode_toggled(self, c):
+        self.calls.append(("gamma_lum", bool(c)))
+        ccr_backend.gamma_luminance = bool(c)
+
 
 def _dialog():
     from widgets.settings_dialog import SettingsDialog
@@ -364,6 +373,35 @@ class TestSettingsDialog:
         # Product default is OFF (density is opt-in); fixture leaves it False.
         d = _dialog()
         assert d._cb_density.isChecked() is False
+
+    # --- Gamma mode toggle (spec/gamma-luminance-mode.md) ----------------- #
+    def test_general_page_has_gamma_toggle(self):
+        d = _dialog()
+        assert hasattr(d, "_cb_gamma_lum")
+        assert d._cb_gamma_lum.isChecked() is False    # per-channel by default
+
+    def test_gamma_toggle_seeds_from_backend(self):
+        ccr_backend.gamma_luminance = True
+        d = _dialog()
+        assert d._cb_gamma_lum.isChecked() is True
+
+    def test_gamma_toggle_staged_until_done(self):
+        ccr_backend.gamma_luminance = False
+        d = _dialog()
+        d._cb_gamma_lum.setChecked(True)
+        assert d._mw.calls == []                        # staged: nothing yet
+        assert ccr_backend.gamma_luminance is False
+        d.accept()                                      # Done
+        assert ("gamma_lum", True) in d._mw.calls
+        assert ccr_backend.gamma_luminance is True
+
+    def test_gamma_toggle_discarded_on_close(self):
+        ccr_backend.gamma_luminance = False
+        d = _dialog()
+        d._cb_gamma_lum.setChecked(True)
+        d.reject()                                      # Escape / close, not Done
+        assert d._mw.calls == []
+        assert ccr_backend.gamma_luminance is False
 
     def test_toggles_seed_from_backend_at_open(self):
         ccr_backend.rgb_merge_mode = True


### PR DESCRIPTION
## Summary

Adds a global **Settings → General** checkbox — **"Hue-preserving Gamma (apply to luminance only)"** — that changes how the **Gamma** slider is applied.

This came out of a discussion of a correct observation: the Gamma slider applies its composite tone curve **per channel** (`apply_curves` with an `"rgb"` curve), and because the curve is non-linear, it distorts the R:G:B ratios and shifts the hue/saturation of non-neutral colours. That per-channel behaviour is the standard filmic look and **stays the default**.

- **Off (default) — per-channel Gamma:** unchanged behavior; existing edits render identically.
- **On — luminance (hue-preserving) Gamma:** apply the *same* tone curve to luminance, derive `k = L'/L`, and scale all channels by `k`. Uniform scaling leaves chromaticity untouched, so **hue and HSV-saturation are preserved** — equivalent to applying the curve in a "Luminosity" blend.

## Design notes

- **Neutrals are bit-for-bit identical** in both modes: the luminance LUT replicates `apply_curves`' 256-level quantization, and the RGB scale rounds (not truncates), so `R=G=B=v → out = v·L'/v = L'`. Toggling the mode only changes non-neutral colours.
- **Not an absolute guarantee:** hue is preserved in the RGB-ratio / HSV sense (not perceptual/CIE-Lab), and only where **no channel clips**. A bright saturated highlight with a strong `+gamma` still scales past white and clips — this is called out in the UI copy and pinned by a test.
- **Global display mode**, persisted like **Auto gain** (`QSettings adjust/gamma_luminance`, default off). Flipping it only re-renders — **no re-conversion, no catalog write**.
- **Scoped to the Gamma slider.** The manual **Curves** editor stays per-channel (a hand-drawn curve is expected to behave per-channel).
- Shadow-noise / div-by-zero guard: the `L'/L` denominator is floored at one count, so pure black stays black and near-black pixels don't blow up `k`.

## Implementation

- `ccr_processor.py`: `apply_gamma_curve(img16, gamma, luminance=False)` (default keeps all existing callers/tests unchanged) + `_gamma_lut16` and `_apply_gamma_luminance` helpers.
- `ccr_backend.py`: `gamma_luminance` flag.
- `ccr_image.py`: both Gamma call sites pass `luminance=ccr_backend.gamma_luminance`.
- `main_window.py`: restore from QSettings at startup; `on_gamma_mode_toggled` re-renders all images (mirrors `on_auto_gain_toggled`).
- `settings_dialog.py`: new "Gamma" group on the General page, staged like the other toggles (applies on Done, discards on close).

Spec: `spec/gamma-luminance-mode.md`.

## Tests

`tests/test_gamma_slider.py`: luminance-mode identity at 0; **bit-for-bit neutral match** vs per-channel across grays/gammas; ratio preservation in luminance mode vs the **ratio shift** the per-channel path produces; the clipping caveat.
`tests/test_settings_dialog.py`: the General page exposes the toggle, seeds from the backend, applies on **Done**, and discards on close.

All 90 gamma + settings-dialog tests pass. (The unrelated `exposure_base` failures in `test_positive_mode`/`test_color_bands` are pre-existing and fail identically on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
