### PR TITLE
release: current-version-only notes; 1.0 key features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,33 +52,21 @@ jobs:
           files: win_installer/FreeCCR_Install_*.exe
           # Release notes shown on every release page.
           # KEEP IN SYNC with the macOS job's upload step below.
-          # The body is static, so refresh "## What's New" for each release.
+          # The body is static. REPLACE "## What's New" with ONLY this release's
+          # changes each time — do not append past versions (git history keeps them).
           body: |
             ## What's New
 
-            **v1.0.0**
-            - **Gamma midtone slider:** a dedicated Gamma slider below Brightness that lifts or lowers midtones through the same tone-curve engine as the Curves editor.
-            - **Hue-preserving Gamma mode:** an optional **Settings → General** toggle that applies Gamma to luminance and scales the colour channels together, so midtone adjustments don't shift hue or saturation. Off by default — the standard per-channel look stays the default.
-            - Bug fixes and stability improvements.
+            **FreeCCR 1.0** — the first stable release. A free, offline desktop app for converting and colour-correcting colour-negative film.
 
-            **v0.9.1**
-            - **Camera profile defaults to None:** new installs now decode RAWs in bare camera-native space (no colour matrix) by default, instead of Camera Matrix (Adobe RGB). Pick Camera Matrix or an ICC/DCP profile from the “Camera profile” dropdown for a matrixed/profiled look; existing selections are unchanged.
-
-            **v0.9.0**
-            - **Auto gain (on by default):** the brightest highlights are placed at the top of the working range automatically, without moving the Gain slider — the top 0.1% of the in-range highlights are set to 99.8% of full. Pixels outside the sampled clear/dense film range are ignored, and it applies to film conversions only. Turn it off in **Settings → General**.
-            - **White balance now uses highlight headroom:** Temperature/Tint are applied in the scene-linear working space *before* the highlight clamp, so warming or cooling a channel lands in recoverable headroom instead of clipping — and cooling can pull blown highlights back down into range.
-            - **Redesigned histogram:** a crisper, self-drawn RGB histogram with a percentile-clipped vertical scale, so a few blown-out highlights no longer crush the rest of the detail to the floor.
-
-            **v0.8.2**
-            - **Density inversion (opt-in):** new Settings → Color Management toggle. When you sample both a clear (film-base) and a dense point, the negative is inverted in optical-density (log) space — the physically-correct recovery of film density — instead of the linear stretch. Off by default; note log inversions look darker.
-            - **Staged Settings toggles:** Positive mode, 3-way RGB merge, and Density inversion now apply when you press **Done** (and are discarded if you close the dialog) instead of taking effect on every click.
-
-            **v0.8.1**
-            - **3-way RGB merge — monochrome sensors:** trichrome capture now supports monochrome (no-CFA) cameras, the ideal trichrome sensor — each frame is a full-resolution grayscale that becomes one channel, at full sensor resolution.
-            - **3-way RGB merge — crosstalk-free Bayer:** Bayer frames now read the raw sensor mosaic directly and take only the wanted colour's photosites (R/B single site, green = average of its two green sites), never mixing in the other colours — instead of the previous quad-binning decode.
-
-            **v0.8.0**
-            - **3-way RGB merge (trichrome capture):** new toggle on Settings → Color Management. Shoot a static scene three times under pure red, then green, then blue light; on import, every 3 RAWs (sorted by filename) merge into one colour image — each frame contributes only its own channel, with no demosaicing — then convert as a negative.
+            Key features:
+            - **Physics-based negative conversion** — models film's non-linear response and density range, not a naive 255−value invert.
+            - **Two-point anchoring** — sample the film's white and black references once, then convert a whole roll consistently; or use **Auto** frame detection for a fast first pass.
+            - **Batch RAW + standard formats** — load a whole folder at once (CR3/CR2/NEF/ARW/DNG, TIFF/JPEG/PNG).
+            - **Full colour correction** — temperature/tint, exposure/gain, brightness, gamma (with an optional hue-preserving mode), highlights/shadows, contrast, saturation, per-channel levels, and a Curves editor — with a live histogram and zoom.
+            - **Crop & straighten, dust removal, camera profiles (ICC / DCP / IT8), and local (area) adjustments.**
+            - **Sync & copy/paste** adjustments across a roll, plus optional **OpenCL GPU acceleration**.
+            - **Completely offline and free** (AGPL-3.0) — no activation, no watermark, no strings.
 
             ## Install
 
