### PR TITLE
feat: trichrome linear TIFF export (raw channel combination, unprocessed)

### DIFF
--- a/spec/trichrome-demosaic-mode.md
+++ b/spec/trichrome-demosaic-mode.md
@@ -1,0 +1,164 @@
+# Trichrome Merge Detail: Demosaic vs Single Photosite
+
+> Status: refined (open questions resolved inline — see "Decisions" at the end).
+> Extends spec/three-way-rgb-merge.md.
+
+## Summary
+
+A per-import choice of how each trichrome frame's colour channel is obtained
+from its Bayer RAW:
+
+- **Demosaic (full resolution)** — NEW, the DEFAULT: each source RAW is decoded
+  through a normal linear demosaic and the frame's own channel is taken from
+  the resulting RGB image. Full sensor resolution.
+- **Single photosite (half resolution)** — the existing behaviour: the RAW
+  Bayer mosaic is phase-sliced so only the wanted colour's photosites are read
+  (no demosaic, guaranteed zero inter-channel crosstalk), at half-sensor
+  resolution.
+
+Selected via a dropdown in the **Settings → Color Management → Trichrome
+capture** group, next to the merge checkbox. Monochrome sensors have no CFA, so
+the choice is irrelevant for them (identical decode either way).
+
+## Goals
+
+- Dropdown "Merge detail" in the Trichrome capture group, following the group's
+  staged-apply pattern (seeded at open, applied on Done via a MainWindow
+  handler, persisted in QSettings under `import/rgb_merge_demosaic`).
+- Default **Demosaic** (full resolution) — including for existing installs
+  (the QSettings default is True).
+- The choice is captured **per merged image at import** (`CCRImage.
+  merge_demosaic`), like `merge_sources`: every later re-read (zoom hi-res,
+  export, linear TIFF export, slice, duplicate) reproduces the same decode at
+  the same canonical resolution, regardless of later toggling. Toggling affects
+  the NEXT import only (same contract as the merge checkbox itself).
+- The demosaic decode preserves the trichrome purity guarantee: **bilinear
+  (LINEAR) demosaic interpolates each colour plane only from its own
+  photosites** — no inter-channel mixing — so "each frame contributes only its
+  own channel" still holds, now interpolated to full resolution.
+
+## Non-Goals
+
+- No per-image override UI; no re-merge of already-loaded images on toggle.
+- No change to monochrome handling, triplet grouping, validation, or the
+  sensor-type guards.
+- No new demosaic algorithm choices (AHD etc. use cross-channel correlation,
+  which would break the purity guarantee; LINEAR only).
+
+## UX
+
+In `_build_color_management_page`, inside the existing "Trichrome capture"
+group, after the checkbox + muted text:
+
+```
+   Merge detail:  [ Demosaic (full resolution)            ▾ ]
+                  [ Single photosite (half resolution)      ]
+   <muted> Demosaic interpolates each frame's own channel from its own
+           photosites (bilinear) at full sensor resolution. Single photosite
+           reads only the raw colour sites — no interpolation at all — at half
+           resolution. Applies to the next import.
+```
+
+- `self._combo_merge_detail`, entries with data `True` (demosaic, index 0) and
+  `False` (photosite).
+- Staged like the sibling toggles: seeded in `_init_toggles` from
+  `ccr_backend.rgb_merge_demosaic`; `_apply_toggles` calls
+  `self._mw.on_rgb_merge_demosaic_changed(bool)` only on change.
+- MainWindow: `on_rgb_merge_demosaic_changed(demosaic)` sets the backend flag,
+  persists `import/rgb_merge_demosaic`, and shows a transient hint ("…applies
+  to the next import"). Startup restore next to `import/rgb_merge_mode`.
+
+## Data Model
+
+- `ccr_backend.rgb_merge_demosaic: bool = True` (in `_init`).
+- `CCRImage.__init__(..., merge_demosaic: bool = True)` → `self.merge_demosaic`.
+  Threaded everywhere `is_merged`/`merge_sources` already are: the merge loader
+  (`_load_merged_triplets` passes the backend flag), `duplicate_images_by_
+  indices`, `slice_image_by_index`.
+- Merged images stay out of the catalog; nothing to persist per image.
+
+## Processing
+
+`ccr_merge._decode_frame_plane(path, frame_pos, preview, demosaic=False)`:
+
+- **Bayer + demosaic**: after the existing sensor-type guards,
+  `raw.postprocess(output_bps=16, no_auto_bright=True, gamma=(1,1),
+  user_flip=0, demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,
+  half_size=preview, use_camera_wb=False, use_auto_wb=False,
+  output_color=rawpy.ColorSpace.raw, no_auto_scale=True,
+  adjust_maximum_thr=0.0, four_color_rgb=False)` — byte-for-byte the kwargs the
+  monochrome path already uses, so decode conventions (linear, absolute values,
+  black-subtracted by libraw, camera-native) stay uniform. The frame's channel
+  is `rgb[..., bayer_channel_indices(color_desc)[frame_pos]]`. Returned
+  `sensor_full` is the full sensor size; `preview` gives a fast half-size
+  decode exactly like monochrome.
+- **Bayer + photosite**: unchanged (mosaic phase-slice).
+- **Monochrome**: unchanged (the flag is ignored; there is no CFA).
+
+`merge_raw_channels(sources, preview=False, demosaic=False)` forwards the flag;
+the canonical full size becomes `sensor_full if (any_mono or demosaic) else
+merged.shape` (a demosaiced Bayer merge, like a monochrome one, may decode a
+half-size preview while its full/export resolution is the full sensor).
+`combine_channels` and white-level scaling are untouched — both modes emit
+absolute values that it scales by `65535/white_level`.
+
+`CCRImage._read_merged` passes `demosaic=self.merge_demosaic`;
+`CCRBackend._export_merged_linear` (linear TIFF export) passes
+`demosaic=getattr(image_obj, "merge_demosaic", True)` — the linear export
+reproduces the image's own import-time decode.
+
+## Integration Points
+
+| Where | Change |
+|---|---|
+| `ccr_merge.py` | `demosaic` param on `_decode_frame_plane` + `merge_raw_channels`; full-size rule; module docstring note. |
+| `ccr_image.py` | Ctor kwarg + attribute; `_read_merged` forwards it. |
+| `ccr_backend.py` | `_init` flag; loader passes it; duplicate + slice thread it; `_export_merged_linear` forwards it. |
+| `settings_dialog.py` | Dropdown + muted text in the Trichrome group; staged seed/apply. |
+| `main_window.py` | Startup restore; `on_rgb_merge_demosaic_changed` handler (persist + hint). |
+
+## Edge Cases
+
+- **Toggling with merged images loaded** → no effect on them (per-image
+  capture); hint says "next import".
+- **Mixed sessions** (some images imported under each mode) → each re-reads
+  correctly with its own captured flag; resolutions differ per image, which the
+  pipeline already supports (monochrome vs Bayer merges differ today).
+- **Monochrome triplets** → identical output in both modes.
+- **Old sessions / defaults** → missing QSettings key reads True (demosaic),
+  per the requested default. Note this CHANGES the default behaviour of a
+  fresh trichrome import from half-res to full-res; the photosite mode remains
+  one dropdown away.
+
+## Test Plan
+
+`tests/test_trichrome_demosaic.py`:
+
+1. **Real-RAW integration** (uses `example_raw/DSC07096.ARW` as all three
+   sources; skipped if missing): `merge_raw_channels([arw]*3, demosaic=True)`
+   returns a full-sensor-size uint16 (H, W, 3) with full_size == merged shape;
+   photosite mode returns the half-size merge; demosaic dims ≈ 2× photosite
+   dims; `preview=True` demosaic decode is half-size while full_size stays
+   full-sensor.
+2. **Threading**: with `merge_raw_channels` monkeypatched to capture kwargs —
+   `CCRImage(..., merge_demosaic=False)._read_merged` passes False; default
+   ctor passes True; `_export_merged_linear` forwards the image's flag;
+   duplicates inherit the source's flag.
+3. **Loader**: `_load_merged_triplets` constructs children with the backend
+   flag (monkeypatched CCRImage or attribute check on the loaded result).
+4. **Settings dialog**: combo defaults to demosaic; staged apply calls the
+   MainWindow handler only on change; QSettings round-trip.
+
+## Decisions
+
+- **LINEAR demosaic only**: bilinear interpolates each colour plane from its
+  own sites — the only algorithm that keeps the "no inter-channel crosstalk"
+  guarantee while adding resolution. Matches the mono/positive decode choice
+  already in the codebase.
+- **Per-image capture, not live-global**: a live flag would make zoom/export
+  re-reads change resolution (and content) under an already-loaded image;
+  capture-at-import mirrors `merge_sources` and keeps every replay identical.
+- **Default demosaic** (explicit request): full-resolution RGB out of the box;
+  the crosstalk-purist photosite mode is the opt-in.
+- **Dropdown, not a checkbox**: the two options are modes with meaningfully
+  different trade-offs (resolution vs zero-interpolation), not an on/off.

--- a/spec/trichrome-linear-tiff-export.md
+++ b/spec/trichrome-linear-tiff-export.md
@@ -1,0 +1,223 @@
+# Trichrome Linear TIFF Export
+
+> Status: refined (round 2 folded inline — see "Review resolutions" at the end).
+
+## Summary
+
+In trichrome (3-way RGB merge) sessions, let the user export a merged image as a
+**16-bit linear TIFF of the raw channel combination** — the exact array
+`merge_raw_channels` produces (each frame's own channel, black-subtracted,
+white-level-scaled, stacked) — with **no other operation**: no negative
+conversion, no adjustments, no crop/orientation, no colour-space re-encode, no
+resize, no ICC burn-in. Conversion is **not** required to export. The option
+exists only for merged (trichrome) images.
+
+Use case: archival / interchange — take the crosstalk-free trichrome combination
+into another tool (darktable, Photoshop, a scientific pipeline) before FreeCCR's
+inversion look is applied.
+
+## Goals
+
+- A new format choice in the existing Export dialog, present **only when merged
+  images are loaded**: `TIFF 16-bit linear merge (unprocessed)`.
+- Exportable set for this format = **all merged images**, converted or not
+  (conversion status is irrelevant to the linear merge).
+- Pixel contract: output file == `merge_raw_channels(merge_sources)` at full
+  canonical resolution, byte-for-byte — `(H, W, 3)` uint16, linear,
+  camera-native RGB, untagged (no ICC profile embedded).
+- Reuse the whole existing export shell: scope radios, destination, naming
+  macros + conflict policy, parallel worker, progress + cancel, failure list,
+  size estimate.
+
+## Non-Goals
+
+- **Not a general "skip processing" export** for normal (non-merged) images —
+  trichrome only, per the request.
+- **No geometry of any kind**: slices and duplicates of a merged image export
+  the **full original merged frame** (values and geometry untouched). A slice's
+  `source_ops`, crops, flips, rotations, and fine rotation are all ignored on
+  this path. Documented in the dialog hint. (Trichrome captures are single
+  static scenes; slicing them is rare. Follow-up if ever needed: apply
+  `source_ops` only.)
+- **No resize** — the format forces "Original size" (the combo is disabled
+  while this format is selected and its stored preference is not overwritten).
+- **No ICC embedding, no colour-space option** — the data is camera-native
+  linear; tagging it sRGB/ProPhoto would be a lie. The colour-space row is
+  hidden for this format and a muted hint explains the file's nature.
+- **No JPEG variant** — linear data in 8-bit gamma-less JPEG is useless.
+- No change to any other export path or to the merge pipeline itself.
+
+## UX / Interaction
+
+### Format combo (`export_dialog.py`)
+
+- When `any(getattr(img, "is_merged", False) for img in ccr_backend.images)`,
+  `_build_ui` appends: `self.format_combo.addItem("TIFF 16-bit linear merge
+  (unprocessed)", "linear")`. Otherwise the entry does not exist (QSettings
+  restore of `"linear"` then falls back to the default TIFF entry via the
+  existing `findData >= 0` guard).
+- While `"linear"` is selected:
+  - Quality row hidden (existing non-JPEG behaviour).
+  - Colour-space row hidden; in its place the (re-used) `colorspace_hint` label
+    shows: *"Raw trichrome combination: camera-native linear RGB, no profile
+    embedded, no conversion or adjustments — full merged resolution. Slices and
+    duplicates export the full original frame."*
+  - Resize combo disabled and displayed at "Original size" (selection restored
+    when switching back to another format; the persisted `export/resize`
+    preference is not clobbered — `_save_settings` skips the resize key for
+    linear, and skips the colorspace key too since none applies).
+  - Scope radios re-labelled and re-counted for the merged set (see below).
+  - Estimate uses the existing TIFF estimator with each image's merged
+    canonical dims.
+
+### Scope semantics
+
+The dialog today computes one `_exportable` predicate at construction
+(converted, or anything in Positive mode). The linear format needs a second
+set. Both are computed in `__init__`:
+
+- `self._converted_indices` — as today.
+- `self._merged_indices` — `[i for i, img in enumerate(ccr_backend.images)
+  if getattr(img, "is_merged", False)]`.
+
+`_active_indices_all()`, `_current_exportable()`, `_selected_exportable()`
+resolve from `format_combo.currentData() == "linear"`. `_on_format_changed`
+updates the three radio labels/enablement in place:
+
+- All: `All merged images (N)` vs the existing converted/positive label.
+- Current: enabled iff the current image is merged (tooltip: *"The current
+  image is not a merged trichrome image."*).
+- Selected: `Selected images (K)` counting only merged selections.
+- If the checked radio becomes disabled by the switch, selection falls back to
+  the All radio (mirrors `_restore_settings`' fallback).
+
+`_scope_indices`, `_update_example`, `_update_estimate`, and
+`_on_export_clicked` all read through the format-aware helpers, so naming,
+estimate and the empty-scope guard follow automatically. The empty-scope
+message becomes format-aware: *"There are no merged images to export."*
+
+### ExportPlan
+
+New field `linear_merge: bool = False`. Set from
+`format_combo.currentData() == "linear"`. `jpg_output` stays False,
+`max_long_side` forced `None`, `output_colorspace` value irrelevant (worker
+ignores it on the linear path).
+
+## Data Model
+
+No new persistent state. `export/format` may persist `"linear"`; restoring it
+in a session without merged images falls back to TIFF (guard exists). No
+catalog impact (merged images are already excluded from the catalog).
+
+## Processing / Maths
+
+None — that is the point. The write path is:
+
+```python
+# ccr_backend.py
+def _export_merged_linear(self, image_obj, output_path: str) -> None:
+    """Write the raw trichrome combination as an untagged 16-bit linear TIFF.
+    Full-resolution re-merge; NO source_ops/crop/orientation/conversion/
+    adjustments/colour management — the file is exactly what
+    merge_raw_channels produced."""
+    from core import ccr_merge
+    from core.ccr_processor import safe_tifffile_imwrite
+    merged, _full = ccr_merge.merge_raw_channels(image_obj.merge_sources,
+                                                 preview=False)
+    out = os.path.splitext(output_path)[0] + ".tiff"
+    if not safe_tifffile_imwrite(out, merged, photometric="rgb",
+                                 compression="deflate"):
+        raise IOError(f"Failed to save image to {out}")
+```
+
+- `compression="deflate"` is lossless (bit-exact values), matching the normal
+  TIFF export; no `iccprofile` argument → untagged.
+- The 3 rawpy decodes per image are the documented cost of any merged-image
+  re-read (spec/three-way-rgb-merge.md, Performance note); the parallel export
+  pool amortises across images exactly as it does for normal exports.
+
+## Integration Points
+
+| Where | Change |
+|---|---|
+| `export_dialog.py` | `_merged_indices`; conditional `"linear"` combo entry; format-aware scope helpers + radio relabeling; hide colour-space row / show linear hint; disable resize; `ExportPlan.linear_merge`; `_save_settings` skips resize/colorspace keys when linear. |
+| `image_preview.py` `ExportItemsWorker.run` | Pass `linear_merge=self.plan.linear_merge` through to `export_items`. |
+| `ccr_backend.py` `export_items` | New kwarg `linear_merge=False`, forwarded per item to `export_image_by_index`. |
+| `ccr_backend.py` `export_image_by_index` | New kwarg `linear_merge=False`. When True: if the image is not merged, record a failure ("not a merged trichrome image") and return False; else `_export_merged_linear(image_obj, output_path)` and return True — **before** any conversion routing (no `ci` inspection, no reference/bwpoint fallback). |
+| `ccr_backend.py` | New `_export_merged_linear` (above). |
+
+Everything else (worker thread, progress dialog, cancel, failure counting,
+conflict resolution, `{name}/{date}/{time}/{seq}` macros, open-folder-when-done)
+is reused untouched.
+
+## Edge Cases
+
+- **Source RAW missing/moved since load** → `merge_raw_channels` raises → the
+  existing per-item failure handling records it; other items continue.
+- **Duplicate of a merged image in scope** → same sources ⇒ identical pixels
+  under a distinct (de-duplicated) display name. Allowed; harmless.
+- **Slice of a merged image in scope** → full original frame (see Non-Goals);
+  the dialog hint states this.
+- **Non-merged image reaches the linear path** (defensive; scope should
+  prevent it) → recorded failure, not a crash.
+- **Positive mode on** → irrelevant: the linear path never consults
+  positive-mode state (it bypasses `read_image` entirely by calling
+  `merge_raw_channels` directly).
+- **`export/format` == "linear" persisted, next session has no merged images**
+  → combo entry absent, `findData` misses, default TIFF stays selected.
+- **Estimate** → existing `get_original_dims` is already `is_merged`-aware
+  (never probes the red RAW at full sensor size); the TIFF estimator is used
+  as-is. Deflate on linear negatives compresses differently than on converted
+  positives — the estimate is approximate, same as today.
+
+## Test Plan
+
+`tests/test_linear_merge_export.py` (offscreen Qt, monkeypatched merge — no
+real trichrome fixture exists in the repo):
+
+1. **Byte-exact write**: monkeypatch `ccr_merge.merge_raw_channels` to return a
+   known uint16 gradient; a stub merged CCRImage exports; read the TIFF back
+   with `tifffile` → array-equal, dtype uint16, shape (H, W, 3); filename ends
+   `.tiff`.
+2. **Nothing else runs**: monkeypatch `apply_adjustments` /
+   `ccr_normalize_with_bwpoint` / `ccr_normalize_with_reference` to raise;
+   linear export of a *converted* merged image still succeeds (proves the
+   routing bypasses conversion and adjustments entirely).
+3. **Non-merged rejection**: `export_image_by_index(..., linear_merge=True)` on
+   a normal image returns False and records a failure through `export_items`.
+4. **Dialog gating**: with no merged images the combo has no "linear" entry;
+   with a merged stub it does.
+5. **Scope math**: mixed backend (merged + normal images) → linear scope counts
+   only merged; converted scope unchanged; radio labels update on format
+   switch; checked-but-disabled radio falls back to All.
+6. **Plan resolution**: selecting linear yields `linear_merge=True`,
+   `max_long_side=None`, `jpg_output=False`.
+7. **Settings hygiene**: switching to linear and exporting does not overwrite
+   the persisted `export/resize` / `export/colorspace` values.
+
+Manual verification (needs a real triplet, not in CI): export a merged frame,
+open the TIFF in a viewer that shows untagged data linearly, confirm it matches
+the pre-conversion negative content and full merged resolution.
+
+## Review resolutions (round 2)
+
+- **Scope predicate collision**: the dialog's single `_exportable` snapshot
+  can't serve two formats → resolved with two index sets and format-aware
+  helpers; radios re-label in place on format change and fall back to All when
+  the checked radio becomes disabled.
+- **QSettings pollution**: persisting `resize`/`colorspace` while the controls
+  are forced/hidden for linear would clobber the user's normal-export
+  preferences → `_save_settings` skips those two keys when linear is selected
+  (scope/destination/template/conflict still persist normally).
+- **Slice ambiguity**: exporting a slice's region would require `source_ops`
+  replay and re-open the "is geometry an operation?" question → v1 exports the
+  full frame, stated in the dialog hint and Non-Goals (follow-up noted).
+- **`.tif` vs `.tiff`**: `_selected_ext()` returns `.tiff` for every non-JPEG
+  format, and `_export_merged_linear` re-normalises the suffix exactly like
+  `write_export_image` — consistent with the normal TIFF export.
+- **Estimator**: no new estimator work; `get_original_dims` already handles
+  merged images and the TIFF heuristic is intentionally approximate.
+- **Why backend-level bypass instead of a `write_export_image` flag**: the
+  linear path must skip `_load_export_source` (which honours crops and resize)
+  and `apply_export_colorspace`; entering the existing chokepoint and disabling
+  most of it piecemeal is more fragile than one small, self-contained writer.

--- a/spec/trichrome-linear-tiff-export.md
+++ b/spec/trichrome-linear-tiff-export.md
@@ -1,14 +1,16 @@
 # Trichrome Linear TIFF Export
 
-> Status: refined (round 2 folded inline — see "Review resolutions" at the end).
+> Status: refined (round 2 folded inline — see "Review resolutions" at the end;
+> round 3 added crop support on request).
 
 ## Summary
 
 In trichrome (3-way RGB merge) sessions, let the user export a merged image as a
 **16-bit linear TIFF of the raw channel combination** — the exact array
 `merge_raw_channels` produces (each frame's own channel, black-subtracted,
-white-level-scaled, stacked) — with **no other operation**: no negative
-conversion, no adjustments, no crop/orientation, no colour-space re-encode, no
+white-level-scaled, stacked) — plus **framing only**: the slice chain (for
+sliced images) and the user's crop. No value processing of any kind: no negative
+conversion, no adjustments, no orientation, no colour-space re-encode, no
 resize, no ICC burn-in. Conversion is **not** required to export. The option
 exists only for merged (trichrome) images.
 
@@ -33,12 +35,15 @@ inversion look is applied.
 
 - **Not a general "skip processing" export** for normal (non-merged) images —
   trichrome only, per the request.
-- **No geometry of any kind**: slices and duplicates of a merged image export
-  the **full original merged frame** (values and geometry untouched). A slice's
-  `source_ops`, crops, flips, rotations, and fine rotation are all ignored on
-  this path. Documented in the dialog hint. (Trichrome captures are single
-  static scenes; slicing them is rare. Follow-up if ever needed: apply
-  `source_ops` only.)
+- **Framing yes, orientation no** (round 3): the export applies the geometry
+  that defines *which pixels the image is* — the slice chain (`source_ops`)
+  and the user crop (`crop_rect` + `crop_angle`, via `apply_crop_to_image`) —
+  but not the display orientation (flips / 90° rotation / fine rotation).
+  An axis-aligned crop is a pure sub-array (values bit-exact); an **angled**
+  crop (and a slice chain with a baked rotation) necessarily resamples with
+  linear interpolation — inherent to the operation, values stay linear.
+  Crop coordinates are defined relative to the (sliced) frame, which is why
+  `source_ops` must apply whenever the crop does.
 - **No resize** — the format forces "Original size" (the combo is disabled
   while this format is selected and its stored preference is not overwritten).
 - **No ICC embedding, no colour-space option** — the data is camera-native
@@ -60,8 +65,8 @@ inversion look is applied.
   - Quality row hidden (existing non-JPEG behaviour).
   - Colour-space row hidden; in its place the (re-used) `colorspace_hint` label
     shows: *"Raw trichrome combination: camera-native linear RGB, no profile
-    embedded, no conversion or adjustments — full merged resolution. Slices and
-    duplicates export the full original frame."*
+    embedded, no conversion or adjustments. Crop and slice framing apply;
+    rotation and flips do not."*
   - Resize combo disabled and displayed at "Original size" (selection restored
     when switching back to another format; the persisted `export/resize`
     preference is not clobbered — `_save_settings` skips the resize key for
@@ -117,18 +122,24 @@ None — that is the point. The write path is:
 # ccr_backend.py
 def _export_merged_linear(self, image_obj, output_path: str) -> None:
     """Write the raw trichrome combination as an untagged 16-bit linear TIFF.
-    Full-resolution re-merge; NO source_ops/crop/orientation/conversion/
-    adjustments/colour management — the file is exactly what
-    merge_raw_channels produced."""
+    Full-resolution re-merge + framing only (slice chain, user crop);
+    NO orientation/conversion/adjustments/colour management."""
     from core import ccr_merge
-    from core.ccr_processor import safe_tifffile_imwrite
+    from core.ccr_processor import apply_crop_to_image, safe_tifffile_imwrite
     merged, _full = ccr_merge.merge_raw_channels(image_obj.merge_sources,
                                                  preview=False)
+    if getattr(image_obj, "source_ops", None):
+        merged = image_obj._apply_source_ops(merged)   # slice framing
+    merged = apply_crop_to_image(merged, getattr(image_obj, "crop_rect", None),
+                                 getattr(image_obj, "crop_angle", 0.0) or 0.0)
     out = os.path.splitext(output_path)[0] + ".tiff"
     if not safe_tifffile_imwrite(out, merged, photometric="rgb",
                                  compression="deflate"):
         raise IOError(f"Failed to save image to {out}")
 ```
+
+`apply_crop_to_image` is a no-op for `crop_rect is None`, so the uncropped,
+unsliced export remains byte-identical to round 2.
 
 - `compression="deflate"` is lossless (bit-exact values), matching the normal
   TIFF export; no `iccprofile` argument → untagged.
@@ -154,10 +165,13 @@ is reused untouched.
 
 - **Source RAW missing/moved since load** → `merge_raw_channels` raises → the
   existing per-item failure handling records it; other items continue.
-- **Duplicate of a merged image in scope** → same sources ⇒ identical pixels
-  under a distinct (de-duplicated) display name. Allowed; harmless.
-- **Slice of a merged image in scope** → full original frame (see Non-Goals);
-  the dialog hint states this.
+- **Duplicate of a merged image in scope** → same sources; identical pixels
+  unless their crops differ. Allowed; harmless.
+- **Slice of a merged image in scope** → its slice chain (and any crop set on
+  the slice) applies, so the file is the framed region the user sees — in raw
+  linear merge values.
+- **Degenerate/None crop** → `apply_crop_to_image` returns the input unchanged
+  (existing guard).
 - **Non-merged image reaches the linear path** (defensive; scope should
   prevent it) → recorded failure, not a crash.
 - **Positive mode on** → irrelevant: the linear path never consults
@@ -221,3 +235,16 @@ the pre-conversion negative content and full merged resolution.
   linear path must skip `_load_export_source` (which honours crops and resize)
   and `apply_export_colorspace`; entering the existing chokepoint and disabling
   most of it piecemeal is more fragile than one small, self-contained writer.
+
+## Round 3 (crop support, on request)
+
+The original non-goal "no geometry of any kind" is relaxed to **framing yes,
+orientation no**: the slice chain and the user crop now apply (they define
+*which pixels* the image is), while flips/rotation/fine rotation and every
+value-processing stage remain excluded. Axis-aligned crops are bit-exact
+sub-arrays; angled crops/slice rotations interpolate (inherent). `source_ops`
+must accompany the crop because crop coordinates live in the sliced frame's
+space. Dialog hint updated accordingly. Tests: axis-aligned crop equals the
+`apply_crop_to_image` sub-array (and stays bit-exact vs the merge), angled
+crop has the box's dimensions, slice chain applies, and the
+uncropped/unsliced path stays byte-identical.

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -42,6 +42,12 @@ class CCRBackend:
         # triplet into one camera-native image (no demosaicing). Global, like
         # positive_mode; persisted by MainWindow. See spec/three-way-rgb-merge.md.
         self.rgb_merge_mode: bool = False
+        # How merge imports extract each frame's channel: True = LINEAR
+        # demosaic at full sensor resolution (default), False = raw-mosaic
+        # single-photosite read at half resolution. Captured per image at
+        # import (CCRImage.merge_demosaic); toggling affects the NEXT import.
+        # Persisted by MainWindow. See spec/trichrome-demosaic-mode.md.
+        self.rgb_merge_demosaic: bool = True
         # Last merge-import rejection (bad count / non-RAW / non-Bayer / decode
         # failure), set by the loader and surfaced by the UI after load, then
         # cleared. Reset at the top of every load so it never goes stale.
@@ -228,7 +234,8 @@ class CCRBackend:
                 return None
             red = triplet[0]
             try:
-                img = CCRImage(red, is_merged=True, merge_sources=list(triplet))
+                img = CCRImage(red, is_merged=True, merge_sources=list(triplet),
+                               merge_demosaic=self.rgb_merge_demosaic)
             except Exception as e:
                 print(f"3-way merge failed for {os.path.basename(red)}: {e}")
                 self.last_merge_error = (
@@ -1202,8 +1209,9 @@ class CCRBackend:
         slice rotation) interpolates. See spec/trichrome-linear-tiff-export.md."""
         from core import ccr_merge
         from core.ccr_processor import apply_crop_to_image, safe_tifffile_imwrite
-        merged, _full = ccr_merge.merge_raw_channels(image_obj.merge_sources,
-                                                     preview=False)
+        merged, _full = ccr_merge.merge_raw_channels(
+            image_obj.merge_sources, preview=False,
+            demosaic=getattr(image_obj, "merge_demosaic", True))
         if getattr(image_obj, "source_ops", None):
             merged = image_obj._apply_source_ops(merged)
         merged = apply_crop_to_image(merged, getattr(image_obj, "crop_rect", None),
@@ -1465,6 +1473,7 @@ class CCRBackend:
                 # (zoom/export), not decode the red RAW alone.
                 is_merged=getattr(img, "is_merged", False),
                 merge_sources=getattr(img, "merge_sources", None),
+                merge_demosaic=getattr(img, "merge_demosaic", True),
                 # preloaded_img is a copy of the (possibly windowed) base — set
                 # the flag before the ctor's first preview render.
                 ws_windowed=getattr(img, "_ws_windowed", False),
@@ -1658,6 +1667,7 @@ class CCRBackend:
                     # and exported file match the merged preview.
                     is_merged=getattr(img_obj, "is_merged", False),
                     merge_sources=getattr(img_obj, "merge_sources", None),
+                    merge_demosaic=getattr(img_obj, "merge_demosaic", True),
                     # The crop above replays the parent's conversion, so the
                     # child's base is windowed iff the parent's was — set before
                     # the ctor's first preview render so it de-windows.

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -1194,13 +1194,20 @@ class CCRBackend:
 
     def _export_merged_linear(self, image_obj, output_path: str) -> None:
         """Write the raw trichrome combination as an untagged 16-bit linear
-        TIFF: exactly what merge_raw_channels produced at full canonical
-        resolution — NO source_ops/crop/orientation/conversion/adjustments/
-        colour management. See spec/trichrome-linear-tiff-export.md."""
+        TIFF: what merge_raw_channels produced at full canonical resolution,
+        plus FRAMING only — the slice chain and the user crop (which is
+        defined in the sliced frame's space, so source_ops must accompany
+        it). NO orientation/conversion/adjustments/colour management; an
+        axis-aligned crop is a bit-exact sub-array, an angled crop (or a
+        slice rotation) interpolates. See spec/trichrome-linear-tiff-export.md."""
         from core import ccr_merge
-        from core.ccr_processor import safe_tifffile_imwrite
+        from core.ccr_processor import apply_crop_to_image, safe_tifffile_imwrite
         merged, _full = ccr_merge.merge_raw_channels(image_obj.merge_sources,
                                                      preview=False)
+        if getattr(image_obj, "source_ops", None):
+            merged = image_obj._apply_source_ops(merged)
+        merged = apply_crop_to_image(merged, getattr(image_obj, "crop_rect", None),
+                                     getattr(image_obj, "crop_angle", 0.0) or 0.0)
         out = os.path.splitext(output_path)[0] + ".tiff"
         if not safe_tifffile_imwrite(out, merged, photometric="rgb",
                                      compression="deflate"):

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -1192,17 +1192,40 @@ class CCRBackend:
             except Exception as e:
                 print(f"Failed to convert image at index {idx}: {e}")
 
+    def _export_merged_linear(self, image_obj, output_path: str) -> None:
+        """Write the raw trichrome combination as an untagged 16-bit linear
+        TIFF: exactly what merge_raw_channels produced at full canonical
+        resolution — NO source_ops/crop/orientation/conversion/adjustments/
+        colour management. See spec/trichrome-linear-tiff-export.md."""
+        from core import ccr_merge
+        from core.ccr_processor import safe_tifffile_imwrite
+        merged, _full = ccr_merge.merge_raw_channels(image_obj.merge_sources,
+                                                     preview=False)
+        out = os.path.splitext(output_path)[0] + ".tiff"
+        if not safe_tifffile_imwrite(out, merged, photometric="rgb",
+                                     compression="deflate"):
+            raise IOError(f"Failed to save image to {out}")
+        print(f"Linear merge saved to {out}")
+
     def export_image_by_index(self, idx: int, output_path: str, jpg_output: bool = False,
                               jpg_quality: int = 95, max_long_side: int = None,
-                              output_colorspace: str = "srgb") -> bool:
+                              output_colorspace: str = "srgb",
+                              linear_merge: bool = False) -> bool:
         """
         Exports the processed image at the given index to the specified output path.
         Routes to bwpoint or reference-frame pipeline depending on how the image was converted.
+        linear_merge=True (trichrome only) bypasses ALL of that and writes the
+        raw channel combination as a linear TIFF.
         Returns True on success.
         """
         if idx is not None and 0 <= idx < len(self.images):
             image_obj = self.images[idx]
             try:
+                if linear_merge:
+                    if not getattr(image_obj, "is_merged", False):
+                        raise ValueError("not a merged trichrome image")
+                    self._export_merged_linear(image_obj, output_path)
+                    return True
                 if self.positive_mode:
                     # Positive mode: export the adjusted positive directly — no
                     # inversion, regardless of any leftover reference_frame.
@@ -1251,7 +1274,8 @@ class CCRBackend:
 
     def export_items(self, items, jpg_output: bool = False, jpg_quality: int = 95,
                      max_long_side: int = None, output_colorspace: str = "srgb",
-                     progress_callback=None, cancel_check=None) -> dict:
+                     progress_callback=None, cancel_check=None,
+                     linear_merge: bool = False) -> dict:
         """
         Exports specific images to explicit output paths using parallel processing.
 
@@ -1285,7 +1309,8 @@ class CCRBackend:
             start_time = time.time()
             success = self.export_image_by_index(idx, output_path, jpg_output=jpg_output,
                                                  jpg_quality=jpg_quality, max_long_side=max_long_side,
-                                                 output_colorspace=output_colorspace)
+                                                 output_colorspace=output_colorspace,
+                                                 linear_merge=linear_merge)
             elapsed = time.time() - start_time
             base_name = os.path.basename(output_path)
             if success:

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -57,6 +57,7 @@ class CCRImage:
         areas: Optional[List[Dict[str, Any]]] = None,
         is_merged: bool = False,
         merge_sources: Optional[list] = None,
+        merge_demosaic: bool = True,
         ws_windowed: bool = False,
         ):
         # Normalize file path to handle Unicode characters properly
@@ -69,6 +70,14 @@ class CCRImage:
         # excluded from the per-file edit catalog. See spec/three-way-rgb-merge.md.
         self.is_merged = bool(is_merged)
         self.merge_sources = list(merge_sources) if merge_sources else None
+        # How this merge extracts each frame's channel — captured at import
+        # (like merge_sources) so every re-read (zoom, export, linear TIFF,
+        # slice, duplicate) reproduces the same decode at the same canonical
+        # resolution regardless of later Settings changes. True = LINEAR
+        # demosaic at full sensor resolution (default); False = raw-mosaic
+        # single-photosite read at half resolution. Monochrome ignores it.
+        # See spec/trichrome-demosaic-mode.md.
+        self.merge_demosaic = bool(merge_demosaic)
         # Sliced images own a chain of slice operations applied to the source
         # file by read_image in every path (preview load, hi-res zoom,
         # full-res export, B/W sampling). Each op is
@@ -429,13 +438,16 @@ class CCRImage:
         """Decode a 3-way RGB-merged image from its source RAWs. Mirrors the tail
         of read_image's RAW branch (slice ops, full-size capture, optional
         downsize) so export / zoom / slice all compose. The merge's native
-        resolution is sensor-native: half-sensor for Bayer (the 2x2 bin is the
-        no-demosaic step), full-sensor for monochrome (no CFA). `preview` only
-        speeds up a monochrome decode (half size); full_decode_size always
-        reports the canonical full resolution, and max_long_side does the rest."""
+        resolution follows the captured merge_demosaic mode: full-sensor for a
+        demosaiced Bayer merge and for monochrome (no CFA), half-sensor for the
+        single-photosite Bayer read (the 2x2 bin IS its full resolution).
+        `preview` speeds up monochrome/demosaic decodes (half size);
+        full_decode_size always reports the canonical full resolution, and
+        max_long_side does the rest."""
         from core import ccr_merge
-        rgb, full_decode_size = ccr_merge.merge_raw_channels(self.merge_sources,
-                                                             preview=preview)
+        rgb, full_decode_size = ccr_merge.merge_raw_channels(
+            self.merge_sources, preview=preview,
+            demosaic=getattr(self, "merge_demosaic", True))
         # Sliced merged children read only their region of the source.
         rgb = self._apply_source_ops(rgb)
         self.original_full_size = self._ops_full_size(full_decode_size)

--- a/src/core/ccr_merge.py
+++ b/src/core/ccr_merge.py
@@ -195,10 +195,19 @@ def extract_cfa_channel(mosaic: np.ndarray, colors: np.ndarray, color_desc,
     return acc / len(phases)            # 1 site for R/B; average of 2 for green
 
 
-def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
+def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False,
+                        demosaic: bool = False):
     """Decode one source RAW and return (plane_2d, white_level, is_mono,
     sensor_full) for the single colour this frame contributes (frame_pos
     0=R/1=G/2=B).
+
+    `demosaic` (Bayer only; monochrome has no CFA and ignores it) switches the
+    channel extraction from the raw-mosaic phase slice to a full-resolution
+    LINEAR (bilinear) demosaic that the frame's channel is then taken from.
+    Bilinear interpolates each colour plane only from its OWN photosites, so
+    the "each frame contributes only its own channel, no inter-channel
+    crosstalk" guarantee still holds — now at full sensor resolution. See
+    spec/trichrome-demosaic-mode.md.
 
     * Bayer (RGGB): read the RAW Bayer mosaic directly (`raw.raw_image_visible`)
       and take ONLY this frame's colour photosites — no demosaic, no libraw
@@ -251,8 +260,32 @@ def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
             raise ValueError(
                 f"3-way merge requires a 2x2 Bayer mosaic or a monochrome "
                 f"sensor; {os.path.basename(path)} is non-Bayer (e.g. X-Trans).")
-        bayer_channel_indices(color_desc)        # guard: raises if not R/G/B
+        channel_indices = bayer_channel_indices(color_desc)  # raises if not R/G/B
         letter = "RGB"[frame_pos]                 # this frame's colour
+
+        if demosaic:
+            # Full-resolution LINEAR demosaic, then take this frame's channel.
+            # Identical decode kwargs to the monochrome path above: linear,
+            # absolute values (no_auto_scale; combine scales by white_level),
+            # black-subtracted by libraw, camera-native. Bilinear interpolates
+            # each plane from its own sites only — no inter-channel mixing.
+            rgb = raw.postprocess(
+                output_bps=16,
+                no_auto_bright=True,
+                gamma=(1, 1),                                  # linear
+                user_flip=0,
+                demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,
+                half_size=preview,     # full res unless a fast preview decode
+                use_camera_wb=False,
+                use_auto_wb=False,
+                output_color=rawpy.ColorSpace.raw,
+                no_auto_scale=True,    # absolute sensor values; scale manually
+                adjust_maximum_thr=0.0,
+                four_color_rgb=False,
+            )
+            plane = rgb[..., channel_indices[frame_pos]]
+            return (np.ascontiguousarray(plane), white_level, False,
+                    sensor_full)
 
         # Read the RAW mosaic and pull only this colour's sites (R/B single,
         # green = average of its two sites) with per-site black subtraction;
@@ -270,13 +303,18 @@ def _decode_frame_plane(path: str, frame_pos: int, preview: bool = False):
                 (plane.shape[0], plane.shape[1]))
 
 
-def merge_raw_channels(sources: Sequence[str],
-                       preview: bool = False) -> Tuple[np.ndarray, Tuple[int, int]]:
+def merge_raw_channels(sources: Sequence[str], preview: bool = False,
+                       demosaic: bool = False) -> Tuple[np.ndarray, Tuple[int, int]]:
     """Merge a (red, green, blue) triplet of RAW files into one (H, W, 3) uint16
-    linear-RGB image, taking only each frame's own colour channel with no
-    demosaicing. Bayer → half-sensor resolution (2x2 bin); monochrome → full
-    sensor resolution (no CFA). `preview` lets a monochrome decode run at half
-    size for fast preview/zoom (Bayer ignores it).
+    linear-RGB image, taking only each frame's own colour channel.
+
+    `demosaic=False` (single photosite): Bayer frames are mosaic-phase-sliced —
+    no demosaic at all — at half-sensor resolution (2x2 bin). `demosaic=True`:
+    Bayer frames go through a LINEAR (bilinear, per-channel — still no
+    inter-channel mixing) demosaic at FULL sensor resolution. Monochrome
+    sensors have no CFA and decode identically in both modes (full sensor).
+    `preview` lets a monochrome or demosaic decode run at half size for fast
+    preview/zoom (the photosite read is already cheap and ignores it).
 
     Returns (merged_rgb, full_size=(H, W)) where full_size is the merged image's
     canonical FULL (export) resolution. Raises ValueError on an unsupported
@@ -293,7 +331,8 @@ def merge_raw_channels(sources: Sequence[str],
     monos: List[bool] = []
     sensor_full: Optional[Tuple[int, int]] = None
     for frame_pos, path in enumerate(sources):       # 0=red, 1=green, 2=blue
-        plane, white_level, mono, sfull = _decode_frame_plane(path, frame_pos, preview)
+        plane, white_level, mono, sfull = _decode_frame_plane(
+            path, frame_pos, preview, demosaic=demosaic)
         planes.append(plane)
         white_levels.append(white_level)
         monos.append(mono)
@@ -309,8 +348,10 @@ def merge_raw_channels(sources: Sequence[str],
                          "(all Bayer, or all monochrome).")
 
     merged = combine_channels(planes[0], planes[1], planes[2], white_levels)
-    # Canonical FULL (export) resolution: full sensor for monochrome (the merge
-    # is full-res; a preview decode may have produced a smaller `merged`), the
-    # 2x2-binned size for Bayer (its only resolution).
-    full_size = sensor_full if any_mono else (merged.shape[0], merged.shape[1])
+    # Canonical FULL (export) resolution: full sensor for monochrome and for a
+    # demosaiced Bayer merge (both may decode a half-size preview while their
+    # export resolution is the full sensor); the 2x2-binned size for a
+    # photosite Bayer merge (its only resolution).
+    full_size = (sensor_full if (any_mono or demosaic)
+                 else (merged.shape[0], merged.shape[1]))
     return merged, full_size

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -188,6 +188,10 @@ class MainWindow(QMainWindow):
         # Restore the global 3-way RGB merge toggle too (affects the next import).
         ccr_backend.rgb_merge_mode = self._settings.value(
             "import/rgb_merge_mode", False, type=bool)
+        # Merge detail: demosaic (full res, default) vs single photosite (half
+        # res). Captured per image at import. See spec/trichrome-demosaic-mode.md.
+        ccr_backend.rgb_merge_demosaic = self._settings.value(
+            "import/rgb_merge_demosaic", True, type=bool)
         # Restore the two-point B/W Density-inversion default (ON — density keeps
         # real highlight headroom in the working space; linear has ~0.15 stops).
         # New two-point conversions bake this; see spec/density-bwpoint-toggle.md.
@@ -629,6 +633,19 @@ class MainWindow(QMainWindow):
         else:
             msg = "3-way RGB merge off."
         self.sliders_panel.set_temporary_hint(msg, duration=5000)
+
+    def on_rgb_merge_demosaic_changed(self, demosaic: bool):
+        """Set how merge imports extract each frame's channel (demosaic at full
+        resolution vs single photosite at half) and persist it. Captured per
+        image at import — already-loaded merges keep their decode; only the
+        NEXT import is affected. See spec/trichrome-demosaic-mode.md."""
+        ccr_backend.rgb_merge_demosaic = bool(demosaic)
+        self._settings.setValue("import/rgb_merge_demosaic", bool(demosaic))
+        self.sliders_panel.set_temporary_hint(
+            ("Trichrome merge detail: demosaic (full resolution)."
+             if demosaic else
+             "Trichrome merge detail: single photosite (half resolution).")
+            + " Applies to the next import.", duration=5000)
 
     # --- Two-point B/W Density inversion (global, persistent) -------------
     def on_density_bwpoint_toggled(self, checked: bool):

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -33,6 +33,10 @@ class ExportPlan:
     open_folder: bool = False
     destination: str = ""
     skipped: int = 0  # files dropped by the "skip existing" policy
+    # Trichrome only: write the raw channel combination as an untagged 16-bit
+    # linear TIFF — no conversion/adjustments/geometry/colour management.
+    # See spec/trichrome-linear-tiff-export.md.
+    linear_merge: bool = False
 
 
 class ExportSettingsDialog(QDialog):
@@ -71,6 +75,14 @@ class ExportSettingsDialog(QDialog):
         # are dropped here.
         converted_set = set(self._converted_indices)
         self._selected_converted = [i for i in (selected_indices or []) if i in converted_set]
+        # Trichrome: the linear-merge format exports MERGED images (converted
+        # or not — conversion is irrelevant to the raw channel combination).
+        self._merged_indices = [idx for idx, img in enumerate(ccr_backend.images)
+                                if getattr(img, "is_merged", False)]
+        merged_set = set(self._merged_indices)
+        self._current_merged = (
+            current_idx is not None and current_idx in merged_set)
+        self._selected_merged = [i for i in (selected_indices or []) if i in merged_set]
         self._bpp_cache = {}  # quality -> bytes per pixel sample
 
         self._settings = QSettings("FreeCCR", "FreeCCR")
@@ -144,6 +156,10 @@ class ExportSettingsDialog(QDialog):
         self.format_combo = QComboBox()
         self.format_combo.addItem("TIFF 16-bit (lossless)", "tiff")
         self.format_combo.addItem("JPEG", "jpeg")
+        if self._merged_indices:
+            # Trichrome only: raw channel combination, nothing else applied.
+            self.format_combo.addItem("TIFF 16-bit linear merge (unprocessed)",
+                                      "linear")
         self.format_combo.currentIndexChanged.connect(self._on_format_changed)
         form.addRow("Format:", self.format_combo)
 
@@ -154,7 +170,8 @@ class ExportSettingsDialog(QDialog):
         self.colorspace_combo.addItem("sRGB", "srgb")
         self.colorspace_combo.addItem("ProPhoto RGB (wide gamut)", "prophoto")
         self.colorspace_combo.currentIndexChanged.connect(self._on_colorspace_changed)
-        form.addRow("Color space:", self.colorspace_combo)
+        self.colorspace_row_label = QLabel("Color space:")
+        form.addRow(self.colorspace_row_label, self.colorspace_combo)
         self.colorspace_hint = QLabel(
             "8-bit ProPhoto JPEG can band — prefer 16-bit TIFF for wide gamut.")
         self.colorspace_hint.setStyleSheet(f"color: {theme.TEXT_MUTED};")
@@ -252,7 +269,12 @@ class ExportSettingsDialog(QDialog):
         self.quality_slider.setValue(s.value("export/jpeg_quality", 92, type=int))
         resize_index = self.resize_combo.findData(s.value("export/resize", 0, type=int))
         if resize_index >= 0:
-            self.resize_combo.setCurrentIndex(resize_index)
+            if self._is_linear():
+                # Format restored to linear merge: the combo is locked at
+                # "Original size" — park the preference for a format switch.
+                self._resize_index_before_linear = resize_index
+            else:
+                self.resize_combo.setCurrentIndex(resize_index)
         conflict_index = self.conflict_combo.findData(s.value("export/conflict", "rename", type=str))
         if conflict_index >= 0:
             self.conflict_combo.setCurrentIndex(conflict_index)
@@ -271,20 +293,60 @@ class ExportSettingsDialog(QDialog):
         s.setValue("export/scope", scope)
         s.setValue("export/filename_template", self.filename_edit.text())
         s.setValue("export/format", self.format_combo.currentData())
-        s.setValue("export/colorspace", self.colorspace_combo.currentData())
+        # Linear merge hides the colour space and forces Original size — don't
+        # let those forced values clobber the user's normal-format preferences.
+        if not self._is_linear():
+            s.setValue("export/colorspace", self.colorspace_combo.currentData())
+            s.setValue("export/resize", self.resize_combo.currentData())
         s.setValue("export/jpeg_quality", self.quality_slider.value())
-        s.setValue("export/resize", self.resize_combo.currentData())
         s.setValue("export/conflict", self.conflict_combo.currentData())
         s.setValue("export/open_folder", self.open_folder_checkbox.isChecked())
 
     # ---------- helpers ----------
 
+    def _is_linear(self) -> bool:
+        return self.format_combo.currentData() == "linear"
+
+    def _exportable_all(self) -> List[int]:
+        return self._merged_indices if self._is_linear() else self._converted_indices
+
+    def _current_exportable(self) -> bool:
+        return self._current_merged if self._is_linear() else self._current_converted
+
+    def _selected_exportable(self) -> List[int]:
+        return self._selected_merged if self._is_linear() else self._selected_converted
+
     def _scope_indices(self) -> List[int]:
-        if self.scope_current_radio.isChecked() and self._current_converted:
+        if self.scope_current_radio.isChecked() and self._current_exportable():
             return [self._current_idx]
-        if self.scope_selected_radio.isChecked() and self._selected_converted:
-            return list(self._selected_converted)
-        return list(self._converted_indices)
+        if self.scope_selected_radio.isChecked() and self._selected_exportable():
+            return list(self._selected_exportable())
+        return list(self._exportable_all())
+
+    def _update_scope_radios(self):
+        """Re-label and re-enable the scope radios for the active format —
+        the linear-merge format exports merged images regardless of
+        conversion, the others export converted (or positive-mode) images."""
+        if self._is_linear():
+            all_label = "All merged images"
+            current_tip = "The current image is not a merged trichrome image."
+            selected_tip = "No merged images are selected."
+        else:
+            all_label = "All images" if self._positive_mode else "All converted images"
+            current_tip = "The current image has not been converted yet."
+            selected_tip = "No converted images are selected."
+        self.scope_all_radio.setText(f"{all_label} ({len(self._exportable_all())})")
+        current_ok = self._current_exportable()
+        self.scope_current_radio.setEnabled(current_ok)
+        self.scope_current_radio.setToolTip("" if current_ok else current_tip)
+        selected = self._selected_exportable()
+        self.scope_selected_radio.setText(f"Selected images ({len(selected)})")
+        self.scope_selected_radio.setEnabled(bool(selected))
+        self.scope_selected_radio.setToolTip("" if selected else selected_tip)
+        # A checked radio that just became empty falls back to All.
+        if ((self.scope_current_radio.isChecked() and not current_ok)
+                or (self.scope_selected_radio.isChecked() and not selected)):
+            self.scope_all_radio.setChecked(True)
 
     def _base_names(self, indices) -> List[str]:
         names = []
@@ -329,14 +391,45 @@ class ExportSettingsDialog(QDialog):
     def _on_format_changed(self):
         self._update_quality_visibility()
         self._update_colorspace_hint()
+        self._update_scope_radios()
+        self._update_linear_mode()
         self._update_example()
         self._schedule_estimate()
+
+    def _update_linear_mode(self):
+        """Linear merge is the raw combination at full resolution: hide the
+        colour-space choice (untagged camera-native data) and force the
+        resize to Original size WITHOUT clobbering the user's stored resize
+        preference for the normal formats."""
+        linear = self._is_linear()
+        self.colorspace_row_label.setVisible(not linear)
+        self.colorspace_combo.setVisible(not linear)
+        if linear:
+            if self.resize_combo.isEnabled():
+                self._resize_index_before_linear = self.resize_combo.currentIndex()
+            self.resize_combo.setCurrentIndex(0)  # "Original size"
+            self.resize_combo.setEnabled(False)
+        elif not self.resize_combo.isEnabled():
+            self.resize_combo.setEnabled(True)
+            restore = getattr(self, "_resize_index_before_linear", None)
+            if restore is not None:
+                self.resize_combo.setCurrentIndex(restore)
 
     def _on_colorspace_changed(self):
         self._update_colorspace_hint()
 
     def _update_colorspace_hint(self):
+        if self._is_linear():
+            self.colorspace_hint.setText(
+                "Raw trichrome combination: camera-native linear RGB, no "
+                "profile embedded, no conversion or adjustments — full merged "
+                "resolution. Slices and duplicates export the full original "
+                "frame.")
+            self.colorspace_hint.setVisible(True)
+            return
         # The banding caution is only relevant for 8-bit ProPhoto JPEG.
+        self.colorspace_hint.setText(
+            "8-bit ProPhoto JPEG can band — prefer 16-bit TIFF for wide gamut.")
         is_prophoto = self.colorspace_combo.currentData() == "prophoto"
         is_jpeg = self.format_combo.currentData() == "jpeg"
         self.colorspace_hint.setVisible(is_prophoto and is_jpeg)
@@ -375,6 +468,8 @@ class ExportSettingsDialog(QDialog):
             self.estimate_label.setText("Estimated total size: —")
             return
         fmt = self.format_combo.currentData()
+        if fmt == "linear":
+            fmt = "tiff"  # same container; the estimator knows tiff/jpeg only
         max_long_side = self._selected_max_long_side()
         bpp = None
         if fmt == "jpeg":
@@ -421,8 +516,9 @@ class ExportSettingsDialog(QDialog):
 
         indices = self._scope_indices()
         if not indices:
+            what = "merged" if self._is_linear() else "converted"
             QMessageBox.information(self, "Nothing to Export",
-                                    "There are no converted images to export.")
+                                    f"There are no {what} images to export.")
             return
 
         names = build_export_names(self._base_names(indices), self.filename_edit.text(),
@@ -445,11 +541,12 @@ class ExportSettingsDialog(QDialog):
             items=items,
             jpg_output=self.format_combo.currentData() == "jpeg",
             jpg_quality=self.quality_slider.value(),
-            max_long_side=self._selected_max_long_side(),
+            max_long_side=None if self._is_linear() else self._selected_max_long_side(),
             output_colorspace=self.colorspace_combo.currentData(),
             open_folder=self.open_folder_checkbox.isChecked(),
             destination=destination,
             skipped=skipped,
+            linear_merge=self._is_linear(),
         )
         self._save_settings()
         self.accept()

--- a/src/widgets/export_dialog.py
+++ b/src/widgets/export_dialog.py
@@ -422,9 +422,8 @@ class ExportSettingsDialog(QDialog):
         if self._is_linear():
             self.colorspace_hint.setText(
                 "Raw trichrome combination: camera-native linear RGB, no "
-                "profile embedded, no conversion or adjustments — full merged "
-                "resolution. Slices and duplicates export the full original "
-                "frame.")
+                "profile embedded, no conversion or adjustments. Crop and "
+                "slice framing apply; rotation and flips do not.")
             self.colorspace_hint.setVisible(True)
             return
         # The banding caution is only relevant for 8-bit ProPhoto JPEG.

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -3950,6 +3950,7 @@ class ExportItemsWorker(QThread):
                 output_colorspace=self.plan.output_colorspace,
                 progress_callback=progress_callback,
                 cancel_check=lambda: self._stop_requested,
+                linear_merge=getattr(self.plan, "linear_merge", False),
             )
         except Exception as e:
             print(f"Failed to export images: {e}")

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -15,9 +15,9 @@ import os
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
-    QApplication, QButtonGroup, QCheckBox, QDialog, QGroupBox, QHBoxLayout, QLabel,
-    QListWidget, QListWidgetItem, QPushButton, QScrollArea, QStackedWidget,
-    QVBoxLayout, QWidget,
+    QApplication, QButtonGroup, QCheckBox, QComboBox, QDialog, QGroupBox,
+    QHBoxLayout, QLabel, QListWidget, QListWidgetItem, QPushButton, QScrollArea,
+    QStackedWidget, QVBoxLayout, QWidget,
 )
 
 from core import color_management
@@ -215,11 +215,26 @@ class SettingsDialog(QDialog):
             "Shoot a static scene three times under pure red, then green, then "
             "blue light. On your NEXT import, every 3 RAWs (sorted by filename) "
             "are merged into one colour image — each frame contributes only its "
-            "own channel, with no demosaicing — then converted as a negative. "
+            "own channel — then converted as a negative. "
             "RAW only (Bayer or monochrome); the selected count must be a "
             "multiple of 3. "
             "Applies to the next import only; merged-image edits are not saved "
             "between sessions."))
+        detail_row = QHBoxLayout()
+        detail_row.setSpacing(theme.GAP_BTN)
+        detail_row.addWidget(QLabel("Merge detail:"))
+        self._combo_merge_detail = QComboBox()
+        self._combo_merge_detail.addItem("Demosaic (full resolution)", True)
+        self._combo_merge_detail.addItem(
+            "Single photosite (half resolution)", False)
+        detail_row.addWidget(self._combo_merge_detail, 1)
+        g3.addLayout(detail_row)
+        g3.addWidget(self._muted(
+            "Demosaic interpolates each frame's own channel from its own "
+            "photosites (bilinear — still no channel mixing) at full sensor "
+            "resolution. Single photosite reads only the raw colour sites — "
+            "no interpolation at all — at half resolution. Applies to the "
+            "next import."))
         lay.addWidget(grp3)
 
         lay.addStretch(1)
@@ -258,6 +273,11 @@ class SettingsDialog(QDialog):
             cb.blockSignals(True)
             cb.setChecked(bool(val))
             cb.blockSignals(False)
+        self._combo_merge_detail.blockSignals(True)
+        self._combo_merge_detail.setCurrentIndex(
+            self._combo_merge_detail.findData(
+                bool(getattr(ccr_backend, "rgb_merge_demosaic", True))))
+        self._combo_merge_detail.blockSignals(False)
 
     def _apply_pending(self):
         """Apply only the toggles whose checkbox differs from the live backend
