### PR TITLE
feat: saved film-stock slopes for black-point-only conversion

### DIFF
--- a/spec/film-stock-slopes.md
+++ b/spec/film-stock-slopes.md
@@ -1,0 +1,291 @@
+# Spec: Saved Film-Stock Slopes for Black-Point-Only Conversion
+
+Status: IMPLEMENTED (v2)
+Owner: FreeCCR
+Feature branch: `feature/film-stock-slopes`
+Builds on: `spec/optional-white-point-default-slope.md` (the default-slope mode)
+
+## 1. Summary
+
+Let the user **save the slope implied by a sampled B/W-point pair as a named
+"film stock" preset**, and later select that preset to drive the
+**black-point-only** conversion instead of the baked scalar
+`DEFAULT_DENSITY_SLOPE`.
+
+Rationale: the density slope `S_den[c] = 1 / log10(base[c] / dense[c])` is a
+property of the **film stock** (per-dye-layer characteristic-curve gamma),
+while the black point is a property of the **light source / session**. The
+default-slope spec already measured that per-channel *density* ratios barely
+move across light sources (B/G 1.16→1.20) where linear ones swing wildly
+(2.55→1.22). So: sample a B/W pair once on a representative frame of a stock,
+save its per-channel density slopes under a name ("Portra 400"), and on every
+future roll of that stock only re-sample the black point — the saved slopes
+supply the stock's contrast *and* per-channel colour character.
+
+Behaviours:
+1. **Slope combo = "Default"** (initial state) → black-point-only conversion is
+   byte-identical to today (scalar `DEFAULT_DENSITY_SLOPE`).
+2. **Slope combo = saved stock** → black-point-only conversion uses the stock's
+   per-channel density slopes.
+3. **White point sampled** → two-point conversion, exactly as today; the combo
+   is inert (disabled) because the sampled pair overrides any preset.
+4. **Save**: with both points sampled, a Save button computes the slopes from
+   the current pair and stores them under a user-entered name.
+5. **Delete**: a saved stock can be deleted; selection falls back to Default.
+
+## 2. Goals / Non-goals
+
+### Goals
+- Save/select/delete named per-channel density-slope presets ("film stocks").
+- Presets drive `_default_slope_invert` per channel; Default keeps the scalar.
+- **Byte-identical** output when Default is selected (regression-safe), and in
+  two-point mode always.
+- The slopes used at convert time are **snapshotted into `conversion_inputs`**
+  so zoom/hi-res replay, export, slice children, catalog restore, re-grade and
+  the density-toggle reprocess all reproduce the conversion even if the preset
+  is later renamed/deleted.
+- Presets persist across sessions (QSettings); the selected stock persists too.
+- Tethered captures convert with the selected stock (black-point-only mode).
+
+### Non-goals
+- No editing of a preset's numbers in the UI (re-sample + re-save to update).
+- No change to two-point conversion (linear or density) — a sampled white point
+  always wins over a preset.
+- No preset import/export files, no bundled factory stock library.
+- No per-image preset assignment — like the B/W points themselves, the selected
+  stock is global convert-time state; per-image state is the snapshot.
+- The auto-exposure (`exposure_base`) behaviour of black-point-only mode is
+  unchanged (still computed from the converted preview).
+
+## 3. Background / decisions made
+
+- **Why per-channel is OK here when the default is a scalar.** The v4 default
+  rejected per-channel slopes because a *universal* baked slope must not encode
+  any one stock/light's colour. A preset is the opposite: the user explicitly
+  wants *that stock's* colour character. Cross-light robustness is retained
+  because slopes multiply `log10(base/img)`, which cancels per-channel light
+  scaling; only the (cheap, per-session) black-point re-sample varies.
+- **What is stored: slopes, not points.** The preset stores the derived
+  `slopes_bgr` triple. Storing the raw B/W pair instead would tie the preset to
+  the session's absolute scan values; the slopes are the invariant. The source
+  pair is kept alongside as provenance metadata only (not used in math).
+- **Density slopes only.** Black-point-only mode is always density-space (the
+  `density_bwpoint` toggle applies to two-point mode only, as today). Linear
+  slopes are light-source-specific and were already rejected in v4.
+- **Snapshot by value.** `conversion_inputs` carries the slope triple itself,
+  never the preset name. Deleting a preset can therefore never break replay of
+  already-converted images. (Same principle as the existing `bw` anchors.)
+- **Precedence.** Sampled white point > selected stock > default scalar. The UI
+  makes this visible: with a white point set the combo is disabled and the mode
+  label says "white point (two-point)".
+
+## 4. UX / Interaction
+
+### 4.1 Placement — Film B/W Point section (sliders panel)
+
+A new row directly under the Set-point buttons, above the mode label:
+
+```
+Film B/W Point
+[Set Black Point] [Set White Point] [✕]
+Film Stock  [ Default slope      ▾ ] [＋] [🗑]
+Slope source: film stock "Portra 400" (black point only)
+[Convert Current] [Convert All]
+```
+
+- **Combo** (`film_stock_combo`): first entry **"Default slope"**, then saved
+  stocks sorted case-insensitively by name. Laid out like the Color Profile
+  row (label column + combo) so it aligns with the section.
+- **Save button** (`＋`, glyph width, tooltip "Save the current B/W-point pair
+  as a named film stock"): enabled **only when both points are sampled**
+  (that's the only time slopes can be computed). Clicking prompts for a name
+  (`QInputDialog.getText`); empty/whitespace names rejected; an existing name
+  asks to overwrite. On success the new stock is **selected** in the combo, so
+  clearing the white point (✕) immediately activates it — the natural
+  "calibrate a stock from the lead frame, then run the roll" flow.
+- **Delete button** (`🗑`, danger-styled glyph like the ✕): enabled only when a
+  saved stock is selected. Confirms, deletes, selection falls back to Default.
+  Already-converted images are unaffected (snapshot by value).
+- **Disabled states**: with a white point sampled, combo + delete are disabled
+  (tooltip: "White point set — two-point conversion in use; clear it (✕) to
+  use a film-stock slope"). Save is disabled unless both points are sampled
+  (tooltip says why).
+
+### 4.2 Mode label
+
+`_update_bwp_mode_label` gains a third case:
+- no black point → hidden (unchanged)
+- white point set → "Slope source: white point (two-point)" (unchanged)
+- black only, Default → "Slope source: default slope (black point only)" (unchanged)
+- black only, stock selected → `Slope source: film stock "<name>" (black point only)`
+
+### 4.3 Hints
+
+The "Black Point sampled!" hint mentions the stock when one is selected
+("…click <b>Convert</b> to use film stock \"Portra 400\"…"). The save action
+confirms with a hint ("Film stock \"Portra 400\" saved.").
+
+### 4.4 Startup
+
+Presets and the selected name are restored from QSettings when the panel is
+built. A selected name that no longer exists (settings edited/corrupt) falls
+back to Default silently.
+
+## 5. Data model
+
+### 5.1 Preset store — `src/core/film_stocks.py` (new)
+
+Pure, Qt-free helpers (unit-testable) plus thin QSettings I/O in the panel:
+
+```python
+FilmStock = {           # plain dict, JSON-safe
+  "name":       str,    # unique, case-insensitive, stripped
+  "slopes_bgr": [b, g, r],   # per-channel density slopes (floats > 0)
+  "black_bgr":  [b, g, r] | None,   # provenance only
+  "white_bgr":  [b, g, r] | None,   # provenance only
+  "created":    str,    # ISO date, informational
+}
+```
+
+- `encode_film_stocks(stocks) -> str` / `decode_film_stocks(s) -> list` —
+  JSON round-trip, defensively validating every record (bad/partial records
+  dropped, slopes coerced to float, non-positive slopes rejected).
+- `upsert_film_stock(stocks, stock) -> list` — replace by case-insensitive
+  name or append; returns a new sorted list.
+- `remove_film_stock(stocks, name) -> list`.
+- `find_film_stock(stocks, name) -> dict | None` (case-insensitive).
+
+QSettings keys (`FreeCCR/FreeCCR`, next to the existing `convert/*` keys):
+- `convert/film_stocks` — the JSON string.
+- `convert/film_stock_selected` — selected stock name; absent/"" = Default.
+
+### 5.2 Backend global state — `CCRBackend`
+
+- `self.film_stock_slopes: tuple[float,float,float] | None = None` — the
+  ACTIVE slopes for black-point-only conversion (None = default scalar).
+- `self.film_stock_name: str | None = None` — for the mode label / hints only.
+- `set_film_stock(name, slopes_bgr)` / `clear_film_stock()`.
+
+Like `black_point_bgr`, this is global convert-time state owned by the panel.
+
+### 5.3 Conversion snapshot — `conversion_inputs`
+
+`mode: "bw"` records gain an optional key:
+- `"slopes": (b, g, r) | None` — the per-channel slopes actually used.
+  Present-and-None (or absent — legacy catalogs) means the default scalar.
+  Only meaningful when `bw[1]` (white) is None; writers set it to None in
+  two-point mode.
+
+Catalog `_ci_to_json`/`_ci_from_json` convert the triple list↔tuple like the
+other tuple keys. Legacy records without `"slopes"` replay as today.
+
+## 6. Processing / math
+
+### 6.1 Slope computation — `compute_density_slopes` (ccr_processor.py, new)
+
+```
+compute_density_slopes(black_point_bgr, white_point_bgr) -> (b, g, r) | None
+per channel c:
+  base  = black[c]; dense = white[c]
+  invalid if base <= 0 or dense <= 0 or base <= dense
+  D[c]  = log10(base / dense);  invalid if D[c] <= 1e-6
+  S[c]  = 1 / D[c]
+returns None if ANY channel is invalid (an unusable pair is rejected whole)
+```
+
+This is `log_bwpoint_slopes`' DENSITY vector, promoted from a diagnostic
+print to a return value (the diagnostic stays as-is).
+
+### 6.2 Inversion — `_default_slope_invert(img_f, black, slopes_bgr=None)`
+
+Per channel `c`: `slope_c = slopes_bgr[c]` if provided else
+`DEFAULT_DENSITY_SLOPE` (identical code path, the scalar becomes a per-channel
+value). Everything else — density floor, clamp-at-0, working-space windowed
+encode / legacy clip, `DEFAULT_DENSITY_GAMMA` — is unchanged. With
+`slopes_bgr=None` the function is byte-identical to today.
+
+Endpoint check: a pixel at the stock's calibration dense value has
+`d[c] = D[c]` per channel, so `out = S[c]·D[c] = 1.0` → white, exactly like
+the two-point density mode at its dense sample. Light-source invariance is
+per-channel unchanged: `log10(k·base / k·img) = log10(base/img)`.
+
+### 6.3 Threading it through (signature additions, all defaulting to None)
+
+- `ccr_normalize_with_bwpoint(..., slopes_bgr=None)` — forwarded to
+  `_default_slope_invert` when `white_point_bgr is None`; ignored otherwise.
+- `apply_bwpoint_normalization(img, black, white=None, density=False,
+  slopes_bgr=None)` — same routing (zoom / slice / restore replay).
+
+## 7. Integration points
+
+Writers (record `"slopes"` at convert time; all pass
+`slopes = ccr_backend.film_stock_slopes if white is None else None`):
+- `sliders_panel._on_convert_current_bwpoint`
+- `ccr_backend.apply_bwpoint_to_all_images` (Convert All)
+- `tether_watcher.CaptureWorker` — snapshot slopes with black/white in
+  `process()` (same mid-decode-flip protection), used in `_convert`.
+
+Replayers (read `ci.get("slopes")` and forward):
+- `ccr_backend._reconvert_in_place` (camera-profile re-grade)
+- `ccr_backend.export_image_by_index` — snapshot branch AND the legacy
+  un-snapshotted branch (which uses the live `self.film_stock_slopes`)
+- `ccr_backend` slice: children replay with the parent's slopes and inherit
+  `"slopes"` in `child_ci`; un-slice parent restore likewise
+- `ccr_backend.reprocess_all_for_density_bwpoint_change` — `dict(ci)` copy
+  already carries `"slopes"`; the black-only replay must forward it
+- `ccr_image` hi-res zoom replay
+- `catalog._replay_conversion` (session restore)
+
+UI / persistence:
+- `sliders_panel.py` — combo row + save/delete buttons, enable/disable logic,
+  mode label, hints, QSettings load/store, backend sync.
+- `main_window.py` — nothing new at startup beyond what the panel does itself
+  (the panel owns the combo; `_restore_bwpoint` stays as-is).
+- `settings_dialog.py` — untouched (this is working state, not a preference).
+
+## 8. Test plan (`tests/test_film_stocks.py`)
+
+Math (`compute_density_slopes`):
+- Known pair → expected per-channel `1/log10(base/dense)` values.
+- Degenerate pairs (base<=dense, zero/negative channel, D≈0) → None.
+
+Inversion (`_default_slope_invert` / `apply_bwpoint_normalization`):
+- `slopes_bgr=None` → byte-identical to current output (regression, both
+  working-space and legacy paths).
+- With slopes from a pair: the pair's dense value maps to white per channel;
+  base maps to black; monotone; per-channel light-scaling invariance
+  (`k·base, k·img` → identical output) still holds.
+- Consistency: preview path (`ccr_normalize_with_bwpoint`) equals replay path
+  (`apply_bwpoint_normalization`) with the same slopes.
+
+Store (`film_stocks.py`):
+- encode/decode round-trip incl. unicode names; corrupt/partial JSON → [].
+- upsert new / overwrite same name (case-insensitive) / sort order; remove;
+  find case-insensitive.
+
+Snapshot / replay:
+- `conversion_inputs` with `"slopes"` survives `_ci_to_json`/`_ci_from_json`
+  (tuple restored); legacy record without the key replays with default scalar.
+- Slice child `child_ci` inherits `"slopes"`.
+- Tether `_convert` records the snapshot slopes.
+
+UI (smoke, offscreen like existing panel tests where present):
+- Save disabled without both points; combo/delete disabled with a white point;
+  delete of the selected stock falls back to Default; mode-label text cases.
+
+Test files are run in small groups (full-suite run hangs — pre-existing).
+
+## 9. Open questions — resolution
+
+1. **Scalar vs per-channel preset** — RESOLVED: per-channel. The preset is
+   opt-in, per-stock colour character is the point, density space keeps the
+   cross-light robustness.
+2. **Disable vs hide the combo in two-point mode** — RESOLVED: disable (with
+   tooltip). Hiding would shift the layout and obscure the save workflow,
+   which happens exactly while both points are set.
+3. **Store points or slopes** — RESOLVED: slopes (invariant), points kept as
+   provenance only.
+4. **Where presets live** — RESOLVED: QSettings JSON next to the persisted
+   B/W points; the catalog stays per-session image state.
+5. **Auto-select after save** — RESOLVED: yes; clearing the white point then
+   activates the stock immediately.

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -80,7 +80,7 @@ def _ci_to_json(ci):
     if out.get("bw") is not None:
         black, white = out["bw"]
         out["bw"] = [list(black), (list(white) if white is not None else None)]
-    for key in ("p_lo", "p_hi", "od"):
+    for key in ("p_lo", "p_hi", "od", "slopes"):
         if out.get(key) is not None:
             out[key] = list(out[key])
     return out
@@ -95,7 +95,7 @@ def _ci_from_json(ci):
     if out.get("bw") is not None:
         black, white = out["bw"]
         out["bw"] = (tuple(black), (tuple(white) if white is not None else None))
-    for key in ("p_lo", "p_hi", "od"):
+    for key in ("p_lo", "p_hi", "od", "slopes"):
         if out.get(key) is not None:
             out[key] = tuple(out[key])
     return out
@@ -441,7 +441,8 @@ def _replay_conversion(img, ci) -> None:
         try:
             black_point, white_point = ci["bw"]
             processed = ccr_normalize_with_bwpoint(img, black_point, white_point,
-                                                   density=ci.get("density", False))
+                                                   density=ci.get("density", False),
+                                                   slopes_bgr=ci.get("slopes"))
         finally:
             img.fine_rotation_angle = saved_fine
         img.resized_raw = processed

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -72,6 +72,15 @@ class CCRBackend:
         self.gamma_luminance: bool = False
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area
+        # Selected film-stock preset for the black-point-only conversion:
+        # per-channel density slopes (B, G, R), or None → the baked scalar
+        # DEFAULT_DENSITY_SLOPE. A sampled white point always overrides it.
+        # Owned by the sliders panel (combo) and persisted there in QSettings;
+        # the name is kept for the mode label / hints only. Unlike the B/W
+        # points this survives a new batch — the preset is per stock, not per
+        # roll. See spec/film-stock-slopes.md.
+        self.film_stock_slopes = None
+        self.film_stock_name = None
         # Global input ICC profile (one app-wide setting; applied to every
         # decode before conversion/adjustments). The parsed profile lives in
         # color_management's module-level holder; these mirror it for the UI.
@@ -743,7 +752,8 @@ class CCRBackend:
                 black_point, white_point = ci["bw"]
                 processed = ccr_normalize_with_bwpoint(
                     image_obj, black_point, white_point,
-                    density=ci.get("density", False))
+                    density=ci.get("density", False),
+                    slopes_bgr=ci.get("slopes"))
             elif ci is not None and ci.get("mode") == "ref_params":
                 processed = ccr_normalize_with_refparams(
                     image_obj, ci["p_lo"], ci["p_hi"], ci["od"])
@@ -1267,16 +1277,21 @@ class CCRBackend:
                                                jpg_out=jpg_output, jpg_quality=jpg_quality,
                                                max_long_side=max_long_side,
                                                output_colorspace=output_colorspace,
-                                               density=ci.get("density", False))
+                                               density=ci.get("density", False),
+                                               slopes_bgr=ci.get("slopes"))
                 elif image_obj.reference_frame is None and self.black_point_bgr is not None:
                     # Legacy/un-snapshotted B/W point conversion — global anchors.
