### PR TITLE
fix(film-stock): selection defaults to Default slope for every new roll

### DIFF
--- a/spec/film-stock-slopes.md
+++ b/spec/film-stock-slopes.md
@@ -44,7 +44,12 @@ Behaviours:
   so zoom/hi-res replay, export, slice children, catalog restore, re-grade and
   the density-toggle reprocess all reproduce the conversion even if the preset
   is later renamed/deleted.
-- Presets persist across sessions (QSettings); the selected stock persists too.
+- Presets persist across sessions (QSettings). The **selection does not**: it
+  resets to "Default slope" at app start, on every new batch load, and on
+  tether session start — a stock chosen for one roll must be re-chosen for the
+  next, never silently applied. (Originally the selection persisted too;
+  reversed by user request — new images always convert with the default slope
+  unless a stock is explicitly chosen for that roll.)
 - Tethered captures convert with the selected stock (black-point-only mode).
 
 ### Non-goals
@@ -125,11 +130,14 @@ The "Black Point sampled!" hint mentions the stock when one is selected
 ("…click <b>Convert</b> to use film stock \"Portra 400\"…"). The save action
 confirms with a hint ("Film stock \"Portra 400\" saved.").
 
-### 4.4 Startup
+### 4.4 Startup / new batch
 
-Presets and the selected name are restored from QSettings when the panel is
-built. A selected name that no longer exists (settings edited/corrupt) falls
-back to Default silently.
+Presets are restored from QSettings when the panel is built; the combo always
+starts on **Default slope** (the legacy `convert/film_stock_selected` key is
+removed on startup). When a new batch is loaded (Open Files / Open Folder /
+tether session start), `MainWindow` calls
+`sliders_panel.reset_film_stock_combo()` and the backend loader clears its own
+copy in `load_images_from_files` — mirroring the per-roll B/W-point reset.
 
 ## 5. Data model
 
