### PR TITLE
fix: wrong-output class - export state corruption, mono double-scale, fine-rotation sampling/double-warp

### DIFF
--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -534,10 +534,19 @@ class CCRImage:
 
                     if is_monochrome:
                         print(f"Detected monochrome sensor for: {os.path.basename(file_path)}")
-                        # For monochrome sensors, use different processing
+                        # Fixed absolute sensor values, like the colour negative
+                        # decode (and ccr_merge's mono path): linear gamma, no
+                        # auto-bright, no_auto_scale — the single manual
+                        # white-level scale below owns the range mapping.
+                        # Without no_auto_scale libraw already stretches to full
+                        # 16-bit and the scale below multiplies AGAIN, clipping
+                        # everything above white_level; auto-bright also varies
+                        # per frame, breaking the "B/W points are absolute
+                        # anchors, constant across the roll" contract.
                         rgb = raw.postprocess(
                             output_bps=16,
-                            no_auto_bright=False,
+                            no_auto_bright=True,
+                            no_auto_scale=True,
                             gamma=(1, 1),
                             user_flip=0,
                             half_size=preview,
@@ -799,10 +808,12 @@ class CCRImage:
     def apply_adjustments(self, image: np.ndarray, settings=None, contrast_base=None,
                           temperature_base=None, brightness_base=None,
                           color_profile=None, areas_override=None,
-                          exposure_base=None) -> np.ndarray:
+                          exposure_base=None, ws_windowed=None) -> np.ndarray:
         """Apply the slider adjustments. The optional overrides let the zoom
         hi-res worker render from a snapshot taken at request time instead of
-        live state the GUI thread may be mutating concurrently."""
+        live state the GUI thread may be mutating concurrently — and let the
+        export pipeline describe the buffer it just produced (ws_windowed)
+        without mutating this image's live state."""
         # Dust removal runs FIRST so the inpainted positive flows through the
         # rest of the adjustment stage (and so a dust-only image is still
         # cleaned even when the early-return guard below would otherwise skip).
@@ -812,6 +823,7 @@ class CCRImage:
         tb = self.temperature_base if temperature_base is None else temperature_base
         bb = self.brightness_base if brightness_base is None else brightness_base
         eb = self.exposure_base if exposure_base is None else exposure_base
+        ws = self._ws_windowed if ws_windowed is None else ws_windowed
         profile = self.color_profile if color_profile is None else color_profile
         areas = (getattr(self, "area_layers", []) if areas_override is None
                  else areas_override)
@@ -825,14 +837,14 @@ class CCRImage:
         # ccr_backend imports CCRImage at load.
         from core.ccr_backend import ccr_backend
         auto_on = getattr(ccr_backend, "auto_gain", True) and self.converted
-        ag = compute_auto_gain_offset(image, self._ws_windowed) if auto_on else 0.0
+        ag = compute_auto_gain_offset(image, ws) if auto_on else 0.0
         eb_eff = 0.0 if auto_on else eb        # suppress-overlap with the baked eb
         if (not s and cb == 0 and tb == 0 and bb == 0 and eb_eff == 0 and ag == 0
                 and not has_areas):
             # No slider/base/area adjustments. A windowed working-space base still
             # has to be de-windowed + window-clamped to a normal full-range image
             # before display/export (the base itself is not directly renderable).
-            if self._ws_windowed:
+            if ws:
                 image = _apply_working_space_recovery(image, 0.0)
             # Black & White still has to map the image to a single luminance channel.
             return self._to_grayscale(image) if profile == "bw" else image
@@ -877,7 +889,7 @@ class CCRImage:
                                     else None),
                      # Windowed working-space base → de-window + Gain/Exposure
                      # recovery happens inside the adjustment call.
-                     ws_windowed=self._ws_windowed)
+                     ws_windowed=ws)
         # Gamma slider: a center-point tone curve driven through the SAME
         # monotone-cubic path as the Curves editor (a single 'rgb' point moving
         # diagonally from center). Applied before the user's manual curves so the
@@ -992,15 +1004,10 @@ class CCRImage:
             # parent's frame coordinates would be meaningless here).
             out = apply_reference_normalization(img, ci["p_lo"], ci["p_hi"], ci["od"])
         elif ci.get("mode") == "bw":
