### PR TITLE
feat: color scopes panel (RGB parade + vectorscope) under the canvas

### DIFF
--- a/spec/cineon-display-transform.md
+++ b/spec/cineon-display-transform.md
@@ -1,0 +1,87 @@
+# Spec: Cineon Film Log → Rec.709 (γ 2.2) Display Transform
+
+Status: REFINED v2
+Owner: FreeCCR
+Feature branch: `feature/color-scopes` (rides the scopes PR — the parade's
+95/685 reference lines mark exactly this transform's black/white anchors)
+
+## 1. Summary
+
+A checkbox in the **Channel Levels** section — "Cineon Log → Rec.709
+(γ 2.2)" — that, when enabled, interprets the fully-adjusted image as Cineon
+printing-density film log and converts it to Rec.709 video with a plain 2.2
+gamma, as the **final pipeline stage after every other adjustment**, before
+display and export. This is the classic Kodak Cineon log-to-video conversion
+(DaVinci's "Cineon Film Log" flavor): 10-bit code 95 = black (Dmin), code
+685 = 90% white.
+
+## 2. Goals / Non-goals
+
+### Goals
+- Per-image on/off flag, stored in `adjustment_settings` under
+  `"cineon_log"` (present-and-True when on; absent when off — like the
+  non-slider `curves` key).
+- Applied identically to preview, hi-res zoom detail, and every export path
+  (all funnel through `CCRImage.apply_adjustments`).
+- Participates in undo/redo, Reset, Compare (hold shows the untransformed
+  image), Copy/Paste of adjustments, Sync-to-All (rides the "Channel
+  Levels" sync group), and the catalog (plain bool in the settings dict).
+- Whole-image only: area layers never carry the flag (a display transform
+  is not a local adjustment). The checkbox is disabled while an area layer
+  is the edit target, showing the global state.
+
+### Non-goals
+- No soft-clip shoulder above code 685 (values clip to white — the classic
+  video-range conversion) and no configurable black/white codes or gamma.
+- No exact Rec.709 OETF (the user asked for a plain 2.2 gamma encode).
+- No OpenCL port: it is a single 65536-entry LUT lookup at the very end of
+  the CPU stage — negligible next to the GPU pass it follows.
+
+## 3. Math (`ccr_processor.apply_cineon_to_rec709`)
+
+Input 16-bit value ≡ 10-bit code `c = v / 65535 * 1023`:
+
+```
+off = 10^((95 − 685) · 0.002 / 0.6)                    # ≈ 0.0108
+lin = (10^((c − 685) · 0.002 / 0.6) − off) / (1 − off) # scene-linear, 685 → 1.0
+out = clip(lin, 0, 1)^(1/2.2) · 65535
+```
+
+0.002 = log₁₀ density per code value, 0.6 = film negative gamma — the
+standard Kodak constants. Implemented as a cached 65536-entry uint16 LUT
+(`lut[img16]`), per-channel (grayscale images pass through unchanged in
+shape). Codes ≤ 95 → 0; codes ≥ 685 → 65535; monotonic.
+
+## 4. Integration
+
+1. **Pipeline** (`ccr_image.apply_adjustments`): after the slider pass,
+   gamma, curves, area compositing and the B&W collapse — immediately
+   before `return adjusted`:
+   `if s.get("cineon_log"): adjusted = apply_cineon_to_rec709(adjusted)`.
+   The hi-res worker snapshots the settings dict and `_hires_signature`
+   hashes its items, so zoom detail re-renders on toggle automatically.
+2. **UI** (`sliders_panel`): checkbox at the bottom of the Channel Levels
+   section. Toggle = a discrete single-undo edit on the **global** dict
+   (mirrors `_on_curve_edit_finished`: `push_undo_state`, write/pop the
+   key, `update_thumbnail_and_preview`, `update_preview`, thumb refresh).
+3. **Rebuild paths**: `on_slider_changed` / `_on_curve_changed` /
+   `copy_adjustment_settings` rebuild the dict from sliders — a new
+   `_attach_cineon` (sibling of `_attach_curves`) re-attaches the flag from
+   the global dict, only when the active layer IS the global layer.
+4. **Populate**: `_load_active_layer` sets the checkbox from the global
+   dict (signals blocked) and disables it while an area layer is active.
+5. **Paste**: strips `cineon_log` when pasting onto an area layer.
+6. **Sync-to-All**: `"cineon_log"` joins the "channels" group keys; targets
+   keep their own flag across the merge when that group is un-synced
+   (mirrors the curves preservation).
+
+## 5. Test plan (`tests/test_cineon_log.py`)
+
+- LUT: everything at/below code 95 → 0; at/above 685 → 65535; monotonic;
+  a mid-scale spot value matches the closed-form math.
+- `apply_cineon_to_rec709`: shape/dtype preserved; neutral input stays
+  neutral per channel.
+- Pipeline: `CCRImage.apply_adjustments` with `{"cineon_log": True}` equals
+  `apply_cineon_to_rec709` of the same call without the flag (final-stage
+  property, no interleaving).
+- Sync group: "channels" includes the key.

--- a/spec/color-scopes-panel.md
+++ b/spec/color-scopes-panel.md
@@ -288,3 +288,8 @@ Pure math (no Qt beyond an offscreen QApplication where widgets are smoked):
   (dashed, `SCOPE_REF` amber, labels at the right edge).
 - **Skin-tone line**: vectorscope draws the +I-axis line from the center to
   the 100% circle (`scopes.skin_tone_direction()`, `SCOPE_SKIN`).
+- **Drag-resizable height**: a thin grab bar on the panel's top edge
+  (visible only while expanded, `SizeVerCursor`); dragging up enlarges the
+  body, clamped to [140, 420] px (default 180). The vectorscope stays
+  square (width follows height); the height persists in QSettings
+  (`scopes/height`).

--- a/spec/color-scopes-panel.md
+++ b/spec/color-scopes-panel.md
@@ -163,8 +163,10 @@ traces.
 - Builds an RGB `QImage` from the scaled counts: three cells side by side
   (R, G, B), each `W` wide × 256 tall, cell pixels = channel theme color ×
   intensity; row 0 = value 255 (image is vertically flipped from the counts
-  array). The QImage is regenerated on `set_data` and drawn scaled to the
-  plot rect (smooth, cached) in `paintEvent`.
+  array). Each sample dot gets a soft 1px plus-shaped dilation and the trace
+  a brightness gain (`_DOT_SPREAD`/`_DOT_GAIN`) so single-pixel samples stay
+  readable at screen scale. The QImage is regenerated on `set_data` and
+  drawn scaled to the plot rect (smooth, cached) in `paintEvent`.
 - **10-bit axis** (display only — the data stays 8-bit/256 bins; 8-bit 255 ≡
   10-bit 1023, so trace geometry is unchanged): a left gutter carries
   DaVinci-style code labels, with a gridline every 128 codes

--- a/spec/color-scopes-panel.md
+++ b/spec/color-scopes-panel.md
@@ -1,6 +1,6 @@
 # Spec: Color Scopes Panel (RGB Parade + Vectorscope)
 
-Status: REFINED v2
+Status: REFINED v3
 Owner: FreeCCR
 Feature branch: `feature/color-scopes`
 
@@ -8,15 +8,16 @@ Feature branch: `feature/color-scopes`
 
 Add a collapsible **Scopes** area at the bottom of the canvas (inside
 `ImagePreview`, between the graphics view and the fine-rotation slider) showing
-two video-style color scopes computed from **what is currently visible in the
-canvas viewport** (zoom, pan, crop, rotation and the applied adjustments all
-included):
+two video-style color scopes computed from **the displayed image** — the
+confirmed crop, orientation and all applied adjustments included; **zoom and
+pan deliberately excluded** (zooming in must not change the scopes; slicing
+produces new images, which are scoped like any other when displayed):
 
 - **RGB Parade** — three side-by-side per-channel waveforms: x = horizontal
-  position across the visible window, y = channel value (0 bottom … 255 top),
-  brightness = pixel count.
+  position across the visible window, y = channel value on a 10-bit axis
+  (0 bottom … 1023 top, DaVinci-style), brightness = pixel count.
 - **Vectorscope** — chroma distribution on the CbCr plane with the standard
-  R/Mg/B/Cy/G/Yl 75% targets.
+  R/Mg/B/Cy/G/Yl 75% targets and the skin-tone indicator line (+I axis).
 
 While the mouse is over the canvas, a readout in the panel header shows the
 RGB value under the cursor, and that value is marked with a circle on the
@@ -28,12 +29,13 @@ parade (one per channel) and on the vectorscope.
 - Collapsible area at the bottom of the canvas; header always visible,
   body (the scopes) shown/hidden by clicking the header toggle.
   **Collapsed by default**; state persists across sessions (QSettings).
-- Scopes computed from the *visible canvas window* — the viewport content:
-  zoomed/panned region only, display crop applied, orientation as displayed.
-  Letterboxed (empty) canvas areas are excluded from the statistics.
-- Live updates: image switch, slider adjustments, convert/unconvert, zoom,
-  pan, rotate/flip, crop, window resize, hi-res detail swap-in. Updates are
-  coalesced with a short debounce so drags stay fluid.
+- Scopes computed from the *displayed image*: display crop applied,
+  orientation as displayed, hi-res detail when present. **Zoom/pan never
+  change the scopes.** Pixels not covered by the image (fine-rotation corner
+  gaps) are excluded from the statistics.
+- Live updates: image switch, slider adjustments, convert/unconvert,
+  rotate/flip, crop confirm/clear, slice results, hi-res detail swap-in.
+  Updates are coalesced with a short debounce so drags stay fluid.
 - Hover probe: RGB value readout (8-bit display values, matching what the
   scopes plot) + marker circles on both scopes. Cleared when the cursor
   leaves the canvas or the image.
@@ -43,12 +45,13 @@ parade (one per channel) and on the vectorscope.
 ### Non-goals
 - No waveform (luma) or histogram scope — the right panel already has a
   histogram; parade + vectorscope only.
-- No scopes for the full image independent of the view (explicitly
-  viewport-based per the feature request).
-- No configurable scope options (scale, skin-tone indicator toggle, 601/709
-  matrix choice) in v1.
+- No viewport-based scoping (an earlier draft computed over the zoomed
+  visible window; dropped — zoom must not affect the scopes).
+- No configurable scope options (scale toggles, 601/709 matrix choice,
+  hiding the skin-tone line / Cineon reference lines) in v1 — the indicators
+  are always on.
 - No GPU path; the computation is a few-ms numpy pass over a small
-  (~360px-wide) downsample of the viewport.
+  (~360px-wide) downsample of the displayed image.
 - No export/snapshot of scope images.
 
 ## 3. UX / Interaction
@@ -76,10 +79,10 @@ parade (one per channel) and on the vectorscope.
   pixel under the cursor:
   - Header readout shows `R nnn G nnn B nnn` + swatch of that color.
   - Parade: one small circle per channel cell at
-    (cursor x-fraction of the viewport, channel value).
+    (cursor x-fraction across the displayed image, channel value).
   - Vectorscope: one circle at the value's (Cb, Cr) position.
-- Cursor outside the image (letterbox) or off the canvas → readout shows
-  `R --- G --- B ---`, markers disappear.
+- Cursor outside the image (canvas letterbox) or off the canvas → readout
+  shows `R --- G --- B ---`, markers disappear.
 - Sampling reads the *preview-resolution* displayed pixmap (the same data the
   scopes are computed from, up to resampling); it does not force a hi-res
   fetch.
@@ -99,26 +102,28 @@ No persisted per-image state. Transient state only:
 
 All functions pure numpy, no Qt imports.
 
-### 5.1 Visible-window capture (in `ImagePreview`, Qt side)
-- Render **only the pixmap item** into an offscreen `QImage`
-  (`Format_RGBA8888`, transparent-filled) of the viewport's aspect at
-  `max_width = 360`:
-  - `s = min(1.0, 360 / viewport_width)`; image size
-    `round(viewport_size * s)`,
+### 5.1 Displayed-image capture (in `ImagePreview`, Qt side)
+- Render **only the pixmap item, whole** — never through the view transform,
+  so zoom/pan cannot influence the result — into an offscreen `QImage`
+  (`Format_RGBA8888`, transparent-filled) of the item's scene-bounds aspect
+  at `max_width = 360`:
+  - `br = pixmap_item.mapToScene(boundingRect()).boundingRect()`,
+  - `s = min(1.0, 360 / br.width())`; image size `round(br.size * s)`,
   - painter transform = `pixmap_item.sceneTransform() *
-    view.viewportTransform() * QTransform.fromScale(s, s)` (Qt composes
-    left-to-right: item → scene → viewport → downscale),
+    QTransform.fromTranslate(-br.left, -br.top) * QTransform.fromScale(s, s)`
+    (Qt composes left-to-right: item → scene → origin-shift → downscale),
   - `drawPixmap(0, 0, pixmap_item.pixmap())` with SmoothPixmapTransform.
-- This bakes in zoom, pan, flips, 90° and fine rotation, display crop, and
-  the hi-res prescale for free; pixels not covered by the image keep
-  alpha 0. Overlay items (reference frame, crop/area/dust/slice chrome)
-  are **not** rendered — only image pixels feed the scopes. In crop/area/
-  dust/slice modes the scopes reflect what those modes display (the full
-  un-cropped image), which is exactly the "visible canvas window".
+- This bakes in flips, 90° and fine rotation, display crop (the displayed
+  pixmap is pre-cropped by `update_preview`), and the hi-res prescale for
+  free; slice results are separate images and scope like any other. Pixels
+  not covered by the image (fine-rotation corner gaps) keep alpha 0. Overlay
+  items (reference frame, crop/area/dust/slice chrome) are **not** rendered —
+  only image pixels feed the scopes. In crop/area/dust/slice modes the scopes
+  reflect what those modes display (the full un-cropped image).
 - numpy view via `constBits()`: rows sliced to `bytesPerLine` then trimmed
   to `w*4` (RGBA8888 is byte-ordered R,G,B,A on all platforms);
-  `rgb (h, w, 3) uint8`, `mask = alpha >= 250` (excludes letterbox AND
-  antialiased image edges, which are blended toward transparent and would
+  `rgb (h, w, 3) uint8`, `mask = alpha >= 250` (excludes uncovered corners
+  AND antialiased image edges, which are blended toward transparent and would
   otherwise pollute the low end).
 
 ### 5.2 RGB parade
@@ -159,10 +164,17 @@ traces.
   (R, G, B), each `W` wide × 256 tall, cell pixels = channel theme color ×
   intensity; row 0 = value 255 (image is vertically flipped from the counts
   array). The QImage is regenerated on `set_data` and drawn scaled to the
-  plot rect (smooth) in `paintEvent`.
-- Graticule: horizontal lines at 25/50/75% + thin separators between cells.
+  plot rect (smooth, cached) in `paintEvent`.
+- **10-bit axis** (display only — the data stays 8-bit/256 bins; 8-bit 255 ≡
+  10-bit 1023, so trace geometry is unchanged): a left gutter carries
+  DaVinci-style code labels, with a gridline every 128 codes
+  (0, 128, …, 896) plus 1023 at the top.
+- **Cineon reference lines** at codes **95** (Dmin black) and **685**
+  (90% white) — dashed, in the accent color (`SCOPE_REF`), drawn over the
+  trace with their code labels at the right edge of the plot.
+- Thin vertical separators between the three cells.
 - Probe: three circles (white fill, dark outline) at
-  `(cell_left + x_frac * cell_w, top + (1 - v/255) * plot_h)`.
+  `(cells_left + (c + x_frac) * cell_w, top + (1 - v/255) * plot_h)`.
 
 ### 6.2 `VectorscopeWidget`
 - Square plot centered in the widget. Bin colors: constant-luma YCbCr→RGB of
@@ -173,6 +185,9 @@ traces.
   a small `S×S` QImage on `set_data`, drawn scaled (smooth).
 - Graticule: outer circle (100%), faint inner circle (75%), crosshair, and
   six 75% target squares labeled R/Mg/B/Cy/G/Yl.
+- **Skin-tone indicator line**: from the center to the 100% circle along the
+  +I axis of YIQ (`scopes.skin_tone_direction()`, ≈132° in our CbCr plane —
+  between the R and Yl targets, closer to R), in `SCOPE_SKIN`.
 - Probe: one circle at the probe value's bin position.
 
 ### 6.3 `ScopesPanel`
@@ -188,17 +203,14 @@ traces.
 
 1. `__init__`: create `self.scopes_panel = ScopesPanel()`, insert after the
    view; create `_scope_timer` (single-shot, 120 ms → `_update_scopes_now`);
-   connect both view scrollbars' `valueChanged` → `_schedule_scope_update`
-   (covers all pan paths — middle-drag, space-drag both move scrollbars);
-   connect `scopes_panel.expanded_changed` → schedule.
-2. `_schedule_scope_update()` called from:
-   - `update_preview` (image switch / adjustments / convert — after
-     `apply_transformations`),
-   - `apply_transformations` (rotate / flip / fine rotation / fit),
-   - `_apply_zoom_scale` and `zoom_to_fit` / the fit-snap branch of
-     `zoom_by` (zoom),
-   - `GraphicsImageView.resizeEvent` (viewport geometry),
-   - `_refresh_item_pixmap` (hi-res detail swap in/out).
+   connect `scopes_panel.expanded_changed` → schedule. **No viewport hooks**
+   (no scrollbar / zoom / resize connections) — zoom and pan must not affect
+   the scopes.
+2. `_schedule_scope_update()` called from exactly two choke points:
+   - `update_preview` (image switch / adjustments / convert / crop
+     confirm-clear / slice results — anything that swaps `current_pixmap`),
+   - `apply_transformations` (rotate / flip / fine rotation, and the hi-res
+     pixmap swaps, which re-run it).
    Collapsed panel → just set the dirty flag.
 3. `_update_scopes_now()`: capture per §5.1; `scopes_panel.set_frame(...)`;
    None capture (no image) → `scopes_panel.clear()`.
@@ -211,18 +223,21 @@ traces.
    `_probe_qimage`, built lazily from `current_pixmap` and keyed on
    `current_pixmap.cacheKey()` (so slider/convert refreshes that swap the
    pixmap invalidate it automatically); out of bounds →
-   `clear_color_probe()`. x_frac = `vp_pos.x() / viewport.width()`.
+   `clear_color_probe()`. x_frac = fraction of the cursor's scene x across
+   the pixmap item's scene bounding rect (the parade's x-domain).
    The probe hook runs at the very top of `mouseMoveEvent` (before the
    mid-pan / mode dispatch early-returns) so it works in every mode.
 7. Theme: new `theme.Paint` constants — `SCOPE_BG`, `SCOPE_GRID`,
-   `SCOPE_MARKER`, reuse `HIST_R/G/B` for parade tints.
+   `SCOPE_LABEL`, `SCOPE_MARKER`, `SCOPE_REF` (Cineon 95/685 lines),
+   `SCOPE_SKIN` (skin-tone line); reuse `HIST_R/G/B` for parade tints.
 
 ## 8. Performance
 
-- Capture ≈ 360×~230 RGBA render + one numpy conversion; parade = 3
-  bincounts over ≤ ~83k masked pixels; vectorscope = 1 bincount + a 128×128
+- Capture ≈ 360×~240 RGBA render + one numpy conversion; parade = 3
+  bincounts over ≤ ~86k masked pixels; vectorscope = 1 bincount + a 128×128
   colorize. Total well under 10 ms on the target machines; debounced at
-  120 ms so wheel-zoom/pan/slider drags never queue more than ~8 updates/s.
+  120 ms so rotate/slider drags never queue more than ~8 updates/s. Zoom and
+  pan trigger no work at all.
 - Probe sampling is O(1) per mouse-move (one cached-QImage pixel read +
   two tiny widget `update()`s that only repaint markers).
 
@@ -261,3 +276,15 @@ Pure math (no Qt beyond an offscreen QApplication where widgets are smoked):
   swatch conveys the color at a glance.
 - Readout stays live while collapsed (the header is visible either way and
   the probe is O(1)); only capture/compute is skipped when collapsed.
+
+## 11. Amendments (v3)
+
+- **Zoom/pan independence** (user feedback): scopes are computed over the
+  whole displayed image, not the zoomed visible window. Crop and slice DO
+  affect them (the displayed pixmap is pre-cropped; slices are new images);
+  zoom/pan do NOT. Capture renders the item through `sceneTransform` only.
+- **10-bit parade axis**: DaVinci-style labels 0–1023 in a left gutter, a
+  gridline every 128 codes plus 1023; Cineon reference lines at 95 and 685
+  (dashed, `SCOPE_REF` amber, labels at the right edge).
+- **Skin-tone line**: vectorscope draws the +I-axis line from the center to
+  the 100% circle (`scopes.skin_tone_direction()`, `SCOPE_SKIN`).

--- a/spec/color-scopes-panel.md
+++ b/spec/color-scopes-panel.md
@@ -1,0 +1,263 @@
+# Spec: Color Scopes Panel (RGB Parade + Vectorscope)
+
+Status: REFINED v2
+Owner: FreeCCR
+Feature branch: `feature/color-scopes`
+
+## 1. Summary
+
+Add a collapsible **Scopes** area at the bottom of the canvas (inside
+`ImagePreview`, between the graphics view and the fine-rotation slider) showing
+two video-style color scopes computed from **what is currently visible in the
+canvas viewport** (zoom, pan, crop, rotation and the applied adjustments all
+included):
+
+- **RGB Parade** — three side-by-side per-channel waveforms: x = horizontal
+  position across the visible window, y = channel value (0 bottom … 255 top),
+  brightness = pixel count.
+- **Vectorscope** — chroma distribution on the CbCr plane with the standard
+  R/Mg/B/Cy/G/Yl 75% targets.
+
+While the mouse is over the canvas, a readout in the panel header shows the
+RGB value under the cursor, and that value is marked with a circle on the
+parade (one per channel) and on the vectorscope.
+
+## 2. Goals / Non-goals
+
+### Goals
+- Collapsible area at the bottom of the canvas; header always visible,
+  body (the scopes) shown/hidden by clicking the header toggle.
+  **Collapsed by default**; state persists across sessions (QSettings).
+- Scopes computed from the *visible canvas window* — the viewport content:
+  zoomed/panned region only, display crop applied, orientation as displayed.
+  Letterboxed (empty) canvas areas are excluded from the statistics.
+- Live updates: image switch, slider adjustments, convert/unconvert, zoom,
+  pan, rotate/flip, crop, window resize, hi-res detail swap-in. Updates are
+  coalesced with a short debounce so drags stay fluid.
+- Hover probe: RGB value readout (8-bit display values, matching what the
+  scopes plot) + marker circles on both scopes. Cleared when the cursor
+  leaves the canvas or the image.
+- Pure-numpy scope math in a new `src/core/scopes.py`, unit-testable without
+  Qt.
+
+### Non-goals
+- No waveform (luma) or histogram scope — the right panel already has a
+  histogram; parade + vectorscope only.
+- No scopes for the full image independent of the view (explicitly
+  viewport-based per the feature request).
+- No configurable scope options (scale, skin-tone indicator toggle, 601/709
+  matrix choice) in v1.
+- No GPU path; the computation is a few-ms numpy pass over a small
+  (~360px-wide) downsample of the viewport.
+- No export/snapshot of scope images.
+
+## 3. UX / Interaction
+
+### 3.1 Placement & chrome
+- New `ScopesPanel(QWidget)` inserted into `ImagePreview.layout` directly
+  **after `self.view`** and before the rotation slider.
+- Header row (~24 px, always visible): a flat toggle button `+ Scopes` /
+  `- Scopes` styled like `CollapsibleSection` in the sliders panel, a stretch,
+  then the hover readout: a small color swatch + `R --- G --- B ---` label
+  (monospace-ish, fixed width so it doesn't jitter).
+- Body (only when expanded): fixed height ~180 px, horizontal layout:
+  parade widget (stretch) + vectorscope widget (fixed square, height×height).
+- Both scope widgets paint on the dark scope background with rounded corners,
+  matching `HistogramWidget` chrome (`theme.Paint`-style constants).
+
+### 3.2 Collapse behaviour
+- Clicking the header toggles the body. Collapsed → no capture/compute work
+  is done (a dirty flag remembers a pending refresh; expanding triggers one).
+- Expanded state saved to `QSettings("FreeCCR", "FreeCCR")` under
+  `scopes/expanded` (bool, default `False`).
+
+### 3.3 Hover probe
+- Moving the mouse over the canvas (any mode) samples the displayed preview
+  pixel under the cursor:
+  - Header readout shows `R nnn G nnn B nnn` + swatch of that color.
+  - Parade: one small circle per channel cell at
+    (cursor x-fraction of the viewport, channel value).
+  - Vectorscope: one circle at the value's (Cb, Cr) position.
+- Cursor outside the image (letterbox) or off the canvas → readout shows
+  `R --- G --- B ---`, markers disappear.
+- Sampling reads the *preview-resolution* displayed pixmap (the same data the
+  scopes are computed from, up to resampling); it does not force a hi-res
+  fetch.
+
+## 4. Data model
+
+No persisted per-image state. Transient state only:
+
+- `ScopesPanel._parade` — `np.ndarray (3, 256, W) float32` counts or None.
+- `ScopesPanel._vector` — `np.ndarray (S, S) float32` counts (S=128) or None.
+- `ScopesPanel._probe` — `(r, g, b, x_frac)` or None.
+- `ImagePreview._scope_timer` — single-shot debounce (120 ms).
+- `ImagePreview._probe_qimage` — cached `QImage` of `current_pixmap` for fast
+  pixel sampling; invalidated whenever `current_pixmap` changes.
+
+## 5. Processing / math (`src/core/scopes.py`)
+
+All functions pure numpy, no Qt imports.
+
+### 5.1 Visible-window capture (in `ImagePreview`, Qt side)
+- Render **only the pixmap item** into an offscreen `QImage`
+  (`Format_RGBA8888`, transparent-filled) of the viewport's aspect at
+  `max_width = 360`:
+  - `s = min(1.0, 360 / viewport_width)`; image size
+    `round(viewport_size * s)`,
+  - painter transform = `pixmap_item.sceneTransform() *
+    view.viewportTransform() * QTransform.fromScale(s, s)` (Qt composes
+    left-to-right: item → scene → viewport → downscale),
+  - `drawPixmap(0, 0, pixmap_item.pixmap())` with SmoothPixmapTransform.
+- This bakes in zoom, pan, flips, 90° and fine rotation, display crop, and
+  the hi-res prescale for free; pixels not covered by the image keep
+  alpha 0. Overlay items (reference frame, crop/area/dust/slice chrome)
+  are **not** rendered — only image pixels feed the scopes. In crop/area/
+  dust/slice modes the scopes reflect what those modes display (the full
+  un-cropped image), which is exactly the "visible canvas window".
+- numpy view via `constBits()`: rows sliced to `bytesPerLine` then trimmed
+  to `w*4` (RGBA8888 is byte-ordered R,G,B,A on all platforms);
+  `rgb (h, w, 3) uint8`, `mask = alpha >= 250` (excludes letterbox AND
+  antialiased image edges, which are blended toward transparent and would
+  otherwise pollute the low end).
+
+### 5.2 RGB parade
+```
+compute_parade(rgb, mask) -> counts (3, 256, W) float32
+```
+For each channel c: `counts[c][v][x]` = number of masked pixels in column x
+with value v. Implemented per channel as one `np.bincount` on
+`x_index * 256 + value` over the masked pixels, reshaped `(W, 256)` and
+transposed.
+
+### 5.3 Vectorscope
+```
+rgb_to_cbcr(rgb) -> (cb, cr)  float, BT.601 full-range:
+  cb = -0.168736 R - 0.331264 G + 0.5 B          # [-127.5, 127.5]
+  cr =  0.5 R - 0.418688 G - 0.081312 B
+compute_vectorscope(rgb, mask, size=128) -> counts (size, size) float32
+```
+Bin index: `ix = clip((cb + 128) * size/256)`, `iy = clip((128 - cr) *
+size/256)` (+Cr points up). One `np.bincount` over `iy * size + ix`.
+
+Graticule targets (R/Mg/B/Cy/G/Yl) are derived at paint time from the same
+`rgb_to_cbcr` at 75% intensity so the boxes always agree with plotted data.
+
+### 5.4 Display normalisation (shared helper)
+```
+scale_counts(counts, pctl=98.0, gamma=0.55) -> [0,1] float32
+```
+Reference = the `pctl` percentile of the *nonzero* counts (robust against a
+dominant flat area crushing everything, same philosophy as the histogram
+widget), then `clip(counts/ref, 0, 1) ** gamma` for visibility of sparse
+traces.
+
+## 6. Rendering (`src/widgets/scopes_panel.py`)
+
+### 6.1 `ParadeScopeWidget`
+- Builds an RGB `QImage` from the scaled counts: three cells side by side
+  (R, G, B), each `W` wide × 256 tall, cell pixels = channel theme color ×
+  intensity; row 0 = value 255 (image is vertically flipped from the counts
+  array). The QImage is regenerated on `set_data` and drawn scaled to the
+  plot rect (smooth) in `paintEvent`.
+- Graticule: horizontal lines at 25/50/75% + thin separators between cells.
+- Probe: three circles (white fill, dark outline) at
+  `(cell_left + x_frac * cell_w, top + (1 - v/255) * plot_h)`.
+
+### 6.2 `VectorscopeWidget`
+- Square plot centered in the widget. Bin colors: constant-luma YCbCr→RGB of
+  each bin's (cb, cr) at Y≈140/255, scaled by intensity (so the trace is
+  tinted by its actual hue, Resolve-style). The `(S, S, 3)` hue LUT is
+  static per size — computed once and cached at module level
+  (`vector_color_lut(size)` in `core/scopes.py`, testable). Regenerated as
+  a small `S×S` QImage on `set_data`, drawn scaled (smooth).
+- Graticule: outer circle (100%), faint inner circle (75%), crosshair, and
+  six 75% target squares labeled R/Mg/B/Cy/G/Yl.
+- Probe: one circle at the probe value's bin position.
+
+### 6.3 `ScopesPanel`
+- `set_frame(rgb, mask)` — computes both scopes and updates the children.
+- `clear()` — empties scopes + probe (image removed).
+- `set_probe(r, g, b, x_frac)` / `clear_probe()` — header readout + child
+  markers.
+- `is_expanded()` / toggle handling + QSettings persistence.
+- Signal `expanded_changed(bool)` so `ImagePreview` can trigger the deferred
+  refresh.
+
+## 7. Integration points (`src/widgets/image_preview.py`)
+
+1. `__init__`: create `self.scopes_panel = ScopesPanel()`, insert after the
+   view; create `_scope_timer` (single-shot, 120 ms → `_update_scopes_now`);
+   connect both view scrollbars' `valueChanged` → `_schedule_scope_update`
+   (covers all pan paths — middle-drag, space-drag both move scrollbars);
+   connect `scopes_panel.expanded_changed` → schedule.
+2. `_schedule_scope_update()` called from:
+   - `update_preview` (image switch / adjustments / convert — after
+     `apply_transformations`),
+   - `apply_transformations` (rotate / flip / fine rotation / fit),
+   - `_apply_zoom_scale` and `zoom_to_fit` / the fit-snap branch of
+     `zoom_by` (zoom),
+   - `GraphicsImageView.resizeEvent` (viewport geometry),
+   - `_refresh_item_pixmap` (hi-res detail swap in/out).
+   Collapsed panel → just set the dirty flag.
+3. `_update_scopes_now()`: capture per §5.1; `scopes_panel.set_frame(...)`;
+   None capture (no image) → `scopes_panel.clear()`.
+4. `clear_preview()` → `scopes_panel.clear()`.
+5. Hover: at the top of `GraphicsImageView.mouseMoveEvent`, call
+   `parent_widget.probe_color_at(event.pos())` (guarded try-free, cheap);
+   `leaveEvent` → `parent_widget.clear_color_probe()`.
+6. `probe_color_at(vp_pos)`: viewport → scene → inverse
+   `_display_transform()` → preview-pixmap pixel; sample the cached
+   `_probe_qimage`, built lazily from `current_pixmap` and keyed on
+   `current_pixmap.cacheKey()` (so slider/convert refreshes that swap the
+   pixmap invalidate it automatically); out of bounds →
+   `clear_color_probe()`. x_frac = `vp_pos.x() / viewport.width()`.
+   The probe hook runs at the very top of `mouseMoveEvent` (before the
+   mid-pan / mode dispatch early-returns) so it works in every mode.
+7. Theme: new `theme.Paint` constants — `SCOPE_BG`, `SCOPE_GRID`,
+   `SCOPE_MARKER`, reuse `HIST_R/G/B` for parade tints.
+
+## 8. Performance
+
+- Capture ≈ 360×~230 RGBA render + one numpy conversion; parade = 3
+  bincounts over ≤ ~83k masked pixels; vectorscope = 1 bincount + a 128×128
+  colorize. Total well under 10 ms on the target machines; debounced at
+  120 ms so wheel-zoom/pan/slider drags never queue more than ~8 updates/s.
+- Probe sampling is O(1) per mouse-move (one cached-QImage pixel read +
+  two tiny widget `update()`s that only repaint markers).
+
+## 9. Test plan (`tests/test_scopes.py`)
+
+Pure math (no Qt beyond an offscreen QApplication where widgets are smoked):
+
+1. `compute_parade`: synthetic 4×4 image with known per-column values → the
+   expected (channel, value, column) bins hold the expected counts; masked
+   pixels are excluded; total counts per channel = mask sum.
+2. `compute_vectorscope`: pure gray frame → all mass in the center bin;
+   pure red / pure blue → mass at the expected quadrant (sign checks on
+   cb/cr); masked-out pixels excluded.
+3. `rgb_to_cbcr`: gray → (0, 0); red → (cb<0, cr>0); blue → (cb>0, cr<0);
+   green → (cb<0, cr<0); yellow ≈ opposite of blue.
+4. `scale_counts`: output in [0,1]; a dominant pile does not crush a sparse
+   trace to 0 (percentile reference); all-zero input → all-zero output.
+5. Widget smoke: construct `ScopesPanel`, feed a synthetic frame via
+   `set_frame`, toggle expand, set/clear probe, `grab()` renders non-empty
+   without errors (offscreen platform, same pattern as
+   `test_histogram_widget.py`).
+6. Integration-ish: `ImagePreview` capture helper returns None with no
+   image (no crash), and a probe outside the pixmap clears the readout —
+   only if constructing `ImagePreview` headless is already done in existing
+   tests; otherwise keep to widget level.
+
+## 10. Resolved questions (v2)
+
+- Future scope types: the header stays a dumb toggle; anything more waits
+  for a real second scope.
+- Cursor over letterbox / off-image: **no markers, dashed readout** — there
+  is no pixel value to represent.
+- Expanded body height: **180 px** (vectorscope 180×180, parade gets the
+  rest of the width).
+- Readout format: **8-bit values only** — matches the scope axes; the
+  swatch conveys the color at a glance.
+- Readout stays live while collapsed (the header is visible either way and
+  the probe is O(1)); only capture/compute is skipped when collapsed.

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -12,7 +12,7 @@ from PySide6.QtGui import QImage, QPixmap  # or from PySide6.QtGui import QImage
 #import lensfunpy  # Make sure lensfunpy is installed
 from core.ccr_processor import (adjust_image, adjust_image_opencl,
                                 BAND_ADJUSTMENT_KEYS, apply_curves,
-                                apply_gamma_curve,
+                                apply_gamma_curve, apply_cineon_to_rec709,
                                 apply_area_layers, apply_crop_to_image,
                                 apply_dust_removal, _apply_working_space_recovery,
                                 compute_auto_gain_offset)
@@ -969,6 +969,12 @@ class CCRImage:
             adjusted = apply_area_layers(adjusted, areas, self._adjust_for_area)
         if profile == "bw":
             adjusted = self._to_grayscale(adjusted)
+        # Cineon film log → Rec.709 (γ 2.2): optional FINAL stage after every
+        # other adjustment (Channel Levels checkbox), so preview, hi-res zoom
+        # and export transform identically. Whole-image only — area layers
+        # never carry the key. See spec/cineon-display-transform.md.
+        if s.get("cineon_log"):
+            adjusted = apply_cineon_to_rec709(adjusted)
         return adjusted
 
     def _adjust_for_area(self, base_u16: np.ndarray, settings: dict) -> np.ndarray:

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3141,6 +3141,44 @@ def apply_gamma_curve(img16: np.ndarray, gamma: float,
     return apply_curves(img16, {"rgb": gamma_curve_points(gamma)})
 
 
+# --- Cineon film log → Rec.709 (γ 2.2) display conversion -------------------
+# Optional FINAL pipeline stage (the "Cineon Log → Rec.709" checkbox in the
+# Channel Levels section; settings key "cineon_log"): interpret the fully-
+# adjusted image as Cineon printing-density log and convert to Rec.709 video
+# with a plain 2.2 gamma. Standard Kodak constants: 10-bit code 95 = black
+# (Dmin), 685 = 90% white — the same codes the Scopes parade marks — with
+# 0.002 log10 density per code over a 0.6 negative gamma. Values above 685
+# clip to white (the classic video-range conversion, no soft shoulder). See
+# spec/cineon-display-transform.md.
+CINEON_BLACK_CODE = 95.0
+CINEON_WHITE_CODE = 685.0
+_CINEON_NEG_GAMMA = 0.6
+_CINEON_DENSITY_PER_CODE = 0.002
+
+_cineon_lut16_cache = None
+
+
+def _cineon_rec709_lut16() -> np.ndarray:
+    """65536-entry uint16 LUT: 16-bit input (≡ 10-bit code · 1023/65535) →
+    Rec.709 gamma-2.2 output. Built once and cached."""
+    global _cineon_lut16_cache
+    if _cineon_lut16_cache is None:
+        code = np.linspace(0.0, 1023.0, 65536, dtype=np.float64)
+        gain = _CINEON_DENSITY_PER_CODE / _CINEON_NEG_GAMMA
+        off = 10.0 ** ((CINEON_BLACK_CODE - CINEON_WHITE_CODE) * gain)
+        lin = (10.0 ** ((code - CINEON_WHITE_CODE) * gain) - off) / (1.0 - off)
+        lin = np.clip(lin, 0.0, 1.0)
+        _cineon_lut16_cache = np.round(
+            np.power(lin, 1.0 / 2.2) * 65535.0).astype(np.uint16)
+    return _cineon_lut16_cache
+
+
+def apply_cineon_to_rec709(img16: np.ndarray) -> np.ndarray:
+    """Cineon log → Rec.709 (γ 2.2), per channel. Applied after ALL other
+    adjustments so preview, hi-res zoom and export transform identically."""
+    return _cineon_rec709_lut16()[img16]
+
+
 # --- Dust removal (spot inpainting) ----------------------------------------
 # Dust edits are stored as NORMALIZED spots (fractions of width/height) on the
 # image, so the same definition reproduces at the 1080px preview, the hi-res

--- a/src/core/scopes.py
+++ b/src/core/scopes.py
@@ -2,7 +2,7 @@
 
 No Qt imports — everything here is unit-testable headless. The Qt side
 (widgets/scopes_panel.py) turns these count arrays into images; the capture of
-the visible canvas window lives in widgets/image_preview.py. See
+the displayed image lives in widgets/image_preview.py. See
 spec/color-scopes-panel.md.
 """
 
@@ -15,6 +15,12 @@ _CB_W = np.array([-0.168736, -0.331264, 0.5], dtype=np.float32)
 _CR_W = np.array([0.5, -0.418688, -0.081312], dtype=np.float32)
 
 VECTOR_SIZE = 128           # vectorscope histogram bins per side
+
+# Parade display axis (DaVinci-style 10-bit code values). The data stays
+# 8-bit/256 bins — 8-bit 255 ≡ 10-bit 1023, so only labels/graticule change.
+PARADE_MAX_CODE = 1023
+PARADE_GRID_STEP = 128      # a graticule line every 128 codes (+ the 1023 top)
+CINEON_REF_CODES = (95, 685)  # Cineon printing-density refs: Dmin / 90% white
 
 
 def rgb_to_cbcr(rgb):
@@ -101,6 +107,17 @@ def vector_color_lut(size=VECTOR_SIZE, luma=140.0):
         lut = np.clip(np.stack([r, g, b], axis=-1) / 255.0, 0.0, 1.0)
         _VECTOR_LUT_CACHE[key] = lut
     return lut
+
+
+def skin_tone_direction():
+    """Unit (cb, cr) direction of the vectorscope skin-tone line: the +I axis
+    of YIQ, mapped through the same RGB→CbCr conversion as the trace. The RGB
+    direction of pure +I (Y=0, Q=0) comes from the NTSC YIQ inverse matrix;
+    in our plane it lands at ≈132° — between the R and Yl targets, closer to
+    R, the classic 10:30–11 o'clock skin line."""
+    cb, cr = rgb_to_cbcr(np.array([0.9563, -0.2721, -1.1070], dtype=np.float32))
+    norm = float(np.hypot(cb, cr))
+    return float(cb) / norm, float(cr) / norm
 
 
 def vector_targets(frac=0.75):

--- a/src/core/scopes.py
+++ b/src/core/scopes.py
@@ -1,0 +1,117 @@
+"""Pure-numpy scope math for the canvas Scopes panel (RGB parade + vectorscope).
+
+No Qt imports — everything here is unit-testable headless. The Qt side
+(widgets/scopes_panel.py) turns these count arrays into images; the capture of
+the visible canvas window lives in widgets/image_preview.py. See
+spec/color-scopes-panel.md.
+"""
+
+import numpy as np
+
+# BT.601 full-range chroma weights (the standard vectorscope plane). For 8-bit
+# RGB input Cb/Cr land in ~[-127.5, 127.5]; both weight rows sum to exactly 0,
+# so every neutral gray maps to the scope center.
+_CB_W = np.array([-0.168736, -0.331264, 0.5], dtype=np.float32)
+_CR_W = np.array([0.5, -0.418688, -0.081312], dtype=np.float32)
+
+VECTOR_SIZE = 128           # vectorscope histogram bins per side
+
+
+def rgb_to_cbcr(rgb):
+    """RGB (..., 3) → (cb, cr) float32 arrays in ~[-128, 128]."""
+    a = np.asarray(rgb, dtype=np.float32)
+    return a @ _CB_W, a @ _CR_W
+
+
+def compute_parade(rgb, mask):
+    """Per-column per-value counts for the RGB parade.
+
+    rgb (H, W, 3) uint8, mask (H, W) bool → counts (3, 256, W) float32 where
+    ``counts[c, v, x]`` = number of masked pixels in column x with value v.
+    """
+    h, w = np.asarray(mask).shape
+    counts = np.zeros((3, 256, w), dtype=np.float32)
+    ys, xs = np.nonzero(mask)
+    if xs.size == 0:
+        return counts
+    base = xs.astype(np.intp) * 256
+    for c in range(3):
+        flat = base + rgb[ys, xs, c].astype(np.intp)
+        counts[c] = np.bincount(flat, minlength=w * 256).reshape(w, 256).T
+    return counts
+
+
+def compute_vectorscope(rgb, mask, size=VECTOR_SIZE):
+    """2D chroma histogram on the CbCr plane.
+
+    Returns (size, size) float32 counts; x = Cb (left→right), y = Cr with
+    +Cr UP (row 0 = strongest red direction) — broadcast-vectorscope
+    orientation, matching :func:`cbcr_to_plot`.
+    """
+    px = np.asarray(rgb)[np.asarray(mask, dtype=bool)]
+    if px.size == 0:
+        return np.zeros((size, size), dtype=np.float32)
+    cb, cr = rgb_to_cbcr(px)
+    scale = size / 256.0
+    ix = np.clip(((cb + 128.0) * scale).astype(np.intp), 0, size - 1)
+    iy = np.clip(((128.0 - cr) * scale).astype(np.intp), 0, size - 1)
+    counts = np.bincount(iy * size + ix, minlength=size * size)
+    return counts.reshape(size, size).astype(np.float32)
+
+
+def cbcr_to_plot(cb, cr, size):
+    """Map chroma coordinates to (x, y) on a size×size plot (same convention
+    as compute_vectorscope: +Cb right, +Cr up)."""
+    scale = size / 256.0
+    return (cb + 128.0) * scale, (128.0 - cr) * scale
+
+
+def scale_counts(counts, pctl=98.0, gamma=0.55):
+    """Normalise raw counts to [0, 1] display intensity.
+
+    The reference is a high percentile of the NONZERO counts — a dominant
+    flat-area pile must clip at full brightness instead of defining the scale
+    and crushing sparse single-pixel traces to invisibility (same philosophy
+    as the histogram widget's vertical scale). The sub-linear gamma then
+    lifts what remains of the faint traces into the visible range.
+    """
+    c = np.asarray(counts, dtype=np.float32)
+    nz = c[c > 0]
+    if nz.size == 0:
+        return np.zeros_like(c)
+    ref = max(float(np.percentile(nz, pctl)), 1.0)
+    return np.clip(c / ref, 0.0, 1.0) ** np.float32(gamma)
+
+
+_VECTOR_LUT_CACHE = {}
+
+
+def vector_color_lut(size=VECTOR_SIZE, luma=140.0):
+    """(size, size, 3) float32 in [0, 1]: the RGB hue of each CbCr bin at a
+    fixed luma. Multiplied by the trace intensity it tints the vectorscope
+    trace with its own hue. Static per size — cached."""
+    key = (size, luma)
+    lut = _VECTOR_LUT_CACHE.get(key)
+    if lut is None:
+        axis = (np.arange(size, dtype=np.float32) + 0.5) * (256.0 / size) - 128.0
+        cb, cr = np.meshgrid(axis, -axis)   # row 0 = +Cr (up), like compute_vectorscope
+        r = luma + 1.402 * cr
+        g = luma - 0.344136 * cb - 0.714136 * cr
+        b = luma + 1.772 * cb
+        lut = np.clip(np.stack([r, g, b], axis=-1) / 255.0, 0.0, 1.0)
+        _VECTOR_LUT_CACHE[key] = lut
+    return lut
+
+
+def vector_targets(frac=0.75):
+    """The six standard vectorscope targets at ``frac`` intensity, derived
+    from the same RGB→CbCr conversion the trace uses (so the boxes always
+    agree with plotted data). Returns [(label, cb, cr)] in R Mg B Cy G Yl
+    order."""
+    prim = (("R", (255, 0, 0)), ("Mg", (255, 0, 255)), ("B", (0, 0, 255)),
+            ("Cy", (0, 255, 255)), ("G", (0, 255, 0)), ("Yl", (255, 255, 0)))
+    out = []
+    for name, c in prim:
+        cb, cr = rgb_to_cbcr(np.array(c, dtype=np.float32) * frac)
+        out.append((name, float(cb), float(cr)))
+    return out

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -108,6 +108,13 @@ class Paint:
     HIST_G = (90, 200, 90)
     HIST_B = (100, 140, 235)
     HIST_PEAK = (235, 235, 235)       # where all channels overlap / clip-all wedge
+    # Scopes panel (widgets/scopes_panel.py): RGB parade + vectorscope under
+    # the canvas. Darker than HIST_BG — the additive traces need contrast.
+    SCOPE_BG = (26, 26, 26)
+    SCOPE_GRID = (255, 255, 255, 30)
+    SCOPE_LABEL = (255, 255, 255, 90)
+    SCOPE_MARKER = (255, 255, 255, 235)
+    SCOPE_MARKER_OUTLINE = (20, 20, 20, 220)
 
 
 class Overlay:

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -115,6 +115,8 @@ class Paint:
     SCOPE_LABEL = (255, 255, 255, 90)
     SCOPE_MARKER = (255, 255, 255, 235)
     SCOPE_MARKER_OUTLINE = (20, 20, 20, 220)
+    SCOPE_REF = (225, 175, 80, 180)   # Cineon 95/685 reference lines (amber)
+    SCOPE_SKIN = (230, 165, 145, 150)  # vectorscope skin-tone line
 
 
 class Overlay:

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -493,9 +493,6 @@ class GraphicsImageView(QGraphicsView):
         # Let the parent widget handle the fitting to avoid conflicts
         if self.parent_widget and self.parent_widget.pixmap_item:
             self.parent_widget._fit_view_to_content()
-        elif self.parent_widget is not None:
-            # No refit (e.g. zoomed in): the viewport still changed shape.
-            self.parent_widget._schedule_scope_update()
 
     def drawForeground(self, painter, rect):
         super().drawForeground(painter, rect)
@@ -761,8 +758,9 @@ class ImagePreview(QWidget):
         self.view.setScene(self.scene)
         self.layout.addWidget(self.view)
 
-        # Scopes (RGB parade + vectorscope) computed from the visible canvas
-        # window — collapsible, below the canvas. See spec/color-scopes-panel.md.
+        # Scopes (RGB parade + vectorscope) computed from the displayed image
+        # (zoom/pan-independent) — collapsible, below the canvas. See
+        # spec/color-scopes-panel.md.
         self.scopes_panel = ScopesPanel()
         self.layout.addWidget(self.scopes_panel)
 
@@ -881,19 +879,17 @@ class ImagePreview(QWidget):
         self._current_image_ref = None
 
         # --- Scopes state ---
-        # Debounced viewport capture → ScopesPanel. The scrollbars cover every
-        # pan path (middle-drag and space-drag both move them); zoom, fit,
-        # image refresh and hi-res swaps schedule from their own choke points.
+        # Debounced displayed-image capture → ScopesPanel. Zoom/pan do NOT
+        # affect the scopes, so no viewport hooks: update_preview (image
+        # switch / adjustments / crop / slice results) and
+        # apply_transformations (orientation, hi-res pixmap swaps) are the
+        # only schedule points.
         self._scope_timer = QTimer(self)
         self._scope_timer.setSingleShot(True)
         self._scope_timer.timeout.connect(self._update_scopes_now)
         self._scopes_dirty = False       # refresh deferred while collapsed
         self._probe_qimage = None        # cached QImage of current_pixmap
         self._probe_qimage_key = None    # its QPixmap.cacheKey()
-        self.view.horizontalScrollBar().valueChanged.connect(
-            self._schedule_scope_update)
-        self.view.verticalScrollBar().valueChanged.connect(
-            self._schedule_scope_update)
         self.scopes_panel.expanded_changed.connect(self._on_scopes_expanded)
 
         self._update_unconvert_action_state()
@@ -1240,9 +1236,6 @@ class ImagePreview(QWidget):
             self._draw_slice_dim()
             if self._slice_lines:
                 self._redraw_slice_lines()
-        # Fit/refit changes what the viewport shows (covers rotate/flip, the
-        # zoom snap-back-to-fit paths, and window resizes with a pixmap).
-        self._schedule_scope_update()
 
     def apply_transformations(self):
         if not self.pixmap_item:
@@ -1304,6 +1297,11 @@ class ImagePreview(QWidget):
         # rebuilds the crop overlay when crop mode is active, keeping the
         # dim region and handles aligned after rotates/flips.)
         self._fit_view_to_content()
+
+        # The displayed image content/orientation may have changed (rotate,
+        # flip, fine rotation, hi-res pixmap swap) — refresh the scopes.
+        # Zoom/pan paths never come through here, so they don't retrigger.
+        self._schedule_scope_update()
 
     def _end_fine_rot_burst(self):
         self._fine_rot_burst_active = False
@@ -1544,7 +1542,6 @@ class ImagePreview(QWidget):
             self._draw_crop_overlay()  # handle sizes track the view scale
         if self.area_mode:
             self._draw_area_overlay()  # area handle sizes track the view scale too
-        self._schedule_scope_update()
 
     def zoom_to_percent(self, pct):
         """Zoom to an absolute percentage of the source's ACTUAL size (1.0 =
@@ -1862,8 +1859,6 @@ class ImagePreview(QWidget):
         else:
             self._item_prescale = 1.0
             self.pixmap_item.setPixmap(self.current_pixmap)
-        # The displayed pixels just swapped (preview ↔ hi-res detail).
-        self._schedule_scope_update()
 
     def _release_hires(self, refresh=True):
         """Free hi-res detail memory (zoomed out / image switched). In-flight
@@ -1877,14 +1872,15 @@ class ImagePreview(QWidget):
             self.apply_transformations()
 
     # --- Scopes (RGB parade + vectorscope) --------------------------------
-    # Computed from the VISIBLE canvas window: only the pixmap item is
-    # re-rendered offscreen at reduced size through the live item→viewport
-    # transform, so zoom/pan/crop/orientation/hi-res are all baked in and
-    # overlays (reference frame, crop chrome, ...) are excluded. See
-    # spec/color-scopes-panel.md.
+    # Computed from the DISPLAYED image: the pixmap item is re-rendered
+    # offscreen at reduced size through its scene transform, so display crop,
+    # orientation and the hi-res prescale are baked in while overlays
+    # (reference frame, crop chrome, ...) are excluded. Zoom/pan deliberately
+    # do NOT change the scopes — the item is captured whole, not through the
+    # viewport. See spec/color-scopes-panel.md.
 
-    SCOPE_CAPTURE_W = 360      # offscreen capture width (px, viewport aspect)
-    SCOPE_DEBOUNCE_MS = 120    # coalesce zoom/pan/slider bursts
+    SCOPE_CAPTURE_W = 360      # offscreen capture width (px, image aspect)
+    SCOPE_DEBOUNCE_MS = 120    # coalesce rotate/slider bursts
 
     def _schedule_scope_update(self, *_):
         """Debounced refresh request; deferred while the panel is collapsed
@@ -1900,32 +1896,34 @@ class ImagePreview(QWidget):
 
     def _update_scopes_now(self):
         self._scopes_dirty = False
-        frame = self._capture_visible_region()
+        frame = self._capture_display_image()
         if frame is None:
             self.scopes_panel.clear()
         else:
             self.scopes_panel.set_frame(*frame)
 
-    def _capture_visible_region(self):
-        """Render only the pixmap item over the viewport into a small RGBA
-        image; returns (rgb (h,w,3) uint8, mask (h,w) bool) or None. Alpha
-        stays 0 wherever the image doesn't cover the viewport — the mask
-        excludes that letterbox (and the antialiased image edge, which is
+    def _capture_display_image(self):
+        """Render the whole pixmap item (the displayed image: crop applied,
+        orientation as shown, hi-res prescale included — zoom/pan excluded)
+        into a small RGBA image; returns (rgb (h,w,3) uint8, mask (h,w) bool)
+        or None. Alpha stays 0 in the corner gaps a fine rotation leaves —
+        the mask excludes them (and the antialiased image edge, which is
         blended toward transparent and would pollute the low end)."""
         if self.pixmap_item is None or self.current_pixmap is None:
             return None
-        vp = self.view.viewport().rect()
-        if vp.width() <= 0 or vp.height() <= 0:
+        br = self.pixmap_item.mapToScene(
+            self.pixmap_item.boundingRect()).boundingRect()
+        if br.width() <= 0 or br.height() <= 0:
             return None
-        s = min(1.0, self.SCOPE_CAPTURE_W / float(vp.width()))
-        w = max(1, round(vp.width() * s))
-        h = max(1, round(vp.height() * s))
+        s = min(1.0, self.SCOPE_CAPTURE_W / br.width())
+        w = max(1, round(br.width() * s))
+        h = max(1, round(br.height() * s))
         img = QImage(w, h, QImage.Format_RGBA8888)
         img.fill(0)
         p = QPainter(img)
         p.setRenderHint(QPainter.SmoothPixmapTransform, True)
         p.setTransform(self.pixmap_item.sceneTransform()
-                       * self.view.viewportTransform()
+                       * QTransform.fromTranslate(-br.left(), -br.top())
                        * QTransform.fromScale(s, s))
         p.drawPixmap(0, 0, self.pixmap_item.pixmap())
         p.end()
@@ -1944,7 +1942,8 @@ class ImagePreview(QWidget):
         t = self.view._display_transform()
         if not t.isInvertible():
             return
-        local = t.inverted()[0].map(self.view.mapToScene(vp_pos))
+        scene_pos = self.view.mapToScene(vp_pos)
+        local = t.inverted()[0].map(scene_pos)
         x, y = int(local.x()), int(local.y())
         pm = self.current_pixmap
         if not (0 <= x < pm.width() and 0 <= y < pm.height()):
@@ -1956,8 +1955,12 @@ class ImagePreview(QWidget):
             self._probe_qimage = pm.toImage()
             self._probe_qimage_key = pm.cacheKey()
         c = self._probe_qimage.pixelColor(x, y)
-        vpw = self.view.viewport().width()
-        x_frac = vp_pos.x() / vpw if vpw > 0 else 0.0
+        # Parade x = fraction across the DISPLAYED image (its scene bounds) —
+        # the same horizontal domain the capture renders, zoom/pan-independent.
+        br = self.pixmap_item.mapToScene(
+            self.pixmap_item.boundingRect()).boundingRect()
+        x_frac = ((scene_pos.x() - br.left()) / br.width()
+                  if br.width() > 0 else 0.0)
         self.scopes_panel.set_probe(c.red(), c.green(), c.blue(), x_frac)
 
     def clear_color_probe(self):

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -12,7 +12,9 @@ from core.ccr_backend import ccr_backend
 from core.ccr_processor import apply_dust_removal
 from core import crop_aspect
 from widgets.export_dialog import ExportSettingsDialog
+from widgets.scopes_panel import ScopesPanel
 from ui import theme
+import numpy as np
 import math
 import copy
 import sys
@@ -205,6 +207,9 @@ class GraphicsImageView(QGraphicsView):
             super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
+        # Hover color probe (Scopes readout + scope markers). Before the mode
+        # dispatch below so it follows the cursor in every mode; O(1) sample.
+        self.parent_widget.probe_color_at(event.pos())
         if self._mid_pan and self._mid_pan_last is not None:
             # Pan by adjusting the (hidden) scrollbars — works even with
             # ScrollBarAlwaysOff, the same mechanism ScrollHandDrag uses.
@@ -488,6 +493,9 @@ class GraphicsImageView(QGraphicsView):
         # Let the parent widget handle the fitting to avoid conflicts
         if self.parent_widget and self.parent_widget.pixmap_item:
             self.parent_widget._fit_view_to_content()
+        elif self.parent_widget is not None:
+            # No refit (e.g. zoomed in): the viewport still changed shape.
+            self.parent_widget._schedule_scope_update()
 
     def drawForeground(self, painter, rect):
         super().drawForeground(painter, rect)
@@ -588,6 +596,8 @@ class GraphicsImageView(QGraphicsView):
         pw = self.parent_widget
         if pw is not None and pw.slice_mode:
             pw._set_slice_ghost(None)
+        if pw is not None:
+            pw.clear_color_probe()
         super().leaveEvent(event)
 
 class CenteringSlider(QSlider):
@@ -751,6 +761,11 @@ class ImagePreview(QWidget):
         self.view.setScene(self.scene)
         self.layout.addWidget(self.view)
 
+        # Scopes (RGB parade + vectorscope) computed from the visible canvas
+        # window — collapsible, below the canvas. See spec/color-scopes-panel.md.
+        self.scopes_panel = ScopesPanel()
+        self.layout.addWidget(self.scopes_panel)
+
         # Fine rotation slider
         self.rotation_slider = CenteringSlider(Qt.Horizontal)
         self.rotation_slider.setMinimum(-4500)
@@ -865,6 +880,22 @@ class ImagePreview(QWidget):
         # removed, so "same image?" must never be answered by index alone.
         self._current_image_ref = None
 
+        # --- Scopes state ---
+        # Debounced viewport capture → ScopesPanel. The scrollbars cover every
+        # pan path (middle-drag and space-drag both move them); zoom, fit,
+        # image refresh and hi-res swaps schedule from their own choke points.
+        self._scope_timer = QTimer(self)
+        self._scope_timer.setSingleShot(True)
+        self._scope_timer.timeout.connect(self._update_scopes_now)
+        self._scopes_dirty = False       # refresh deferred while collapsed
+        self._probe_qimage = None        # cached QImage of current_pixmap
+        self._probe_qimage_key = None    # its QPixmap.cacheKey()
+        self.view.horizontalScrollBar().valueChanged.connect(
+            self._schedule_scope_update)
+        self.view.verticalScrollBar().valueChanged.connect(
+            self._schedule_scope_update)
+        self.scopes_panel.expanded_changed.connect(self._on_scopes_expanded)
+
         self._update_unconvert_action_state()
 
         # --- Add hotkey support ---
@@ -917,6 +948,11 @@ class ImagePreview(QWidget):
         self._zoom = 1.0
         self._item_prescale = 1.0
         self.rotation_slider.setEnabled(False)
+        self._scope_timer.stop()
+        self._scopes_dirty = False
+        self._probe_qimage = None
+        self._probe_qimage_key = None
+        self.scopes_panel.clear()
         self._sync_zoom_combo()
         self._update_unconvert_action_state()
 
@@ -1140,6 +1176,7 @@ class ImagePreview(QWidget):
 
         self._update_unconvert_action_state()
         self._sync_zoom_combo()
+        self._schedule_scope_update()
 
     def update_reference_rect(self, start, end):
         # Build the base (coarse) transform
@@ -1203,6 +1240,9 @@ class ImagePreview(QWidget):
             self._draw_slice_dim()
             if self._slice_lines:
                 self._redraw_slice_lines()
+        # Fit/refit changes what the viewport shows (covers rotate/flip, the
+        # zoom snap-back-to-fit paths, and window resizes with a pixmap).
+        self._schedule_scope_update()
 
     def apply_transformations(self):
         if not self.pixmap_item:
@@ -1504,6 +1544,7 @@ class ImagePreview(QWidget):
             self._draw_crop_overlay()  # handle sizes track the view scale
         if self.area_mode:
             self._draw_area_overlay()  # area handle sizes track the view scale too
+        self._schedule_scope_update()
 
     def zoom_to_percent(self, pct):
         """Zoom to an absolute percentage of the source's ACTUAL size (1.0 =
@@ -1821,6 +1862,8 @@ class ImagePreview(QWidget):
         else:
             self._item_prescale = 1.0
             self.pixmap_item.setPixmap(self.current_pixmap)
+        # The displayed pixels just swapped (preview ↔ hi-res detail).
+        self._schedule_scope_update()
 
     def _release_hires(self, refresh=True):
         """Free hi-res detail memory (zoomed out / image switched). In-flight
@@ -1832,6 +1875,93 @@ class ImagePreview(QWidget):
         if had and refresh and self.pixmap_item is not None:
             self._refresh_item_pixmap()
             self.apply_transformations()
+
+    # --- Scopes (RGB parade + vectorscope) --------------------------------
+    # Computed from the VISIBLE canvas window: only the pixmap item is
+    # re-rendered offscreen at reduced size through the live item→viewport
+    # transform, so zoom/pan/crop/orientation/hi-res are all baked in and
+    # overlays (reference frame, crop chrome, ...) are excluded. See
+    # spec/color-scopes-panel.md.
+
+    SCOPE_CAPTURE_W = 360      # offscreen capture width (px, viewport aspect)
+    SCOPE_DEBOUNCE_MS = 120    # coalesce zoom/pan/slider bursts
+
+    def _schedule_scope_update(self, *_):
+        """Debounced refresh request; deferred while the panel is collapsed
+        (the pending flag replays it on expand)."""
+        if not self.scopes_panel.is_expanded():
+            self._scopes_dirty = True
+            return
+        self._scope_timer.start(self.SCOPE_DEBOUNCE_MS)
+
+    def _on_scopes_expanded(self, expanded):
+        if expanded and (self._scopes_dirty or self.pixmap_item is not None):
+            self._scope_timer.start(0)
+
+    def _update_scopes_now(self):
+        self._scopes_dirty = False
+        frame = self._capture_visible_region()
+        if frame is None:
+            self.scopes_panel.clear()
+        else:
+            self.scopes_panel.set_frame(*frame)
+
+    def _capture_visible_region(self):
+        """Render only the pixmap item over the viewport into a small RGBA
+        image; returns (rgb (h,w,3) uint8, mask (h,w) bool) or None. Alpha
+        stays 0 wherever the image doesn't cover the viewport — the mask
+        excludes that letterbox (and the antialiased image edge, which is
+        blended toward transparent and would pollute the low end)."""
+        if self.pixmap_item is None or self.current_pixmap is None:
+            return None
+        vp = self.view.viewport().rect()
+        if vp.width() <= 0 or vp.height() <= 0:
+            return None
+        s = min(1.0, self.SCOPE_CAPTURE_W / float(vp.width()))
+        w = max(1, round(vp.width() * s))
+        h = max(1, round(vp.height() * s))
+        img = QImage(w, h, QImage.Format_RGBA8888)
+        img.fill(0)
+        p = QPainter(img)
+        p.setRenderHint(QPainter.SmoothPixmapTransform, True)
+        p.setTransform(self.pixmap_item.sceneTransform()
+                       * self.view.viewportTransform()
+                       * QTransform.fromScale(s, s))
+        p.drawPixmap(0, 0, self.pixmap_item.pixmap())
+        p.end()
+        buf = np.frombuffer(img.constBits(), dtype=np.uint8)
+        rows = buf.reshape(h, img.bytesPerLine())[:, :w * 4].reshape(h, w, 4)
+        rgb = np.ascontiguousarray(rows[:, :, :3])
+        mask = rows[:, :, 3] >= 250
+        return rgb, mask
+
+    def probe_color_at(self, vp_pos):
+        """Hover probe: sample the displayed preview pixel under the cursor
+        and feed the Scopes readout/markers. Off-image → cleared."""
+        if self.pixmap_item is None or self.current_pixmap is None:
+            self.clear_color_probe()
+            return
+        t = self.view._display_transform()
+        if not t.isInvertible():
+            return
+        local = t.inverted()[0].map(self.view.mapToScene(vp_pos))
+        x, y = int(local.x()), int(local.y())
+        pm = self.current_pixmap
+        if not (0 <= x < pm.width() and 0 <= y < pm.height()):
+            self.clear_color_probe()
+            return
+        # Sampling goes through a cached QImage of the preview pixmap, keyed
+        # on cacheKey() so any refresh that swaps the pixmap invalidates it.
+        if self._probe_qimage is None or self._probe_qimage_key != pm.cacheKey():
+            self._probe_qimage = pm.toImage()
+            self._probe_qimage_key = pm.cacheKey()
+        c = self._probe_qimage.pixelColor(x, y)
+        vpw = self.view.viewport().width()
+        x_frac = vp_pos.x() / vpw if vpw > 0 else 0.0
+        self.scopes_panel.set_probe(c.red(), c.green(), c.blue(), x_frac)
+
+    def clear_color_probe(self):
+        self.scopes_panel.clear_probe()
 
     # --- Slice mode ------------------------------------------------------
     # Splits one scan containing several photos into separate images. Moving

--- a/src/widgets/scopes_panel.py
+++ b/src/widgets/scopes_panel.py
@@ -30,6 +30,11 @@ _RADIUS = 10           # rounded scope backgrounds (matches HistogramWidget)
 _PAD = 6.0             # plot inset inside the rounded background
 _MARKER_R = 4.0        # probe circle radius
 _READOUT_EMPTY = "R --- G --- B ---"
+# Parade dot rendering: single-pixel waveform samples read too faint/thin at
+# screen scale, so each dot gets a soft 1px plus-shaped dilation (neighbors
+# lit at _DOT_SPREAD of the center) and the trace a brightness gain.
+_DOT_GAIN = 1.35
+_DOT_SPREAD = 0.55
 
 
 def _marker_pen_brush():
@@ -108,6 +113,15 @@ class ParadeScopeWidget(_ScopeWidgetBase):
             self._set_trace(None, None)
             return
         inten = scopes.scale_counts(counts)
+        # Bigger, brighter dots: soft-dilate each sample into its 4 neighbors
+        # and lift the overall trace intensity (see _DOT_GAIN/_DOT_SPREAD).
+        soft = inten * np.float32(_DOT_SPREAD)
+        grown = inten.copy()
+        grown[:, 1:, :] = np.maximum(grown[:, 1:, :], soft[:, :-1, :])
+        grown[:, :-1, :] = np.maximum(grown[:, :-1, :], soft[:, 1:, :])
+        grown[:, :, 1:] = np.maximum(grown[:, :, 1:], soft[:, :, :-1])
+        grown[:, :, :-1] = np.maximum(grown[:, :, :-1], soft[:, :, 1:])
+        inten = np.clip(grown * np.float32(_DOT_GAIN), 0.0, 1.0)
         w = inten.shape[2]
         img = np.zeros((256, 3 * w, 3), dtype=np.uint8)
         tints = (theme.Paint.HIST_R, theme.Paint.HIST_G, theme.Paint.HIST_B)

--- a/src/widgets/scopes_panel.py
+++ b/src/widgets/scopes_panel.py
@@ -151,6 +151,13 @@ class ParadeScopeWidget(_ScopeWidgetBase):
             return (cells.bottom()
                     - code / float(scopes.PARADE_MAX_CODE) * cells.height())
 
+        # Trace FIRST — its pixmap is opaque (black where empty), so the
+        # graticule must go on top of it (like the vectorscope's), or loading
+        # an image wipes the grid from view.
+        trace = self._trace_pixmap(round(cells.width()), round(cells.height()))
+        if trace is not None:
+            p.drawPixmap(cells.topLeft(), trace)
+
         # DaVinci-style graticule: a labeled line every 128 codes + the top.
         grid = QColor(*theme.Paint.SCOPE_GRID)
         label = QColor(*theme.Paint.SCOPE_LABEL)
@@ -168,10 +175,6 @@ class ParadeScopeWidget(_ScopeWidgetBase):
         for k in range(1, 3):
             gx = cells.left() + cells.width() * k / 3.0
             p.drawLine(QPointF(gx, cells.top()), QPointF(gx, cells.bottom()))
-
-        trace = self._trace_pixmap(round(cells.width()), round(cells.height()))
-        if trace is not None:
-            p.drawPixmap(cells.topLeft(), trace)
 
         # Cineon reference levels (Dmin 95 / 90%-white 685), over the trace so
         # they stay readable; labels at the right edge, just above the line.

--- a/src/widgets/scopes_panel.py
+++ b/src/widgets/scopes_panel.py
@@ -1,0 +1,337 @@
+"""Collapsible Scopes panel under the canvas: RGB parade + vectorscope.
+
+Both scopes are computed from the VISIBLE canvas window — zoom, pan, display
+crop and orientation exactly as shown. ImagePreview captures the viewport
+pixels (image only, no overlays; letterbox masked out) and feeds them in via
+:meth:`ScopesPanel.set_frame`; all math lives in ``core/scopes.py`` and all
+presentation here. A hover probe (RGB readout in the header + marker circles
+on both scopes) follows the cursor on the canvas via :meth:`set_probe`.
+Collapsed by default; the expanded state persists in QSettings. See
+spec/color-scopes-panel.md.
+"""
+
+import numpy as np
+from PySide6.QtCore import Qt, QPointF, QRectF, QSettings, Signal
+from PySide6.QtGui import (QColor, QFont, QImage, QPainter, QPainterPath,
+                           QPen, QBrush, QPixmap)
+from PySide6.QtWidgets import (QHBoxLayout, QLabel, QPushButton, QSizePolicy,
+                               QVBoxLayout, QWidget)
+
+from core import scopes
+from ui import theme
+
+_BODY_H = 180          # expanded body height (vectorscope is _BODY_H square)
+_RADIUS = 10           # rounded scope backgrounds (matches HistogramWidget)
+_PAD = 6.0             # plot inset inside the rounded background
+_MARKER_R = 4.0        # probe circle radius
+_READOUT_EMPTY = "R --- G --- B ---"
+
+
+def _marker_pen_brush():
+    pen = QPen(QColor(*theme.Paint.SCOPE_MARKER_OUTLINE), 1.5)
+    brush = QBrush(QColor(*theme.Paint.SCOPE_MARKER))
+    return pen, brush
+
+
+class _ScopeWidgetBase(QWidget):
+    """Shared chrome: rounded dark background, border, data/probe storage."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._img = None       # composed QImage of the trace, or None
+        self._img_buf = None   # numpy buffer backing _img (must outlive it)
+        self._probe = None     # (r, g, b, x_frac) or None
+        self._trace_version = 0
+        self._trace_cache = None   # (key, QPixmap) — scaled trace for repaints
+
+    def set_probe(self, probe):
+        self._probe = probe
+        self.update()
+
+    def _set_trace(self, img, buf):
+        self._img = img
+        self._img_buf = buf
+        self._trace_version += 1
+        self._trace_cache = None
+        self.update()
+
+    def _trace_pixmap(self, w, h):
+        """The trace QImage smooth-scaled to (w, h), cached — the probe marker
+        moves on every mouse-move and must not re-rescale the trace each
+        repaint."""
+        if self._img is None or w <= 0 or h <= 0:
+            return None
+        dpr = self.devicePixelRatioF()
+        key = (w, h, dpr, self._trace_version)
+        if self._trace_cache is None or self._trace_cache[0] != key:
+            pm = QPixmap.fromImage(self._img.scaled(
+                max(1, round(w * dpr)), max(1, round(h * dpr)),
+                Qt.IgnoreAspectRatio, Qt.SmoothTransformation))
+            pm.setDevicePixelRatio(dpr)
+            self._trace_cache = (key, pm)
+        return self._trace_cache[1]
+
+    def _begin_paint(self):
+        """Start the painter, fill/clip the rounded background; returns
+        (painter, plot_rect)."""
+        p = QPainter(self)
+        p.setRenderHint(QPainter.Antialiasing, True)
+        bg_rect = QRectF(self.rect()).adjusted(0.5, 0.5, -0.5, -0.5)
+        bg_path = QPainterPath()
+        bg_path.addRoundedRect(bg_rect, _RADIUS, _RADIUS)
+        p.fillPath(bg_path, QColor(*theme.Paint.SCOPE_BG))
+        p.setClipPath(bg_path)
+        self._bg_path = bg_path
+        return p, bg_rect.adjusted(_PAD, _PAD, -_PAD, -_PAD)
+
+    def _end_paint(self, p):
+        p.setClipping(False)
+        p.setPen(QPen(QColor(theme.BORDER), 1))
+        p.setBrush(Qt.NoBrush)
+        p.drawPath(self._bg_path)
+        p.end()
+
+
+class ParadeScopeWidget(_ScopeWidgetBase):
+    """Three side-by-side per-channel waveforms: x = position across the
+    visible window, y = value (0 bottom … 255 top), brightness = count."""
+
+    def set_data(self, counts):
+        """counts (3, 256, W) raw parade counts, or None to clear."""
+        if counts is None or counts.shape[2] == 0:
+            self._set_trace(None, None)
+            return
+        inten = scopes.scale_counts(counts)
+        w = inten.shape[2]
+        img = np.zeros((256, 3 * w, 3), dtype=np.uint8)
+        tints = (theme.Paint.HIST_R, theme.Paint.HIST_G, theme.Paint.HIST_B)
+        for c in range(3):
+            tint = np.array(tints[c], dtype=np.float32)
+            # row 0 = value 255 (top of the plot)
+            cell = inten[c, ::-1, :, None] * tint
+            img[:, c * w:(c + 1) * w, :] = cell.astype(np.uint8)
+        buf = np.ascontiguousarray(img)
+        self._set_trace(QImage(buf.data, 3 * w, 256, 3 * w * 3,
+                               QImage.Format_RGB888), buf)
+
+    def paintEvent(self, event):
+        p, plot = self._begin_paint()
+        # Quarter-tone gridlines + separators between the three cells.
+        p.setPen(QPen(QColor(*theme.Paint.SCOPE_GRID), 1))
+        for k in range(1, 4):
+            gy = plot.top() + plot.height() * k / 4.0
+            p.drawLine(QPointF(plot.left(), gy), QPointF(plot.right(), gy))
+        for k in range(1, 3):
+            gx = plot.left() + plot.width() * k / 3.0
+            p.drawLine(QPointF(gx, plot.top()), QPointF(gx, plot.bottom()))
+        trace = self._trace_pixmap(round(plot.width()), round(plot.height()))
+        if trace is not None:
+            p.drawPixmap(plot.topLeft(), trace)
+        if self._probe is not None:
+            r, g, b, x_frac = self._probe
+            pen, brush = _marker_pen_brush()
+            p.setPen(pen)
+            p.setBrush(brush)
+            cell_w = plot.width() / 3.0
+            for c, v in enumerate((r, g, b)):
+                x = plot.left() + (c + x_frac) * cell_w
+                y = plot.top() + (1.0 - v / 255.0) * plot.height()
+                p.drawEllipse(QPointF(x, y), _MARKER_R, _MARKER_R)
+        self._end_paint(p)
+
+
+class VectorscopeWidget(_ScopeWidgetBase):
+    """Chroma distribution on the CbCr plane (+Cb right, +Cr up) with the
+    standard 75% R/Mg/B/Cy/G/Yl targets; the trace is tinted by its hue."""
+
+    def set_data(self, counts):
+        """counts (S, S) raw vectorscope counts, or None to clear."""
+        if counts is None:
+            self._set_trace(None, None)
+            return
+        size = counts.shape[0]
+        inten = scopes.scale_counts(counts)
+        lut = scopes.vector_color_lut(size)
+        buf = np.ascontiguousarray(
+            (inten[:, :, None] * lut * 255.0).astype(np.uint8))
+        self._set_trace(QImage(buf.data, size, size, size * 3,
+                               QImage.Format_RGB888), buf)
+
+    def _square(self):
+        """The centered plot square (spans Cb/Cr ∈ [-128, 128])."""
+        side = min(self.width(), self.height()) - 2 * _PAD
+        cx, cy = self.width() / 2.0, self.height() / 2.0
+        return QRectF(cx - side / 2.0, cy - side / 2.0, side, side)
+
+    def _chroma_point(self, sq, cb, cr):
+        radius = sq.width() / 2.0
+        return QPointF(sq.center().x() + cb / 128.0 * radius,
+                       sq.center().y() - cr / 128.0 * radius)
+
+    def paintEvent(self, event):
+        p, _plot = self._begin_paint()
+        sq = self._square()
+        radius = sq.width() / 2.0
+        scope_circle = QPainterPath()
+        scope_circle.addEllipse(sq.center(), radius, radius)
+        # Trace, clipped to the round scope face.
+        trace = self._trace_pixmap(round(sq.width()), round(sq.height()))
+        if trace is not None:
+            p.save()
+            p.setClipPath(scope_circle, Qt.IntersectClip)
+            p.drawPixmap(sq.topLeft(), trace)
+            p.restore()
+        # Graticule: outer circle, faint 75% circle, crosshair.
+        grid = QColor(*theme.Paint.SCOPE_GRID)
+        p.setBrush(Qt.NoBrush)
+        p.setPen(QPen(grid, 1))
+        p.drawEllipse(sq.center(), radius, radius)
+        p.drawEllipse(sq.center(), radius * 0.75, radius * 0.75)
+        p.drawLine(QPointF(sq.left(), sq.center().y()),
+                   QPointF(sq.right(), sq.center().y()))
+        p.drawLine(QPointF(sq.center().x(), sq.top()),
+                   QPointF(sq.center().x(), sq.bottom()))
+        # 75% targets, derived from the same RGB→CbCr mapping as the trace.
+        label = QColor(*theme.Paint.SCOPE_LABEL)
+        font = p.font()
+        font.setPixelSize(9)
+        p.setFont(font)
+        for name, cb, cr in scopes.vector_targets():
+            pt = self._chroma_point(sq, cb, cr)
+            p.setPen(QPen(grid, 1))
+            p.drawRect(QRectF(pt.x() - 3, pt.y() - 3, 6, 6))
+            p.setPen(label)
+            # Label just outside the target, pushed away from the center.
+            dx, dy = pt.x() - sq.center().x(), pt.y() - sq.center().y()
+            norm = max((dx * dx + dy * dy) ** 0.5, 1e-6)
+            p.drawText(QPointF(pt.x() + dx / norm * 10 - 4,
+                               pt.y() + dy / norm * 10 + 4), name)
+        if self._probe is not None:
+            r, g, b, _x_frac = self._probe
+            cb, cr = scopes.rgb_to_cbcr(np.array([r, g, b], dtype=np.float32))
+            pen, brush = _marker_pen_brush()
+            p.setPen(pen)
+            p.setBrush(brush)
+            p.drawEllipse(self._chroma_point(sq, float(cb), float(cr)),
+                          _MARKER_R, _MARKER_R)
+        self._end_paint(p)
+
+
+class ScopesPanel(QWidget):
+    """Header (toggle + hover RGB readout, always visible) over a collapsible
+    body holding the parade and the vectorscope."""
+
+    expanded_changed = Signal(bool)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._settings = QSettings("FreeCCR", "FreeCCR")
+        expanded = self._settings.value("scopes/expanded", False, type=bool)
+
+        self._toggle_btn = QPushButton()
+        self._toggle_btn.setCheckable(True)
+        self._toggle_btn.setChecked(expanded)
+        self._toggle_btn.setStyleSheet(
+            "QPushButton { text-align: left; padding: 4px 6px; "
+            f"background: {theme.SURFACE}; border: none; border-radius: {theme.RADIUS_SM}px; "
+            f"color: {theme.TEXT}; font-size: 11px; font-weight: bold; }}"
+            f"QPushButton:checked {{ background: {theme.SURFACE_ACTIVE}; }}"
+        )
+        self._toggle_btn.clicked.connect(self._on_toggle)
+
+        self._swatch = QLabel()
+        self._swatch.setFixedSize(12, 12)
+        self._readout = QLabel(_READOUT_EMPTY)
+        # Font set via QFont (not QSS) so the width computed from the label's
+        # fontMetrics below matches what actually renders.
+        readout_font = QFont("Consolas")
+        readout_font.setStyleHint(QFont.Monospace)
+        readout_font.setPixelSize(11)
+        self._readout.setFont(readout_font)
+        self._readout.setStyleSheet(f"color: {theme.TEXT_MUTED};")
+        # Fixed width so live values don't make the header jitter.
+        self._readout.setMinimumWidth(
+            self._readout.fontMetrics().horizontalAdvance("R 888 G 888 B 888") + 12)
+        self._readout.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+        header.setSpacing(theme.GAP_BTN)
+        header.addWidget(self._toggle_btn, 1)
+        header.addWidget(self._swatch)
+        header.addWidget(self._readout)
+
+        self.parade = ParadeScopeWidget()
+        self.vectorscope = VectorscopeWidget()
+        self.vectorscope.setFixedWidth(_BODY_H)
+
+        self._body = QWidget()
+        self._body.setFixedHeight(_BODY_H)
+        body_layout = QHBoxLayout(self._body)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+        body_layout.setSpacing(theme.GAP_BTN)
+        body_layout.addWidget(self.parade, 1)
+        body_layout.addWidget(self.vectorscope)
+        self._body.setVisible(expanded)
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, theme.GAP_ROW, 0, 0)
+        outer.setSpacing(theme.GAP_ROW)
+        outer.addLayout(header)
+        outer.addWidget(self._body)
+        self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
+
+        self._sync_toggle_text()
+        self._set_swatch(None)
+
+    # -- collapse ---------------------------------------------------------
+    def is_expanded(self):
+        return self._toggle_btn.isChecked()
+
+    def _sync_toggle_text(self):
+        self._toggle_btn.setText(
+            f"{'-' if self.is_expanded() else '+'} Scopes")
+
+    def _on_toggle(self, checked):
+        self._body.setVisible(checked)
+        self._sync_toggle_text()
+        self._settings.setValue("scopes/expanded", bool(checked))
+        self.expanded_changed.emit(bool(checked))
+
+    # -- data -------------------------------------------------------------
+    def set_frame(self, rgb, mask):
+        """Feed the visible-window pixels: rgb (H, W, 3) uint8 + mask (H, W)
+        bool (False = letterbox pixels, excluded from the statistics)."""
+        self.parade.set_data(scopes.compute_parade(rgb, mask))
+        self.vectorscope.set_data(scopes.compute_vectorscope(rgb, mask))
+
+    def clear(self):
+        """No image displayed — empty both scopes and the probe."""
+        self.parade.set_data(None)
+        self.vectorscope.set_data(None)
+        self.clear_probe()
+
+    # -- hover probe --------------------------------------------------------
+    def set_probe(self, r, g, b, x_frac):
+        """Cursor is over an image pixel: readout + marker circles."""
+        self._readout.setText(f"R {r:3d} G {g:3d} B {b:3d}")
+        self._set_swatch(QColor(r, g, b))
+        probe = (int(r), int(g), int(b), float(x_frac))
+        self.parade.set_probe(probe)
+        self.vectorscope.set_probe(probe)
+
+    def clear_probe(self):
+        self._readout.setText(_READOUT_EMPTY)
+        self._set_swatch(None)
+        self.parade.set_probe(None)
+        self.vectorscope.set_probe(None)
+
+    def _set_swatch(self, color):
+        if color is None:
+            self._swatch.setStyleSheet(
+                f"background: transparent; border: 1px solid {theme.BORDER}; "
+                "border-radius: 2px;")
+        else:
+            self._swatch.setStyleSheet(
+                f"background: {color.name()}; border: 1px solid {theme.BORDER}; "
+                "border-radius: 2px;")

--- a/src/widgets/scopes_panel.py
+++ b/src/widgets/scopes_panel.py
@@ -1,13 +1,16 @@
 """Collapsible Scopes panel under the canvas: RGB parade + vectorscope.
 
-Both scopes are computed from the VISIBLE canvas window — zoom, pan, display
-crop and orientation exactly as shown. ImagePreview captures the viewport
-pixels (image only, no overlays; letterbox masked out) and feeds them in via
+Both scopes are computed from the DISPLAYED image — display crop and
+orientation exactly as shown; zoom/pan deliberately do not affect them.
+ImagePreview captures the pixmap item offscreen (image only, no overlays;
+fine-rotation corner gaps masked out) and feeds it in via
 :meth:`ScopesPanel.set_frame`; all math lives in ``core/scopes.py`` and all
-presentation here. A hover probe (RGB readout in the header + marker circles
-on both scopes) follows the cursor on the canvas via :meth:`set_probe`.
-Collapsed by default; the expanded state persists in QSettings. See
-spec/color-scopes-panel.md.
+presentation here. The parade uses a DaVinci-style 10-bit axis (0–1023, a
+line every 128 codes) plus the Cineon reference levels 95/685; the
+vectorscope carries the 75% targets and the skin-tone line. A hover probe
+(RGB readout in the header + marker circles on both scopes) follows the
+cursor on the canvas via :meth:`set_probe`. Collapsed by default; the
+expanded state persists in QSettings. See spec/color-scopes-panel.md.
 """
 
 import numpy as np
@@ -94,7 +97,8 @@ class _ScopeWidgetBase(QWidget):
 
 class ParadeScopeWidget(_ScopeWidgetBase):
     """Three side-by-side per-channel waveforms: x = position across the
-    visible window, y = value (0 bottom … 255 top), brightness = count."""
+    displayed image, y = value on a 10-bit axis (0 bottom … 1023 top),
+    brightness = count. Cineon reference lines at codes 95 and 685."""
 
     def set_data(self, counts):
         """counts (3, 256, W) raw parade counts, or None to clear."""
@@ -116,26 +120,62 @@ class ParadeScopeWidget(_ScopeWidgetBase):
 
     def paintEvent(self, event):
         p, plot = self._begin_paint()
-        # Quarter-tone gridlines + separators between the three cells.
-        p.setPen(QPen(QColor(*theme.Paint.SCOPE_GRID), 1))
-        for k in range(1, 4):
-            gy = plot.top() + plot.height() * k / 4.0
-            p.drawLine(QPointF(plot.left(), gy), QPointF(plot.right(), gy))
+        font = p.font()
+        font.setPixelSize(9)
+        p.setFont(font)
+        fm = p.fontMetrics()
+        # Left gutter for the 10-bit code labels; the waveform cells fill the
+        # rest. The axis is display-only: 8-bit 255 ≡ 10-bit 1023, so the
+        # trace/probe geometry is untouched.
+        gutter = fm.horizontalAdvance("1023") + 6
+        cells = QRectF(plot.left() + gutter, plot.top(),
+                       plot.width() - gutter, plot.height())
+
+        def code_y(code):
+            return (cells.bottom()
+                    - code / float(scopes.PARADE_MAX_CODE) * cells.height())
+
+        # DaVinci-style graticule: a labeled line every 128 codes + the top.
+        grid = QColor(*theme.Paint.SCOPE_GRID)
+        label = QColor(*theme.Paint.SCOPE_LABEL)
+        codes = list(range(0, scopes.PARADE_MAX_CODE, scopes.PARADE_GRID_STEP))
+        codes.append(scopes.PARADE_MAX_CODE)
+        for code in codes:
+            y = code_y(code)
+            p.setPen(QPen(grid, 1))
+            p.drawLine(QPointF(cells.left(), y), QPointF(cells.right(), y))
+            p.setPen(label)
+            p.drawText(QRectF(plot.left(), y - fm.height() / 2.0,
+                              gutter - 5, fm.height()),
+                       Qt.AlignRight | Qt.AlignVCenter, str(code))
+        p.setPen(QPen(grid, 1))
         for k in range(1, 3):
-            gx = plot.left() + plot.width() * k / 3.0
-            p.drawLine(QPointF(gx, plot.top()), QPointF(gx, plot.bottom()))
-        trace = self._trace_pixmap(round(plot.width()), round(plot.height()))
+            gx = cells.left() + cells.width() * k / 3.0
+            p.drawLine(QPointF(gx, cells.top()), QPointF(gx, cells.bottom()))
+
+        trace = self._trace_pixmap(round(cells.width()), round(cells.height()))
         if trace is not None:
-            p.drawPixmap(plot.topLeft(), trace)
+            p.drawPixmap(cells.topLeft(), trace)
+
+        # Cineon reference levels (Dmin 95 / 90%-white 685), over the trace so
+        # they stay readable; labels at the right edge, just above the line.
+        ref = QColor(*theme.Paint.SCOPE_REF)
+        for code in scopes.CINEON_REF_CODES:
+            y = code_y(code)
+            p.setPen(QPen(ref, 1, Qt.DashLine))
+            p.drawLine(QPointF(cells.left(), y), QPointF(cells.right(), y))
+            p.drawText(QPointF(cells.right() - fm.horizontalAdvance(str(code)) - 3,
+                               y - 3), str(code))
+
         if self._probe is not None:
             r, g, b, x_frac = self._probe
             pen, brush = _marker_pen_brush()
             p.setPen(pen)
             p.setBrush(brush)
-            cell_w = plot.width() / 3.0
+            cell_w = cells.width() / 3.0
             for c, v in enumerate((r, g, b)):
-                x = plot.left() + (c + x_frac) * cell_w
-                y = plot.top() + (1.0 - v / 255.0) * plot.height()
+                x = cells.left() + (c + x_frac) * cell_w
+                y = cells.top() + (1.0 - v / 255.0) * cells.height()
                 p.drawEllipse(QPointF(x, y), _MARKER_R, _MARKER_R)
         self._end_paint(p)
 
@@ -191,6 +231,11 @@ class VectorscopeWidget(_ScopeWidgetBase):
                    QPointF(sq.right(), sq.center().y()))
         p.drawLine(QPointF(sq.center().x(), sq.top()),
                    QPointF(sq.center().x(), sq.bottom()))
+        # Skin-tone indicator: center → 100% circle along the +I axis.
+        ucb, ucr = scopes.skin_tone_direction()
+        p.setPen(QPen(QColor(*theme.Paint.SCOPE_SKIN), 1))
+        p.drawLine(sq.center(),
+                   self._chroma_point(sq, ucb * 128.0, ucr * 128.0))
         # 75% targets, derived from the same RGB→CbCr mapping as the trace.
         label = QColor(*theme.Paint.SCOPE_LABEL)
         font = p.font()
@@ -300,8 +345,9 @@ class ScopesPanel(QWidget):
 
     # -- data -------------------------------------------------------------
     def set_frame(self, rgb, mask):
-        """Feed the visible-window pixels: rgb (H, W, 3) uint8 + mask (H, W)
-        bool (False = letterbox pixels, excluded from the statistics)."""
+        """Feed the displayed-image pixels: rgb (H, W, 3) uint8 + mask (H, W)
+        bool (False = uncovered pixels, e.g. fine-rotation corner gaps,
+        excluded from the statistics)."""
         self.parade.set_data(scopes.compute_parade(rgb, mask))
         self.vectorscope.set_data(scopes.compute_vectorscope(rgb, mask))
 

--- a/src/widgets/scopes_panel.py
+++ b/src/widgets/scopes_panel.py
@@ -23,7 +23,9 @@ from PySide6.QtWidgets import (QHBoxLayout, QLabel, QPushButton, QSizePolicy,
 from core import scopes
 from ui import theme
 
-_BODY_H = 180          # expanded body height (vectorscope is _BODY_H square)
+_BODY_H = 180          # default expanded body height (vectorscope is square)
+_BODY_MIN = 140        # drag-resize clamp (grip on the panel's top edge)
+_BODY_MAX = 420
 _RADIUS = 10           # rounded scope backgrounds (matches HistogramWidget)
 _PAD = 6.0             # plot inset inside the rounded background
 _MARKER_R = 4.0        # probe circle radius
@@ -262,9 +264,54 @@ class VectorscopeWidget(_ScopeWidgetBase):
         self._end_paint(p)
 
 
+class _ResizeGrip(QWidget):
+    """Thin grab bar on the panel's top edge: drag UP to enlarge the scopes
+    body, down to shrink, clamped to [_BODY_MIN, _BODY_MAX]. Only shown while
+    the panel is expanded; the final height persists in QSettings."""
+
+    def __init__(self, panel):
+        super().__init__(panel)
+        self._panel = panel
+        self._drag = None    # (press global y, body height at press)
+        self.setFixedHeight(7)
+        self.setCursor(Qt.SizeVerCursor)
+
+    def paintEvent(self, event):
+        p = QPainter(self)
+        p.setRenderHint(QPainter.Antialiasing, True)
+        p.setPen(Qt.NoPen)
+        p.setBrush(QColor(*theme.Paint.SCOPE_LABEL))
+        w = 36.0
+        p.drawRoundedRect(
+            QRectF(self.width() / 2.0 - w / 2.0, 2.0, w, 3.0), 1.5, 1.5)
+        p.end()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self._drag = (event.globalPosition().y(),
+                          self._panel.body_height())
+            event.accept()
+
+    def mouseMoveEvent(self, event):
+        if self._drag is not None:
+            start_y, start_h = self._drag
+            # The panel sits at the bottom of the canvas column, so dragging
+            # the top edge UP means a LARGER body.
+            self._panel.set_body_height(
+                start_h + (start_y - event.globalPosition().y()))
+            event.accept()
+
+    def mouseReleaseEvent(self, event):
+        if self._drag is not None:
+            self._drag = None
+            self._panel._save_body_height()
+            event.accept()
+
+
 class ScopesPanel(QWidget):
     """Header (toggle + hover RGB readout, always visible) over a collapsible
-    body holding the parade and the vectorscope."""
+    body holding the parade and the vectorscope. The top edge is a drag
+    handle for resizing the body height."""
 
     expanded_changed = Signal(bool)
 
@@ -308,10 +355,8 @@ class ScopesPanel(QWidget):
 
         self.parade = ParadeScopeWidget()
         self.vectorscope = VectorscopeWidget()
-        self.vectorscope.setFixedWidth(_BODY_H)
 
         self._body = QWidget()
-        self._body.setFixedHeight(_BODY_H)
         body_layout = QHBoxLayout(self._body)
         body_layout.setContentsMargins(0, 0, 0, 0)
         body_layout.setSpacing(theme.GAP_BTN)
@@ -319,9 +364,16 @@ class ScopesPanel(QWidget):
         body_layout.addWidget(self.vectorscope)
         self._body.setVisible(expanded)
 
+        # Drag-resizable body height (grip on the top edge), persisted.
+        self._grip = _ResizeGrip(self)
+        self._grip.setVisible(expanded)
+        self.set_body_height(
+            self._settings.value("scopes/height", _BODY_H, type=int))
+
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, theme.GAP_ROW, 0, 0)
         outer.setSpacing(theme.GAP_ROW)
+        outer.addWidget(self._grip)
         outer.addLayout(header)
         outer.addWidget(self._body)
         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
@@ -329,7 +381,7 @@ class ScopesPanel(QWidget):
         self._sync_toggle_text()
         self._set_swatch(None)
 
-    # -- collapse ---------------------------------------------------------
+    # -- collapse / resize ------------------------------------------------
     def is_expanded(self):
         return self._toggle_btn.isChecked()
 
@@ -339,9 +391,23 @@ class ScopesPanel(QWidget):
 
     def _on_toggle(self, checked):
         self._body.setVisible(checked)
+        self._grip.setVisible(checked)
         self._sync_toggle_text()
         self._settings.setValue("scopes/expanded", bool(checked))
         self.expanded_changed.emit(bool(checked))
+
+    def body_height(self):
+        # minimumHeight == the fixed height — reliable even before layout.
+        return self._body.minimumHeight()
+
+    def set_body_height(self, h):
+        """Clamp + apply a body height; the vectorscope stays square."""
+        h = int(max(_BODY_MIN, min(_BODY_MAX, h)))
+        self._body.setFixedHeight(h)
+        self.vectorscope.setFixedWidth(h)
+
+    def _save_body_height(self):
+        self._settings.setValue("scopes/height", self.body_height())
 
     # -- data -------------------------------------------------------------
     def set_frame(self, rgb, mask):

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -36,7 +36,10 @@ SYNC_GROUPS = [
         "ch_input_gain", "ch_master_shift", "ch_master_gain",
         "ch_r_shift", "ch_r_gain", "ch_r_blackpoint",
         "ch_g_shift", "ch_g_gain", "ch_g_blackpoint",
-        "ch_b_shift", "ch_b_gain", "ch_b_blackpoint")),
+        "ch_b_shift", "ch_b_gain", "ch_b_blackpoint",
+        # Non-slider flag (Cineon log → Rec.709 display conversion) — rides
+        # the Channel Levels sync group, preserved specially in the merge.
+        "cineon_log")),
     ("bands", "Subtractive Saturations (per color)",
      tuple(BAND_ADJUSTMENT_KEYS) + ("band_feather",)),
     # "curves" lives outside ADJUSTMENT_KEYS (it's a nested structure, not a
@@ -632,6 +635,21 @@ class SlidersPanel(QWidget):
         self.od_section.add_layout(self.create_slider("B Gain"))
         self.od_section.add_layout(self.create_slider("B Blackpoint"))
 
+        # Cineon film log → Rec.709 (γ 2.2) display conversion — a FINAL
+        # pipeline stage after every other adjustment (incl. curves/areas),
+        # identical for preview, zoom detail and export. Non-slider flag
+        # ("cineon_log" in adjustment_settings); whole-image only, so it is
+        # disabled while an area layer is the edit target. See
+        # spec/cineon-display-transform.md.
+        self.cineon_checkbox = QCheckBox("Cineon Log → Rec.709 (γ 2.2)")
+        self.cineon_checkbox.setToolTip(
+            "Interpret the adjusted image as Cineon film log (10-bit black at "
+            "code 95, 90% white at 685 — the levels the Scopes parade marks) "
+            "and convert to Rec.709 video with a 2.2 gamma, as the final step "
+            "before display/export.")
+        self.cineon_checkbox.toggled.connect(self._on_cineon_toggled)
+        self.od_section.add_widget(self.cineon_checkbox)
+
         # --- Populate Subtractive Saturations (per-color bands) ---
         # A swatch button per color selects which band's sliders are shown;
         # all 24 sliders exist (and feed adjustment_settings) regardless.
@@ -909,6 +927,15 @@ class SlidersPanel(QWidget):
                 self.sliders[i].setValue(val)
                 self.sliders[i].blockSignals(False)
                 self.slider_value_labels[i].setText(str(val))
+        # Cineon display conversion is whole-image: the checkbox always shows
+        # the GLOBAL flag and is only editable when the global layer is active.
+        img = ccr_backend.get_image_by_index(idx) if idx is not None else None
+        self.cineon_checkbox.blockSignals(True)
+        self.cineon_checkbox.setChecked(
+            bool(img is not None and img.adjustment_settings.get("cineon_log")))
+        self.cineon_checkbox.blockSignals(False)
+        self.cineon_checkbox.setEnabled(
+            img is not None and img.active_area_id is None)
 
     def set_current_idx(self, idx):
         # Clear any pending adjustments for the previous image
@@ -1119,6 +1146,7 @@ class SlidersPanel(QWidget):
         if self.current_idx is not None:
             adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
             self._attach_curves(adjustment)
+            self._attach_cineon(adjustment)
 
             # Immediate lightweight feedback - just store the adjustment settings
             if 0 <= self.current_idx < len(ccr_backend.images):
@@ -1145,6 +1173,37 @@ class SlidersPanel(QWidget):
             adjustment["curves"] = curves
         return adjustment
 
+    def _attach_cineon(self, adjustment: dict) -> dict:
+        """Re-attach the non-slider Cineon-log flag onto a freshly rebuilt
+        adjustment dict (sibling of _attach_curves) — but only when the GLOBAL
+        layer is the edit target: the final display transform is whole-image,
+        so area dicts never carry it."""
+        img = (ccr_backend.get_image_by_index(self.current_idx)
+               if self.current_idx is not None else None)
+        if (img is not None and img.active_area_id is None
+                and img.adjustment_settings.get("cineon_log")):
+            adjustment["cineon_log"] = True
+        return adjustment
+
+    def _on_cineon_toggled(self, checked):
+        """Cineon log → Rec.709 checkbox: a discrete, single-undo edit on the
+        GLOBAL settings dict. Mirrors _on_curve_edit_finished's settle path —
+        regenerate the preview first, then display it."""
+        if self.current_idx is None:
+            return
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None:
+            return
+        self.end_undo_burst()
+        img.push_undo_state()
+        if checked:
+            img.adjustment_settings["cineon_log"] = True
+        else:
+            img.adjustment_settings.pop("cineon_log", None)
+        img.update_thumbnail_and_preview()
+        self.parent().parent().image_preview.update_preview(self.current_idx)
+        self._update_thumb()
+
     def _on_curve_changed(self):
         """Live tone-curve edit — mirror on_slider_changed's feedback +
         debounced heavy-processing path so a curve drag behaves like a slider
@@ -1153,6 +1212,7 @@ class SlidersPanel(QWidget):
             return
         adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
         self._attach_curves(adjustment)
+        self._attach_cineon(adjustment)
         if 0 <= self.current_idx < len(ccr_backend.images):
             self._begin_undo_burst(ccr_backend.images[self.current_idx])
             self._store_active_settings(self.current_idx, adjustment)
@@ -1388,6 +1448,12 @@ class SlidersPanel(QWidget):
                 existing_curves = img.adjustment_settings.get("curves")
                 if existing_curves is not None:
                     merged["curves"] = existing_curves
+                # Same for the Cineon flag when the channels group (which
+                # carries it) is NOT being synced — the rebuild from
+                # adjustment_keys would silently drop it otherwise.
+                if ("cineon_log" not in keys
+                        and img.adjustment_settings.get("cineon_log")):
+                    merged["cineon_log"] = True
                 img.adjustment_settings = merged
             if curves_changes:
                 if src_curves:
@@ -1748,6 +1814,7 @@ class SlidersPanel(QWidget):
             # Get the current adjustment settings from sliders
             self.copied_adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
             self._attach_curves(self.copied_adjustment)
+            self._attach_cineon(self.copied_adjustment)
             print(f"Copied adjustment settings: {self.copied_adjustment}")
             self.set_temporary_hint("Adjustments Copied!", duration=4000)
         else:
@@ -1778,9 +1845,14 @@ class SlidersPanel(QWidget):
 
             # Save the adjustment to the ACTIVE layer and update preview. Copy
             # the dict so the clipboard isn't aliased by the image's settings.
+            pasted = copy.deepcopy(self.copied_adjustment)
+            img = ccr_backend.get_image_by_index(self.current_idx)
+            if img is not None and img.active_area_id is not None:
+                # The Cineon display conversion is whole-image only — never
+                # paste it into an area layer's dict.
+                pasted.pop("cineon_log", None)
             ccr_backend.set_active_settings_by_index(
-                self.current_idx, copy.deepcopy(self.copied_adjustment),
-                reprocess=True)
+                self.current_idx, pasted, reprocess=True)
             self.parent().parent().image_preview.update_preview(self.current_idx)
             self.set_temporary_hint("Adjustments Pasted!", duration=2000)
             

--- a/tests/test_cineon_log.py
+++ b/tests/test_cineon_log.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Tests for the Cineon film log → Rec.709 (γ 2.2) display conversion — the
+optional FINAL pipeline stage behind the Channel Levels checkbox (settings
+key "cineon_log"). See spec/cineon-display-transform.md."""
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_processor import (apply_cineon_to_rec709,  # noqa: E402
+                                _cineon_rec709_lut16,
+                                CINEON_BLACK_CODE, CINEON_WHITE_CODE)
+
+
+def _codes():
+    """10-bit code value of every 16-bit LUT index."""
+    return np.linspace(0.0, 1023.0, 65536)
+
+
+# --- LUT math ---------------------------------------------------------------
+
+def test_lut_black_and_white_anchors():
+    lut = _cineon_rec709_lut16()
+    codes = _codes()
+    assert (lut[codes <= CINEON_BLACK_CODE] == 0).all()      # Dmin and below → black
+    assert (lut[codes >= CINEON_WHITE_CODE] == 65535).all()  # 90% white and above → clip
+
+
+def test_lut_monotonic_and_range():
+    lut = _cineon_rec709_lut16().astype(np.int64)
+    assert (np.diff(lut) >= 0).all()
+    assert lut[0] == 0 and lut[-1] == 65535
+
+
+def test_lut_matches_closed_form_midscale():
+    lut = _cineon_rec709_lut16()
+    for code in (200.0, 390.0, 500.0, 600.0):
+        idx = int(round(code * 65535.0 / 1023.0))
+        c = idx * 1023.0 / 65535.0            # exact code at that index
+        off = 10.0 ** ((95.0 - 685.0) * 0.002 / 0.6)
+        lin = (10.0 ** ((c - 685.0) * 0.002 / 0.6) - off) / (1.0 - off)
+        expected = round((max(lin, 0.0) ** (1 / 2.2)) * 65535.0)
+        assert abs(int(lut[idx]) - expected) <= 1
+
+
+# --- apply function ----------------------------------------------------------
+
+def test_apply_preserves_shape_dtype_and_neutrality():
+    img = np.linspace(0, 65535, 2 * 3 * 3, dtype=np.uint16).reshape(2, 3, 3)
+    out = apply_cineon_to_rec709(img)
+    assert out.shape == img.shape and out.dtype == np.uint16
+    # A neutral pixel (R=G=B) stays neutral — the LUT is per-channel identical.
+    gray = np.full((2, 2, 3), 30000, dtype=np.uint16)
+    out_g = apply_cineon_to_rec709(gray)
+    assert (out_g[..., 0] == out_g[..., 1]).all()
+    assert (out_g[..., 1] == out_g[..., 2]).all()
+
+
+# --- pipeline: final stage after all other adjustments ------------------------
+
+def _bare_image_obj():
+    """A CCRImage shell with just the attributes apply_adjustments reads when
+    every stage is overridden via parameters (no file/decoding needed)."""
+    from core.ccr_image import CCRImage
+    obj = CCRImage.__new__(CCRImage)
+    obj.tint_balance_factor = 1.0
+    obj.converted = False          # Auto Gain path off (conversion-only)
+    return obj
+
+
+def _apply(obj, img, settings):
+    return obj.apply_adjustments(
+        img, settings=settings, contrast_base=0, temperature_base=0,
+        brightness_base=0, exposure_base=0, ws_windowed=False,
+        color_profile="color", areas_override=[])
+
+
+def test_pipeline_applies_cineon_as_final_stage():
+    rng = np.random.default_rng(3)
+    img = rng.integers(0, 65536, (8, 8, 3), dtype=np.uint16)
+    obj = _bare_image_obj()
+    # Same heavy path with and without the flag (both dicts are non-empty);
+    # the flagged result must be exactly the post-adjustment result pushed
+    # through the LUT — i.e. a pure final stage, nothing interleaved.
+    base = _apply(obj, img, {"saturation": 0})
+    out = _apply(obj, img, {"saturation": 0, "cineon_log": True})
+    assert np.array_equal(out, apply_cineon_to_rec709(base))
+    # With a real adjustment active the property still holds.
+    base2 = _apply(obj, img, {"contrast": 30})
+    out2 = _apply(obj, img, {"contrast": 30, "cineon_log": True})
+    assert np.array_equal(out2, apply_cineon_to_rec709(base2))
+    # Absent/falsy flag → no transform.
+    assert np.array_equal(base, _apply(obj, img, {"saturation": 0,
+                                                  "cineon_log": 0}))
+
+
+# --- panel wiring -------------------------------------------------------------
+
+def test_sync_group_carries_cineon_key():
+    from widgets.sliders_panel import SYNC_GROUPS
+    channels = dict((gid, keys) for gid, _l, keys in SYNC_GROUPS)["channels"]
+    assert "cineon_log" in channels
+
+
+def test_panel_has_checkbox_default_unchecked():
+    from widgets.sliders_panel import SlidersPanel
+    panel = SlidersPanel(None)
+    assert not panel.cineon_checkbox.isChecked()
+    # _attach_cineon is a no-op with no image selected.
+    adj = {}
+    panel._attach_cineon(adj)
+    assert "cineon_log" not in adj

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -144,6 +144,20 @@ def test_vector_color_lut_center_is_neutral():
     assert r > g and r > b
 
 
+def test_skin_tone_direction_between_red_and_yellow():
+    ucb, ucr = scopes.skin_tone_direction()
+    assert abs((ucb * ucb + ucr * ucr) ** 0.5 - 1.0) < 1e-5   # unit vector
+    import math
+    skin = math.atan2(ucr, ucb)
+    r_cb, r_cr = scopes.rgb_to_cbcr(np.array([255, 0, 0], np.float32))
+    y_cb, y_cr = scopes.rgb_to_cbcr(np.array([255, 255, 0], np.float32))
+    red = math.atan2(float(r_cr), float(r_cb))
+    yellow = math.atan2(float(y_cr), float(y_cb))
+    # The classic skin line sits between the R and Yl targets (10:30-11
+    # o'clock), i.e. between their angles in the upper-left quadrant.
+    assert red < skin < yellow
+
+
 def test_vector_targets():
     targets = dict((n, (cb, cr)) for n, cb, cr in scopes.vector_targets())
     assert set(targets) == {"R", "Mg", "B", "Cy", "G", "Yl"}
@@ -200,7 +214,7 @@ def test_scope_widgets_accept_none():
 
 # --- ImagePreview capture helper ---------------------------------------------
 
-def test_capture_visible_region():
+def test_capture_display_image():
     from PySide6.QtWidgets import (QGraphicsPixmapItem, QWidget, QVBoxLayout)
     from PySide6.QtGui import QPixmap, QColor
     from widgets.image_preview import ImagePreview
@@ -217,7 +231,7 @@ def test_capture_visible_region():
     host.show()                        # offscreen: activates the layout so the
     _app.processEvents()               # view gets its real viewport geometry
 
-    assert ip._capture_visible_region() is None   # no image → None
+    assert ip._capture_display_image() is None   # no image → None
 
     pm = QPixmap(120, 80)
     pm.fill(QColor(200, 50, 25))
@@ -225,14 +239,26 @@ def test_capture_visible_region():
     ip.pixmap_item = QGraphicsPixmapItem(pm)
     ip.scene.addItem(ip.pixmap_item)
     ip._fit_view_to_content()
-    frame = ip._capture_visible_region()
+    frame = ip._capture_display_image()
     assert frame is not None
     rgb, mask = frame
     assert rgb.shape[2] == 3 and mask.shape == rgb.shape[:2]
-    assert mask.any()
+    # The whole (un-rotated) image is covered — no letterbox in the capture.
+    assert mask.all()
+    # Uncropped, unrotated: the capture keeps the image aspect (120:80).
+    assert abs(rgb.shape[1] / rgb.shape[0] - 1.5) < 0.05
     inside = rgb[mask]
     # The solid color survives the round-trip (smooth scaling tolerance).
     assert abs(int(np.median(inside[:, 0])) - 200) <= 2
     assert abs(int(np.median(inside[:, 1])) - 50) <= 2
     assert abs(int(np.median(inside[:, 2])) - 25) <= 2
+
+    # Zoom/pan must NOT change the scopes: an aggressive zoom-in + pan leaves
+    # the capture bit-identical (it never looks through the view transform).
+    ip.view.scale(4.0, 4.0)
+    ip.view.translate(37.0, -21.0)
+    _app.processEvents()
+    rgb2, mask2 = ip._capture_display_image()
+    assert rgb2.shape == rgb.shape
+    assert np.array_equal(rgb2, rgb) and np.array_equal(mask2, mask)
     host.hide()

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Tests for the Scopes panel: core/scopes.py math (parade / vectorscope /
+scaling) and a headless smoke of widgets/scopes_panel.py + the ImagePreview
+capture helper. See spec/color-scopes-panel.md."""
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core import scopes  # noqa: E402
+from widgets.scopes_panel import ScopesPanel  # noqa: E402
+
+
+# --- rgb_to_cbcr ------------------------------------------------------------
+
+def test_cbcr_gray_is_center():
+    for v in (0, 64, 128, 255):
+        cb, cr = scopes.rgb_to_cbcr(np.array([v, v, v], dtype=np.uint8))
+        assert abs(float(cb)) < 1e-3 and abs(float(cr)) < 1e-3
+
+
+def test_cbcr_primary_directions():
+    cb, cr = scopes.rgb_to_cbcr(np.array([255, 0, 0], np.float32))
+    assert cb < 0 and cr > 0          # red: up-left
+    cb, cr = scopes.rgb_to_cbcr(np.array([0, 0, 255], np.float32))
+    assert cb > 0 and cr < 0          # blue: right, slightly down
+    cb, cr = scopes.rgb_to_cbcr(np.array([0, 255, 0], np.float32))
+    assert cb < 0 and cr < 0          # green: down-left
+
+
+def test_cbcr_complements_are_opposite():
+    a = scopes.rgb_to_cbcr(np.array([255, 255, 0], np.float32))   # yellow
+    b = scopes.rgb_to_cbcr(np.array([0, 0, 255], np.float32))     # blue
+    assert abs(a[0] + b[0]) < 1e-3 and abs(a[1] + b[1]) < 1e-3
+
+
+# --- compute_parade ---------------------------------------------------------
+
+def _frame(w=4, h=3, value=(10, 20, 30)):
+    rgb = np.zeros((h, w, 3), np.uint8)
+    rgb[:] = value
+    return rgb, np.ones((h, w), bool)
+
+
+def test_parade_shape_and_totals():
+    rgb, mask = _frame()
+    counts = scopes.compute_parade(rgb, mask)
+    assert counts.shape == (3, 256, 4)
+    for c in range(3):
+        assert counts[c].sum() == mask.sum()
+
+
+def test_parade_bins_land_per_column():
+    rgb, mask = _frame(w=3, h=2)
+    rgb[:, 1] = (100, 150, 200)       # column 1 differs
+    counts = scopes.compute_parade(rgb, mask)
+    assert counts[0, 10, 0] == 2 and counts[0, 100, 1] == 2
+    assert counts[1, 150, 1] == 2 and counts[2, 200, 1] == 2
+    assert counts[0, 100, 0] == 0     # value stays in its own column
+
+
+def test_parade_respects_mask():
+    rgb, mask = _frame(w=2, h=2)
+    mask[:, 1] = False
+    counts = scopes.compute_parade(rgb, mask)
+    assert counts[:, :, 1].sum() == 0
+    assert counts[0].sum() == 2
+
+
+def test_parade_empty_mask():
+    rgb, mask = _frame()
+    counts = scopes.compute_parade(rgb, ~mask)
+    assert counts.sum() == 0
+
+
+# --- compute_vectorscope ----------------------------------------------------
+
+def test_vectorscope_gray_hits_center():
+    rgb, mask = _frame(value=(128, 128, 128))
+    counts = scopes.compute_vectorscope(rgb, mask, size=128)
+    assert counts.shape == (128, 128)
+    # Exactly neutral chroma sits on the bin boundary between 63 and 64 —
+    # float32 weight rounding may land it either side, so check the 2×2 core.
+    assert counts[63:65, 63:65].sum() == mask.sum()
+    assert counts.sum() == mask.sum()
+
+
+def test_vectorscope_red_lands_up_left():
+    rgb, mask = _frame(value=(255, 0, 0))
+    counts = scopes.compute_vectorscope(rgb, mask, size=128)
+    ys, xs = np.nonzero(counts)
+    assert ys[0] < 64 and xs[0] < 64  # +Cr is up (small row), -Cb is left
+
+
+def test_vectorscope_blue_lands_right():
+    rgb, mask = _frame(value=(0, 0, 255))
+    counts = scopes.compute_vectorscope(rgb, mask, size=128)
+    ys, xs = np.nonzero(counts)
+    assert xs[0] > 64 and ys[0] > 64
+
+
+def test_vectorscope_respects_mask():
+    rgb, mask = _frame(value=(0, 255, 0))
+    mask[0, :] = False
+    counts = scopes.compute_vectorscope(rgb, mask)
+    assert counts.sum() == mask.sum()
+
+
+# --- scale_counts -----------------------------------------------------------
+
+def test_scale_counts_range_and_zero():
+    assert scopes.scale_counts(np.zeros((4, 4))).sum() == 0
+    out = scopes.scale_counts(np.array([0.0, 1.0, 5.0, 1e6]))
+    assert out.min() >= 0.0 and out.max() <= 1.0
+
+
+def test_scale_counts_dominant_pile_does_not_crush_traces():
+    counts = np.ones(100, np.float32)
+    counts[0] = 1e6                    # a huge flat-area pile
+    out = scopes.scale_counts(counts)
+    # The percentile reference keeps the 1-count trace visible, the pile clips.
+    assert out[1] > 0.5 and out[0] == 1.0
+
+
+# --- vectorscope LUT / targets ----------------------------------------------
+
+def test_vector_color_lut_center_is_neutral():
+    lut = scopes.vector_color_lut(128)
+    assert lut.shape == (128, 128, 3)
+    assert lut.min() >= 0.0 and lut.max() <= 1.0
+    center = lut[64, 64]
+    assert np.allclose(center, center[0], atol=0.02)   # gray-ish
+    # Top-left region (toward red): R dominates.
+    r, g, b = lut[16, 32]
+    assert r > g and r > b
+
+
+def test_vector_targets():
+    targets = dict((n, (cb, cr)) for n, cb, cr in scopes.vector_targets())
+    assert set(targets) == {"R", "Mg", "B", "Cy", "G", "Yl"}
+    assert targets["R"][0] < 0 and targets["R"][1] > 0
+    # Complementary pairs are point-symmetric about the center.
+    for a, b in (("R", "Cy"), ("G", "Mg"), ("B", "Yl")):
+        assert abs(targets[a][0] + targets[b][0]) < 1e-3
+        assert abs(targets[a][1] + targets[b][1]) < 1e-3
+
+
+# --- widget smoke -----------------------------------------------------------
+
+def _panel():
+    p = ScopesPanel()
+    p.resize(700, 220)
+    return p
+
+
+def test_panel_set_frame_and_grab():
+    p = _panel()
+    if not p.is_expanded():
+        p._toggle_btn.click()
+    rng = np.random.default_rng(7)
+    rgb = rng.integers(0, 256, (90, 160, 3), dtype=np.uint8)
+    mask = np.ones((90, 160), bool)
+    mask[:, :20] = False               # a letterbox strip
+    p.set_frame(rgb, mask)
+    assert p.parade._img is not None and p.vectorscope._img is not None
+    assert not p.grab().isNull()
+    p._toggle_btn.click()              # restore default collapsed state
+    assert not p.is_expanded()
+
+
+def test_panel_probe_and_clear():
+    p = _panel()
+    p.set_probe(255, 128, 3, 0.5)
+    assert "255" in p._readout.text() and "128" in p._readout.text()
+    assert p.parade._probe == (255, 128, 3, 0.5)
+    p.clear_probe()
+    assert p.parade._probe is None and "---" in p._readout.text()
+    rgb = np.zeros((4, 4, 3), np.uint8)
+    p.set_frame(rgb, np.ones((4, 4), bool))
+    p.clear()
+    assert p.parade._img is None and p.vectorscope._img is None
+
+
+def test_scope_widgets_accept_none():
+    p = _panel()
+    p.parade.set_data(None)
+    p.vectorscope.set_data(None)
+    assert not p.parade.grab().isNull()
+    assert not p.vectorscope.grab().isNull()
+
+
+# --- ImagePreview capture helper ---------------------------------------------
+
+def test_capture_visible_region():
+    from PySide6.QtWidgets import (QGraphicsPixmapItem, QWidget, QVBoxLayout)
+    from PySide6.QtGui import QPixmap, QColor
+    from widgets.image_preview import ImagePreview
+
+    # ImagePreview expects a two-level parent chain (MainWindow layout).
+    host = QWidget()
+    host_lay = QVBoxLayout(host)
+    mid = QWidget(host)
+    host_lay.addWidget(mid)
+    mid_lay = QVBoxLayout(mid)
+    ip = ImagePreview(mid)
+    mid_lay.addWidget(ip)
+    host.resize(700, 600)
+    host.show()                        # offscreen: activates the layout so the
+    _app.processEvents()               # view gets its real viewport geometry
+
+    assert ip._capture_visible_region() is None   # no image → None
+
+    pm = QPixmap(120, 80)
+    pm.fill(QColor(200, 50, 25))
+    ip.current_pixmap = pm
+    ip.pixmap_item = QGraphicsPixmapItem(pm)
+    ip.scene.addItem(ip.pixmap_item)
+    ip._fit_view_to_content()
+    frame = ip._capture_visible_region()
+    assert frame is not None
+    rgb, mask = frame
+    assert rgb.shape[2] == 3 and mask.shape == rgb.shape[:2]
+    assert mask.any()
+    inside = rgb[mask]
+    # The solid color survives the round-trip (smooth scaling tolerance).
+    assert abs(int(np.median(inside[:, 0])) - 200) <= 2
+    assert abs(int(np.median(inside[:, 1])) - 50) <= 2
+    assert abs(int(np.median(inside[:, 2])) - 25) <= 2
+    host.hide()

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -212,6 +212,18 @@ def test_scope_widgets_accept_none():
     assert not p.vectorscope.grab().isNull()
 
 
+def test_body_height_resize_clamps_and_keeps_vectorscope_square():
+    p = _panel()
+    p.set_body_height(300)
+    assert p.body_height() == 300
+    assert p.vectorscope.minimumWidth() == 300
+    p.set_body_height(10_000)      # clamp to max
+    assert p.body_height() == 420
+    p.set_body_height(-50)         # clamp to min
+    assert p.body_height() == 140
+    p.set_body_height(180)         # restore the default
+
+
 # --- ImagePreview capture helper ---------------------------------------------
 
 def test_capture_display_image():

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -212,6 +212,22 @@ def test_scope_widgets_accept_none():
     assert not p.vectorscope.grab().isNull()
 
 
+def test_parade_dots_are_dilated():
+    # A single lit bin must bleed into its 4 neighbors (soft dilation) so
+    # isolated waveform samples stay visible at screen scale.
+    p = _panel()
+    counts = np.zeros((3, 256, 9), np.float32)
+    counts[0, 128, 4] = 1.0
+    p.parade.set_data(counts)
+    buf = p.parade._img_buf            # (256, 3*9, 3), red cell = cols 0..8
+    row = 255 - 128                    # value 128, rows flipped (255 at top)
+    center = int(buf[row, 4, 0])
+    assert center > 0
+    for r, c in ((row - 1, 4), (row + 1, 4), (row, 3), (row, 5)):
+        neighbor = int(buf[r, c, 0])
+        assert 0 < neighbor < center   # lit, but dimmer than the sample
+
+
 def test_body_height_resize_clamps_and_keeps_vectorscope_square():
     p = _panel()
     p.set_body_height(300)

--- a/tests/test_sub_saturation_crop_undo.py
+++ b/tests/test_sub_saturation_crop_undo.py
@@ -158,7 +158,11 @@ class TestSyncGroups:
     def test_groups_partition_adjustment_keys(self):
         from widgets.sliders_panel import SYNC_GROUPS, SlidersPanel
         keys = [k for _gid, _label, group_keys in SYNC_GROUPS for k in group_keys]
-        assert sorted(keys) == sorted(SlidersPanel.ADJUSTMENT_KEYS)
+        # The groups cover every slider key exactly once, plus the documented
+        # non-slider flag that rides the channels group (cineon_log — see
+        # spec/cineon-display-transform.md; curves sync separately, like crop).
+        assert sorted(keys) == sorted(
+            list(SlidersPanel.ADJUSTMENT_KEYS) + ["cineon_log"])
         assert len(keys) == len(set(keys))
 
     def test_expected_group_ids(self):


### PR DESCRIPTION
## Summary

Adds a collapsible **Scopes** area at the bottom of the canvas (between the graphics view and the fine-rotation slider) with two video-style color scopes, per `spec/color-scopes-panel.md`:

- **RGB Parade** — three side-by-side per-channel waveforms on a DaVinci-style **10-bit axis** (labeled gridlines every 128 codes, 0–1023) with **Cineon reference lines at 95 (Dmin) and 685 (90% white)**, dashed amber, labeled at the plot's right edge. x = position across the displayed image, brightness = pixel count.
- **Vectorscope** — chroma distribution on the CbCr plane (BT.601), hue-tinted trace, the standard 75% R/Mg/B/Cy/G/Yl targets, and the **skin-tone indicator line** (+I axis of YIQ, derived through the same RGB→CbCr conversion as the trace).

Both scopes are computed from the **displayed image**: the pixmap item is re-rendered offscreen at reduced size through its scene transform, so the confirmed crop, orientation, and hi-res detail are baked in while overlays (reference frame, crop chrome, …) are excluded. **Zoom and pan deliberately do not affect the scopes** — the item is captured whole, never through the viewport; slices are separate images and scope like any other.

**Hover probe**: moving the mouse over the canvas shows the RGB value under the cursor (readout + swatch in the panel header, live even while collapsed) and marks that value with a circle on the parade (one per channel) and on the vectorscope. Off-image → dashed readout, no markers.

**Drag-resizable**: the panel's top edge is a grab handle — drag up to enlarge the scopes (clamped 140–420 px, default 180; vectorscope stays square; height persists in QSettings).

**Cineon Log → Rec.709 (γ 2.2)** (`spec/cineon-display-transform.md`): a new checkbox in the Channel Levels section applies the classic Kodak Cineon log-to-video conversion (black at code 95, 90% white at 685 — exactly the codes the parade's reference lines mark) as the **final pipeline stage after all other adjustments**, identically for preview, hi-res zoom, and every export path (one insertion at the end of `CCRImage.apply_adjustments`). Stored as a non-slider `cineon_log` settings key: participates in undo/Reset/Compare/Copy-Paste/catalog and rides the Channel Levels sync group; whole-image only (disabled while an area layer is the edit target). Implemented as a cached 65536-entry LUT.

## Implementation

- `src/core/scopes.py` — pure-numpy math (parade/vectorscope binning, percentile-referenced intensity scaling, CbCr conversion/targets/hue LUT, skin-tone direction, 10-bit axis constants), fully unit-testable without Qt.
- `src/widgets/scopes_panel.py` — `ScopesPanel` (header toggle + readout, QSettings-persisted expanded state, collapsed by default) with `ParadeScopeWidget`/`VectorscopeWidget`; scaled trace pixmaps are cached so per-mouse-move marker repaints don't re-rescale the trace.
- `src/widgets/image_preview.py` — displayed-image capture helper, 120 ms debounced updates from exactly two choke points (`update_preview`, `apply_transformations` — no viewport/zoom/scrollbar hooks), hover probe sampling through the cached preview QImage (keyed on `QPixmap.cacheKey()`); zero work while collapsed (deferred-dirty replay on expand).

## Testing

- `tests/test_scopes.py` — 21 tests: parade/vectorscope binning + mask handling, CbCr directions/complements, skin-tone line direction (between R and Yl targets), scale robustness, hue LUT neutrality, widget smoke, resize clamping, and an end-to-end capture round-trip that asserts **bit-identical scopes after a 4× zoom + pan**.
- `tests/test_cineon_log.py` — 7 tests: LUT anchors (≤95 → black, ≥685 → white), monotonicity, closed-form spot checks, shape/neutrality, the **final-stage property** (`apply_adjustments` with the flag ≡ LUT of the same call without it), and sync-group wiring.
- Regression groups (all pass): `test_crop_overlay`, `test_crop_hires`, `test_slice`, `test_histogram_widget`, `test_area_editing`, `test_dust_removal`, `test_histogram_crop`, `test_positive_mode`, `test_crop_panel`, `test_thread_safe_previews`, `test_tether_watcher`, `test_curves`, `test_film_stock_ui`, `test_color_bands`, `test_sub_saturation_crop_undo` (partition invariant updated for the documented non-slider key), `test_export`, `test_catalog`.
- Visual verification (offscreen captures): 10-bit graticule labels, Cineon 95/685 lines, skin-tone line, probe markers, enlarged (320 px) panel via the grip API, the Channel Levels checkbox, full `MainWindow` layout, and a scripted zoom check confirming the scopes stay unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