-                    # white_point_bgr may be None → default-slope mode.
+                    # white_point_bgr may be None → default-slope mode (with the
+                    # live film-stock slopes, if a preset is selected).
                     ccr_normalize_with_bwpoint(image_obj, self.black_point_bgr, self.white_point_bgr,
                                                output_path=output_path,
                                                jpg_out=jpg_output, jpg_quality=jpg_quality,
                                                max_long_side=max_long_side,
                                                output_colorspace=output_colorspace,
-                                               density=self.density_bwpoint)
+                                               density=self.density_bwpoint,
+                                               slopes_bgr=(self.film_stock_slopes
+                                                           if self.white_point_bgr is None
+                                                           else None))
                 else:
                     ccr_normalize_with_reference(image_obj, output_path=output_path,
                                                  jpg_out=jpg_output,
@@ -1642,10 +1657,12 @@ class CCRBackend:
                     from core.ccr_processor import apply_bwpoint_normalization
                     black_point, white_point = parent_ci["bw"]
                     bw_density = parent_ci.get("density", False)
+                    bw_slopes = parent_ci.get("slopes")
                     crop = apply_bwpoint_normalization(crop, black_point, white_point,
-                                                       density=bw_density)
+                                                       density=bw_density,
+                                                       slopes_bgr=bw_slopes)
                     child_ci = {"mode": "bw", "bw": parent_ci["bw"], "fine_rot": 0,
-                                "density": bw_density}
+                                "density": bw_density, "slopes": bw_slopes}
 
                 index = len(children) + 1
                 child = CCRImage(
@@ -1786,6 +1803,7 @@ class CCRBackend:
         norm_params = None
         bw_points = None
         bw_density = False
+        bw_slopes = None
         if ci is not None and ci.get("mode") == "ref":
             child_full = template.read_image(template.file_path, preview=True)
             if child_full is not None:
@@ -1800,6 +1818,7 @@ class CCRBackend:
         elif ci is not None and ci.get("mode") == "bw":
             bw_points = ci["bw"]
             bw_density = ci.get("density", False)
+            bw_slopes = ci.get("slopes")
 
         # Re-decode the source canvas. The constructor raises if the file is
         # gone/unreadable; fail the reset gracefully and leave the list
@@ -1835,11 +1854,13 @@ class CCRBackend:
                 "p_hi": norm_params[1], "od": norm_params[2]}
         elif bw_points is not None:
             parent.resized_raw = apply_bwpoint_normalization(
-                parent.resized_raw, *bw_points, density=bw_density)
+                parent.resized_raw, *bw_points, density=bw_density,
+                slopes_bgr=bw_slopes)
             parent.converted = True
             parent._ws_windowed = _ws_enabled()   # bw base is windowed when enabled
             parent.conversion_inputs = {"mode": "bw", "bw": bw_points,
-                                        "fine_rot": 0, "density": bw_density}
+                                        "fine_rot": 0, "density": bw_density,
+                                        "slopes": bw_slopes}
         parent.tint_balance_factor = template.tint_balance_factor
         parent.contrast_base = template.contrast_base
         parent.temperature_base = template.temperature_base