-            # The bwpoint pipeline bakes the fine rotation into the preview
-            # pixels BEFORE normalization — replicate that here so the
-            # detail layer lines up with the preview content.
-            fine_angle = ci.get("fine_rot", 0) / 100.0
-            if fine_angle != 0:
-                h0, w0 = img.shape[:2]
-                rot = cv2.getRotationMatrix2D((w0 // 2, h0 // 2), -fine_angle, 1.0)
-                img = cv2.warpAffine(img, rot, (w0, h0), flags=cv2.INTER_LINEAR,
-                                     borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+            # The bwpoint pipeline keeps the preview un-rotated (display
+            # semantics — the canvas item applies the fine rotation), so the
+            # replay must NOT warp either; ci["fine_rot"] is an informational
+            # snapshot only.
             black_point, white_point = ci["bw"]
             out = apply_bwpoint_normalization(img, black_point, white_point,
                                               density=ci.get("density", False))

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -1299,17 +1299,16 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
     if img is None:
         raise ValueError("CCRImage: could not load image data for B/W point conversion")
 
-    # --- Fine rotation (same as main pipeline) ---
+    # Fine rotation uses DISPLAY semantics, like the reference pipeline: the
+    # per-pixel B/W-point mapping is rotation-independent, so the preview
+    # result stays un-rotated (the canvas item applies the live angle) and an
+    # export warps ONCE at the end, on an expanded canvas. Warping here as
+    # well used to (a) show the rotation twice on screen — the baked warp
+    # plus the display transform — and (b) double-warp exports, with the
+    # first warp cropping the corners on the un-expanded canvas.
     fine_angle = ccr_image.fine_rotation_angle / 100.0
     h_flip = ccr_image.horizontal_mirrored
     v_flip = ccr_image.vertical_mirrored
-    h, w = img.shape[:2]
-    if fine_angle != 0:
-        center_rot = (w // 2, h // 2)
-        rot_mat = cv2.getRotationMatrix2D(center_rot, -fine_angle, 1.0)
-        img = cv2.warpAffine(img, rot_mat, (w, h), flags=cv2.INTER_LINEAR,
-                              borderMode=cv2.BORDER_CONSTANT, borderValue=0)
-        del rot_mat
 
     # --- BWPN: B/W point values are absolute anchors, constant across the whole roll ---
     #
@@ -1375,16 +1374,20 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
     # del shadow_corrected, gamma_corrected, rgb_inverted
     gc.collect()
 
-    # Non-destructive base offsets applied through the adjustment pipeline (UI shows 0).
-    # contrast_base set to 0 to disable the baked-in contrast S-curve (was 40).
-    ccr_image.contrast_base = 0
-    ccr_image.temperature_base = 0
-
     # Working space: the B/W-point inversions emit a WINDOWED base when enabled
-    # (highlight headroom preserved). Flag the image so apply_adjustments de-windows
-    # this base. False when the feature is off → legacy full-range, byte-identical.
+    # (highlight headroom preserved). False when the feature is off → legacy
+    # full-range, byte-identical.
     ws = _ws_enabled()
-    ccr_image._ws_windowed = ws
+    if output_path is None:
+        # Preview conversion: the result becomes the live resized_raw, so the
+        # live state is updated to describe it. Non-destructive base offsets
+        # applied through the adjustment pipeline (UI shows 0); contrast_base
+        # 0 disables the baked-in contrast S-curve (was 40). An EXPORT must
+        # not touch any of this — flagging a never-converted image's live
+        # full-range resized_raw as windowed blows its preview to near-white.
+        ccr_image.contrast_base = 0
+        ccr_image.temperature_base = 0
+        ccr_image._ws_windowed = ws
     if ws:
         print(f"[working-space] windowed base: ~{_WS_HEADROOM_STOPS:.1f} stops "
               f"highlight headroom — recover with White Point (drag negative)")
@@ -1399,7 +1402,12 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
 
     # --- User adjustments (export only) ---
     if output_path is not None:
-        rgb_result = ccr_image.apply_adjustments(rgb_result)
+        # Describe the buffer this conversion just produced via overrides
+        # (same values a preview conversion would have baked into live state)
+        # so a never-converted image's live state stays untouched.
+        rgb_result = ccr_image.apply_adjustments(rgb_result, contrast_base=0,
+                                                 temperature_base=0,
+                                                 ws_windowed=ws)
 
     # --- Export path: flips, rotation, file write ---
     if output_path is not None:

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -247,24 +247,39 @@ class GraphicsImageView(QGraphicsView):
             self.viewport().update()
             self.parent_widget.update_reference_rect(self._drag_start, self._drag_end)
 
-    def _update_bw_rect(self, start, end):
-        """Draw the B/W point selection rect on the canvas."""
+    def _display_transform(self):
+        """The pixmap item's full display transform: coarse flips/90° PLUS the
+        fine rotation about the pixmap center. Must mirror
+        apply_transformations exactly (including its crop/dust-mode fine-
+        rotation suppression) — sampling that inverts only the coarse part
+        lands tens of pixels away from the on-screen cursor/marquee whenever a
+        fine rotation is active (e.g. set automatically by Auto Frame)."""
         pw = self.parent_widget
         cx = pw.current_pixmap.width() / 2
         cy = pw.current_pixmap.height() / 2
-        base_transform = QTransform()
-        base_transform.translate(cx, cy)
+        t = QTransform()
+        t.translate(cx, cy)
         if pw.current_vertical_flip:
-            base_transform.scale(1, -1)
+            t.scale(1, -1)
         if pw.current_horizontal_flip:
-            base_transform.scale(-1, 1)
+            t.scale(-1, 1)
         if pw.current_rotation:
-            base_transform.rotate(pw.current_rotation)
-        base_transform.translate(-cx, -cy)
+            t.rotate(pw.current_rotation)
+        t.translate(-cx, -cy)
+        if pw.current_fine_rotation and not pw.crop_mode and not pw.dust_mode:
+            t.translate(cx, cy)
+            t.rotate(pw.current_fine_rotation / 100.0)
+            t.translate(-cx, -cy)
+        return t
 
-        if not base_transform.isInvertible():
+    def _update_bw_rect(self, start, end):
+        """Draw the B/W point selection rect on the canvas. The rect lives in
+        image space (its item carries the display transform), so what is
+        drawn is exactly the region the release handler samples."""
+        display_transform = self._display_transform()
+        if not display_transform.isInvertible():
             return
-        inv = base_transform.inverted()[0]
+        inv = display_transform.inverted()[0]
         s = inv.map(start)
         e = inv.map(end)
         rect = QRectF(min(s.x(), e.x()), min(s.y(), e.y()),
@@ -278,26 +293,16 @@ class GraphicsImageView(QGraphicsView):
         else:
             self._bw_rect_item.setPen(QPen(color, 2, Qt.DashLine))
             self._bw_rect_item.setRect(rect)
-        self._bw_rect_item.setTransform(base_transform)
+        self._bw_rect_item.setTransform(display_transform)
 
     def _sample_wb_point(self, scene_pos):
         """Sample a small neighborhood at the clicked point and auto-set the
         temperature/tint sliders so that point becomes neutral."""
         pw = self.parent_widget
-        cx = pw.current_pixmap.width() / 2
-        cy = pw.current_pixmap.height() / 2
-        base_transform = QTransform()
-        base_transform.translate(cx, cy)
-        if pw.current_vertical_flip:
-            base_transform.scale(1, -1)
-        if pw.current_horizontal_flip:
-            base_transform.scale(-1, 1)
-        if pw.current_rotation:
-            base_transform.rotate(pw.current_rotation)
-        base_transform.translate(-cx, -cy)
-        if not base_transform.isInvertible():
+        display_transform = self._display_transform()
+        if not display_transform.isInvertible():
             return
-        local = base_transform.inverted()[0].map(scene_pos)
+        local = display_transform.inverted()[0].map(scene_pos)
         # Displayed pixmap may be a crop of the full image — map back to
         # full-image coordinates before indexing resized_raw.
         fx, fy = pw.map_displayed_to_full(local.x(), local.y())
@@ -364,17 +369,9 @@ class GraphicsImageView(QGraphicsView):
             drag_end_scene = self.mapToScene(event.pos())
 
             pw = self.parent_widget
-            cx = pw.current_pixmap.width() / 2
-            cy = pw.current_pixmap.height() / 2
-            base_transform = QTransform()
-            base_transform.translate(cx, cy)
-            if pw.current_vertical_flip:
-                base_transform.scale(1, -1)
-            if pw.current_horizontal_flip:
-                base_transform.scale(-1, 1)
-            if pw.current_rotation:
-                base_transform.rotate(pw.current_rotation)
-            base_transform.translate(-cx, -cy)
+            # Full display transform (incl. fine rotation) — the sampled
+            # region must be the pixels under the on-screen marquee.
+            display_transform = self._display_transform()
 
             mode = self.bwpoint_mode
             self.bwpoint_mode = None
@@ -382,8 +379,8 @@ class GraphicsImageView(QGraphicsView):
             self._bw_drag_end = None
             self.setCursor(Qt.ArrowCursor)
 
-            if base_transform.isInvertible():
-                inv = base_transform.inverted()[0]
+            if display_transform.isInvertible():
+                inv = display_transform.inverted()[0]
                 s = inv.map(drag_start_scene)
                 e = inv.map(drag_end_scene)
                 # Map from displayed (possibly cropped/rotated) coords to

--- a/tests/test_wrong_output_fixes.py
+++ b/tests/test_wrong_output_fixes.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Regression tests for the wrong-output fixes.
+
+1. Exporting via the B/W-point pipeline must not mutate the live image's
+   state (_ws_windowed / contrast_base / temperature_base / exposure_base) —
+   flagging a never-converted image's full-range resized_raw as windowed
+   blew its next preview render to near-white.
+2. The B/W-point conversion uses display semantics for fine rotation: the
+   preview result is identical for any fine_rotation_angle (the canvas item
+   rotates it), instead of baking a warp the display then applied AGAIN.
+3. render_hires_base replays a "bw" conversion without warping, matching the
+   un-rotated preview.
+4. GraphicsImageView._display_transform includes the fine rotation, so
+   scene→pixel sampling lands on the pixels under the cursor (the old
+   coarse-only inverse drifted by ~r·sin(θ) under a fine rotation).
+"""
+import os
+import sys
+
+import cv2
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_image import CCRImage  # noqa: E402
+from core.ccr_processor import ccr_normalize_with_bwpoint, _ws_enabled  # noqa: E402
+
+BLACK_POINT = (60000.0, 58000.0, 56000.0)   # clear film base (high scan values)
+WHITE_POINT = (9000.0, 8500.0, 8000.0)      # dense/exposed area (low scan values)
+
+
+def _make_scan(tmp_path, name="scan.png"):
+    """A 16-bit-ish gradient 'negative' saved as PNG (8-bit is fine — the
+    reader rescales to uint16)."""
+    path = str(tmp_path / name)
+    g = np.linspace(40, 220, 120, dtype=np.uint8)
+    img = np.dstack([np.tile(g, (90, 1))] * 3)
+    cv2.imwrite(path, img)
+    return path
+
+
+# --- 1. export must not mutate live state -----------------------------------
+
+def test_export_does_not_mutate_live_state(tmp_path):
+    img = CCRImage(_make_scan(tmp_path))
+    assert img.converted is False
+    before = (img._ws_windowed, img.contrast_base, img.temperature_base,
+              getattr(img, "exposure_base", 0.0))
+    out = str(tmp_path / "out.jpg")
+    ccr_normalize_with_bwpoint(img, BLACK_POINT, WHITE_POINT,
+                               output_path=out, jpg_out=True)
+    assert os.path.exists(out)
+    after = (img._ws_windowed, img.contrast_base, img.temperature_base,
+             getattr(img, "exposure_base", 0.0))
+    assert after == before, "export mutated live image state"
+    assert img._ws_windowed is False  # full-range raw scan stays unflagged
+
+
+def test_preview_conversion_still_updates_live_state(tmp_path):
+    img = CCRImage(_make_scan(tmp_path))
+    img.contrast_base = 40  # legacy baked S-curve value; conversion must reset
+    result = ccr_normalize_with_bwpoint(img, BLACK_POINT, WHITE_POINT)
+    assert result is not None
+    assert img.contrast_base == 0
+    assert img.temperature_base == 0
+    assert img._ws_windowed == _ws_enabled()
+
+
+# --- 2. fine rotation is no longer baked into the preview conversion --------
+
+def test_bw_preview_identical_for_any_fine_rotation(tmp_path):
+    path = _make_scan(tmp_path)
+    img_a = CCRImage(path)
+    img_a.fine_rotation_angle = 0
+    img_b = CCRImage(path)
+    img_b.fine_rotation_angle = 300  # 3 degrees
+
+    out_a = ccr_normalize_with_bwpoint(img_a, BLACK_POINT, WHITE_POINT)
+    out_b = ccr_normalize_with_bwpoint(img_b, BLACK_POINT, WHITE_POINT)
+    assert np.array_equal(out_a, out_b), \
+        "fine rotation leaked into the conversion pixels (display owns it)"
+
+
+# --- 3. hi-res bw replay matches the un-rotated preview ----------------------
+
+def test_hires_bw_replay_ignores_fine_rot(tmp_path):
+    img = CCRImage(_make_scan(tmp_path))
+    ci_rot = {"mode": "bw", "bw": (BLACK_POINT, WHITE_POINT),
+              "fine_rot": 300, "density": False}
+    ci_flat = {"mode": "bw", "bw": (BLACK_POINT, WHITE_POINT),
+               "fine_rot": 0, "density": False}
+    out_rot = img.render_hires_base(max_long_side=256, conversion_inputs=ci_rot)
+    out_flat = img.render_hires_base(max_long_side=256, conversion_inputs=ci_flat)
+    assert out_rot is not None
+    assert np.array_equal(out_rot, out_flat)
+
+
+# --- 4. sampling transform includes the fine rotation ------------------------
+
+class _PreviewStub:
+    def __init__(self, w=200, h=100, fine=0):
+        from PySide6.QtGui import QPixmap
+        self.current_pixmap = QPixmap(w, h)
+        self.current_vertical_flip = False
+        self.current_horizontal_flip = False
+        self.current_rotation = 0
+        self.current_fine_rotation = fine
+        self.crop_mode = False
+        self.dust_mode = False
+
+
+class _ViewStub:
+    from widgets.image_preview import GraphicsImageView as _G
+    _display_transform = _G._display_transform
+
+    def __init__(self, pw):
+        self.parent_widget = pw
+
+
+def test_display_transform_rotates_about_center():
+    from PySide6.QtCore import QPointF
+    view = _ViewStub(_PreviewStub(w=200, h=100, fine=300))  # +3 degrees
+    t = view._display_transform()
+    # The center is the rotation pivot — must map to itself.
+    c = t.map(QPointF(100.0, 50.0))
+    assert abs(c.x() - 100.0) < 1e-6 and abs(c.y() - 50.0) < 1e-6
+    # A point on the +x axis from center rotates by exactly 3 degrees.
+    p = t.map(QPointF(200.0, 50.0))
+    theta = np.radians(3.0)
+    assert abs(p.x() - (100.0 + 100.0 * np.cos(theta))) < 1e-6
+    assert abs(p.y() - (50.0 + 100.0 * np.sin(theta))) < 1e-6
+    # Round trip: inverse(display) really undoes it.
+    inv = t.inverted()[0]
+    q = inv.map(p)
+    assert abs(q.x() - 200.0) < 1e-6 and abs(q.y() - 50.0) < 1e-6
+
+
+def test_display_transform_suppressed_in_crop_and_dust_modes():
+    from PySide6.QtCore import QPointF
+    pw = _PreviewStub(w=200, h=100, fine=300)
+    pw.crop_mode = True
+    t = _ViewStub(pw)._display_transform()
+    p = t.map(QPointF(200.0, 50.0))
+    assert abs(p.x() - 200.0) < 1e-6 and abs(p.y() - 50.0) < 1e-6
+    pw.crop_mode, pw.dust_mode = False, True
+    t = _ViewStub(pw)._display_transform()
+    p = t.map(QPointF(200.0, 50.0))
+    assert abs(p.x() - 200.0) < 1e-6 and abs(p.y() - 50.0) < 1e-6
+
+
+def test_display_transform_identity_without_fine_rotation():
+    from PySide6.QtCore import QPointF
+    t = _ViewStub(_PreviewStub(fine=0))._display_transform()
+    p = t.map(QPointF(37.0, 91.0))
+    assert abs(p.x() - 37.0) < 1e-6 and abs(p.y() - 91.0) < 1e-6


### PR DESCRIPTION
Fixes the four silent wrong-output bugs from the comprehensive code review (B1, B2, B9, B10). Follow-up to #76 (crash class).

## 1. Export via the B/W-point pipeline corrupted live image state (B1)

`ccr_normalize_with_bwpoint` unconditionally wrote `contrast_base`, `temperature_base`, and `_ws_windowed` on the live image — including on the export path. With the working space enabled (default) and a global black point set, exporting a **never-converted** image flagged its full-range `resized_raw` as a windowed base; the next preview render ran the de-windowing recovery `(v − 512)/1024` on full-range data, turning everything above ~2.3 % of scale pure white until reload.

**Fix:** the live-state writes now happen only on the preview path (`output_path is None`), where the result actually becomes `resized_raw`. The export path describes the buffer it just produced through new `apply_adjustments` overrides (`ws_windowed`, plus the base values a preview conversion would have baked) — byte-identical exports, zero live-state mutation. The override plumbing follows the existing snapshot-override pattern used by the hi-res zoom worker.

## 2. Monochrome RAWs white-level-scaled twice (B2)

The mono decode branch called `raw.postprocess` without `no_auto_scale=True` (and with auto-brighten on), so libraw already stretched the data to full 16-bit range — then the shared `white_level < 65535` guard multiplied by `65535/white_level` again. On a 14-bit mono RAW that's ×4: everything above ~25 % grey clipped to white, and a B/W point sampled from clear film base read a useless 65535. Auto-brighten also varied per frame, violating the documented "B/W points are absolute anchors, constant across the roll" contract.

**Fix:** the mono decode now uses `no_auto_scale=True` + `no_auto_bright=True` with the single manual white-level scale — the same semantics as the colour negative decode and `ccr_merge._decode_frame_plane`. ⚠ **No automated test** — this needs a real monochrome RAW (e.g. a 14-bit mono DNG); please verify one loads at sane brightness and that film-base samples are no longer clipped.

## 3. B/W marquee and WB eyedropper sampled the wrong pixels under fine rotation (B9)

The sampling handlers inverted only the coarse flip/90° transform, but the canvas also rotates the image by `fine_rotation_angle`. The sampled region was displaced ~r·sin(θ) from the on-screen marquee — ~25–50 px near the frame edge at 3° — silently poisoning the film-base sample. Auto Frame sets fine rotation automatically, so this needed no slider interaction to trigger. (The reference-frame path was already correct by contract: the conversion warps the decode before sampling, so its base-only mapping is intentional and untouched.)

**Fix:** a shared `GraphicsImageView._display_transform()` mirrors `apply_transformations` exactly (coarse + fine rotation, including the crop/dust-mode suppression); the B/W drag rect, B/W release sampling, and WB eyedropper all invert it. The drawn marquee now carries the same transform, so the on-screen rectangle is exactly the region sampled.

## 4. B/W conversion displayed (and exported) the fine rotation twice (B10)

The conversion baked the rotation warp into its output while `apply_transformations` rotated the display again — +3° showed as +6°, and returning the slider to 0 left +3° baked into the pixels. The export tail warped a second time too, with the first warp cropping corners on an un-expanded canvas.

**Fix:** the B/W conversion now uses display semantics, like the reference pipeline. The per-pixel B/W mapping is rotation-independent, so the preview result stays un-rotated (the canvas item applies the live angle — the slider stays live after conversion, matching ref-converted images), exports warp exactly once at the end on the expanded canvas, and `render_hires_base`'s bw replay no longer warps (`ci["fine_rot"]` remains as an informational snapshot). Catalog restores replay through the same function, so reloaded sessions are consistent automatically. Side benefit: no more inverted-white border wedges from the baked warp's zero-filled corners.

## Tests

`tests/test_wrong_output_fixes.py` (7 tests): export leaves live state untouched while preview conversion still updates it; conversion output is bit-identical for any fine-rotation angle; hi-res bw replay matches; `_display_transform` rotates about the pixmap center, round-trips through its inverse, respects crop/dust suppression, and is identity at 0°.

Also green: `test_density_bwpoint`, `test_default_slope`, `test_working_space`, `test_auto_gain`, `test_zoom_hires`, `test_crop_hires`, `test_export`, `test_opencl_accuracy`, `test_white_balance_ws`, `test_slice`, `test_sub_saturation_crop_undo`, `test_gamma_slider`, `test_curves`, `test_color_bands`, `test_dust_removal`, `test_zoom_percent`, `test_crop_overlay`, `test_area_editing`, `test_histogram_crop`, `test_color_profile`, `test_positive_mode` — 372 tests, 0 failures. (Run in groups to avoid the pre-existing order-dependent full-suite hang documented in #76.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012C4T6y6ciHgWs8vmQPKS2B
