### PR TITLE
fix: thread-safety crash class - QPixmap on workers, threads at exit, loader cancel race

### DIFF
--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -83,10 +83,18 @@ class CCRBackend:
         # Removal must not lose their stored edits, so saves merge these
         # back into the records (duplicates, by contrast, are deleted).
         self._catalog_preserved = {}
+        # Load-generation token: every load_images_from_files call and clear()
+        # bumps it, and a loader thread only publishes its batch when its
+        # snapshot is still current (see _commit_load). Protects against a
+        # cancelled load resurrecting its partial batch and against a stale,
+        # abandoned loader thread clobbering a newer load.
+        self._load_generation = 0
 
     def load_images_from_files(self, file_paths: List[str], cancel_flag=None) -> int:
         """Load files (with catalog restore). Returns the number of FILES
         that produced at least one image (a sliced file yields several)."""
+        self._load_generation += 1
+        gen = self._load_generation
         self.images.clear()
         self.file_paths = file_paths
         # A fresh batch is a new roll: drop any B/W point sampled from the
@@ -105,7 +113,7 @@ class CCRBackend:
         # 3-way RGB merge: handle the whole batch on a dedicated path (sort,
         # validate multiple-of-3 + RAW, group into triplets, merge each).
         if self.rgb_merge_mode:
-            return self._load_merged_triplets(file_paths, cancel_flag)
+            return self._load_merged_triplets(file_paths, cancel_flag, gen)
 
         # Read the catalog ONCE for the whole batch — per-file reads would
         # re-parse the entire JSON N times across the loader threads.
@@ -135,6 +143,9 @@ class CCRBackend:
         max_workers = min(8, os.cpu_count() or 1)
         
         loaded_file_count = 0
+        # Collect into a local list (both branches) and publish once at the
+        # end — the backend lists must never hold a half-loaded batch.
+        results = []
         if max_workers == 1:
             # Sequential fallback
             for path in file_paths:
@@ -142,11 +153,9 @@ class CCRBackend:
                     break
                 _path, imgs = load_single_image(path)
                 if imgs:
-                    self.images.extend(imgs)
+                    results.extend(imgs)
                     loaded_file_count += 1
         else:
-            # Parallel loading - collect into local list to avoid concurrent modification
-            results = []
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 future_to_path = {executor.submit(load_single_image, path): path for path in file_paths}
 
@@ -158,16 +167,39 @@ class CCRBackend:
                         results.extend(imgs)
                         loaded_file_count += 1
 
-            # Slices of one file keep their catalog order within the file
-            results.sort(key=lambda img: (os.path.basename(img.file_path),
-                                          getattr(img, "_catalog_order", 0)))
-            self.images = results
-
-        # Keep file_paths derived from actually-loaded images so the two lists stay in sync
-        self.file_paths = [img.file_path for img in self.images]
+        # Slices of one file keep their catalog order within the file
+        results.sort(key=lambda img: (os.path.basename(img.file_path),
+                                      getattr(img, "_catalog_order", 0)))
+        # Publish only when still current: a cancelled load must not resurrect
+        # the batch the Cancel handler just cleared, and a superseded load
+        # (user re-opened while this thread was still decoding) must not
+        # clobber the newer batch.
+        if not self._commit_load(gen, results, cancel_flag):
+            return 0
         return loaded_file_count
 