@@ -1888,6 +1909,18 @@ class CCRBackend:
     def set_black_point(self, bgr_tuple):
         self.black_point_bgr = bgr_tuple
 
+    def set_film_stock(self, name, slopes_bgr):
+        """Select a saved film-stock preset: its per-channel density slopes
+        drive the black-point-only conversion instead of the baked scalar
+        DEFAULT_DENSITY_SLOPE. See spec/film-stock-slopes.md."""
+        self.film_stock_name = name
+        self.film_stock_slopes = tuple(float(s) for s in slopes_bgr)
+
+    def clear_film_stock(self):
+        """Back to the baked default scalar slope for black-point-only mode."""
+        self.film_stock_name = None
+        self.film_stock_slopes = None
+
     def apply_bwpoint_to_all_images(self, progress_callback=None):
         """
         Apply B/W point film negative conversion to all loaded images using the same
@@ -1901,6 +1934,10 @@ class CCRBackend:
         # only a black point, conversion uses the baked default slope.
         if self.white_point_bgr is not None:
             log_bwpoint_slopes(self.black_point_bgr, self.white_point_bgr)
+        # Film-stock slopes apply only in black-point-only mode — a sampled
+        # white point wins. Snapshot once so every image in the batch converts
+        # (and records) the same recipe.
+        slopes = self.film_stock_slopes if self.white_point_bgr is None else None
         total = len(self.images)
         if progress_callback:
             progress_callback(0, total)
@@ -1911,7 +1948,7 @@ class CCRBackend:
                     img.reload_image()
                 processed = ccr_normalize_with_bwpoint(
                     img, self.black_point_bgr, self.white_point_bgr,
-                    density=self.density_bwpoint
+                    density=self.density_bwpoint, slopes_bgr=slopes
                 )
                 if processed is not None:
                     img.resized_raw = processed
@@ -1922,6 +1959,7 @@ class CCRBackend:
                            tuple(self.white_point_bgr) if self.white_point_bgr is not None else None),
                     "fine_rot": img.fine_rotation_angle,
                     "density": bool(self.density_bwpoint),
+                    "slopes": slopes,
                 }
                 img.update_thumbnail_and_preview()
             except Exception as e:

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -1068,7 +1068,8 @@ class CCRImage:
             # snapshot only.
             black_point, white_point = ci["bw"]
             out = apply_bwpoint_normalization(img, black_point, white_point,
-                                              density=ci.get("density", False))
+                                              density=ci.get("density", False),
+                                              slopes_bgr=ci.get("slopes"))
         else:
             return None
         print(f"Hi-res convert: {time.time() - t0:.2f}s")

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -1070,24 +1070,31 @@ def _apply_working_space_recovery(img16: np.ndarray, exposure: float,
     return d.astype(np.uint16)
 
 
-def _default_slope_invert(img_f: np.ndarray, black_point_bgr) -> np.ndarray:
-    """Density-space inversion for the black-point-only mode, using the baked
-    scalar DEFAULT_DENSITY_SLOPE. `img_f` is a float32 (H,W,3) BGR array.
+def _default_slope_invert(img_f: np.ndarray, black_point_bgr,
+                          slopes_bgr=None) -> np.ndarray:
+    """Density-space inversion for the black-point-only mode. `img_f` is a
+    float32 (H,W,3) BGR array.
 
-    Per channel: out = clip(DEFAULT_DENSITY_SLOPE * max(log10(base/img), 0), 0, 1),
-    then an optional display gamma, scaled to uint16. The per-channel base divide
-    is the ONLY place colour balance enters, and log10(base/img) cancels any
-    per-channel light-source scaling — so re-sampling the black point under a new
-    light keeps colour consistent without a white point."""
+    Per channel: out = clip(slope[c] * max(log10(base/img), 0), 0, 1),
+    then an optional display gamma, scaled to uint16. `slopes_bgr` is a saved
+    film-stock preset's per-channel density slopes (spec/film-stock-slopes.md);
+    None uses the baked scalar DEFAULT_DENSITY_SLOPE for every channel —
+    byte-identical to the pre-preset behaviour. The per-channel base divide
+    carries the light source's colour balance (log10(base/img) cancels any
+    per-channel light scaling, so re-sampling the black point under a new
+    light keeps colour consistent without a white point); a film stock's
+    slopes add that stock's per-channel contrast character on top."""
     out = np.empty_like(img_f)
     for c in range(3):
         base = max(float(black_point_bgr[c]), 1.0)
+        slope = (DEFAULT_DENSITY_SLOPE if slopes_bgr is None
+                 else float(slopes_bgr[c]))
         ch = np.maximum(img_f[..., c], _DENSITY_FLOOR)   # copy; avoids /0 & log(0)
         np.divide(base, ch, out=ch)                      # base / img
         np.log10(ch, out=ch)                             # optical density above base
         np.maximum(ch, 0.0, out=ch)                      # clamp (img brighter than base)
+        ch *= np.float32(slope)                          # slope = contrast (per channel)
         out[..., c] = ch
-    out *= np.float32(DEFAULT_DENSITY_SLOPE)             # single scalar = contrast
     if _ws_enabled():
         # Keep highlight overshoot (density above the 1/SLOPE ceiling) as headroom.
         if DEFAULT_DENSITY_GAMMA != 1.0:
@@ -1271,7 +1278,8 @@ def _twopoint_invert(img_f: np.ndarray, black_point_bgr, white_point_bgr,
 def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
                                output_path=None, jpg_out=False,
                                jpg_quality=95, max_long_side=None,
-                               output_colorspace="srgb", density=False):
+                               output_colorspace="srgb", density=False,
+                               slopes_bgr=None):
     """
     Film negative conversion using the same pipeline as ccr_normalize_with_reference
     but with explicit per-channel B/W points instead of auto-detected percentiles.
@@ -1288,6 +1296,11 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
                      stretch. Density is opt-in; callers pass the live setting.
                      Ignored when white_point_bgr is None (that path is always
                      density). See spec/density-bwpoint-toggle.md.
+    slopes_bgr:      black-point-only mode only — a saved film-stock preset's
+                     per-channel density slopes replacing the scalar
+                     DEFAULT_DENSITY_SLOPE. None = default slope. Ignored when
+                     a white point is given (the sampled pair wins). See
+                     spec/film-stock-slopes.md.
 
     Pipeline: BWPN (user B/W points) → inversion → saturation boost → shadow correction
     ODAI is skipped because per-channel B/W point mapping already normalises channels.
@@ -1317,9 +1330,10 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
     img_f = img.astype(np.float32)
     if white_point_bgr is None:
         # --- Default-slope mode (black point only): density-space inversion ---
-        rgb_inverted = _default_slope_invert(img_f, black_point_bgr)
+        rgb_inverted = _default_slope_invert(img_f, black_point_bgr, slopes_bgr)
         del img_f
-        print(f"BWPN (default slope): {time.time() - total_start_time:.3f}s")
+        print(f"BWPN ({'film-stock slope' if slopes_bgr is not None else 'default slope'}): "
+              f"{time.time() - total_start_time:.3f}s")
     else:
         # --- Two-point mode (ODAI skipped: per-channel B/W points already
         # equalise channels). density=True recovers optical density (log space);
@@ -1796,26 +1810,29 @@ def apply_reference_normalization(img: np.ndarray, p_lo, p_hi, od_factors) -> np
 
 
 def apply_bwpoint_normalization(img: np.ndarray, black_point_bgr, white_point_bgr=None,
-                                density: bool = False) -> np.ndarray:
+                                density: bool = False,
+                                slopes_bgr=None) -> np.ndarray:
     """B/W-point conversion at any resolution: absolute per-channel anchors +
     inversion — mirrors ccr_normalize_with_bwpoint's preview path (the anchors
     are global constants, so no rescaling is needed). Used for the zoom hi-res
     replay and slice/reset, so it MUST match the entry pipeline exactly.
 
     When white_point_bgr is None, the default-slope mode is used: a density-space