@@ -157,7 +165,9 @@ FilmStock = {           # plain dict, JSON-safe
 
 QSettings keys (`FreeCCR/FreeCCR`, next to the existing `convert/*` keys):
 - `convert/film_stocks` — the JSON string.
-- `convert/film_stock_selected` — selected stock name; absent/"" = Default.
+- `convert/film_stock_selected` — LEGACY (selection persisted originally);
+  no longer written, and removed on panel startup so old installs also start
+  on Default.
 
 ### 5.2 Backend global state — `CCRBackend`
 

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -75,10 +75,11 @@ class CCRBackend:
         # Selected film-stock preset for the black-point-only conversion:
         # per-channel density slopes (B, G, R), or None → the baked scalar
         # DEFAULT_DENSITY_SLOPE. A sampled white point always overrides it.
-        # Owned by the sliders panel (combo) and persisted there in QSettings;
-        # the name is kept for the mode label / hints only. Unlike the B/W
-        # points this survives a new batch — the preset is per stock, not per
-        # roll. See spec/film-stock-slopes.md.
+        # Owned by the sliders panel (combo); the name is kept for the mode
+        # label / hints only. Like the B/W points, the SELECTION is per
+        # roll/session: it resets to Default on every new batch (and at app
+        # start) so a stock chosen for one roll can't silently convert the
+        # next — only the saved PRESETS persist. See spec/film-stock-slopes.md.
         self.film_stock_slopes = None
         self.film_stock_name = None
         # Global input ICC profile (one app-wide setting; applied to every
@@ -118,6 +119,10 @@ class CCRBackend:
         # QSettings copy is intact and still restores at next app start.
         self.black_point_bgr = None
         self.white_point_bgr = None
+        # Same for the film-stock selection: every new batch starts on the
+        # default slope unless the user picks a stock for THIS roll (the
+        # panel's combo is reset by MainWindow when it kicks off the load).
+        self.clear_film_stock()
         # Per-load merge error: reset up front so a prior load's message can't
         # carry over and be shown after this (possibly successful) one.
         self.last_merge_error = None

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -889,6 +889,9 @@ class MainWindow(QMainWindow):
                         QMessageBox.warning(self, "3-way RGB merge", err)
                         return
                 self._stop_loader_if_running()
+                # New batch = new roll: the combo returns to "Default slope"
+                # (the backend loader clears its copy too).
+                self.sliders_panel.reset_film_stock_combo()
                 self.thumbnail_list.show_loading_dialog()
                 self._loader_thread = QThread()
                 self._loader_worker = ImageLoaderWorker(files=valid_files)
@@ -929,6 +932,9 @@ class MainWindow(QMainWindow):
                 return
                 
             self._stop_loader_if_running()
+            # New batch = new roll: the combo returns to "Default slope"
+            # (the backend loader clears its copy too).
+            self.sliders_panel.reset_film_stock_combo()
             self.thumbnail_list.show_loading_dialog()
             self._loader_thread = QThread()
             self._loader_worker = ImageLoaderWorker(normalized_folder)
@@ -1022,6 +1028,9 @@ class MainWindow(QMainWindow):
         # roll's point must not carry over.
         ccr_backend.black_point_bgr = None
         ccr_backend.white_point_bgr = None
+        # And the film-stock selection resets for the same reason (the combo
+        # sync also clears the backend copy).
+        self.sliders_panel.reset_film_stock_combo()
 
         # Long-lived worker on its own event-loop QThread (spec §9.1.7); work is
         # delivered by QMetaObject.invokeMethod (queued) so it runs off-GUI.

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -458,8 +458,12 @@ class SlidersPanel(QWidget):
         self._settings = QSettings("FreeCCR", "FreeCCR")
         self._film_stocks = decode_film_stocks(
             self._settings.value("convert/film_stocks", "", type=str))
-        self._reload_film_stock_combo(
-            select=self._settings.value("convert/film_stock_selected", "", type=str))
+        # The PRESETS persist across sessions; the SELECTION does not — every
+        # session (and every new batch, see reset_film_stock_combo) starts on
+        # "Default slope" so a stock chosen for one roll can't silently apply
+        # to the next. Drop the legacy persisted-selection key.
+        self._settings.remove("convert/film_stock_selected")
+        self._reload_film_stock_combo(select="")
 
         # Shows which slope source the next conversion will use.
         self.bwp_mode_label = QLabel("")
@@ -1616,19 +1620,27 @@ class SlidersPanel(QWidget):
 
     def _apply_film_stock_selection(self):
         """Sync the combo's selection into the backend (the slopes the next
-        black-point-only conversion uses), persist it, refresh the label."""
+        black-point-only conversion uses) and refresh the label. The selection
+        is session/batch state — deliberately NOT persisted (see __init__)."""
         idx = self.film_stock_combo.currentIndex()
         if idx <= 0:
             ccr_backend.clear_film_stock()
-            self._settings.remove("convert/film_stock_selected")
         else:
             stock = self._film_stocks[idx - 1]
             ccr_backend.set_film_stock(stock["name"], stock["slopes_bgr"])
-            self._settings.setValue("convert/film_stock_selected", stock["name"])
         self._update_bwp_mode_label()
 
     def _on_film_stock_changed(self, _index):
         self._apply_film_stock_selection()
+
+    def reset_film_stock_combo(self):
+        """Back to "Default slope". Called when a new batch is loaded (and on
+        tether session start): a stock chosen for the previous roll must not
+        silently convert the next one — mirrors the B/W-point reset."""
+        if self.film_stock_combo.currentIndex() != 0:
+            self.film_stock_combo.setCurrentIndex(0)  # signal syncs the backend
+        else:
+            self._apply_film_stock_selection()
 
     def _save_film_stocks_to_settings(self):
         self._settings.setValue("convert/film_stocks",

--- a/tests/test_film_stocks.py
+++ b/tests/test_film_stocks.py
@@ -247,5 +247,24 @@ def test_remove_and_find():
     assert remove_film_stock(stocks, "PORTRA 400") == []
 
 
+# --- selection is per roll/session -------------------------------------------
+def test_new_batch_resets_film_stock_selection():
+    # A stock chosen for one roll must not silently convert the next: loading
+    # a new batch clears the backend selection (the panel combo is reset by
+    # MainWindow on the same load; see spec §4.4). Mirrors the B/W-point reset.
+    from core.ccr_backend import ccr_backend
+    saved = (ccr_backend.film_stock_name, ccr_backend.film_stock_slopes,
+             list(ccr_backend.images), list(ccr_backend.file_paths or []))
+    try:
+        ccr_backend.set_film_stock("Portra 400", (0.8, 0.7, 0.6))
+        assert ccr_backend.film_stock_slopes is not None
+        ccr_backend.load_images_from_files([])   # a fresh (empty) batch
+        assert ccr_backend.film_stock_name is None
+        assert ccr_backend.film_stock_slopes is None
+    finally:
+        (ccr_backend.film_stock_name, ccr_backend.film_stock_slopes,
+         ccr_backend.images, ccr_backend.file_paths) = saved
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

The Film Stock selection was sticky by design: persisted in QSettings across app restarts, and deliberately surviving new batch loads (unlike the B/W points). In practice that means a stock chosen once for one roll **silently converts every later image** — including new rolls loaded days later — until the user remembers to switch back to "Default slope".

## Change

The **selection** is now per roll/session; the saved **presets** still persist forever:

- **App start**: the combo always opens on "Default slope". The legacy `convert/film_stock_selected` key is no longer written and is removed on startup, so existing installs also start clean.
- **New batch** (Open Files / Open Folder): the combo resets to "Default slope" when the load is kicked off, and `ccr_backend.load_images_from_files` clears its own copy (covers headless/merge/folder paths through the single funnel).
- **Tether session start**: same reset, alongside the existing B/W-point clear.

This exactly mirrors the per-roll B/W-point behavior — different rolls have different stocks, so neither should carry over.

Already-converted images are unaffected: the slopes used at convert time are snapshotted into `conversion_inputs`, so replay/export of previous conversions keeps their original stock.

## Tests / spec

New backend regression test: choose a stock, load a fresh batch, selection is cleared. 17 film-stock tests pass; dust suite (which imports the touched UI modules) passes as an import smoke. Spec updated: goals, §4.4 "Startup / new batch", QSettings key marked legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