-    def _load_merged_triplets(self, file_paths: List[str], cancel_flag=None) -> int:
+    def _commit_load(self, gen, results, cancel_flag=None) -> bool:
+        """Atomically publish a finished load. Refuses when the load was
+        cancelled or when the generation snapshot is stale (a newer load or
+        clear() superseded this thread) — a stale loader must never resurrect
+        its batch over the current one. gen=None commits unconditionally
+        unless cancelled. Returns True when the batch was published."""
+        stale = gen is not None and gen != self._load_generation
+        if cancel_flag and cancel_flag():
+            # Cancelled while still current (no newer load owns the state):
+            # leave a consistent empty session, not entry-time file_paths
+            # alongside an empty image list.
+            if not stale:
+                self.images = []
+                self.file_paths = []
+            return False
+        if stale:
+            return False
+        self.images = results
+        self.file_paths = [img.file_path for img in results]
+        return True
+
+    def _load_merged_triplets(self, file_paths: List[str], cancel_flag=None, gen=None) -> int:
         """3-way RGB merge load: sort by filename, validate (multiple of 3, all
         RAW), group into (red, green, blue) triplets, and merge each into one
         CCRImage (in parallel). Returns the number of merged images produced. A
@@ -178,15 +210,18 @@ class CCRBackend:
 
         ordered = ccr_merge.sort_for_merge(file_paths)
         ok, err = ccr_merge.validate_merge_inputs(ordered)
+        current = gen is None or gen == self._load_generation
         if not ok:
             self.last_merge_error = err
-            self.images = []
-            self.file_paths = []
+            if current:  # a stale thread must not wipe a newer batch
+                self.images = []
+                self.file_paths = []
             return 0
 
         triplets = ccr_merge.group_into_triplets(ordered)
         # Progress bar in merged units: total = number of triplets (not 3N files).
-        self.file_paths = [t[0] for t in triplets]
+        if current:
+            self.file_paths = [t[0] for t in triplets]
 
         def load_triplet(order, triplet):
             if cancel_flag and cancel_flag():
@@ -234,8 +269,8 @@ class CCRBackend:
         results.sort(key=lambda im: (os.path.basename(im.file_path),
                                      getattr(im, "_catalog_order", 0)))
         self._dedupe_display_names(results)
-        self.images = results
-        self.file_paths = [im.file_path for im in self.images]
+        if not self._commit_load(gen, results, cancel_flag):
+            return 0
         return len(results)
 
     @staticmethod
@@ -260,6 +295,9 @@ class CCRBackend:
         Clear all images and file paths from the backend.
         This is useful for resetting the state of the backend.
         """
+        # Invalidate any in-flight loader commit (see _commit_load): Cancel
+        # clears the session, and the loader must not resurrect its batch.
+        self._load_generation += 1
         self.images.clear()
         self.file_paths.clear()
 

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -7,6 +7,7 @@ import exifread
 import cv2
 import logging
 import time
+from PySide6.QtCore import QCoreApplication, QThread
 from PySide6.QtGui import QImage, QPixmap  # or from PySide6.QtGui import QImage, QPixmap if you use PySide
 #import lensfunpy  # Make sure lensfunpy is installed
 from core.ccr_processor import (adjust_image, adjust_image_opencl,
@@ -741,16 +742,24 @@ class CCRImage:
                        if (self.converted or self._positive_mode_active())
                        else self._auto_brightness_for_preview(adjusted_img))
 
-        # Create thumbnail
-        thumb_img = self.resize_image_to_max_pixel(display_img, thumbnail_size)
-        thumb_img_8 = to_8bit(thumb_img)
-        qimage = self.generate_qimage_from_np_array_8(thumb_img_8)
-        self.thumbnail = QPixmap.fromImage(qimage)
-
-        # Create preview
+        # Create thumbnail + preview pixels (8-bit RGB numpy — safe on any thread)
+        thumb_img_8 = to_8bit(self.resize_image_to_max_pixel(display_img, thumbnail_size))
         preview_img = self.resize_image_to_max_pixel(display_img, preview_size)
-        qimage = self.generate_qimage_from_np_array_8(to_8bit(preview_img))
-        self.resized_preview = QPixmap.fromImage(qimage)
+        preview_img_8bit = to_8bit(preview_img)
+
+        # QPixmap may only be created on the GUI thread, but the batch paths
+        # (initial load, auto-frame-all, B/W convert-all) run this method on
+        # pool/QThread workers. Off the GUI thread, stash the pixels and let
+        # the first GUI-thread read of .thumbnail/.resized_preview build the
+        # pixmaps (see the property getters).
+        if self._on_gui_thread():
+            self.thumbnail = QPixmap.fromImage(
+                self.generate_qimage_from_np_array_8(thumb_img_8))
+            self.resized_preview = QPixmap.fromImage(
+                self.generate_qimage_from_np_array_8(preview_img_8bit))
+        else:
+            self._thumb_np8 = thumb_img_8
+            self._preview_np8 = preview_img_8bit
         # Compute the per-channel histogram over the 8-bit preview (RGB). When a
         # crop is set, it's computed over only the kept (cropped) region so it
         # matches what the canvas shows. Same normalized-rect + angle contract as