-    inversion with the baked scalar DEFAULT_DENSITY_SLOPE is applied to the black
-    point alone (see _default_slope_invert). Otherwise the two-point math runs,
-    in optical-density space when density=True or the legacy linear transmittance
-    stretch when density=False (default; bit-identical to the prior behaviour).
-    Replay callers pass ci.get("density", False) so legacy conversions stay
-    linear. See spec/density-bwpoint-toggle.md.
+    inversion applied to the black point alone (see _default_slope_invert), with
+    `slopes_bgr` (a film-stock preset's per-channel density slopes, snapshotted
+    in conversion_inputs["slopes"]) or the baked scalar DEFAULT_DENSITY_SLOPE
+    when None. Otherwise the two-point math runs, in optical-density space when
+    density=True or the legacy linear transmittance stretch when density=False
+    (default; bit-identical to the prior behaviour). Replay callers pass
+    ci.get("density", False) / ci.get("slopes") so legacy conversions stay
+    as converted. See spec/density-bwpoint-toggle.md, spec/film-stock-slopes.md.
 
     The post-invert "look" stays DISABLED so the hi-res replay matches the
     look-less preview/export path."""
     img_f = img.astype(np.float32)
     if white_point_bgr is None:
         # Default-slope mode (black point only): density-space inversion.
-        return _default_slope_invert(img_f, black_point_bgr)
+        return _default_slope_invert(img_f, black_point_bgr, slopes_bgr)
     return _twopoint_invert(img_f, black_point_bgr, white_point_bgr, density)
 
 
@@ -1860,6 +1877,30 @@ def log_bwpoint_slopes(black_point_bgr, white_point_bgr):
         print(f"  per-channel LINEAR  (B,G,R) = {[round(s, 4) for s in lin]}")
         print(f"  per-channel DENSITY (B,G,R) = {[round(s, 4) for s in den]}")
     print("=== bake the LINEAR vector (current pipeline) OR the DENSITY vector (log) ===")
+
+
+def compute_density_slopes(black_point_bgr, white_point_bgr):
+    """Per-channel DENSITY slopes implied by a sampled B/W-point pair:
+    S[c] = 1 / log10(base[c] / dense[c]) — the value that maps the pair's dense
+    sample to display white in _default_slope_invert. This is what a film-stock
+    preset stores (spec/film-stock-slopes.md): a property of the stock (its
+    per-dye-layer characteristic-curve gamma), invariant to per-channel light
+    scaling — unlike the linear slope (see log_bwpoint_slopes above).
+
+    Returns a (B, G, R) tuple of floats, or None when ANY channel is unusable
+    (non-positive sample, base not above dense, or ~zero density range): a pair
+    that can't characterise all three channels is rejected whole."""
+    slopes = []
+    for c in range(3):
+        base = float(black_point_bgr[c])
+        dense = float(white_point_bgr[c])
+        if base <= 0.0 or dense <= 0.0 or base <= dense:
+            return None
+        d = float(np.log10(base / dense))
+        if d <= 1e-6:
+            return None
+        slopes.append(1.0 / d)
+    return tuple(slopes)
 
 
 def auto_fine_angle(img16: np.ndarray, debug: bool = False) -> float:

--- a/src/core/film_stocks.py
+++ b/src/core/film_stocks.py
@@ -1,0 +1,115 @@
+"""Named film-stock slope presets for the black-point-only conversion.
+
+A "film stock" is a per-channel DENSITY-slope triple saved from a sampled
+B/W-point pair (compute_density_slopes) under a user-chosen name. Selecting a
+stock makes _default_slope_invert use its slopes instead of the baked scalar
+DEFAULT_DENSITY_SLOPE; the black point is still re-sampled per session / light
+source, which is what keeps colour consistent across lights. See
+spec/film-stock-slopes.md.
+
+Pure JSON helpers only (no Qt): the sliders panel persists the encoded string
+in QSettings under convert/film_stocks and the selected name under
+convert/film_stock_selected. Records are validated defensively on decode so a
+hand-edited or corrupt settings value can never crash the panel. Names are
+unique case-insensitively; lists returned by the helpers are always new lists
+sorted case-insensitively by name.
+"""
+import json
+import math
+
+
+def _triple(value, positive=False):
+    """Coerce a 3-sequence of finite numbers to a [float]*3 list, else None.
+    With positive=True, every component must also be > 0 (slopes)."""
+    if isinstance(value, (str, bytes)) or value is None:
+        return None
+    try:
+        vals = [float(x) for x in value]
+    except (TypeError, ValueError):
+        return None
+    if len(vals) != 3 or any(not math.isfinite(x) for x in vals):
+        return None
+    if positive and any(x <= 0.0 for x in vals):
+        return None
+    return vals
+
+
+def _valid_stock(record):
+    """Validate/normalise one stock record into the canonical dict shape;
+    None if unusable (no name, or no valid positive slope triple). The
+    black/white source points are provenance only — optional."""
+    if not isinstance(record, dict):
+        return None
+    name = str(record.get("name") or "").strip()
+    slopes = _triple(record.get("slopes_bgr"), positive=True)
+    if not name or slopes is None:
+        return None
+    return {
+        "name": name,
+        "slopes_bgr": slopes,
+        "black_bgr": _triple(record.get("black_bgr")),
+        "white_bgr": _triple(record.get("white_bgr")),
+        "created": str(record.get("created") or ""),
+    }
+
+
+def _sorted_stocks(stocks):
+    return sorted(stocks, key=lambda s: s["name"].casefold())
+
+
+def decode_film_stocks(text):
+    """JSON string → validated, name-sorted list of stock dicts. Corrupt JSON
+    or a non-list top level → []; bad records are dropped individually and
+    case-insensitive duplicate names keep the first occurrence."""
+    try:
+        data = json.loads(text) if text else []
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(data, list):
+        return []
+    out, seen = [], set()
+    for record in data:
+        stock = _valid_stock(record)
+        if stock is None or stock["name"].casefold() in seen:
+            continue
+        seen.add(stock["name"].casefold())
+        out.append(stock)
+    return _sorted_stocks(out)
+
+
+def encode_film_stocks(stocks):
+    """Inverse of decode_film_stocks (records re-validated on the way out so a
+    bad in-memory record can't poison the persisted store)."""
+    clean = [s for s in map(_valid_stock, stocks or []) if s is not None]
+    return json.dumps(clean)
+
+
+def find_film_stock(stocks, name):
+    """Case-insensitive lookup by name; None when absent."""
+    key = str(name or "").strip().casefold()
+    if not key:
+        return None
+    for stock in stocks or []:
+        if stock["name"].casefold() == key:
+            return stock
+    return None
+
+
+def upsert_film_stock(stocks, stock):
+    """Insert `stock`, replacing any existing record with the same name
+    (case-insensitive). Returns a NEW sorted list; raises ValueError on an
+    invalid record so a caller bug surfaces instead of silently dropping."""
+    stock = _valid_stock(stock)
+    if stock is None:
+        raise ValueError("invalid film stock record")
+    key = stock["name"].casefold()
+    out = [s for s in (stocks or []) if s["name"].casefold() != key]
+    out.append(stock)
+    return _sorted_stocks(out)
+
+
+def remove_film_stock(stocks, name):
+    """Drop the record matching `name` (case-insensitive); returns a NEW list.
+    Unknown names are a no-op — the result is simply the surviving records."""
+    key = str(name or "").strip().casefold()
+    return [s for s in (stocks or []) if s["name"].casefold() != key]

--- a/src/core/tether_watcher.py
+++ b/src/core/tether_watcher.py
@@ -186,19 +186,21 @@ class TetherWatchWorker(QObject):
             black = ccr_backend.black_point_bgr
             white = ccr_backend.white_point_bgr
             positive = ccr_backend.positive_mode
-            # white may be None → default-slope conversion (black point only).
+            # white may be None → default-slope conversion (black point only),
+            # where a selected film-stock preset supplies per-channel slopes.
+            slopes = ccr_backend.film_stock_slopes if white is None else None
             convert = (not positive and black is not None)
             for img in imgs:
                 if self._cancelled:
                     return
                 if convert and not img.converted:
-                    self._convert(img, black, white)
+                    self._convert(img, black, white, slopes)
                 self.captured.emit(img)
         except Exception as e:
             self.captureError.emit(path, str(e))
 
     @staticmethod
