### PR TITLE
release: v1.1.0 What's New notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,16 +57,14 @@ jobs:
           body: |
             ## What's New
 
-            **FreeCCR 1.0** — the first stable release. A free, offline desktop app for converting and colour-correcting colour-negative film.
+            **FreeCCR 1.1** — colour scopes, a rebuilt dust-removal engine, and film-stock slope presets.
 
-            Key features:
-            - **Physics-based negative conversion** — models film's non-linear response and density range, not a naive 255−value invert.
-            - **Two-point anchoring** — sample the film's white and black references once, then convert a whole roll consistently; or use **Auto** frame detection for a fast first pass.
-            - **Batch RAW + standard formats** — load a whole folder at once (CR3/CR2/NEF/ARW/DNG, TIFF/JPEG/PNG).
-            - **Full colour correction** — temperature/tint, exposure/gain, brightness, gamma (with an optional hue-preserving mode), highlights/shadows, contrast, saturation, per-channel levels, and a Curves editor — with a live histogram and zoom.
-            - **Crop & straighten, dust removal, camera profiles (ICC / DCP / IT8), and local (area) adjustments.**
-            - **Sync & copy/paste** adjustments across a roll, plus optional **OpenCL GPU acceleration**.
-            - **Completely offline and free** (AGPL-3.0) — no activation, no watermark, no strings.
+            - **Colour scopes panel** — RGB parade + vectorscope under the canvas, computed from the visible viewport. 10-bit parade axis with Cineon 95/685 reference lines, a skin-tone line on the vectorscope, and a drag-resizable panel.
+            - **Dust removal, rebuilt** — spots now heal by cloning real neighbouring texture (film grain preserved, 16-bit native) instead of a blurry averaged fill — no more smooth round smudges or streaky patches, and traced hairs no longer leave a bright ghost of the stroke.
+            - **Dust tools** — adjustable edge **Feather** (per image, re-heals live), a much finer minimum brush (0.05% of image width on a log-scaled slider), and **Ctrl+Z** in dust mode now undoes the last spot while keeping your zoom.
+            - **Film-stock slope presets** — save a sampled B/W pair's per-channel density slopes under a name (e.g. "Portra 400") and convert whole rolls with it in black-point-only mode. The selection resets to **Default** for every new roll, so a stock never silently applies to the next batch.
+            - **Trichrome / 3-way merge** — linear TIFF export (raw channel combination), exports honour the crop, and a merge-detail dropdown (demosaic vs single photosite).
+            - **Stability** — fixes for a thread-safety crash class (worker-thread pixmaps, loader cancel race, threads at exit) and a wrong-output class (export state corruption, mono double-scale, fine-rotation sampling).
 
             ## Install
 
@@ -163,16 +161,14 @@ jobs:
           body: |
             ## What's New
 
-            **FreeCCR 1.0** — the first stable release. A free, offline desktop app for converting and colour-correcting colour-negative film.
+            **FreeCCR 1.1** — colour scopes, a rebuilt dust-removal engine, and film-stock slope presets.
 
-            Key features:
-            - **Physics-based negative conversion** — models film's non-linear response and density range, not a naive 255−value invert.
-            - **Two-point anchoring** — sample the film's white and black references once, then convert a whole roll consistently; or use **Auto** frame detection for a fast first pass.
-            - **Batch RAW + standard formats** — load a whole folder at once (CR3/CR2/NEF/ARW/DNG, TIFF/JPEG/PNG).
-            - **Full colour correction** — temperature/tint, exposure/gain, brightness, gamma (with an optional hue-preserving mode), highlights/shadows, contrast, saturation, per-channel levels, and a Curves editor — with a live histogram and zoom.
-            - **Crop & straighten, dust removal, camera profiles (ICC / DCP / IT8), and local (area) adjustments.**
-            - **Sync & copy/paste** adjustments across a roll, plus optional **OpenCL GPU acceleration**.
-            - **Completely offline and free** (AGPL-3.0) — no activation, no watermark, no strings.
+            - **Colour scopes panel** — RGB parade + vectorscope under the canvas, computed from the visible viewport. 10-bit parade axis with Cineon 95/685 reference lines, a skin-tone line on the vectorscope, and a drag-resizable panel.
+            - **Dust removal, rebuilt** — spots now heal by cloning real neighbouring texture (film grain preserved, 16-bit native) instead of a blurry averaged fill — no more smooth round smudges or streaky patches, and traced hairs no longer leave a bright ghost of the stroke.
+            - **Dust tools** — adjustable edge **Feather** (per image, re-heals live), a much finer minimum brush (0.05% of image width on a log-scaled slider), and **Ctrl+Z** in dust mode now undoes the last spot while keeping your zoom.
+            - **Film-stock slope presets** — save a sampled B/W pair's per-channel density slopes under a name (e.g. "Portra 400") and convert whole rolls with it in black-point-only mode. The selection resets to **Default** for every new roll, so a stock never silently applies to the next batch.
+            - **Trichrome / 3-way merge** — linear TIFF export (raw channel combination), exports honour the crop, and a merge-detail dropdown (demosaic vs single photosite).
+            - **Stability** — fixes for a thread-safety crash class (worker-thread pixmaps, loader cancel race, threads at exit) and a wrong-output class (export state corruption, mono double-scale, fine-rotation sampling).
 
             ## Install
 


### PR DESCRIPTION
Replaces the static release body in both release.yml jobs (kept in sync) with the 1.1 changes: colour scopes panel, rebuilt clone-heal dust removal + Feather/finer brush/dust-mode Ctrl+Z, film-stock slope presets with per-roll Default reset, trichrome export improvements, and the stability fix classes. Tag v1.1.0 will be pushed after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4