### PR TITLE
fix: address xhigh code-review findings on crop + gamma changes

### DIFF
--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3064,6 +3064,20 @@ def build_channel_lut(points) -> np.ndarray:
     return np.clip(y, 0.0, 255.0).astype(np.float32)
 
 
+# Shared LUT expansion: turn a 256-entry (0..255) curve into a full
+# 65536 -> uint16 LUT. Used by both apply_curves (per-channel) and the Gamma
+# luminance LUT, so the two stay bit-for-bit identical. The sample/source ramps
+# are pure constants — built once at import, not per call.
+_LUT16_SAMPLE = np.arange(65536, dtype=np.float32)
+_LUT16_SRC_IDX = np.arange(256, dtype=np.float32) * (65535.0 / 255.0)
+
+
+def _expand_curve256_to_lut16(curve256: np.ndarray) -> np.ndarray:
+    """Expand a 256-entry (output 0..255) curve to a 16-bit input->output LUT."""
+    return np.interp(_LUT16_SAMPLE, _LUT16_SRC_IDX,
+                     curve256 * (65535.0 / 255.0)).astype(np.uint16)
+
+
 def apply_curves(img16: np.ndarray, curves) -> np.ndarray:
     """Apply Photoshop-style tone curves to a 16-bit RGB image.
 
@@ -3076,17 +3090,14 @@ def apply_curves(img16: np.ndarray, curves) -> np.ndarray:
         return img16
 
     rgb_lut = build_channel_lut(curves.get("rgb"))     # 256 -> 0..255 float
-    sample = np.arange(65536, dtype=np.float32)
-    src_idx = np.arange(256, dtype=np.float32) * (65535.0 / 255.0)
+    rgb_idx = np.clip(np.rint(rgb_lut), 0, 255).astype(np.intp)
 
     out = np.empty_like(img16)
     for c, key in enumerate(("r", "g", "b")):
-        # Compose per-channel curve over the composite curve in 0..255 space.
+        # Compose the per-channel curve over the composite curve in 0..255 space,
+        # then expand to a full 16-bit LUT (shared with the Gamma luminance path).
         ch_lut = build_channel_lut(curves.get(key))
-        composed = ch_lut[np.clip(np.rint(rgb_lut), 0, 255).astype(np.intp)]
-        # Expand the 256-point composed curve to a full 16-bit LUT.
-        lut16 = np.interp(sample, src_idx,
-                          composed * (65535.0 / 255.0)).astype(np.uint16)
+        lut16 = _expand_curve256_to_lut16(ch_lut[rgb_idx])
         out[..., c] = lut16[img16[..., c]]
     return out
 
@@ -3116,10 +3127,7 @@ def _gamma_lut16(gamma: float) -> np.ndarray:
     np.rint) — so a neutral pixel renders bit-for-bit identically in both the
     per-channel and luminance paths."""
     curve256 = np.rint(build_channel_lut(gamma_curve_points(gamma)))   # 256 levels
-    sample = np.arange(65536, dtype=np.float32)
-    src_idx = np.arange(256, dtype=np.float32) * (65535.0 / 255.0)
-    return np.interp(sample, src_idx,
-                     curve256 * (65535.0 / 255.0)).astype(np.uint16)
+    return _expand_curve256_to_lut16(curve256)
 
 
 # Rec.601 luma weights (R, G, B) — the same weights the saturation / shadow

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -657,23 +657,32 @@ class MainWindow(QMainWindow):
         no re-conversion and no catalog write. See spec/auto-gain.md."""
         ccr_backend.auto_gain = bool(checked)
         self._settings.setValue("adjust/auto_gain", bool(checked))
+        self._rerender_all_for_global_mode(
+            "Auto gain on — highlights auto-placed at the top of the window."
+            if checked else
+            "Auto gain off — the Gain slider alone controls exposure.")
+
+    def _rerender_all_for_global_mode(self, hint: str):
+        """Re-render every loaded image after a global DISPLAY-mode change (Auto
+        gain, Gamma mode) that is read live inside apply_adjustments but is NOT
+        baked per image. The cached resized_preview/thumbnail must be REGENERATED
+        before re-display — update_all_thumbnails/update_preview only re-show the
+        cache (see sliders_panel._on_curve_edit_finished), so without the
+        regenerate pass the change wouldn't appear until the user nudged a slider.
+        No re-conversion, no catalog write."""
         if ccr_backend.images:
             QApplication.setOverrideCursor(Qt.WaitCursor)
             try:
-                # The auto-gain offset recomputes live in apply_adjustments, so a
-                # plain re-render reflects the new state. Drop the zoom hi-res
-                # cache (its render baked the old offset).
+                for img in ccr_backend.images:
+                    img.update_thumbnail_and_preview()
+                # The zoom hi-res cache baked the old mode — drop it.
                 self.image_preview._release_hires(refresh=False)
                 self.thumbnail_list.update_all_thumbnails()
                 if self.image_preview.current_idx is not None:
                     self.image_preview.update_preview(self.image_preview.current_idx)
             finally:
                 QApplication.restoreOverrideCursor()
-        self.sliders_panel.set_temporary_hint(
-            "Auto gain on — highlights auto-placed at the top of the window."
-            if checked else
-            "Auto gain off — the Gain slider alone controls exposure.",
-            duration=5000)
+        self.sliders_panel.set_temporary_hint(hint, duration=5000)
 
     # --- Gamma application mode (global, persistent) ----------------------
     def on_gamma_mode_toggled(self, checked: bool):
@@ -683,22 +692,9 @@ class MainWindow(QMainWindow):
         Mirrors on_auto_gain_toggled. See spec/gamma-luminance-mode.md."""
         ccr_backend.gamma_luminance = bool(checked)
         self._settings.setValue("adjust/gamma_luminance", bool(checked))