-    def _convert(img, black, white):
+    def _convert(img, black, white, slopes=None):
         """Bake the saved B/W-point conversion into the image (preview + the
         conversion_inputs snapshot the export/catalog paths replay). Mirrors
         CCRBackend.apply_bwpoint_to_all_images. On failure the image is left
@@ -207,7 +209,8 @@ class TetherWatchWorker(QObject):
         from core.ccr_backend import ccr_backend
         try:
             density = bool(ccr_backend.density_bwpoint)
-            processed = ccr_normalize_with_bwpoint(img, black, white, density=density)
+            processed = ccr_normalize_with_bwpoint(img, black, white, density=density,
+                                                   slopes_bgr=slopes)
             if processed is not None:
                 img.resized_raw = processed
             img.converted = True
@@ -216,6 +219,7 @@ class TetherWatchWorker(QObject):
                 "bw": (tuple(black), tuple(white) if white is not None else None),
                 "fine_rot": img.fine_rotation_angle,
                 "density": density,
+                "slopes": tuple(slopes) if slopes is not None else None,
             }
             img.update_thumbnail_and_preview()
         except Exception as e:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -215,6 +215,9 @@ class MainWindow(QMainWindow):
         # Restore a persisted global B/W point (set in a prior session) so
         # tethering can auto-convert captures right away. Before any image loads.
         self._restore_bwpoint()
+        # Reflect the restored B/W state (and the panel's restored film-stock
+        # selection) in the slope-source label right away.
+        self.sliders_panel._update_bwp_mode_label()
 
         self.installEventFilter(self)
         self.create_menu()

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -1,16 +1,25 @@
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QSlider, QLabel, QHBoxLayout,
                                 QSizePolicy, QStyleOptionSlider, QFrame, QStyle,
                                 QPushButton, QDialog, QMessageBox, QScrollArea,
-                                QCheckBox, QComboBox)
-from PySide6.QtCore import Qt, QTimer, QThread, Signal, QRectF
+                                QCheckBox, QComboBox, QInputDialog)
+from PySide6.QtCore import Qt, QTimer, QThread, Signal, QRectF, QSettings
 from PySide6.QtGui import (QKeySequence, QShortcut, QPainter, QColor,
                            QLinearGradient, QPen)
 from core.ccr_backend import ccr_backend
-from core.ccr_processor import COLOR_BANDS, BAND_PARAMS, BAND_ADJUSTMENT_KEYS
+from core.ccr_processor import (COLOR_BANDS, BAND_PARAMS, BAND_ADJUSTMENT_KEYS,
+                                compute_density_slopes)
+from core.film_stocks import (decode_film_stocks, encode_film_stocks,
+                              find_film_stock, upsert_film_stock,
+                              remove_film_stock)
 from widgets.curve_editor import CurveEditor
 from widgets.histogram_widget import HistogramWidget
 from ui import theme
 import copy
+from datetime import date
+
+# First combo entry of the film-stock selector: the baked scalar
+# DEFAULT_DENSITY_SLOPE (no preset). See spec/film-stock-slopes.md.
+FILM_STOCK_DEFAULT_LABEL = "Default slope"
 
 # Setting groups offered by the "Sync to All" dialog. The adjustment-key
 # groups partition SlidersPanel.ADJUSTMENT_KEYS exactly; "crop" syncs the
@@ -410,6 +419,45 @@ class SlidersPanel(QWidget):
         bwp_row.addWidget(self.white_point_btn)
         bwp_row.addWidget(self.clear_white_point_btn)
         scroll_layout.addLayout(bwp_row)
+
+        # --- Film-stock slope presets (spec/film-stock-slopes.md) ---
+        # Save the per-channel density slopes implied by a sampled B/W pair
+        # under a stock name; a selected stock replaces the baked scalar
+        # DEFAULT_DENSITY_SLOPE for black-point-only conversions. A sampled
+        # white point always wins, so the selector is disabled then.
+        stock_label = QLabel("Film Stock")
+        stock_label.setFixedWidth(theme.LABEL_COL_W)
+        stock_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        stock_label.setFixedHeight(theme.CONTROL_H)
+        stock_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.film_stock_combo = QComboBox()
+        self.film_stock_combo.setFixedHeight(theme.CONTROL_H)
+        self.save_film_stock_btn = QPushButton("＋")
+        self.save_film_stock_btn.setFixedWidth(theme.GLYPH_W)
+        self.save_film_stock_btn.setFixedHeight(theme.CONTROL_H)
+        self.save_film_stock_btn.setToolTip(
+            "Save the sampled B/W-point pair as a named film stock — its "
+            "slope then converts future rolls from just a black point")
+        self.delete_film_stock_btn = QPushButton("−")
+        self.delete_film_stock_btn.setFixedWidth(theme.GLYPH_W)
+        self.delete_film_stock_btn.setFixedHeight(theme.CONTROL_H)
+        theme.style_button(self.delete_film_stock_btn, "danger", glyph_only=True)
+        self.delete_film_stock_btn.setToolTip("Delete the selected film stock")
+        stock_row = QHBoxLayout()
+        stock_row.setSpacing(theme.GAP_TIGHT)
+        stock_row.addWidget(stock_label, alignment=Qt.AlignVCenter)
+        stock_row.addWidget(self.film_stock_combo, 1)
+        stock_row.addWidget(self.save_film_stock_btn)
+        stock_row.addWidget(self.delete_film_stock_btn)
+        scroll_layout.addLayout(stock_row)
+        # Presets + last selection persist across sessions (same QSettings
+        # store as the persisted B/W points themselves).
+        self._settings = QSettings("FreeCCR", "FreeCCR")
+        self._film_stocks = decode_film_stocks(
+            self._settings.value("convert/film_stocks", "", type=str))
+        self._reload_film_stock_combo(
+            select=self._settings.value("convert/film_stock_selected", "", type=str))
+
         # Shows which slope source the next conversion will use.
         self.bwp_mode_label = QLabel("")
         self.bwp_mode_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
@@ -652,6 +700,9 @@ class SlidersPanel(QWidget):
         self.white_point_btn.clicked.connect(self._on_set_white_point)
         self.clear_white_point_btn.clicked.connect(self._on_clear_white_point)
         self.black_point_btn.clicked.connect(self._on_set_black_point)
+        self.film_stock_combo.currentIndexChanged.connect(self._on_film_stock_changed)
+        self.save_film_stock_btn.clicked.connect(self._on_save_film_stock)
+        self.delete_film_stock_btn.clicked.connect(self._on_delete_film_stock)
         self.convert_current_bwp_btn.clicked.connect(self._on_convert_current_bwpoint)
         self.convert_all_bwp_btn.clicked.connect(self._on_convert_all_bwpoint)
 
@@ -815,8 +866,14 @@ class SlidersPanel(QWidget):
         convert. The toolbar's Convert/Un-convert/Auto Frame are gated
         separately in ImagePreview."""
         for btn in (self.white_point_btn, self.black_point_btn,
-                    self.convert_current_bwp_btn, self.convert_all_bwp_btn):
+                    self.convert_current_bwp_btn, self.convert_all_bwp_btn,
+                    self.film_stock_combo, self.save_film_stock_btn,
+                    self.delete_film_stock_btn):
             btn.setEnabled(enabled)
+        if enabled:
+            # Leaving Positive mode: re-apply the conditional film-stock
+            # gating (save needs both points, selector needs no white point).
+            self._update_bwp_mode_label()
 
     def save_slider_values(self, image_id):
         pass
@@ -1438,21 +1495,144 @@ class SlidersPanel(QWidget):
             "before converting.", duration=6000)
 
     def _update_bwp_mode_label(self):
-        """Reflect which slope source the next B/W-point conversion will use."""
+        """Reflect which slope source the next B/W-point conversion will use,
+        and gate the film-stock controls to the states where they apply."""
         if not hasattr(self, "bwp_mode_label"):
             return
         bp_set = ccr_backend.black_point_bgr is not None
         wp_set = ccr_backend.white_point_bgr is not None
+        stock = ccr_backend.film_stock_name
         if not bp_set:
             text = ""
         elif wp_set:
             text = "Slope source: white point (two-point)"
+        elif stock:
+            text = f'Slope source: film stock "{stock}" (black point only)'
         else:
             text = "Slope source: default slope (black point only)"
         self.bwp_mode_label.setText(text)
         # Hide when empty so it reserves no vertical space — keeps the Set-point
         # row and the Convert row tight together (no gap) until a point is set.
         self.bwp_mode_label.setVisible(bool(text))