@@ -761,7 +770,6 @@ class CCRImage:
         # presentation — the percentile-clipped vertical scale, smoothing,
         # filled curves and clip markers — lives in HistogramWidget, which paints
         # at the widget's real resolution. See widgets/histogram_widget.py.
-        preview_img_8bit = to_8bit(preview_img)
         hist_source = apply_crop_to_image(
             preview_img_8bit, self.crop_rect, getattr(self, "crop_angle", 0.0) or 0.0)
         counts = np.empty((3, 256), dtype=np.float32)
@@ -776,6 +784,44 @@ class CCRImage:
             thumb_img_8.data, w, h, bytes_per_line, QImage.Format_RGB888
         )
         return qimage
+
+    @staticmethod
+    def _on_gui_thread() -> bool:
+        """True on the Qt GUI thread — or with no app at all, where eager
+        QPixmap creation matches the historical (pre-deferral) behaviour."""
+        app = QCoreApplication.instance()
+        return app is None or QThread.currentThread() is app.thread()
+
+    # QPixmap is GUI-thread-only. When update_thumbnail_and_preview runs on a
+    # worker (batch load / auto-frame-all / B/W convert-all pools), it stashes
+    # the rendered 8-bit pixels in _thumb_np8/_preview_np8 instead of building
+    # pixmaps; the first GUI-thread read below materializes them. A read from
+    # a worker thread returns the previous pixmap untouched.
+    @property
+    def thumbnail(self):
+        if self._thumb_np8 is not None and self._on_gui_thread():
+            self._thumbnail_pix = QPixmap.fromImage(
+                self.generate_qimage_from_np_array_8(self._thumb_np8))
+            self._thumb_np8 = None
+        return self._thumbnail_pix
+
+    @thumbnail.setter
+    def thumbnail(self, value):
+        self._thumbnail_pix = value
+        self._thumb_np8 = None
+
+    @property
+    def resized_preview(self):
+        if self._preview_np8 is not None and self._on_gui_thread():
+            self._preview_pix = QPixmap.fromImage(
+                self.generate_qimage_from_np_array_8(self._preview_np8))
+            self._preview_np8 = None
+        return self._preview_pix
+
+    @resized_preview.setter
+    def resized_preview(self, value):
+        self._preview_pix = value
+        self._preview_np8 = None
 
     @staticmethod
     def _to_grayscale(image: np.ndarray) -> np.ndarray:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -296,6 +296,19 @@ class MainWindow(QMainWindow):
             # running QThread can't abort the process at teardown.
             if hasattr(self, "dust_panel"):
                 self.dust_panel.shutdown()
+            # Same for in-flight hi-res zoom renders (parentless QThreads
+            # tracked by the preview): destroyed-while-running aborts the exit.
+            if hasattr(self, "image_preview"):
+                self.image_preview.shutdown_workers()
+            # And for loader threads — active or previously abandoned. Their
+            # RAW decodes are not interruptible, so wait them out; the
+            # load-generation guard keeps their results from landing.
+            self._stop_loader_if_running()
+            for t in list(getattr(self, '_abandoned_loaders', [])):
+                try:
+                    t.wait()
+                except RuntimeError:
+                    pass
             # Persist the edit catalog so reopening these files restores
             # their conversion/slices/crop/adjustments.
             ccr_backend.save_catalog()
@@ -760,18 +773,49 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "3-way RGB merge", err)
 
     def _stop_loader_if_running(self):