@@ -268,6 +288,9 @@ class SettingsDialog(QDialog):
             self._mw.on_positive_mode_toggled(bool(self._cb_positive.isChecked()))
         if bool(self._cb_rgb_merge.isChecked()) != bool(ccr_backend.rgb_merge_mode):
             self._mw.on_rgb_merge_mode_toggled(bool(self._cb_rgb_merge.isChecked()))
+        staged_detail = bool(self._combo_merge_detail.currentData())
+        if staged_detail != bool(getattr(ccr_backend, "rgb_merge_demosaic", True)):
+            self._mw.on_rgb_merge_demosaic_changed(staged_detail)
         if bool(self._cb_density.isChecked()) != bool(ccr_backend.density_bwpoint):
             self._mw.on_density_bwpoint_toggled(bool(self._cb_density.isChecked()))
         if bool(self._cb_auto_gain.isChecked()) != bool(ccr_backend.auto_gain):

--- a/tests/test_linear_merge_export.py
+++ b/tests/test_linear_merge_export.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Trichrome linear TIFF export (spec/trichrome-linear-tiff-export.md).
+
+The linear-merge format writes merge_raw_channels' output byte-for-byte as an
+untagged 16-bit TIFF — no conversion, no adjustments, no geometry, no colour
+management — and is offered only when merged images are loaded. No real
+trichrome triplet exists in the repo, so merge_raw_channels is monkeypatched
+with a known array.
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+import tifffile  # noqa: E402
+from PySide6.QtCore import QSettings  # noqa: E402
+
+from core import ccr_merge  # noqa: E402
+from core.ccr_backend import ccr_backend  # noqa: E402
+from widgets.export_dialog import ExportSettingsDialog  # noqa: E402
+
+MERGED = (np.linspace(0, 65535, 48 * 64 * 3, dtype=np.float64)
+          .reshape(48, 64, 3).astype(np.uint16))
+
+
+@pytest.fixture(autouse=True)
+def _clean_backend():
+    """CCRBackend is an enforced singleton; leave it empty for other modules."""
+    yield
+    ccr_backend.images = []
+    ccr_backend.file_paths = []
+
+
+@pytest.fixture
+def fake_merge(monkeypatch):
+    calls = []
+
+    def _fake(sources, preview=False):
+        calls.append((tuple(sources), preview))
+        return MERGED.copy(), MERGED.shape[:2]
+
+    monkeypatch.setattr(ccr_merge, "merge_raw_channels", _fake)
+    return calls
+
+
+def _merged_stub(tmp_path, name="tri_RGB.arw", converted=False):
+    return SimpleNamespace(
+        is_merged=True,
+        merge_sources=[str(tmp_path / f"{c}.arw") for c in "rgb"],
+        file_path=str(tmp_path / name),
+        display_name=name,
+        converted=converted,
+        conversion_inputs={"mode": "bw", "bw": ((1, 1, 1), None),
+                           "fine_rot": 0, "density": False} if converted else None,
+        reference_frame=None,
+        resized_raw=MERGED,
+        original_full_size=MERGED.shape[:2],
+    )
+
+
+def _normal_stub(tmp_path, name="plain.png", converted=True):
+    return SimpleNamespace(
+        is_merged=False, merge_sources=None,
+        file_path=str(tmp_path / name), display_name=name,
+        converted=converted, conversion_inputs=None, reference_frame=None,
+        resized_raw=MERGED, original_full_size=MERGED.shape[:2],
+    )
+
+
+# --- backend write path ------------------------------------------------------
+
+def test_linear_export_is_byte_exact_untagged_tiff(tmp_path, fake_merge):
+    ccr_backend.images = [_merged_stub(tmp_path)]
+    out = str(tmp_path / "out.arw")  # wrong ext on purpose
+    assert ccr_backend.export_image_by_index(0, out, linear_merge=True)
+    written = str(tmp_path / "out.tiff")
+    assert os.path.exists(written)
+    with tifffile.TiffFile(written) as tf:
+        arr = tf.asarray()
+        page = tf.pages[0]
+        assert 34675 not in page.tags  # no InterColorProfile (untagged)
+    assert arr.dtype == np.uint16
+    assert np.array_equal(arr, MERGED)
+    # Full-resolution re-merge, not the preview
+    assert fake_merge == [(tuple(ccr_backend.images[0].merge_sources), False)]
+
+
+def test_linear_export_bypasses_conversion_and_adjustments(tmp_path, fake_merge,
+                                                           monkeypatch):
+    """A CONVERTED merged image must export through the linear path without
+    touching any conversion pipeline or apply_adjustments."""
+    import core.ccr_backend as backend_mod
+
+    def _boom(*a, **k):
+        raise AssertionError("conversion pipeline must not run for linear export")
+
+    for fn in ("ccr_normalize_with_bwpoint", "ccr_normalize_with_reference",
+               "ccr_normalize_with_refparams", "ccr_export_positive"):
+        monkeypatch.setattr(backend_mod, fn, _boom)
+
+    stub = _merged_stub(tmp_path, converted=True)
+    stub.apply_adjustments = _boom
+    ccr_backend.images = [stub]
+    assert ccr_backend.export_image_by_index(
+        0, str(tmp_path / "conv.tiff"), linear_merge=True)
+    assert np.array_equal(tifffile.imread(str(tmp_path / "conv.tiff")), MERGED)
+
+
+def test_linear_export_rejects_non_merged(tmp_path, fake_merge):
+    ccr_backend.images = [_normal_stub(tmp_path)]
+    assert not ccr_backend.export_image_by_index(
+        0, str(tmp_path / "no.tiff"), linear_merge=True)
+    assert not os.path.exists(str(tmp_path / "no.tiff"))
+    result = ccr_backend.export_items([(0, str(tmp_path / "no2.tiff"))],
+                                      linear_merge=True)
+    assert result["failed"] == 1 and result["exported"] == 0
+
+
+def test_normal_export_unaffected_by_default_flag(tmp_path, fake_merge,
+                                                  monkeypatch):
+    """linear_merge defaults False: a normal export still routes to the
+    conversion pipelines."""
+    import core.ccr_backend as backend_mod
+    routed = []
+    monkeypatch.setattr(backend_mod, "ccr_normalize_with_bwpoint",
+                        lambda *a, **k: routed.append("bw"))
+    stub = _merged_stub(tmp_path, converted=True)
+    ccr_backend.images = [stub]
+    assert ccr_backend.export_image_by_index(0, str(tmp_path / "n.tiff"))
+    assert routed == ["bw"]
+
+
+# --- dialog ------------------------------------------------------------------
+
+@pytest.fixture
+def _export_settings_guard():
+    """Snapshot/restore the persisted export/* keys the dialog writes."""
+    s = QSettings("FreeCCR", "FreeCCR")
+    keys = ["export/destination", "export/scope", "export/filename_template",
+            "export/format", "export/colorspace", "export/jpeg_quality",
+            "export/resize", "export/conflict", "export/open_folder"]
+    saved = {k: s.value(k) for k in keys}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            s.remove(k)
+        else:
+            s.setValue(k, v)
+
+
+def _select_format(dialog, data):
+    idx = dialog.format_combo.findData(data)
+    assert idx >= 0
+    dialog.format_combo.setCurrentIndex(idx)
+
+
+def test_linear_entry_absent_without_merged_images(tmp_path,
+                                                   _export_settings_guard):
+    ccr_backend.images = [_normal_stub(tmp_path)]
+    dlg = ExportSettingsDialog()
+    assert dlg.format_combo.findData("linear") == -1
+
+
+def test_linear_entry_and_scope_with_merged_images(tmp_path,
+                                                   _export_settings_guard):
+    merged = _merged_stub(tmp_path)               # NOT converted
+    normal = _normal_stub(tmp_path, converted=True)
+    ccr_backend.images = [merged, normal]
+    dlg = ExportSettingsDialog(current_idx=1, selected_indices=[0, 1])
+    assert dlg.format_combo.findData("linear") >= 0
+
+    # Normal format: converted set (the normal image only)
+    _select_format(dlg, "tiff")
+    assert dlg._scope_indices() == [1]
+
+    # Linear: merged set only, regardless of conversion; current (normal
+    # image) is not exportable here
+    _select_format(dlg, "linear")
+    assert dlg._scope_indices() == [0]
+    assert "All merged images (1)" in dlg.scope_all_radio.text()
+    assert not dlg.scope_current_radio.isEnabled()
+    assert dlg.scope_selected_radio.isEnabled()
+    assert "(1)" in dlg.scope_selected_radio.text()
+    assert not dlg.resize_combo.isEnabled()
+    assert not dlg.colorspace_combo.isVisible()
+
+    # Switching back restores the normal semantics
+    _select_format(dlg, "tiff")
+    assert dlg._scope_indices() == [1]
+    assert dlg.resize_combo.isEnabled()
+
+
+def test_plan_resolution_for_linear(tmp_path, _export_settings_guard):
+    ccr_backend.images = [_merged_stub(tmp_path)]
+    dlg = ExportSettingsDialog(current_idx=0)
+    _select_format(dlg, "linear")
+    dlg.dest_edit.setText(str(tmp_path / "outdir"))
+    dlg._on_export_clicked()
+    assert dlg.plan is not None
+    assert dlg.plan.linear_merge is True
+    assert dlg.plan.jpg_output is False
+    assert dlg.plan.max_long_side is None
+    assert len(dlg.plan.items) == 1
+    assert dlg.plan.items[0][1].endswith(".tiff")
+
+
+def test_linear_save_does_not_clobber_resize_pref(tmp_path,
+                                                  _export_settings_guard):
+    s = QSettings("FreeCCR", "FreeCCR")
+    s.setValue("export/resize", 2000)
+    s.setValue("export/colorspace", "prophoto")
+    ccr_backend.images = [_merged_stub(tmp_path)]
+    dlg = ExportSettingsDialog(current_idx=0)
+    _select_format(dlg, "linear")
+    dlg._save_settings()
+    assert s.value("export/resize", type=int) == 2000
+    assert s.value("export/colorspace", type=str) == "prophoto"
+    assert s.value("export/format", type=str) == "linear"
+
+
+def test_restored_linear_format_parks_resize_pref(tmp_path,
+                                                  _export_settings_guard):
+    s = QSettings("FreeCCR", "FreeCCR")
+    s.setValue("export/format", "linear")
+    s.setValue("export/resize", 2000)
+    ccr_backend.images = [_merged_stub(tmp_path)]
+    dlg = ExportSettingsDialog(current_idx=0)
+    # Restored into linear: resize locked at Original size…
+    assert dlg._is_linear()
+    assert not dlg.resize_combo.isEnabled()
+    assert dlg.resize_combo.currentData() == 0
+    # …and switching to a normal format brings the saved preference back.
+    _select_format(dlg, "tiff")
+    assert dlg.resize_combo.isEnabled()
+    assert dlg.resize_combo.currentData() == 2000

