### PR TITLE
test: fix native test-suite crashes (onnxruntime ordering + per-file isolation)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""
+pytest session setup.
+
+Mirror src/main.py's startup ordering: import onnxruntime BEFORE any PySide6/Qt
+import. onnxruntime's native DLLs fail to initialise if first loaded AFTER Qt on
+Windows ("DLL initialization routine failed" — a hard access violation under
+pytest's accumulated native state). Several GUI tests build a MainWindow whose
+dust panel probes dust_detect.is_available() -> `import onnxruntime`, which would
+then load after Qt and crash the whole run.
+
+pytest imports this conftest before any test module (and thus before any test's
+module-level QApplication), so pre-loading onnxruntime here makes that later
+import a cached no-op — the suite neither crashes nor emits faulthandler
+access-violation noise. Guarded so it is a no-op when onnxruntime is absent.
+See spec/dust-removal.md §8.
+"""
+try:
+    import onnxruntime  # noqa: F401  (must precede any PySide6/Qt import)
+except Exception:
+    pass

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,26 +1,101 @@
 #!/usr/bin/env python3
 """
-Test runner for FreeCCR: runs the full pytest suite.
-"""
+Test runner for FreeCCR.
 
+Runs each test file in its OWN pytest subprocess (process isolation), then
+aggregates the results. This is deliberate, not a convenience: the GUI/native
+tests build and tear down hundreds of Qt MainWindows, QThreads, OpenCL contexts
+and rawpy decodes, and running them all in a single process accumulates native
+heap corruption that segfaults an otherwise-green suite near the end (a *roaming*
+crash — the location moves between runs). fork() isn't available on Windows, so
+per-file subprocesses are the portable isolation. Every file passes cleanly on
+its own, so isolation makes the whole run reliable and reportable.
+
+Usage:
+    python tests/run_tests.py                 # whole suite, isolated per file
+    python tests/run_tests.py test_crop_panel # one file (name, with/without .py)
+    python tests/run_tests.py crop            # substring match across files
+"""
 import os
+import re
 import sys
 import subprocess
 from pathlib import Path
 
+# Matches the counts in pytest's terminal summary, e.g. "2 failed, 25 passed".
+_COUNT = re.compile(r"(\d+)\s+(passed|failed|error|errors|skipped|xfailed|xpassed)")
+
+
+def _select(tests_dir: Path, args: list[str]) -> list[Path]:
+    if not args:
+        return sorted(tests_dir.glob("test_*.py"))
+    found: set[Path] = set()
+    for a in args:
+        stem = a[:-3] if a.endswith(".py") else a
+        matches = list(tests_dir.glob(f"{stem}.py")) or list(tests_dir.glob(f"*{stem}*.py"))
+        found.update(m for m in matches if m.name.startswith("test_"))
+    return sorted(found)
+
+
+def _counts(output: str) -> dict:
+    """Parse pass/fail/etc. from the last pytest summary line present."""
+    for line in reversed(output.splitlines()):
+        if any(k in line for k in (" passed", " failed", " error", " skipped")):
+            hits = _COUNT.findall(line)
+            if hits:
+                d: dict = {}
+                for n, kind in hits:
+                    d[kind.rstrip("s")] = d.get(kind.rstrip("s"), 0) + int(n)
+                return d
+    return {}
+
 
 def main() -> int:
     tests_dir = Path(__file__).parent
-    print("FreeCCR Test Suite")
-    print("=" * 60)
     env = dict(os.environ)
     env.setdefault("QT_QPA_PLATFORM", "offscreen")  # headless Qt for CI
-    result = subprocess.run(
-        [sys.executable, "-m", "pytest", str(tests_dir), "-v"],
-        cwd=tests_dir.parent,
-        env=env,
-    )
-    return result.returncode
+
+    files = _select(tests_dir, sys.argv[1:])
+    if not files:
+        print("No matching test files.")
+        return 5
+
+    print("FreeCCR Test Suite  (per-file process isolation)")
+    print("=" * 66)
+    total = {"passed": 0, "failed": 0, "error": 0, "skipped": 0}
+    problems: list[tuple[str, str]] = []
+
+    for f in files:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pytest", str(f), "-q", "-p", "no:cacheprovider"],
+            cwd=tests_dir.parent, env=env, capture_output=True, text=True)
+        out = proc.stdout + proc.stderr
+        c = _counts(out)
+        for k in total:
+            total[k] += c.get(k, 0)
+        native_fault = "fatal exception" in out.lower() or "access violation" in out.lower()
+        # pytest exit codes: 0 all-pass, 1 tests-failed, 5 no-tests; anything
+        # else (or a faulthandler dump) means the process itself died natively.
+        if proc.returncode not in (0, 1) or native_fault:
+            status = "CRASH"
+        elif proc.returncode == 1 or c.get("failed") or c.get("error"):
+            status = "FAIL"
+        else:
+            status = "ok"
+        if status != "ok":
+            problems.append((f.name, status))
+        extra = "".join(f", {c[k]} {k}" for k in ("failed", "error", "skipped") if c.get(k))
+        print(f"  {status:5} {f.name:44} {c.get('passed', 0):>4} passed{extra}")
+
+    print("=" * 66)
+    print(f"TOTAL  {total['passed']} passed, {total['failed']} failed, "
+          f"{total['error']} error, {total['skipped']} skipped  "
+          f"({len(files)} files)")
+    if problems:
+        print("Problem files: " + ", ".join(f"{n} [{s}]" for n, s in problems))
+        return 1
+    print("All test files passed.")
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_opencl_accuracy.py
+++ b/tests/test_opencl_accuracy.py
@@ -9,10 +9,13 @@ import sys
 import os
 import time
 