-        """Cancel and join any in-progress loader thread."""
-        if getattr(self, '_loader_thread', None) is not None:
-            try:
-                if self._loader_thread.isRunning():
-                    if self._loader_worker is not None:
-                        self._loader_worker.cancel()
-                    self._loader_thread.quit()
-                    self._loader_thread.wait(3000)
-            except RuntimeError:
-                pass
-            self._loader_thread = None
-            self._loader_worker = None
+        """Cancel and join any in-progress loader thread. A loader that
+        outlives the wait (in-flight RAW decodes are not interruptible) is
+        parked instead of dropped: its UI effects are disconnected here, its
+        backend commit is refused by the load-generation guard, and the
+        Python refs are kept until it really finishes — a running QThread
+        whose wrapper is garbage-collected hard-aborts the process."""
+        thread = getattr(self, '_loader_thread', None)
+        worker = getattr(self, '_loader_worker', None)
+        self._loader_thread = None
+        self._loader_worker = None
+        if thread is None:
+            return
+        try:
+            if thread.isRunning():
+                if worker is not None:
+                    worker.cancel()
+                thread.quit()
+                if not thread.wait(3000):
+                    # Detach the stale thread's UI effects; keep its
+                    # quit/deleteLater wiring so it still winds down.
+                    if worker is not None:
+                        try:
+                            worker.finished.disconnect(self.thumbnail_list.load_thumbnails)
+                        except (RuntimeError, TypeError):
+                            pass
+                    try:
+                        thread.finished.disconnect(self._cleanup_loader)
+                    except (RuntimeError, TypeError):
+                        pass
+                    if not hasattr(self, '_abandoned_loaders'):
+                        self._abandoned_loaders = []
+                    self._abandoned_loaders.append(thread)
+                    thread.finished.connect(
+                        lambda t=thread: self._reap_abandoned_loader(t))
+        except RuntimeError:
+            pass
+
+    def _reap_abandoned_loader(self, thread):
+        """Drop the parked reference once an abandoned loader has finished."""
+        try:
+            self._abandoned_loaders.remove(thread)
+        except (AttributeError, ValueError):
+            pass
 
     def open_files(self):
         # Loading a new batch replaces the current one — persist its edits first

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1744,6 +1744,19 @@ class ImagePreview(QWidget):
         self._refresh_item_pixmap()
         self.apply_transformations()
 
