### PR TITLE
feat(dust): finer manual brush — 0.05% floor, log-scaled size slider

### DIFF
--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -86,7 +86,10 @@ in the catalog, and undoable.
 ### 3.2 DustRemovalPanel layout (top → bottom)
 1. Header: **Dust Removal**.
 2. **Manual** group:
-   - **Brush size** slider (label shows size as a % of image width).
+   - **Brush size** slider, log-scaled over 0.05%–20% of image width so tiny
+     specks get fine steps (0.05% ≈ 3 px radius on a 6000 px scan) while big
+     scratch-covering sizes stay reachable; the label shows the size as a % of
+     image width. The canvas Ctrl+wheel resize clamps to the same range.
    - Hint: "Click or drag over dust to remove it."
    - **Undo last spot** button and **Clear all** button.
 3. Separator.

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -12,6 +12,8 @@ build even when onnxruntime is absent — the AI section then shows an
 unavailable/needs-download state and the manual brush is unaffected.
 See spec/dust-removal.md.
 """
+import math
+
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
                                 QPushButton, QSlider, QFrame, QProgressBar,
                                 QMessageBox)
@@ -19,6 +21,29 @@ from PySide6.QtCore import Qt, QObject, QThread, Signal
 
 from core import dust_detect
 from ui import theme
+
+# Brush radius limits as a fraction of image width (the canvas clamps to the
+# same range). The slider maps its integer steps onto this range LOG-scaled:
+# dust spotting needs fine steps at the small end (0.05% is ~3 px radius on a
+# 6000 px scan) without giving up the big scratch-covering sizes at the top —
+# linearly, everything below 1% would sit in the first pixels of travel.
+DUST_BRUSH_R_MIN = 0.0005
+DUST_BRUSH_R_MAX = 0.2
+BRUSH_STEPS = 300
+_BRUSH_LOG_SPAN = math.log(DUST_BRUSH_R_MAX / DUST_BRUSH_R_MIN)
+
+
+def slider_to_brush_r(value: int) -> float:
+    """Slider step (0..BRUSH_STEPS) -> normalized brush radius, log-scaled."""
+    v = max(0, min(BRUSH_STEPS, int(value)))
+    return DUST_BRUSH_R_MIN * math.exp(_BRUSH_LOG_SPAN * v / BRUSH_STEPS)
+
+
+def brush_r_to_slider(r_norm: float) -> int:
+    """Normalized brush radius -> nearest slider step (inverse of the above)."""
+    r = max(DUST_BRUSH_R_MIN, min(DUST_BRUSH_R_MAX, float(r_norm)))
+    return int(round(BRUSH_STEPS * math.log(r / DUST_BRUSH_R_MIN)
+                     / _BRUSH_LOG_SPAN))
 
 
 class _DetectWorker(QObject):
@@ -143,11 +168,11 @@ class DustRemovalPanel(QWidget):
         brush_lbl = QLabel("Brush size")
         brush_lbl.setFixedWidth(theme.LABEL_COL_W)
         self.brush_slider = QSlider(Qt.Horizontal)
-        self.brush_slider.setMinimum(2)     # r = value/1000  ->  0.002 .. 0.200
-        self.brush_slider.setMaximum(200)
-        self.brush_slider.setValue(12)      # 0.012 (1.2% of image width)
+        self.brush_slider.setMinimum(0)     # log scale: see slider_to_brush_r
+        self.brush_slider.setMaximum(BRUSH_STEPS)
+        self.brush_slider.setValue(brush_r_to_slider(0.012))  # 1.2% default
         self.brush_slider.setFixedHeight(theme.CONTROL_H)
-        self.brush_value = QLabel("1.2%")
+        self.brush_value = QLabel("1.20%")
         self.brush_value.setFixedWidth(theme.VALUE_COL_W)
         self.brush_slider.valueChanged.connect(self._on_brush_changed)
         brush_row.addWidget(brush_lbl)
@@ -263,23 +288,26 @@ class DustRemovalPanel(QWidget):
             self._luma = None
             self._prob_image_ref = None
         # Push the current brush size to the canvas so they agree on entry.
-        self.image_preview.set_dust_brush_size(self.brush_slider.value() / 1000.0)
+        self.image_preview.set_dust_brush_size(
+            slider_to_brush_r(self.brush_slider.value()))
         self._refresh_ai_section()
         self.status_label.setText("")
 
     def sync_brush_size(self, r_norm: float):
         """Reflect a wheel-driven brush change from the canvas without
-        re-emitting back to the canvas."""
-        v = max(2, min(200, int(round(r_norm * 1000))))
+        re-emitting back to the canvas. The label shows the canvas's exact
+        radius (the slider is quantized to its nearest log step)."""
         self.brush_slider.blockSignals(True)
-        self.brush_slider.setValue(v)
+        self.brush_slider.setValue(brush_r_to_slider(r_norm))
         self.brush_slider.blockSignals(False)
-        self.brush_value.setText(f"{v / 10.0:.1f}%")
+        r = max(DUST_BRUSH_R_MIN, min(DUST_BRUSH_R_MAX, float(r_norm)))
+        self.brush_value.setText(f"{r * 100.0:.2f}%")
 
     # --- Manual handlers --------------------------------------------------
     def _on_brush_changed(self, value):