-        if ccr_backend.images:
-            QApplication.setOverrideCursor(Qt.WaitCursor)
-            try:
-                # The mode is read live in apply_adjustments, so a plain re-render
-                # reflects it. Drop the zoom hi-res cache (it baked the old mode).
-                self.image_preview._release_hires(refresh=False)
-                self.thumbnail_list.update_all_thumbnails()
-                if self.image_preview.current_idx is not None:
-                    self.image_preview.update_preview(self.image_preview.current_idx)
-            finally:
-                QApplication.restoreOverrideCursor()
-        self.sliders_panel.set_temporary_hint(
-            "Gamma: hue-preserving (luminance) mode."
-            if checked else
-            "Gamma: per-channel mode (standard).",
-            duration=5000)
+        self._rerender_all_for_global_mode(
+            "Gamma: hue-preserving (luminance) mode." if checked else
+            "Gamma: per-channel mode (standard).")
 
     def show_activation_dialog(self):
         QMessageBox.information(

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1676,6 +1676,11 @@ class ImagePreview(QWidget):
                 img.contrast_base, img.temperature_base, img.brightness_base,
                 getattr(img, "exposure_base", 0.0),
                 getattr(img, "color_profile", "color"),
+                # Global display modes read live inside apply_adjustments — a
+                # toggle must invalidate the baked hi-res tile (spec/auto-gain.md,
+                # spec/gamma-luminance-mode.md).
+                bool(getattr(ccr_backend, "gamma_luminance", False)),
+                bool(getattr(ccr_backend, "auto_gain", True)),
                 areas_sig, dust_sig)
 
     HIRES_MAX_LONG_SIDE = 4500   # bounds non-RAW decodes (RAW half-size passes through)
@@ -2815,11 +2820,14 @@ class ImagePreview(QWidget):
         angle = (angle + 180.0) % 360.0 - 180.0
         if abs(angle) < 0.75:
             angle = 0.0  # snap to straight
-        # The knob and the panel straighten slider are two-way synced and the
-        # slider only spans ±45°; clamp here so the knob can't drive the box past
-        # what the slider can represent (which would desync them and silently
-        # drop the excess rotation on the next slider nudge).
-        angle = max(-45.0, min(45.0, angle))
+        # The knob and the panel straighten slider are two-way synced over ±45°,
+        # so hold a FRESH box to that range. But a crop entered with a folded
+        # micro-rotation can legitimately start beyond ±45 (committed crop_angle
+        # ±45 folded with the canvas rotation ±45 → up to ±90); never snap that
+        # existing angle inward on an incidental touch — only forbid pushing it
+        # further out. `angle0` is the box angle at drag start.
+        base = drag["angle0"]
+        angle = max(min(-45.0, base), min(max(45.0, base), angle))
         self._pending_crop_angle = angle
         self._pending_crop_local = QRectF(box0)
 
@@ -3039,10 +3047,19 @@ class ImagePreview(QWidget):
             # with no selection means "remove the crop", so Reset + Done actually
             # restores the full frame instead of silently keeping the previously
             # committed crop. A no-op when the image isn't cropped.
-            if img_obj.crop_rect is not None or getattr(img_obj, "crop_angle", 0.0):
+            fold = self._crop_fold_fine and bool(
+                getattr(img_obj, "fine_rotation_angle", 0))
+            if (img_obj.crop_rect is not None
+                    or getattr(img_obj, "crop_angle", 0.0) or fold):
                 img_obj.push_undo_state()
                 img_obj.crop_rect = None
                 img_obj.crop_angle = 0.0
+                if fold:
+                    # Entry folded the image's micro-rotation into the (now reset)
+                    # straighten; the leveled crop-mode preview + 0° slider showed
+                    # it gone, so clear it too instead of letting it snap back on
+                    # exit. Matches the box-present fold path above; one undo.
+                    img_obj.fine_rotation_angle = 0
                 applied = True
                 cleared = True
         self._exit_crop_mode()

--- a/tests/test_crop_panel.py
+++ b/tests/test_crop_panel.py
@@ -203,6 +203,18 @@ class TestCropHooks:
         ip._drag_rotate_box(drag, QPointF(50, 150))
         assert ip._pending_crop_angle == pytest.approx(-45.0)
 