+    def shutdown_workers(self):
+        """Quiesce in-flight hi-res render threads (app close). A running
+        parentless QThread whose Python wrapper is destroyed at interpreter
+        teardown hard-aborts the process ("QThread: Destroyed while thread is
+        still running"), so closeEvent must wait them out. The interruption
+        checkpoints in HiResDetailWorker.run keep the wait short — the
+        un-interruptible part is at most one RAW decode."""
+        for w in list(self._hires_workers):
+            w.requestInterruption()
+        for w in list(self._hires_workers):
+            w.wait()
+        self._hires_workers.clear()
+
     def _invalidate_hires_display(self):
         """Same-image refresh (adjustments/crop/conversion changed): drop the
         stale hi-res display layer, keep the decoded base where possible, and
@@ -3796,7 +3809,7 @@ class HiResDetailWorker(QThread):
                 base = self._img.render_hires_base(
                     max_long_side=self._cap,
                     conversion_inputs=self._conversion_inputs)
-            if base is None:
+            if base is None or self.isInterruptionRequested():
                 return
             t1 = _time.perf_counter()
             display = self._img.apply_adjustments(
@@ -3817,6 +3830,8 @@ class HiResDetailWorker(QThread):
             print(f"Hi-res detail: base {(t1 - t0) * 1000:.0f} ms, "
                   f"adjust+8bit {(t2 - t1) * 1000:.0f} ms "
                   f"({display8.shape[1]}x{display8.shape[0]})")
+            if self.isInterruptionRequested():
+                return  # app is closing — receiver is being torn down
             self.finished_hires.emit(self.req_img, self.req_sig,
                                      self.req_adj_sig, base, display8)
         except Exception as e:

--- a/src/widgets/thumbnail_list.py
+++ b/src/widgets/thumbnail_list.py
@@ -173,10 +173,13 @@ class ThumbnailList(QWidget):
     def show_loading_dialog(self):
         # Pass a callback to cancel the worker thread
         def cancel_loading():
-            # Access the worker from the main window and call cancel
+            # Access the worker from the main window and call cancel.
+            # _loader_worker can already be None (cleanup ran while the
+            # dialog was still up) — Cancel must not die on None.cancel().
             main_window = self._main_window()
-            if hasattr(main_window, '_loader_worker'):
-                main_window._loader_worker.cancel()
+            worker = getattr(main_window, '_loader_worker', None)
+            if worker is not None:
+                worker.cancel()
         self.loading_dialog = LoadingDialog(self, cancel_callback=cancel_loading)
         self.loading_dialog.show()
         QApplication.processEvents()

--- a/tests/test_loader_cancel.py
+++ b/tests/test_loader_cancel.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Batch-load cancel/supersede semantics (CCRBackend._commit_load).
+
+Cancelling a load calls ccr_backend.clear() on the GUI thread while the
+loader thread is still collecting results; the loader used to finish with
+`self.images = results`, silently resurrecting the partial batch (and a
+stale, abandoned loader could clobber a newer load the same way). The fix
+publishes a batch only when the load is uncancelled AND its generation
+snapshot is still current. These tests pin that contract.
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+import pytest  # noqa: E402
+
+from core.ccr_backend import CCRBackend  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_backend():
+    """CCRBackend is an enforced singleton — every CCRBackend() below is the
+    global instance, so leave it empty for other test modules."""
+    yield
+    backend = CCRBackend()
+    backend.images = []
+    backend.file_paths = []
+
+
+def _make_pngs(tmp_path, n=3):
+    paths = []
+    for i in range(n):
+        p = str(tmp_path / f"scan_{i}.png")
+        cv2.imwrite(p, np.full((32, 48, 3), 100 + i, dtype=np.uint8))
+        paths.append(p)
+    return paths
+
+
+def _stub_image(name="x.png"):
+    return SimpleNamespace(file_path=name)
+
+
+# --- happy path is unchanged ------------------------------------------------
+
+def test_uncancelled_load_publishes_batch(tmp_path):
+    backend = CCRBackend()
+    paths = _make_pngs(tmp_path)
+    count = backend.load_images_from_files(paths)
+    assert count == len(paths)
+    assert len(backend.images) == len(paths)
+    assert backend.file_paths == [img.file_path for img in backend.images]
+
+
+# --- cancel must not resurrect the partial batch ----------------------------
+
+def test_cancelled_load_publishes_nothing(tmp_path):
+    backend = CCRBackend()
+    paths = _make_pngs(tmp_path)
+    calls = {"n": 0}
+
+    def cancel_after_a_few():
+        calls["n"] += 1
+        return calls["n"] > 2  # cancel lands mid-load, like the Cancel button
+
+    count = backend.load_images_from_files(paths, cancel_flag=cancel_after_a_few)
+    assert count == 0
+    assert backend.images == []
+    assert backend.file_paths == []
+
+
+def test_immediately_cancelled_load_publishes_nothing(tmp_path):
+    backend = CCRBackend()
+    count = backend.load_images_from_files(_make_pngs(tmp_path),
+                                           cancel_flag=lambda: True)
+    assert count == 0
+    assert backend.images == []
+
+
+# --- generation guard: stale loaders must not clobber newer state -----------
+
+def test_commit_refused_for_stale_generation():
+    backend = CCRBackend()
+    backend._load_generation += 1
+    stale_gen = backend._load_generation
+    current = [_stub_image("current.png")]
+    backend.images = current
+    backend.file_paths = ["current.png"]
+    backend._load_generation += 1  # a newer load/clear superseded stale_gen
+    assert backend._commit_load(stale_gen, [_stub_image("stale.png")]) is False
+    assert backend.images is current
+    assert backend.file_paths == ["current.png"]
+
+
+def test_commit_accepted_for_current_generation():
+    backend = CCRBackend()
+    backend._load_generation += 1
+    img = _stub_image("fresh.png")
+    assert backend._commit_load(backend._load_generation, [img]) is True
+    assert backend.images == [img]
+    assert backend.file_paths == ["fresh.png"]
+
+
+def test_clear_invalidates_inflight_commit():
+    backend = CCRBackend()
+    backend._load_generation += 1
+    gen = backend._load_generation
+    backend.clear()  # the Cancel handler's clear() bumps the generation
+    assert backend._commit_load(gen, [_stub_image()]) is False
+    assert backend.images == []
+
+
+def test_commit_without_generation_still_honors_cancel():
+    backend = CCRBackend()
+    assert backend._commit_load(None, [_stub_image()], cancel_flag=lambda: True) is False
+    assert backend._commit_load(None, [_stub_image()]) is True

--- a/tests/test_thread_safe_previews.py
+++ b/tests/test_thread_safe_previews.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Thread-safety of CCRImage preview building.
+
+QPixmap may only be created on the Qt GUI thread, but the batch paths
+(initial load, auto-frame-all, B/W convert-all) run
+CCRImage.update_thumbnail_and_preview on pool/QThread workers. The fix defers
+pixmap construction off the GUI thread: workers stash the rendered 8-bit
+pixels, and the first GUI-thread read of .thumbnail/.resized_preview builds
+the pixmaps. These tests pin that contract in both directions.
+"""
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+import cv2
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_image import CCRImage  # noqa: E402
+
+
+def _make_png(tmp_path, name="scan.png"):
+    path = str(tmp_path / name)
+    cv2.imwrite(path, np.full((64, 96, 3), 128, dtype=np.uint8))
+    return path
+
+
+def _build_on_worker(path):
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(CCRImage, path).result()
+
+
+# --- GUI-thread construction keeps the historical eager behaviour ----------
+
+def test_gui_thread_build_is_eager(tmp_path):
+    img = CCRImage(_make_png(tmp_path))
+    assert img._thumb_np8 is None and img._preview_np8 is None
+    assert img.thumbnail is not None and not img.thumbnail.isNull()
+    assert img.resized_preview is not None and not img.resized_preview.isNull()
+
+
+# --- worker-thread construction defers pixmap creation ---------------------
+
+def test_worker_thread_build_defers_pixmaps(tmp_path):
+    img = _build_on_worker(_make_png(tmp_path))
+    assert img._thumb_np8 is not None and img._preview_np8 is not None
+    assert img._thumbnail_pix is None and img._preview_pix is None
+
+
+def test_gui_thread_read_materializes_and_clears_stash(tmp_path):
+    img = _build_on_worker(_make_png(tmp_path))
+    pm = img.thumbnail
+    assert pm is not None and not pm.isNull() and pm.width() > 0
+    assert img._thumb_np8 is None
+    pv = img.resized_preview
+    assert pv is not None and not pv.isNull()
+    assert img._preview_np8 is None
+
+
+def test_worker_rerender_of_existing_image_defers(tmp_path):
+    """reload_image()/update_thumbnail_and_preview() on a QThread (the B/W
+    convert-all path) must stash pixels, not build pixmaps."""
+    img = CCRImage(_make_png(tmp_path))
+    old_pm = img.thumbnail
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        ex.submit(img.update_thumbnail_and_preview).result()
+    assert img._thumb_np8 is not None and img._preview_np8 is not None
+    # A worker-thread read must NOT materialize (returns the stale pixmap)
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        stale = ex.submit(lambda: img.thumbnail).result()
+    assert stale is old_pm
+    assert img._thumb_np8 is not None
+    # ...but a GUI-thread read builds the fresh one
+    assert img.thumbnail is not None and img._thumb_np8 is None
+
+
+def test_setter_clears_pending_stash(tmp_path):
+    img = _build_on_worker(_make_png(tmp_path))
+    img.thumbnail = None
+    img.resized_preview = None
+    assert img._thumb_np8 is None and img._preview_np8 is None
+    assert img.thumbnail is None and img.resized_preview is None
+
+
+def test_histogram_data_present_after_worker_build(tmp_path):
+    img = _build_on_worker(_make_png(tmp_path))
+    assert img.histogram_data is not None
+    assert img.histogram_data.shape == (3, 256)
+
+
+# --- hi-res worker shutdown at app close ------------------------------------
+
+def test_shutdown_workers_waits_out_inflight_renders(tmp_path):
+    """closeEvent must be able to quiesce hi-res render threads; a running
+    QThread destroyed at teardown hard-aborts the process. Uses the real
+    ImagePreview.shutdown_workers body on a minimal host (a full ImagePreview
+    needs a MainWindow parent)."""
+    from widgets.image_preview import ImagePreview, HiResDetailWorker
+
+    class _Host:
+        shutdown_workers = ImagePreview.shutdown_workers
+
+        def __init__(self):
+            self._hires_workers = set()
+
+    img = CCRImage(_make_png(tmp_path))
+    host = _Host()
+    worker = HiResDetailWorker(img, "sig", "adj", None, 512)
+    host._hires_workers.add(worker)
+    worker.start()
+    host.shutdown_workers()
+    assert not worker.isRunning()
+    assert not host._hires_workers