+        # Film-stock controls: a sampled white point overrides any preset (the
+        # two-point math uses the pair), so selector + delete are disabled then.
+        # Save needs BOTH points — that's the only time slopes can be computed.
+        # All stay disabled in global Positive mode (nothing to convert), like
+        # the rest of the section (set_negative_controls_enabled).
+        positive = bool(ccr_backend.positive_mode)
+        self.film_stock_combo.setEnabled(not wp_set and not positive)
+        self.film_stock_combo.setToolTip(
+            "White point set — two-point conversion in use; clear it (✕) to "
+            "use a film-stock slope" if wp_set else
+            "Slope preset for black-point-only conversion: a saved film "
+            "stock's per-channel slopes, or the built-in default")
+        self.save_film_stock_btn.setEnabled(bp_set and wp_set and not positive)
+        self.delete_film_stock_btn.setEnabled(
+            not wp_set and not positive
+            and self.film_stock_combo.currentIndex() > 0)
+
+    # --- Film-stock slope presets (spec/film-stock-slopes.md) --------------
+
+    def _reload_film_stock_combo(self, select=""):
+        """Rebuild the combo from self._film_stocks and select the stock named
+        `select` (''/unknown → Default). Pushes the result into the backend."""
+        combo = self.film_stock_combo
+        combo.blockSignals(True)
+        combo.clear()
+        combo.addItem(FILM_STOCK_DEFAULT_LABEL)
+        for stock in self._film_stocks:
+            combo.addItem(stock["name"])
+        selected = find_film_stock(self._film_stocks, select)
+        combo.setCurrentIndex(
+            0 if selected is None else 1 + self._film_stocks.index(selected))
+        combo.blockSignals(False)
+        self._apply_film_stock_selection()
+
+    def _apply_film_stock_selection(self):
+        """Sync the combo's selection into the backend (the slopes the next
+        black-point-only conversion uses), persist it, refresh the label."""
+        idx = self.film_stock_combo.currentIndex()
+        if idx <= 0:
+            ccr_backend.clear_film_stock()
+            self._settings.remove("convert/film_stock_selected")
+        else:
+            stock = self._film_stocks[idx - 1]
+            ccr_backend.set_film_stock(stock["name"], stock["slopes_bgr"])
+            self._settings.setValue("convert/film_stock_selected", stock["name"])
+        self._update_bwp_mode_label()
+
+    def _on_film_stock_changed(self, _index):
+        self._apply_film_stock_selection()
+
+    def _save_film_stocks_to_settings(self):
+        self._settings.setValue("convert/film_stocks",
+                                encode_film_stocks(self._film_stocks))
+
+    def _on_save_film_stock(self):
+        """Save the sampled B/W pair's per-channel density slopes as a named
+        film stock, and select it — so clearing the white point (✕) switches
+        the roll straight onto the new preset."""
+        black = ccr_backend.black_point_bgr
+        white = ccr_backend.white_point_bgr
+        if black is None or white is None:
+            return
+        slopes = compute_density_slopes(black, white)
+        if slopes is None:
+            QMessageBox.warning(
+                self, "Unusable B/W Pair",
+                "These B/W points don't span a usable density range on every "
+                "channel — the black point (film base) must be brighter than "
+                "the white point (dense area) in all of R, G and B. Re-sample "
+                "the points and try again.")
+            return
+        name, ok = QInputDialog.getText(
+            self, "Save Film Stock", 'Film stock name (e.g. "Portra 400"):')
+        if not ok:
+            return
+        name = name.strip()
+        if not name:
+            return
+        if find_film_stock(self._film_stocks, name) is not None:
+            if QMessageBox.question(
+                    self, "Replace Film Stock",
+                    f'A film stock named "{name}" already exists. Replace it?',
+                    QMessageBox.Yes | QMessageBox.No,
+                    QMessageBox.No) != QMessageBox.Yes:
+                return
+        self._film_stocks = upsert_film_stock(self._film_stocks, {
+            "name": name,
+            "slopes_bgr": list(slopes),
+            # Provenance only — the slopes are the invariant the preset needs.
+            "black_bgr": [float(v) for v in black],
+            "white_bgr": [float(v) for v in white],
+            "created": date.today().isoformat(),
+        })
+        self._save_film_stocks_to_settings()
+        self._reload_film_stock_combo(select=name)
+        self.set_temporary_hint(
+            f'Film stock "{name}" saved — clear the White Point (✕) to '
+            "convert future rolls of this stock from just a black point.",
+            duration=8000)
+
+    def _on_delete_film_stock(self):
+        """Delete the selected stock; selection falls back to Default. Images
+        already converted with it keep their conversion — the slopes were
+        snapshotted by value into conversion_inputs at convert time."""
+        idx = self.film_stock_combo.currentIndex()
+        if idx <= 0:
+            return
+        name = self._film_stocks[idx - 1]["name"]
+        if QMessageBox.question(
+                self, "Delete Film Stock",
+                f'Delete film stock "{name}"? Images already converted with '
+                "it are unaffected.",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No) != QMessageBox.Yes:
+            return
+        self._film_stocks = remove_film_stock(self._film_stocks, name)
+        self._save_film_stocks_to_settings()
+        self._reload_film_stock_combo()   # falls back to Default slope
+        self.set_temporary_hint(f'Film stock "{name}" deleted.', duration=5000)
 
     def on_bwpoint_sampled(self, mode):
         label = "White Point" if mode == "white" else "Black Point"
@@ -1468,9 +1648,12 @@ class SlidersPanel(QWidget):
             self.set_temporary_hint(
                 f"{label} sampled! Both points set — click <b>Convert All</b>.", duration=5000)
         elif bp_set:
-            # Black point alone is enough — default slope fills in for the white.
+            # Black point alone is enough — the selected film stock (or the
+            # default slope) fills in for the white.
+            stock = ccr_backend.film_stock_name
+            source = f'film stock "{stock}"' if stock else "the default slope"
             self.set_temporary_hint(
-                "Black Point sampled! Click <b>Convert</b> to use the default slope, "
+                f"Black Point sampled! Click <b>Convert</b> to use {source}, "
                 "or set a <b>White Point</b> for a custom slope.", duration=6000)
         else:
             self.set_temporary_hint(
@@ -1492,9 +1675,13 @@ class SlidersPanel(QWidget):
                 img.reload_image()
             from core.ccr_processor import ccr_normalize_with_bwpoint
             white = ccr_backend.white_point_bgr  # may be None → default slope
+            # Film-stock slopes apply only in black-point-only mode — a
+            # sampled white point wins (spec/film-stock-slopes.md).
+            slopes = ccr_backend.film_stock_slopes if white is None else None
             processed = ccr_normalize_with_bwpoint(
                 img, ccr_backend.black_point_bgr, white,
-                density=ccr_backend.density_bwpoint
+                density=ccr_backend.density_bwpoint,
+                slopes_bgr=slopes
             )
             if processed is not None:
                 img.resized_raw = processed
@@ -1505,6 +1692,7 @@ class SlidersPanel(QWidget):
                        tuple(white) if white is not None else None),
                 "fine_rot": img.fine_rotation_angle,
                 "density": bool(ccr_backend.density_bwpoint),
+                "slopes": slopes,
             }
             img.update_thumbnail_and_preview()
             mw = self.parent().parent()