-# Add src directory to path to import ccr_processor
+# Add repo root AND src/ to the path (like the other test files): ccr_processor's
+# own internal imports use `from core...`, so src/ must be importable — otherwise
+# this file only collects when another test happens to have added src/ first.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from src.core.ccr_processor import adjust_image, adjust_image_opencl, OPENCL_AVAILABLE, cleanup_opencl
+from core.ccr_processor import adjust_image, adjust_image_opencl, OPENCL_AVAILABLE, cleanup_opencl
 
 def test_adjustment_accuracy():
     """Test that OpenCL produces identical results to CPU version."""
@@ -157,7 +160,7 @@ def test_opencl_initialization():
         print("OpenCL not available")
         return False
     
-    from src.core.ccr_processor import _initialize_opencl
+    from core.ccr_processor import _initialize_opencl
     
     success = _initialize_opencl()
     if success:


### PR DESCRIPTION
## Summary

Fixes the two native faults that made `pytest tests/` crash mid-run and blocked a clean full-suite pass. Result: **`python tests/run_tests.py` → 714 passed, 0 failed, 0 error (37 files).**

## Root causes (dug in with faulthandler tracebacks)

**1. onnxruntime-after-Qt DLL crash (deterministic).** GUI tests build a `MainWindow` whose dust panel calls `dust_detect.is_available()` → `import onnxruntime`. onnxruntime's native DLLs fail to initialize when first loaded **after** Qt — `"DLL initialization routine failed"`, which surfaces as a hard access violation under pytest's accumulated state. Verified: onnxruntime imports fine standalone and *before* Qt, but crashes when imported *after* a `QApplication` exists.

`src/main.py` already guards the app against this (it imports onnxruntime before any PySide6 import). The tests had no equivalent. **Fix:** add `tests/conftest.py` that pre-imports onnxruntime (guarded) — pytest loads conftest before any test module's `QApplication`, so the later import is a cached no-op. Cost ~0.13s.

**2. Roaming native heap corruption.** Even with #1 fixed, a single-process run segfaults near the end at a *moving* location (run 1 died at `test_zoom_percent`, run 3 at `test_tether_watcher`) — accumulated corruption from building hundreds of Qt MainWindows / QThreads / OpenCL contexts / rawpy decodes in one process. `fork()` isn't available on Windows, so **fix:** rewrite `tests/run_tests.py` to run **each test file in its own pytest subprocess** and aggregate results. Every file passes cleanly alone, so isolation makes the whole run reliable and reportable.

## Also fixed

`tests/test_opencl_accuracy.py` — per-file isolation exposed a latent bug: it imported `from src.core.ccr_processor` with only the repo root on `sys.path`, but `ccr_processor`'s own imports use `from core...`, so it only *collected* when another test had already added `src/`. Now adds `src/` to the path and imports via `core.` like the rest of the suite.

## Notes

- **No production code changed** — this is all test-harness.
- The canonical command (`python tests/run_tests.py`) is now reliably green. A raw single-process `pytest tests/` is still subject to the roaming corruption (inherent to a native-heavy GUI suite on Windows without `fork`); the runner's per-file isolation is the supported way to run the whole suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