+    def test_rotate_knob_preserves_folded_angle_over_45(self):
+        # A crop entered with a folded micro-rotation can legitimately start
+        # beyond ±45 (committed crop_angle ±45 folded with the canvas rotation
+        # ±45 → up to ±90). An incidental knob touch must NOT snap it to 45 (that
+        # silently discards rotation) — it may only forbid pushing further out.
+        ip, _h = _make_preview()
+        drag = {"box0": QRectF(100, 100, 100, 100),
+                "start": QPointF(150, 50), "angle0": 60.0}
+        ip._drag_rotate_box(drag, QPointF(145, 50))    # tiny nudge
+        assert ip._pending_crop_angle > 45.0            # not collapsed to 45
+        assert ip._pending_crop_angle <= 60.0 + 1e-6    # not pushed past the start
+
     def test_reset_pending_crop(self):
         ip, _h = _make_preview()
         ip.set_crop_panel(_RatioPanel(1.5))
@@ -286,6 +298,21 @@ class TestStraightenFoldIn:
         ip.confirm_crop()
         assert img.crop_rect is None
         assert not img.undo                          # no-op, no undo snapshot
+
+    def test_reset_then_confirm_clears_folded_fine_rotation(self):
+        # Entering crop on a cropped image that also has a fine micro-rotation
+        # folds the rotation into the (leveled) straighten. Reset zeroes the
+        # straighten and the preview shows level, so Done must clear the fine
+        # rotation too — not let it snap back on exit (matches the box-present
+        # fold path).
+        ip, img, _ok = self._entered(fine=500, crop_rect=(0.1, 0.1, 0.9, 0.9))
+        assert ip._crop_fold_fine is True
+        ip.reset_pending_crop()                      # box -> None, straighten -> 0
+        ip.confirm_crop()                            # Done
+        assert img.crop_rect is None                 # crop cleared
+        assert img.fine_rotation_angle == 0          # leveled, matching straighten 0
+        assert img.undo
+        assert img.undo[-1][2] == 500                # original fine captured for undo
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the seven findings from the xhigh `/code-review` of the merged crop-reset (#67) and gamma-luminance (#68) changes — four correctness bugs, three cleanups.

## Correctness

**1. Gamma / Auto-gain toggle left the display stale.** `update_all_thumbnails`/`update_preview` only re-show the **cached** `resized_preview`/`thumbnail` (see `sliders_panel._on_curve_edit_finished`), so a global display-mode change didn't appear until the user nudged a slider. Added a shared `_rerender_all_for_global_mode()` that **regenerates each image's cache** (through `apply_adjustments`, which reads the flag) *before* re-displaying — mirroring the positive/density reprocess-then-display pattern. Fixes both `on_gamma_mode_toggled` and `on_auto_gain_toggled`.

**2. Hi-res zoom signature omitted the global flags.** `_current_adj_sig` hashed only per-image state, so an in-flight `HiResDetailWorker` rendered under the old mode could pass validation and persist when zoomed in during a toggle. Now includes `gamma_luminance` and `auto_gain`.

**3. Rotate-knob ±45° clamp silently collapsed a legitimate >45° crop angle.** A crop entered with a folded micro-rotation can start beyond ±45° (committed `crop_angle` ±45 folded with the canvas `fine_rotation` ±45 → up to ±90). The hard clamp snapped it to 45° on any knob touch, discarding rotation. Now clamps **relative to the drag-start angle**: a fresh box is held to ±45°, but an existing out-of-range angle is never snapped inward — only pushing *further* out is forbidden.

**4. Reset+Done on a folded image left a stale `fine_rotation_angle`.** The no-box clear branch cleared `crop_rect`/`crop_angle` but not the folded fine rotation, so the frame snapped back to a tilt the leveled crop preview + 0° straighten slider showed as gone. Now clears the folded fine rotation too (single undo), matching the box-present fold path.

## Cleanup

**5.** Factored the 256→16-bit LUT expansion into a shared `_expand_curve256_to_lut16()`; `apply_curves` and `_gamma_lut16` both use it, so the bit-for-bit-neutral invariant lives in one place (the spec's stated intent).

**6.** Collapsed the duplicated auto-gain/gamma re-render blocks into `_rerender_all_for_global_mode()`.

**7.** Hoisted the per-call `np.arange` sample/src_idx ramps to module constants.

## Tests / verification

- New regression tests in `tests/test_crop_panel.py`: `test_rotate_knob_preserves_folded_angle_over_45` (#3) and `test_reset_then_confirm_clears_folded_fine_rotation` (#4).
- `apply_curves` output is unchanged: `test_curves` (18) and the `test_gamma_slider` bit-for-bit neutral-match all pass.
- #1 and #2 verified against a scripted `MainWindow`/`ImagePreview`: both toggles regenerate every image cache before re-display, and `_current_adj_sig` changes when either flag flips.
- Affected suites green individually (gamma, curves, all crop, settings, auto-gain, area-editing, histogram, sub-saturation). The combined-run native crash is the repo's known flaky teardown, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