--- a/tests/test_film_stock_ui.py
+++ b/tests/test_film_stock_ui.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+UI smoke tests for the film-stock slope selector in the sliders panel
+(spec/film-stock-slopes.md §4): combo/save/delete gating per B/W-point state,
+the slope-source label text, the save flow (name prompt → persist →
+auto-select) and delete falling back to Default. Modal dialogs are
+monkeypatched; the panel's QSettings is redirected to a temp ini so tests
+never touch the user's real store.
+"""
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication, QMessageBox, QInputDialog  # noqa: E402
+from PySide6.QtCore import QSettings  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+from core.film_stocks import decode_film_stocks  # noqa: E402
+import widgets.sliders_panel as sliders_panel_mod  # noqa: E402
+from widgets.sliders_panel import SlidersPanel, FILM_STOCK_DEFAULT_LABEL  # noqa: E402
+
+BASE_BGR = (11385.0, 14569.0, 7022.0)
+WHITE_BGR = (760.0, 420.0, 117.0)
+PORTRA = {"name": "Portra 400", "slopes_bgr": [0.85, 0.65, 0.56],
+          "black_bgr": None, "white_bgr": None, "created": ""}
+
+
+@pytest.fixture
+def panel(tmp_path):
+    """A SlidersPanel whose film-stock QSettings lives in a temp ini, with a
+    clean backend B/W state. Backend globals are restored afterwards."""
+    p = SlidersPanel(None)
+    p._settings = QSettings(str(tmp_path / "test.ini"), QSettings.IniFormat)
+    p._film_stocks = []
+    p._reload_film_stock_combo()
+    ccr_backend.black_point_bgr = None
+    ccr_backend.white_point_bgr = None
+    ccr_backend.positive_mode = False
+    ccr_backend.clear_film_stock()
+    p._update_bwp_mode_label()
+    yield p
+    ccr_backend.black_point_bgr = None
+    ccr_backend.white_point_bgr = None
+    ccr_backend.clear_film_stock()
+
+
+def _select_stock(panel, stocks, name):
+    panel._film_stocks = list(stocks)
+    panel._reload_film_stock_combo(select=name)
+
+
+def test_default_only_combo_and_gating(panel):
+    assert panel.film_stock_combo.count() == 1
+    assert panel.film_stock_combo.itemText(0) == FILM_STOCK_DEFAULT_LABEL
+    assert panel.film_stock_combo.isEnabled()          # selectable pre-sampling
+    assert not panel.save_film_stock_btn.isEnabled()   # needs BOTH points
+    assert not panel.delete_film_stock_btn.isEnabled() # Default not deletable
+    assert panel.bwp_mode_label.text() == ""           # no black point yet
+
+
+def test_black_only_states_and_label(panel):
+    _select_stock(panel, [PORTRA], "Portra 400")
+    ccr_backend.set_black_point(BASE_BGR)
+    panel._update_bwp_mode_label()
+    assert ccr_backend.film_stock_slopes == (0.85, 0.65, 0.56)
+    assert panel.bwp_mode_label.text() == \
+        'Slope source: film stock "Portra 400" (black point only)'
+    assert not panel.save_film_stock_btn.isEnabled()
+    assert panel.delete_film_stock_btn.isEnabled()
+    # Back to Default: backend cleared, label reverts, delete gated off.
+    panel.film_stock_combo.setCurrentIndex(0)
+    assert ccr_backend.film_stock_slopes is None
+    assert panel.bwp_mode_label.text() == \
+        "Slope source: default slope (black point only)"
+    assert not panel.delete_film_stock_btn.isEnabled()
+
+
+def test_white_point_overrides_and_disables_selector(panel):
+    _select_stock(panel, [PORTRA], "Portra 400")
+    ccr_backend.set_black_point(BASE_BGR)
+    ccr_backend.set_white_point(WHITE_BGR)
+    panel._update_bwp_mode_label()
+    assert panel.bwp_mode_label.text() == "Slope source: white point (two-point)"
+    assert not panel.film_stock_combo.isEnabled()
+    assert panel.save_film_stock_btn.isEnabled()       # both points → can save
+    assert not panel.delete_film_stock_btn.isEnabled()
+
+
+def test_positive_mode_disables_everything(panel):
+    ccr_backend.set_black_point(BASE_BGR)
+    ccr_backend.set_white_point(WHITE_BGR)
+    ccr_backend.positive_mode = True
+    panel.set_negative_controls_enabled(False)
+    assert not panel.film_stock_combo.isEnabled()
+    assert not panel.save_film_stock_btn.isEnabled()
+    assert not panel.delete_film_stock_btn.isEnabled()
+    # Leaving positive mode re-applies the CONDITIONAL gating, not blanket-on.
+    ccr_backend.positive_mode = False
+    panel.set_negative_controls_enabled(True)
+    assert not panel.film_stock_combo.isEnabled()      # white point still set
+    assert panel.save_film_stock_btn.isEnabled()
+
+
+def test_save_flow_persists_and_selects(panel, monkeypatch):
+    ccr_backend.set_black_point(BASE_BGR)
+    ccr_backend.set_white_point(WHITE_BGR)
+    panel._update_bwp_mode_label()
+    monkeypatch.setattr(QInputDialog, "getText",
+                        staticmethod(lambda *a, **k: ("Portra 400", True)))
+    panel._on_save_film_stock()
+    # Persisted (round-trips through the store) and auto-selected.
+    stored = decode_film_stocks(
+        panel._settings.value("convert/film_stocks", "", type=str))
+    assert [s["name"] for s in stored] == ["Portra 400"]
+    assert stored[0]["black_bgr"] == list(BASE_BGR)    # provenance kept
+    assert panel.film_stock_combo.currentText() == "Portra 400"
+    assert panel._settings.value("convert/film_stock_selected", "", type=str) \
+        == "Portra 400"
+    # The saved slopes reproduce the pair (S = 1/log10(base/dense)).
+    from core.ccr_processor import compute_density_slopes
+    assert tuple(stored[0]["slopes_bgr"]) == \
+        pytest.approx(compute_density_slopes(BASE_BGR, WHITE_BGR))
+    # Clearing the white point activates the stock for the backend.
+    ccr_backend.white_point_bgr = None
+    panel._update_bwp_mode_label()
+    assert panel.film_stock_combo.isEnabled()
+    assert ccr_backend.film_stock_slopes == tuple(stored[0]["slopes_bgr"])
+
+
+def test_save_rejects_unusable_pair(panel, monkeypatch):
+    ccr_backend.set_black_point((100.0, 14569.0, 7022.0))   # B: base < dense
+    ccr_backend.set_white_point(WHITE_BGR)
+    warned = []
+    monkeypatch.setattr(QMessageBox, "warning",
+                        staticmethod(lambda *a, **k: warned.append(a)))
+    monkeypatch.setattr(QInputDialog, "getText",
+                        staticmethod(lambda *a, **k: pytest.fail(
+                            "name prompt reached with an unusable pair")))
+    panel._on_save_film_stock()
+    assert warned
+    assert panel._film_stocks == []
+
+
+def test_delete_falls_back_to_default(panel, monkeypatch):
+    _select_stock(panel, [PORTRA], "Portra 400")
+    ccr_backend.set_black_point(BASE_BGR)
+    panel._update_bwp_mode_label()
+    monkeypatch.setattr(QMessageBox, "question",
+                        staticmethod(lambda *a, **k: QMessageBox.Yes))
+    panel._on_delete_film_stock()
+    assert panel._film_stocks == []
+    assert panel.film_stock_combo.currentText() == FILM_STOCK_DEFAULT_LABEL
+    assert ccr_backend.film_stock_slopes is None
+    assert decode_film_stocks(
+        panel._settings.value("convert/film_stocks", "", type=str)) == []
+    assert panel.bwp_mode_label.text() == \
+        "Slope source: default slope (black point only)"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_film_stocks.py
+++ b/tests/test_film_stocks.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Tests for saved film-stock slopes (spec/film-stock-slopes.md).
+
+A film stock is a per-channel DENSITY-slope triple S[c] = 1/log10(base/dense)
+computed from a sampled B/W-point pair and saved under a name. In the
+black-point-only conversion the selected stock's slopes replace the baked
+scalar DEFAULT_DENSITY_SLOPE:
+    out[c] = clip(S[c] * max(log10(base/img), 0), 0, 1)
+The slopes ride conversion_inputs["slopes"] by value, so replay (zoom, export,
+slice, catalog restore) reproduces the conversion even after the preset is
+deleted. With slopes_bgr=None everything is byte-identical to the default
+scalar path.
+
+apply_bwpoint_normalization and the film_stocks store are pure (no Qt), so
+these run headless.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.ccr_processor import (  # noqa: E402
+    apply_bwpoint_normalization,
+    compute_density_slopes,
+    DEFAULT_DENSITY_SLOPE,
+)
+from core.film_stocks import (  # noqa: E402
+    decode_film_stocks,
+    encode_film_stocks,
+    find_film_stock,
+    upsert_film_stock,
+    remove_film_stock,
+)
+
+# The calibration black/white pair (BGR) used across the default-slope tests.
+BASE_BGR = (11385.0, 14569.0, 7022.0)    # clear film base (high scan values)
+WHITE_BGR = (760.0, 420.0, 117.0)        # dense area (low scan values)
+
+
+@pytest.fixture(autouse=True)
+def _force_legacy_full_range(monkeypatch):
+    """Pin the LEGACY full-range inversion (base→0, dense→65535); the windowed
+    working space is covered in test_working_space.py."""
+    monkeypatch.setenv("FREECCR_WORKING_SPACE", "0")
+
+
+def _img(pixels_bgr, dtype=np.uint16):
+    """Build a (1, N, 3) image from a list of (B,G,R) tuples."""
+    return np.array([pixels_bgr], dtype=dtype)
+
+
+def _stock(name, slopes=(0.85, 0.65, 0.56), **extra):
+    rec = {"name": name, "slopes_bgr": list(slopes)}
+    rec.update(extra)
+    return rec
+
+
+# --- compute_density_slopes ------------------------------------------------
+
+def test_slopes_match_formula():
+    slopes = compute_density_slopes(BASE_BGR, WHITE_BGR)
+    assert slopes is not None
+    for c in range(3):
+        expected = 1.0 / np.log10(BASE_BGR[c] / WHITE_BGR[c])
+        assert abs(slopes[c] - expected) < 1e-9
+        assert slopes[c] > 0
+
+
+def test_slopes_reject_degenerate_pairs():
+    # Any single bad channel rejects the whole pair.
+    assert compute_density_slopes((100.0, 14569.0, 7022.0), WHITE_BGR) is None   # base < dense (B)
+    assert compute_density_slopes(BASE_BGR, (760.0, 0.0, 117.0)) is None         # zero dense (G)
+    assert compute_density_slopes((0.0, 14569.0, 7022.0), WHITE_BGR) is None     # zero base (B)
+    assert compute_density_slopes(WHITE_BGR, WHITE_BGR) is None                  # base == dense
+    assert compute_density_slopes((760.0001, 14569.0, 7022.0),
+                                  (760.0, 420.0, 117.0)) is None                 # ~zero density range
+
+
+def test_slopes_light_source_invariant_quantity():
+    """The stored quantity itself is invariant to per-channel light scaling
+    (both samples scale together when re-sampled under a new light)."""
+    k = (1.7, 0.6, 2.3)
+    scaled_base = tuple(b * kk for b, kk in zip(BASE_BGR, k))
+    scaled_white = tuple(w * kk for w, kk in zip(WHITE_BGR, k))
+    a = compute_density_slopes(BASE_BGR, WHITE_BGR)
+    b = compute_density_slopes(scaled_base, scaled_white)
+    np.testing.assert_allclose(a, b, rtol=1e-9)
+
+
+# --- black-point-only inversion with stock slopes ---------------------------
+
+def test_none_slopes_match_default_scalar():
+    """slopes_bgr=None ≡ the scalar DEFAULT_DENSITY_SLOPE in every channel —
+    the regression guarantee that Default keeps today's output."""
+    px = [(3000, 2500, 900), (1500, 1200, 400), (500, 300, 120)]
+    a = apply_bwpoint_normalization(_img(px), BASE_BGR, None)
+    b = apply_bwpoint_normalization(_img(px), BASE_BGR, None,
+                                    slopes_bgr=(DEFAULT_DENSITY_SLOPE,) * 3)
+    np.testing.assert_array_equal(a, b)
+
+
+def test_stock_slopes_map_calibration_pair_to_endpoints():
+    """With the slopes computed FROM a pair, that pair's dense sample maps to
+    ~white and its base to ~black — the stock reproduces its calibration."""
+    slopes = compute_density_slopes(BASE_BGR, WHITE_BGR)
+    img = _img([tuple(map(round, BASE_BGR)), tuple(map(round, WHITE_BGR))])
+    out = apply_bwpoint_normalization(img, BASE_BGR, None,
+                                      slopes_bgr=slopes).astype(int)
+    assert np.all(out[0, 0] < 3), f"base expected ~black, got {out[0, 0]}"
+    assert np.all(out[0, 1] >= 65400), f"dense expected ~white, got {out[0, 1]}"
+
+
+def test_stock_slopes_match_density_formula():
+    """out[c] = clip(S[c] * max(log10(base/img), 0), 0, 1) * 65535."""
+    slopes = compute_density_slopes(BASE_BGR, WHITE_BGR)
+    px = [(3000, 2500, 900), (1500, 1200, 400), (500, 300, 120)]
+    out = apply_bwpoint_normalization(_img(px), BASE_BGR, None,
+                                      slopes_bgr=slopes).astype(int)
+    for i, p in enumerate(px):
+        for c in range(3):
+            d = max(float(np.log10(BASE_BGR[c] / max(float(p[c]), 1.0))), 0.0)
+            expected = int(np.clip(slopes[c] * d, 0.0, 1.0) * 65535.0)
+            assert abs(out[0, i, c] - expected) <= 1, (i, c, out[0, i, c], expected)
+
+
+def test_stock_slopes_light_source_invariant_output():
+    """Re-sampling the black point under a new light (per-channel factor k on
+    base AND img) keeps the output identical for the SAME saved slopes — the
+    core promise: slopes travel across sessions, the black point adapts."""
+    slopes = compute_density_slopes(BASE_BGR, WHITE_BGR)
+    base = np.array(BASE_BGR, dtype=np.float32)
+    px = np.array([3000.0, 2500.0, 900.0], dtype=np.float32)
+    k = np.array([1.7, 0.6, 2.3], dtype=np.float32)
+    out1 = apply_bwpoint_normalization(np.array([[px]], dtype=np.float32),
+                                       tuple(base), None,
+                                       slopes_bgr=slopes).astype(int)
+    out2 = apply_bwpoint_normalization(np.array([[px * k]], dtype=np.float32),
+                                       tuple(base * k), None,
+                                       slopes_bgr=slopes).astype(int)
+    assert np.all(np.abs(out1 - out2) <= 1), (out1, out2)
+
+
+def test_stock_slopes_actually_differ_from_default():
+    """Sanity: this pair's slopes are NOT the default scalar, so the preset
+    visibly changes the rendering (otherwise the feature would be a no-op)."""
+    slopes = compute_density_slopes(BASE_BGR, WHITE_BGR)
+    assert any(abs(s - DEFAULT_DENSITY_SLOPE) > 1e-3 for s in slopes)
+    px = [(3000, 2500, 900)]
+    a = apply_bwpoint_normalization(_img(px), BASE_BGR, None)
+    b = apply_bwpoint_normalization(_img(px), BASE_BGR, None, slopes_bgr=slopes)
+    assert not np.array_equal(a, b)
+
+
+# --- conversion_inputs snapshot round-trip ----------------------------------
+
+def test_catalog_roundtrip_with_slopes():
+    from core.catalog import _ci_to_json, _ci_from_json
+    slopes = compute_density_slopes(BASE_BGR, WHITE_BGR)
+    ci = {"mode": "bw", "bw": (BASE_BGR, None), "fine_rot": 0,
+          "density": True, "slopes": slopes}
+    j = _ci_to_json(ci)
+    assert j["slopes"] == list(slopes)          # JSON-safe list
+    back = _ci_from_json(j)
+    assert back["slopes"] == tuple(slopes)      # tuple restored
+    assert back["bw"][1] is None
+
+
+def test_catalog_roundtrip_legacy_without_slopes():
+    """Legacy records (pre-feature) have no 'slopes' key and must replay with
+    the default scalar — ci.get('slopes') is None end to end."""
+    from core.catalog import _ci_to_json, _ci_from_json
+    ci = {"mode": "bw", "bw": (BASE_BGR, None), "fine_rot": 0}
+    back = _ci_from_json(_ci_to_json(ci))
+    assert back.get("slopes") is None
+
+
+# --- film_stocks store -------------------------------------------------------
+
+def test_decode_corrupt_or_wrong_shape_is_empty():
+    assert decode_film_stocks("") == []
+    assert decode_film_stocks(None) == []
+    assert decode_film_stocks("not json {") == []
+    assert decode_film_stocks('{"name": "x"}') == []      # not a list
+
+
+def test_decode_drops_bad_records_keeps_good():
+    good = _stock("Portra 400")
+    bad = [
+        {"slopes_bgr": [1, 1, 1]},                        # no name
+        {"name": "  ", "slopes_bgr": [1, 1, 1]},          # blank name
+        {"name": "neg", "slopes_bgr": [1, -1, 1]},        # non-positive slope
+        {"name": "short", "slopes_bgr": [1, 1]},          # not a triple
+        {"name": "nan", "slopes_bgr": [1, float("nan"), 1]},
+        {"name": "str", "slopes_bgr": "abc"},
+        "not-a-dict",
+    ]
+    out = decode_film_stocks(encode_film_stocks([good]) )
+    assert [s["name"] for s in out] == ["Portra 400"]
+    import json
+    out = decode_film_stocks(json.dumps([good] + bad))
+    assert [s["name"] for s in out] == ["Portra 400"]
+
+
+def test_decode_dedups_case_insensitive_and_sorts():
+    import json
+    text = json.dumps([_stock("portra 400"), _stock("Ektar 100"),
+                       _stock("PORTRA 400")])   # dup keeps first
+    out = decode_film_stocks(text)
+    assert [s["name"] for s in out] == ["Ektar 100", "portra 400"]
+
+
+def test_roundtrip_unicode_and_provenance():
+    stock = _stock("フジ 400H", black_bgr=list(BASE_BGR),
+                   white_bgr=list(WHITE_BGR), created="2026-07-02")
+    out = decode_film_stocks(encode_film_stocks([stock]))
+    assert out[0]["name"] == "フジ 400H"
+    assert out[0]["black_bgr"] == list(BASE_BGR)
+    assert out[0]["white_bgr"] == list(WHITE_BGR)
+    assert out[0]["created"] == "2026-07-02"
+
+
+def test_upsert_adds_replaces_and_sorts():
+    stocks = upsert_film_stock([], _stock("Portra 400", (0.8, 0.8, 0.8)))
+    stocks = upsert_film_stock(stocks, _stock("Ektar 100"))
+    assert [s["name"] for s in stocks] == ["Ektar 100", "Portra 400"]
+    # Case-insensitive replace: one record survives, with the new values.
+    stocks = upsert_film_stock(stocks, _stock("PORTRA 400", (0.5, 0.5, 0.5)))
+    assert len(stocks) == 2
+    replaced = find_film_stock(stocks, "portra 400")
+    assert replaced["name"] == "PORTRA 400"
+    assert replaced["slopes_bgr"] == [0.5, 0.5, 0.5]
+    with pytest.raises(ValueError):
+        upsert_film_stock(stocks, {"name": "bad", "slopes_bgr": [0, 0, 0]})
+
+
+def test_remove_and_find():
+    stocks = upsert_film_stock([], _stock("Portra 400"))
+    assert find_film_stock(stocks, "  portra 400 ") is not None
+    assert find_film_stock(stocks, "") is None
+    assert find_film_stock(stocks, "Ektar 100") is None
+    assert remove_film_stock(stocks, "nope") == stocks     # unknown → no-op
+    assert remove_film_stock(stocks, "PORTRA 400") == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Adds **named film-stock slope presets** for the black-point-only B/W conversion (spec: `spec/film-stock-slopes.md`).