@@ -170,33 +158,21 @@ jobs:
           files: FreeCCR_macOS_*.zip
           # Release notes shown on every release page.
           # KEEP IN SYNC with the Windows job's upload step above.
-          # The body is static, so refresh "## What's New" for each release.
+          # The body is static. REPLACE "## What's New" with ONLY this release's
+          # changes each time — do not append past versions (git history keeps them).
           body: |
             ## What's New
 
-            **v1.0.0**
-            - **Gamma midtone slider:** a dedicated Gamma slider below Brightness that lifts or lowers midtones through the same tone-curve engine as the Curves editor.
-            - **Hue-preserving Gamma mode:** an optional **Settings → General** toggle that applies Gamma to luminance and scales the colour channels together, so midtone adjustments don't shift hue or saturation. Off by default — the standard per-channel look stays the default.
-            - Bug fixes and stability improvements.
+            **FreeCCR 1.0** — the first stable release. A free, offline desktop app for converting and colour-correcting colour-negative film.
 
-            **v0.9.1**
-            - **Camera profile defaults to None:** new installs now decode RAWs in bare camera-native space (no colour matrix) by default, instead of Camera Matrix (Adobe RGB). Pick Camera Matrix or an ICC/DCP profile from the “Camera profile” dropdown for a matrixed/profiled look; existing selections are unchanged.
-
-            **v0.9.0**
-            - **Auto gain (on by default):** the brightest highlights are placed at the top of the working range automatically, without moving the Gain slider — the top 0.1% of the in-range highlights are set to 99.8% of full. Pixels outside the sampled clear/dense film range are ignored, and it applies to film conversions only. Turn it off in **Settings → General**.
-            - **White balance now uses highlight headroom:** Temperature/Tint are applied in the scene-linear working space *before* the highlight clamp, so warming or cooling a channel lands in recoverable headroom instead of clipping — and cooling can pull blown highlights back down into range.
-            - **Redesigned histogram:** a crisper, self-drawn RGB histogram with a percentile-clipped vertical scale, so a few blown-out highlights no longer crush the rest of the detail to the floor.
-
-            **v0.8.2**
-            - **Density inversion (opt-in):** new Settings → Color Management toggle. When you sample both a clear (film-base) and a dense point, the negative is inverted in optical-density (log) space — the physically-correct recovery of film density — instead of the linear stretch. Off by default; note log inversions look darker.
-            - **Staged Settings toggles:** Positive mode, 3-way RGB merge, and Density inversion now apply when you press **Done** (and are discarded if you close the dialog) instead of taking effect on every click.
-
-            **v0.8.1**
-            - **3-way RGB merge — monochrome sensors:** trichrome capture now supports monochrome (no-CFA) cameras, the ideal trichrome sensor — each frame is a full-resolution grayscale that becomes one channel, at full sensor resolution.
-            - **3-way RGB merge — crosstalk-free Bayer:** Bayer frames now read the raw sensor mosaic directly and take only the wanted colour's photosites (R/B single site, green = average of its two green sites), never mixing in the other colours — instead of the previous quad-binning decode.
-
-            **v0.8.0**
-            - **3-way RGB merge (trichrome capture):** new toggle on Settings → Color Management. Shoot a static scene three times under pure red, then green, then blue light; on import, every 3 RAWs (sorted by filename) merge into one colour image — each frame contributes only its own channel, with no demosaicing — then convert as a negative.
+            Key features:
+            - **Physics-based negative conversion** — models film's non-linear response and density range, not a naive 255−value invert.
+            - **Two-point anchoring** — sample the film's white and black references once, then convert a whole roll consistently; or use **Auto** frame detection for a fast first pass.
+            - **Batch RAW + standard formats** — load a whole folder at once (CR3/CR2/NEF/ARW/DNG, TIFF/JPEG/PNG).
+            - **Full colour correction** — temperature/tint, exposure/gain, brightness, gamma (with an optional hue-preserving mode), highlights/shadows, contrast, saturation, per-channel levels, and a Curves editor — with a live histogram and zoom.
+            - **Crop & straighten, dust removal, camera profiles (ICC / DCP / IT8), and local (area) adjustments.**
+            - **Sync & copy/paste** adjustments across a roll, plus optional **OpenCL GPU acceleration**.
+            - **Completely offline and free** (AGPL-3.0) — no activation, no watermark, no strings.
 
             ## Install
 


### PR DESCRIPTION
Replaces the ever-growing appended What's New history with a current-release-only convention. For 1.0, shows FreeCCR's key features rather than an incremental changelog. Both build jobs kept in sync; guidance comment updated to 'replace, don't append'.