### PR DESCRIPTION
Fixes the three crash-class bugs found in the comprehensive code review (the "crash class" batch: B3, B11, B5).

## 1. QPixmap created on worker threads (intermittent native crashes)

`update_thumbnail_and_preview` builds QPixmaps, and three batch paths run it on pool/QThread workers: the initial batch load (`ccr_backend.load_images_from_files` → `CCRImage.__init__`), `auto_frame_all_images`, and `apply_bwpoint_to_all_images`. Qt requires QPixmap to be used only on the GUI thread — the codebase already acknowledges this (`reload_image_decode_only` was built to defer pixmap building) but these paths bypassed it. This is the most plausible source of the long-standing intermittent native crashes in full-suite test runs.

**Fix:** off the GUI thread, `update_thumbnail_and_preview` now stashes the rendered 8-bit numpy pixels instead of building pixmaps; `thumbnail` / `resized_preview` became properties whose first GUI-thread read materializes the QPixmap (worker-thread reads return the previous pixmap untouched). GUI-thread behavior is unchanged (eager build). No call sites needed changes — all pixmap consumers already read through the backend getters on the GUI thread.

## 2. Hi-res detail QThreads never stopped at app close (crash on exit)

Zooming in spawns parentless `HiResDetailWorker` QThreads; `closeEvent` quiesced tether and dust threads but not these. Zoom into a converted RAW, quit immediately → "QThread: Destroyed while thread is still running" → hard abort.

