### PR TITLE
ui(film-stock): combo entry Default, mode label Anchor source

### DIFF
--- a/spec/film-stock-slopes.md
+++ b/spec/film-stock-slopes.md
@@ -45,7 +45,7 @@ Behaviours:
   the density-toggle reprocess all reproduce the conversion even if the preset
   is later renamed/deleted.
 - Presets persist across sessions (QSettings). The **selection does not**: it
-  resets to "Default slope" at app start, on every new batch load, and on
+  resets to "Default" at app start, on every new batch load, and on
   tether session start — a stock chosen for one roll must be re-chosen for the
   next, never silently applied. (Originally the selection persisted too;
   reversed by user request — new images always convert with the default slope
@@ -93,12 +93,12 @@ A new row directly under the Set-point buttons, above the mode label:
 ```
 Film B/W Point
 [Set Black Point] [Set White Point] [✕]
-Film Stock  [ Default slope      ▾ ] [＋] [🗑]
-Slope source: film stock "Portra 400" (black point only)
+Film Stock  [ Default            ▾ ] [＋] [🗑]
+Anchor source: film stock "Portra 400" (black point only)
 [Convert Current] [Convert All]
 ```
 
-- **Combo** (`film_stock_combo`): first entry **"Default slope"**, then saved
+- **Combo** (`film_stock_combo`): first entry **"Default"**, then saved
   stocks sorted case-insensitively by name. Laid out like the Color Profile
   row (label column + combo) so it aligns with the section.
 - **Save button** (`＋`, glyph width, tooltip "Save the current B/W-point pair
@@ -118,11 +118,12 @@ Slope source: film stock "Portra 400" (black point only)
 
 ### 4.2 Mode label
 
-`_update_bwp_mode_label` gains a third case:
+`_update_bwp_mode_label` gains a third case (prefix renamed "Slope source" →
+"Anchor source" by user request):
 - no black point → hidden (unchanged)
-- white point set → "Slope source: white point (two-point)" (unchanged)
-- black only, Default → "Slope source: default slope (black point only)" (unchanged)
-- black only, stock selected → `Slope source: film stock "<name>" (black point only)`
+- white point set → "Anchor source: white point (two-point)"
+- black only, Default → "Anchor source: default slope (black point only)"
+- black only, stock selected → `Anchor source: film stock "<name>" (black point only)`
 
 ### 4.3 Hints
 
@@ -133,7 +134,7 @@ confirms with a hint ("Film stock \"Portra 400\" saved.").
 ### 4.4 Startup / new batch
 
 Presets are restored from QSettings when the panel is built; the combo always
-starts on **Default slope** (the legacy `convert/film_stock_selected` key is
+starts on **Default** (the legacy `convert/film_stock_selected` key is
 removed on startup). When a new batch is loaded (Open Files / Open Folder /
 tether session start), `MainWindow` calls
 `sliders_panel.reset_film_stock_combo()` and the backend loader clears its own

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -889,7 +889,7 @@ class MainWindow(QMainWindow):
                         QMessageBox.warning(self, "3-way RGB merge", err)
                         return
                 self._stop_loader_if_running()
-                # New batch = new roll: the combo returns to "Default slope"
+                # New batch = new roll: the combo returns to "Default"
                 # (the backend loader clears its copy too).
                 self.sliders_panel.reset_film_stock_combo()
                 self.thumbnail_list.show_loading_dialog()
@@ -932,7 +932,7 @@ class MainWindow(QMainWindow):
                 return
                 
             self._stop_loader_if_running()
-            # New batch = new roll: the combo returns to "Default slope"
+            # New batch = new roll: the combo returns to "Default"
             # (the backend loader clears its copy too).
             self.sliders_panel.reset_film_stock_combo()
             self.thumbnail_list.show_loading_dialog()

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -19,7 +19,7 @@ from datetime import date
 
 # First combo entry of the film-stock selector: the baked scalar
 # DEFAULT_DENSITY_SLOPE (no preset). See spec/film-stock-slopes.md.
-FILM_STOCK_DEFAULT_LABEL = "Default slope"
+FILM_STOCK_DEFAULT_LABEL = "Default"
 
 # Setting groups offered by the "Sync to All" dialog. The adjustment-key
 # groups partition SlidersPanel.ADJUSTMENT_KEYS exactly; "crop" syncs the
@@ -460,7 +460,7 @@ class SlidersPanel(QWidget):
             self._settings.value("convert/film_stocks", "", type=str))
         # The PRESETS persist across sessions; the SELECTION does not — every
         # session (and every new batch, see reset_film_stock_combo) starts on
-        # "Default slope" so a stock chosen for one roll can't silently apply
+        # "Default" so a stock chosen for one roll can't silently apply
         # to the next. Drop the legacy persisted-selection key.
         self._settings.remove("convert/film_stock_selected")
         self._reload_film_stock_combo(select="")
@@ -1575,11 +1575,11 @@ class SlidersPanel(QWidget):
         if not bp_set:
             text = ""
         elif wp_set:
-            text = "Slope source: white point (two-point)"
+            text = "Anchor source: white point (two-point)"
         elif stock:
-            text = f'Slope source: film stock "{stock}" (black point only)'
+            text = f'Anchor source: film stock "{stock}" (black point only)'
         else:
-            text = "Slope source: default slope (black point only)"
+            text = "Anchor source: default slope (black point only)"
         self.bwp_mode_label.setText(text)
         # Hide when empty so it reserves no vertical space — keeps the Set-point
         # row and the Convert row tight together (no gap) until a point is set.
@@ -1634,7 +1634,7 @@ class SlidersPanel(QWidget):
         self._apply_film_stock_selection()
 
     def reset_film_stock_combo(self):
-        """Back to "Default slope". Called when a new batch is loaded (and on
+        """Back to "Default". Called when a new batch is loaded (and on
         tether session start): a stock chosen for the previous roll must not
         silently convert the next one — mirrors the B/W-point reset."""
         if self.film_stock_combo.currentIndex() != 0:
@@ -1709,7 +1709,7 @@ class SlidersPanel(QWidget):
             return
         self._film_stocks = remove_film_stock(self._film_stocks, name)
         self._save_film_stocks_to_settings()
-        self._reload_film_stock_combo()   # falls back to Default slope
+        self._reload_film_stock_combo()   # falls back to Default
         self.set_temporary_hint(f'Film stock "{name}" deleted.', duration=5000)
 
     def on_bwpoint_sampled(self, mode):

--- a/tests/test_film_stock_ui.py
+++ b/tests/test_film_stock_ui.py
@@ -72,14 +72,14 @@ def test_black_only_states_and_label(panel):
     panel._update_bwp_mode_label()
     assert ccr_backend.film_stock_slopes == (0.85, 0.65, 0.56)
     assert panel.bwp_mode_label.text() == \
-        'Slope source: film stock "Portra 400" (black point only)'
+        'Anchor source: film stock "Portra 400" (black point only)'
     assert not panel.save_film_stock_btn.isEnabled()
     assert panel.delete_film_stock_btn.isEnabled()
     # Back to Default: backend cleared, label reverts, delete gated off.
     panel.film_stock_combo.setCurrentIndex(0)
     assert ccr_backend.film_stock_slopes is None
     assert panel.bwp_mode_label.text() == \
-        "Slope source: default slope (black point only)"
+        "Anchor source: default slope (black point only)"
     assert not panel.delete_film_stock_btn.isEnabled()
 
 
@@ -88,7 +88,7 @@ def test_white_point_overrides_and_disables_selector(panel):
     ccr_backend.set_black_point(BASE_BGR)
     ccr_backend.set_white_point(WHITE_BGR)
     panel._update_bwp_mode_label()
-    assert panel.bwp_mode_label.text() == "Slope source: white point (two-point)"
+    assert panel.bwp_mode_label.text() == "Anchor source: white point (two-point)"
     assert not panel.film_stock_combo.isEnabled()
     assert panel.save_film_stock_btn.isEnabled()       # both points → can save
     assert not panel.delete_film_stock_btn.isEnabled()
@@ -122,8 +122,10 @@ def test_save_flow_persists_and_selects(panel, monkeypatch):
     assert [s["name"] for s in stored] == ["Portra 400"]
     assert stored[0]["black_bgr"] == list(BASE_BGR)    # provenance kept
     assert panel.film_stock_combo.currentText() == "Portra 400"
+    # The SELECTION is session-only (per roll) — never persisted; only the
+    # preset list is. See spec §2 goals / §4.4.
     assert panel._settings.value("convert/film_stock_selected", "", type=str) \
-        == "Portra 400"
+        == ""
     # The saved slopes reproduce the pair (S = 1/log10(base/dense)).
     from core.ccr_processor import compute_density_slopes
     assert tuple(stored[0]["slopes_bgr"]) == \
@@ -162,7 +164,7 @@ def test_delete_falls_back_to_default(panel, monkeypatch):
     assert decode_film_stocks(
         panel._settings.value("convert/film_stocks", "", type=str)) == []
     assert panel.bwp_mode_label.text() == \
-        "Slope source: default slope (black point only)"
+        "Anchor source: default slope (black point only)"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Label text changes requested by the user: the Film Stock combo's first entry is now **Default** (was 'Default slope'), and the B/W-point mode label prefix is now **Anchor source:** (was 'Slope source:') across all three cases. Also fixes a UI test missed by PR #83's selection-persistence removal (it still asserted the legacy QSettings key was written). 24 film-stock tests pass. Spec label references updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4