-        self.brush_value.setText(f"{value / 10.0:.1f}%")
-        self.image_preview.set_dust_brush_size(value / 1000.0)
+        r = slider_to_brush_r(value)
+        self.brush_value.setText(f"{r * 100.0:.2f}%")
+        self.image_preview.set_dust_brush_size(r)
 
     def _on_undo_last(self):
         if not self.image_preview.dust_undo_last():

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -11,6 +11,7 @@ from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, Q
 from core.ccr_backend import ccr_backend
 from core.ccr_processor import apply_dust_removal
 from core import crop_aspect
+from widgets.dust_panel import DUST_BRUSH_R_MIN, DUST_BRUSH_R_MAX
 from widgets.export_dialog import ExportSettingsDialog
 from widgets.scopes_panel import ScopesPanel
 from ui import theme
@@ -2407,13 +2408,16 @@ class ImagePreview(QWidget):
         self.dust_panel = panel
 
     def set_dust_brush_size(self, r_norm: float):
-        self._dust_brush_r = max(0.002, min(0.2, float(r_norm)))
+        self._dust_brush_r = max(DUST_BRUSH_R_MIN,
+                                 min(DUST_BRUSH_R_MAX, float(r_norm)))
 
     def adjust_dust_brush(self, step: int, anchor_scene=None):
         """Wheel-resize the brush (exponential); keep the panel slider + the
         on-canvas brush ring in sync."""
         factor = 1.15 if step > 0 else (1.0 / 1.15)
-        self._dust_brush_r = max(0.002, min(0.2, self._dust_brush_r * factor))
+        self._dust_brush_r = max(DUST_BRUSH_R_MIN,
+                                 min(DUST_BRUSH_R_MAX,
+                                     self._dust_brush_r * factor))
         if getattr(self, "dust_panel", None) is not None:
             self.dust_panel.sync_brush_size(self._dust_brush_r)
         self._update_dust_cursor(anchor_scene)

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -302,13 +302,33 @@ class TestPanelWiring:
         assert panel is not None
 
     def test_brush_slider_drives_canvas(self):
-        from widgets.dust_panel import DustRemovalPanel
+        from widgets.dust_panel import (DustRemovalPanel, brush_r_to_slider,
+                                        slider_to_brush_r)
         prev = _StubPreview()
         panel = DustRemovalPanel(_StubMain(), prev)
-        panel._on_brush_changed(30)            # 30 / 1000 = 0.030 of width
-        assert abs(prev.brush - 0.030) < 1e-9
+        panel._on_brush_changed(brush_r_to_slider(0.030))
+        # Log-step quantization: nearest step is within ~1% of the target r.
+        assert abs(prev.brush - 0.030) < 0.030 * 0.015
         panel.sync_brush_size(0.05)            # canvas -> slider, no feedback loop
-        assert abs(panel.brush_slider.value() - 50) <= 1
+        assert panel.brush_slider.value() == brush_r_to_slider(0.05)
+        # Mapping round-trips through the slider's integer steps.
+        v = brush_r_to_slider(0.012)
+        assert brush_r_to_slider(slider_to_brush_r(v)) == v
+
+    def test_brush_reaches_fine_sizes(self):
+        # The slider bottom is 0.05% of image width (~3 px radius on a 6000 px
+        # scan) — finer than the old 0.2% floor; the 20% top is unchanged.
+        from widgets.dust_panel import (DustRemovalPanel, BRUSH_STEPS,
+                                        DUST_BRUSH_R_MIN, DUST_BRUSH_R_MAX)
+        assert DUST_BRUSH_R_MIN <= 0.0005
+        prev = _StubPreview()
+        panel = DustRemovalPanel(_StubMain(), prev)
+        assert panel.brush_slider.minimum() == 0
+        assert panel.brush_slider.maximum() == BRUSH_STEPS
+        panel._on_brush_changed(0)
+        assert abs(prev.brush - DUST_BRUSH_R_MIN) < 1e-12
+        panel._on_brush_changed(BRUSH_STEPS)
+        assert abs(prev.brush - DUST_BRUSH_R_MAX) < 1e-12
 
     def test_done_button_exits_mode(self):
         from widgets.dust_panel import DustRemovalPanel


### PR DESCRIPTION
## Problem

The manual dust brush could not get small enough for fine specks: both the panel slider minimum and the Ctrl+wheel clamp bottomed out at **0.2% of image width** — a 12 px radius on a 6000 px export.

## Change

- **New floor: 0.05%** of image width (~3 px radius at 6000 px; the mask rasterizer already guarantees >= 1 px at preview resolution). Ceiling unchanged at 20%.
- **Log-scaled slider**: the range is now 400:1, so a linear track would cram every fine size below 1% into the first pixels of travel. The slider's 300 integer steps map onto the range logarithmically (~2% size change per step) — fine sizes get real travel, big scratch-covering sizes stay reachable.
- The range lives in shared constants (`DUST_BRUSH_R_MIN`/`DUST_BRUSH_R_MAX` in `dust_panel.py`); the canvas wheel clamp imports them, so slider and Ctrl+wheel can never disagree. Wheel keeps its exponential 1.15x steps.
- Label shows two decimals ("0.05%".."20.00%"); on wheel changes it shows the canvas's exact radius while the slider snaps to its nearest step.

Independent of #81 (branched off main); no conflicts expected — different files except non-overlapping regions of the test file and spec.

## Tests

`tests/test_dust_removal.py`: panel-wiring test updated to the log mapping (drive canvas, sync back, integer round-trip); new test pins the reachable range (slider bottom == 0.05% floor, top == 20%). 34 tests pass (with test_wrong_output_fixes.py in the same run — also proves the new cross-module import is cycle-free). Spec §3.2 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