**Fix:** `ImagePreview.shutdown_workers()` requests interruption and waits out in-flight renders; `HiResDetailWorker.run` got interruption checkpoints (after the decode, before the emit) so the wait is bounded by at most one un-interruptible RAW decode. Wired into `closeEvent`, which now also winds down loader threads (active or abandoned).

## 3. Batch-load cancel race (cancel didn't cancel; re-open could clobber/crash)

- Cancel set the worker flag and cleared the backend, but the loader thread later executed `self.images = results` — silently resurrecting the partial batch.
- Re-opening a folder waited only 3 s for the old thread; in-flight RAW decodes exceed that, so the abandoned thread could later clobber the new batch, trigger a stale `load_thumbnails` rebuild, null the *new* loader's refs via the old `_cleanup_loader` connection, and risk a destroyed-while-running abort once GC collected the wrapper.

**Fix:**
- Loads publish through a new `CCRBackend._commit_load`, guarded by a load-generation token bumped by every `load_images_from_files` call and by `clear()`. A cancelled load leaves a consistent empty session; a superseded (stale-generation) load changes nothing. The sequential and 3-way-merge branches now accumulate locally and publish through the same guard (previously the sequential branch mutated `self.images` mid-load).
- `_stop_loader_if_running` parks a loader that outlives the wait instead of dropping refs to a running QThread: its `load_thumbnails` / `_cleanup_loader` connections are disconnected (quit/deleteLater wiring kept), and the reference is held in `_abandoned_loaders` until the thread really finishes.
- The LoadingDialog cancel callback no longer dies on `None.cancel()` when cleanup ran while the dialog was still up.

## Tests

- `tests/test_thread_safe_previews.py` (7 tests): eager GUI-thread build, worker-thread deferral, GUI-read materialization, worker re-render deferral, setter semantics, histogram availability, and `shutdown_workers` waiting out a live render thread.
- `tests/test_loader_cancel.py` (7 tests): happy-path publish, cancelled loads publish nothing (mid-load and immediate), stale-generation commit refusal, current-generation commit, `clear()` invalidation, cancel handling without a generation.

## Verification

- All 14 new tests pass; the affected areas (`test_zoom_hires`, `test_tether_watcher`, `test_slice`, `test_three_way_merge`, etc.) pass.
- Full suite: 714/728 ran with **zero failures** before hitting a hang that **reproduces identically on unmodified `main`** (order-dependent, e.g. `test_settings_dialog + test_slice + test_sub_saturation_crop_undo + test_tether_watcher` hangs in a tether test at ~0% CPU on both trees) — pre-existing, not a regression. The remaining 14 tests (`test_zoom_percent`) pass standalone under these changes.
- Note: the historical ~13 `exposure_base` failures no longer occur on `main` or this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012C4T6y6ciHgWs8vmQPKS2B