The density slope `S[c] = 1/log10(base[c]/dense[c])` implied by a sampled B/W-point pair is a property of the **film stock** (per-dye-layer characteristic-curve gamma), while the black point is a property of the **light source / session** — and per-channel *density* slopes were already measured to be stable across light sources in the default-slope work (`spec/optional-white-point-default-slope.md` §3). So: calibrate a stock once from a lead frame, save its slopes under a name, and every future roll of that stock converts from just a re-sampled black point — with the stock's contrast *and* per-channel colour character.

## Behaviour

- **"Default slope" selected (initial state)** → byte-identical to today (scalar `DEFAULT_DENSITY_SLOPE`); regression-tested.
- **Saved stock selected** → `_default_slope_invert` uses its per-channel slopes in black-point-only mode.
- **White point sampled** → two-point conversion exactly as today; the selector is disabled (the pair wins).
- Slopes are **snapshotted by value** into `conversion_inputs["slopes"]`, so hi-res zoom replay, export, slice children, un-slice restore, catalog restore, camera-profile regrade and the density-toggle reprocess all reproduce the conversion even if the preset is later deleted. Legacy records without the key replay with the default scalar.
- Tethered captures convert with the selected stock; presets + selection persist in QSettings (`convert/film_stocks`, `convert/film_stock_selected`).

## UI (Film B/W Point section)

```
[Set Black Point] [Set White Point] [✕]
Film Stock  [ Portra 400 ▾ ] [＋] [−]
Slope source: film stock "Portra 400" (black point only)
[Convert Current] [Convert All]
```

- **＋ Save** — enabled only with both points sampled; prompts for a name (overwrite confirm on collision), computes `compute_density_slopes`, persists, and **auto-selects** the new stock so clearing the white point (✕) activates it immediately.
- **− Delete** — enabled only when a saved stock is selected; confirms; selection falls back to Default (converted images unaffected).
- The combo + gating respect Positive mode and the two-point override; the slope-source label names the active stock.

## Tests

- `tests/test_film_stocks.py` (23) — slope math (formula, degenerate-pair rejection, light-source invariance of the stored quantity *and* the output), `slopes_bgr=None` ≡ default scalar, calibration pair maps to endpoints, catalog snapshot round-trip incl. legacy records, store encode/decode/upsert/remove (corrupt JSON, unicode, case-insensitive dedup).
- `tests/test_film_stock_ui.py` (7) — combo/save/delete gating per state (incl. Positive mode restore), label text, save flow (persist + auto-select + provenance), unusable-pair rejection, delete fallback. QSettings redirected to a temp ini.
- Neighbouring groups pass: `test_default_slope`, `test_density_bwpoint`, `test_catalog`, `test_tether_watcher`, `test_working_space`, `test_auto_exposure`, `test_auto_gain`, `test_slice`, `test_zoom_hires`, `test_positive_mode`, `test_export`, `test_export_naming` (run in small groups; full-suite hang is pre-existing).
- UI visually verified offscreen (dark theme, both states) via the qt-testing capture harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012C4T6y6ciHgWs8vmQPKS2B