--- a/tests/test_linear_merge_export.py
+++ b/tests/test_linear_merge_export.py
@@ -46,7 +46,7 @@ def _clean_backend():
 def fake_merge(monkeypatch):
     calls = []
 
-    def _fake(sources, preview=False):
+    def _fake(sources, preview=False, demosaic=False):
         calls.append((tuple(sources), preview))
         return MERGED.copy(), MERGED.shape[:2]
 

--- a/tests/test_linear_merge_export.py
+++ b/tests/test_linear_merge_export.py
@@ -141,6 +141,56 @@ def test_normal_export_unaffected_by_default_flag(tmp_path, fake_merge,
     assert routed == ["bw"]
 
 
+# --- framing: crop + slice chain (round 3) -----------------------------------
+
+def test_linear_export_applies_axis_aligned_crop_bit_exact(tmp_path, fake_merge):
+    from core.ccr_processor import apply_crop_to_image
+    stub = _merged_stub(tmp_path)
+    stub.crop_rect = (0.25, 0.25, 0.75, 0.75)
+    stub.crop_angle = 0.0
+    ccr_backend.images = [stub]
+    out = str(tmp_path / "crop.tiff")
+    assert ccr_backend.export_image_by_index(0, out, linear_merge=True)
+    written = tifffile.imread(out)
+    expected = apply_crop_to_image(MERGED, stub.crop_rect, 0.0)
+    assert written.dtype == np.uint16
+    assert written.shape[0] < MERGED.shape[0] and written.shape[1] < MERGED.shape[1]
+    assert np.array_equal(written, expected)  # pure sub-array, values untouched
+
+
+def test_linear_export_applies_angled_crop(tmp_path, fake_merge):
+    stub = _merged_stub(tmp_path)
+    stub.crop_rect = (0.25, 0.25, 0.75, 0.75)
+    stub.crop_angle = 10.0
+    ccr_backend.images = [stub]
+    out = str(tmp_path / "angled.tiff")
+    assert ccr_backend.export_image_by_index(0, out, linear_merge=True)
+    written = tifffile.imread(out)
+    # The rotated crop outputs the box's own dimensions (interpolated values).
+    assert written.shape == (MERGED.shape[0] // 2, MERGED.shape[1] // 2, 3)
+    assert written.dtype == np.uint16
+
+
+def test_linear_export_applies_slice_chain_and_crop(tmp_path, fake_merge):
+    """A sliced merged image exports its framed region (slice chain, then the
+    crop defined in the sliced frame's space) — values stay bit-exact for
+    unrotated framing."""
+    from types import MethodType
+    from core.ccr_image import CCRImage
+
+    stub = _merged_stub(tmp_path)
+    stub.source_ops = [(0, (0.5, 0.0, 1.0, 0.5))]  # right-top quadrant
+    stub._apply_source_ops = MethodType(CCRImage._apply_source_ops, stub)
+    stub.crop_rect = (0.0, 0.0, 0.5, 1.0)          # left half OF THE SLICE
+    stub.crop_angle = 0.0
+    ccr_backend.images = [stub]
+    out = str(tmp_path / "slice.tiff")
+    assert ccr_backend.export_image_by_index(0, out, linear_merge=True)
+    written = tifffile.imread(out)
+    h, w = MERGED.shape[:2]
+    assert np.array_equal(written, MERGED[0:h // 2, w // 2:w // 2 + w // 4])
+
+
 # --- dialog ------------------------------------------------------------------
 
 @pytest.fixture

--- a/tests/test_trichrome_demosaic.py
+++ b/tests/test_trichrome_demosaic.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Trichrome merge detail: demosaic vs single photosite
+(spec/trichrome-demosaic-mode.md).
+
+Demosaic (the new default) decodes each frame through a LINEAR (bilinear,
+per-channel — no inter-channel mixing) demosaic at full sensor resolution;
+single photosite is the original raw-mosaic phase slice at half resolution.
+The choice is captured per image at import and reproduced by every re-read.
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core import ccr_merge  # noqa: E402
+from core.ccr_backend import ccr_backend  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+
+ARW = os.path.join(os.path.dirname(__file__), "..", "example_raw", "DSC07096.ARW")
+
+
+@pytest.fixture(autouse=True)
+def _clean_backend():
+    saved_demosaic = ccr_backend.rgb_merge_demosaic
+    saved_mode = ccr_backend.rgb_merge_mode
+    yield
+    ccr_backend.images = []
+    ccr_backend.file_paths = []
+    ccr_backend.rgb_merge_demosaic = saved_demosaic
+    ccr_backend.rgb_merge_mode = saved_mode
+
+
+@pytest.fixture
+def capture_merge(monkeypatch):
+    calls = []
+
+    def _fake(sources, preview=False, demosaic=False):
+        calls.append({"sources": tuple(sources), "preview": preview,
+                      "demosaic": demosaic})
+        return np.full((40, 60, 3), 1000, dtype=np.uint16), (40, 60)
+
+    monkeypatch.setattr(ccr_merge, "merge_raw_channels", _fake)
+    return calls
+
+
+def _png(tmp_path, name="r.png"):
+    """A tiny real image file; a non-image extension (e.g. .arw for loader
+    tests) is written as PNG bytes then renamed — the merge decode is
+    monkeypatched, only the file's existence and name matter."""
+    path = str(tmp_path / name)
+    tmp = str(tmp_path / "_w.png")
+    cv2.imwrite(tmp, np.full((32, 48, 3), 90, dtype=np.uint8))
+    os.replace(tmp, path)
+    return path
+
+
+# --- real-RAW integration (decodes the example ARW; skipped if absent) -------
+
+@pytest.mark.skipif(not os.path.exists(ARW), reason="example ARW not present")
+def test_demosaic_is_full_resolution_photosite_is_half():
+    m_ph, full_ph = ccr_merge.merge_raw_channels([ARW] * 3, demosaic=False)
+    m_dm, full_dm = ccr_merge.merge_raw_channels([ARW] * 3, demosaic=True)
+    assert m_dm.dtype == np.uint16 and m_dm.ndim == 3 and m_dm.shape[2] == 3
+    assert m_dm.mean() > 0
+    assert full_ph == m_ph.shape[:2]
+    assert full_dm == m_dm.shape[:2]
+    # Demosaic is the full sensor; photosite is the 2x2-binned half.
+    assert abs(m_dm.shape[0] - 2 * m_ph.shape[0]) <= 4
+    assert abs(m_dm.shape[1] - 2 * m_ph.shape[1]) <= 4
+
+
+@pytest.mark.skipif(not os.path.exists(ARW), reason="example ARW not present")
+def test_demosaic_preview_decodes_half_but_reports_full():
+    m_full, full_full = ccr_merge.merge_raw_channels([ARW] * 3, demosaic=True)
+    m_prev, full_prev = ccr_merge.merge_raw_channels([ARW] * 3, preview=True,
+                                                     demosaic=True)
+    assert full_prev == full_full                      # canonical size stable
+    assert abs(2 * m_prev.shape[0] - m_full.shape[0]) <= 4
+    assert abs(2 * m_prev.shape[1] - m_full.shape[1]) <= 4
+
+
+# --- per-image capture and threading -----------------------------------------
+
+def test_ccrimage_captures_and_forwards_the_flag(tmp_path, capture_merge):
+    p = _png(tmp_path)
+    img = CCRImage(p, is_merged=True, merge_sources=[p, p, p],
+                   merge_demosaic=False)
+    assert img.merge_demosaic is False
+    assert capture_merge[-1]["demosaic"] is False
+
+    img2 = CCRImage(p, is_merged=True, merge_sources=[p, p, p])
+    assert img2.merge_demosaic is True                 # default: demosaic
+    assert capture_merge[-1]["demosaic"] is True
+
+
+def test_linear_export_reproduces_the_captured_decode(tmp_path, capture_merge):
+    stub = SimpleNamespace(is_merged=True, merge_sources=["r", "g", "b"],
+                           merge_demosaic=False)
+    ccr_backend.images = [stub]
+    assert ccr_backend.export_image_by_index(
+        0, str(tmp_path / "lin.tiff"), linear_merge=True)
+    assert capture_merge[-1] == {"sources": ("r", "g", "b"),
+                                 "preview": False, "demosaic": False}
+
+
+def test_duplicate_inherits_the_flag(tmp_path, capture_merge):
+    p = _png(tmp_path)
+    img = CCRImage(p, is_merged=True, merge_sources=[p, p, p],
+                   merge_demosaic=False)
+    ccr_backend.images = [img]
+    ccr_backend.file_paths = [p]
+    assert ccr_backend.duplicate_images_by_indices([0]) == 1
+    dup = ccr_backend.images[1]           # copy is inserted after its source
+    assert dup.is_duplicate
+    assert dup.is_merged and dup.merge_demosaic is False
+
+
+def test_loader_stamps_the_backend_flag(tmp_path, capture_merge):
+    paths = [_png(tmp_path, f"tri_{c}.arw") for c in "abc"]  # RAW-named
+    ccr_backend.rgb_merge_mode = True
+    ccr_backend.rgb_merge_demosaic = False
+    try:
+        count = ccr_backend.load_images_from_files(paths)
+    finally:
+        ccr_backend.rgb_merge_mode = False
+    assert count == 1
+    assert ccr_backend.images[0].merge_demosaic is False
+    assert capture_merge[-1]["demosaic"] is False


### PR DESCRIPTION
Trichrome-only export of the raw channel combination as a linear TIFF, per request: no conversion needed to export, nothing applied beyond putting the 3 channels together.

Spec: `spec/trichrome-linear-tiff-export.md` (authored + refined per the project workflow; round-2 resolutions folded inline).

## What it does

A new format entry in the existing Export dialog — **"TIFF 16-bit linear merge (unprocessed)"** — that appears **only when merged (trichrome) images are loaded**. It writes exactly what `merge_raw_channels` produced: each frame's own channel (crosstalk-free), per-site black-subtracted, white-level-scaled, stacked — as an **untagged 16-bit linear TIFF** at full merged resolution (deflate compression, lossless).

**Framing applies, values don't change** (round 3, on request): the user's crop (`crop_rect` + `crop_angle`) and — for sliced images — the slice chain are honoured, since crop coordinates live in the sliced frame's space. An axis-aligned crop is a bit-exact sub-array; an angled crop necessarily interpolates (values stay linear).

Deliberately absent, per "no extra operation":
- no negative conversion — **conversion is not required to export** (scope = all merged images, converted or not)
- no slider adjustments, no auto gain / exposure base
- no flips, 90° rotation, or fine rotation
- no colour-space re-encode, no ICC embedded (the data is camera-native linear; tagging it sRGB would be a lie — a muted hint in the dialog explains this)
- no resize (locked at Original size while this format is selected, without clobbering the persisted resize preference for the normal formats)

## How it's wired

- `ExportPlan.linear_merge` → `ExportItemsWorker` → `export_items(linear_merge=)` → `export_image_by_index(linear_merge=True)` routes to a small self-contained writer (`CCRBackend._export_merged_linear`) **ahead of** all conversion routing. A non-merged image on this path is a recorded failure, not a crash.
- Scope radios re-label and re-count for the merged set on format switch ("All merged images (N)"), falling back to All if the checked radio empties; switching back restores the normal converted-set semantics.
- Everything else is the existing export shell reused untouched: naming macros, conflict policy, parallel worker, progress + cancel, open-folder-when-done.
- The writer applies `source_ops` (slice framing) then `apply_crop_to_image`; both are no-ops when unset, so an uncropped, unsliced export is byte-identical to the merge output.

## Tests

`tests/test_linear_merge_export.py` (12 tests, `merge_raw_channels` monkeypatched — the repo has no real trichrome triplet):
- axis-aligned crop is bit-exact vs the merge output; angled crop yields the box's dimensions; slice chain + crop compose correctly
- written TIFF is byte-exact vs the merge output, uint16, no ICC tag, `.tiff` suffix normalised, full-res re-merge (not preview)
- a **converted** merged image still routes to the linear writer with every conversion pipeline and `apply_adjustments` monkeypatched to raise — proves the bypass
- non-merged image → False + recorded failure through `export_items`; default flag leaves normal exports routing to conversion
- dialog: entry absent without merged images; scope math for mixed batches; plan resolution (`linear_merge=True`, `max_long_side=None`); QSettings hygiene (resize/colorspace prefs not clobbered; restored-into-linear parks the resize pref and returns it on format switch)

Also green: `test_export`, `test_three_way_merge`, `test_export_naming`, `test_settings_dialog` (118 tests). Visual check: offscreen themed capture of the dialog in linear mode confirms the layout (merged scope counts, hidden colour-space row with hint, locked resize, `.tiff` example name).

Manual verification (needs a real triplet, none in CI): export a merged frame and confirm the TIFF opens as linear untagged data at full merged resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012C4T6y6ciHgWs8vmQPKS2B
