### PR TITLE
test: green the exposure_base stub failures

### DIFF
--- a/tests/test_color_bands.py
+++ b/tests/test_color_bands.py
@@ -236,6 +236,9 @@ class TestPipelineIntegration:
         img_obj.contrast_base = 0
         img_obj.temperature_base = 0
         img_obj.brightness_base = 0
+        img_obj.exposure_base = 0
+        img_obj.converted = False
+        img_obj._ws_windowed = False
         img_obj.tint_balance_factor = 1.0
         out = img_obj.apply_adjustments(_patch(RED))
         assert _hsv_of(out)[..., 1].max() < 0.02
@@ -248,6 +251,9 @@ class TestPipelineIntegration:
         img_obj.contrast_base = 0
         img_obj.temperature_base = 0
         img_obj.brightness_base = 0
+        img_obj.exposure_base = 0
+        img_obj.converted = False
+        img_obj._ws_windowed = False
         img_obj.tint_balance_factor = 1.0
         img = _patch(RED)
         out = img_obj.apply_adjustments(img)

--- a/tests/test_color_profile.py
+++ b/tests/test_color_profile.py
@@ -26,6 +26,9 @@ def _stub_image(color_profile="color", adjustment_settings=None):
     img.contrast_base = 0
     img.temperature_base = 0
     img.brightness_base = 0
+    img.exposure_base = 0
+    img.converted = False
+    img._ws_windowed = False
     img.tint_balance_factor = 1.0
     return img
 

--- a/tests/test_positive_mode.py
+++ b/tests/test_positive_mode.py
@@ -334,6 +334,9 @@ def _stub_image(resized_raw, color_profile="color", adjustment_settings=None):
     img.contrast_base = 0
     img.temperature_base = 0
     img.brightness_base = 0
+    img.exposure_base = 0
+    img.converted = False
+    img._ws_windowed = False
     img.tint_balance_factor = 1.0
     img.area_layers = []
     img.fine_rotation_angle = 0


### PR DESCRIPTION
## Summary

Greens the 13 long-standing "pre-existing" test failures (in `test_color_bands`, `test_color_profile`, `test_positive_mode`) — the ones that made the suite unable to run clean.

## Root cause

These tests build `CCRImage` stubs with `CCRImage.__new__(CCRImage)` (deliberately skipping the heavy file-loading `__init__`), then hand-set `contrast_base` / `temperature_base` / `brightness_base`. But `apply_adjustments` also reads `self.exposure_base`, `self.converted`, and `self._ws_windowed` — all set **only** in `__init__` (no class-level defaults) and added *after* these stubs were written (by the Auto-gain and Exposure-slider work). So the stubs hit `AttributeError: 'CCRImage' object has no attribute 'exposure_base'`.

This is **stub-completeness debt, not a production bug** — a real `CCRImage` always sets these in `__init__` (verified). So the fix is to complete the stubs, not weaken production.

## Fix

Add `exposure_base = 0`, `converted = False`, `_ws_windowed = False` to each of the four stub sites, next to the three bases they already set. `converted = False` keeps Auto-gain out of these focused adjustment-math tests — i.e. the pre-Auto-gain behavior they were written against — so the assertions stay deterministic.

**No production code changed.**

## Result

All **67** tests in the three suites pass (was **13 failing**). Combined with the other cleanup, the only remaining non-green items in the suite are the **native access-violation faults** in `test_dust_removal` / `test_tether_watcher` (a separate stability issue — those tests pass but the process faults on teardown; worth investigating next toward a clean 1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
