### PR TITLE
fix: macOS reports - convert crash (ASCII stdout), scanner TIFF decode, preview hue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,8 @@ jobs:
             --include-package=numpy \
             --include-package=utils \
             --include-package=pyopencl \
+            --include-package=imagecodecs \
+            --include-package-data=imagecodecs \
             --include-data-dir="$PYOPENCL_CL_DIR=pyopencl/cl" \
             --enable-plugin=pyside6 \
             --include-data-dir=src/icons=icons \

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -18,6 +18,7 @@ nuitka --msvc=latest --jobs=6 --standalone --assume-yes-for-downloads --include-
 --include-data-dir=src/icons=icons --include-data-dir=LICENSES=LICENSES --windows-icon-from-ico=src/icons/freeccr_logo.ico ^
 --windows-console-mode=attach --include-package=pyopencl --include-data-dir="%PYOPENCL_CL_DIR%=pyopencl/cl" ^
 --include-package=onnxruntime --include-package-data=onnxruntime ^
+--include-package=imagecodecs --include-package-data=imagecodecs ^
 --nofollow-import-to=doctest --nofollow-import-to=IPython ^
 --nofollow-import-to=PIL.PdfParser --nofollow-import-to=PIL.PdfImagePlugin ^
 --output-filename=freeccr.exe src/main.py

--- a/macos_build_scripts/build_compatible.sh
+++ b/macos_build_scripts/build_compatible.sh
@@ -73,6 +73,8 @@ python -m nuitka \
     --standalone \
     --include-package=numpy \
     --include-package=pyopencl \
+    --include-package=imagecodecs \
+    --include-package-data=imagecodecs \
     --include-data-dir="$PYOPENCL_CL_DIR=pyopencl/cl" \
     --enable-plugin=pyside6 \
     --include-data-dir=src/icons=icons \

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ exifread
 opencv-python
 rawpy
 tifffile
+imagecodecs
 requests
 nuitka
 pyopencl

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -34,6 +34,44 @@ except ImportError:
     PIL_AVAILABLE = False
     logging.warning("PIL/Pillow not available, some image formats may not be supported")
 
+
+def _read_tiff_bgr(file_path: str):
+    """Decode a TIFF with tifffile and return it in OpenCV's BGR channel
+    order (any dtype). Handles the layouts OpenCV chokes on with scanner
+    TIFFs (Pakon / Nikon Coolscan): planar storage (PlanarConfiguration=2,
+    which tifffile returns as (C, H, W)), alpha channels (dropped), and
+    exotic sample formats; compressed files decode via imagecodecs."""
+    arr = tifffile.imread(file_path)
+    if arr is None:
+        return None
+    arr = np.asarray(arr)
+    if (arr.ndim == 3 and arr.shape[0] in (3, 4)
+            and arr.shape[2] not in (3, 4)):
+        arr = np.moveaxis(arr, 0, -1)   # planar (C, H, W) -> (H, W, C)
+    if arr.ndim == 3 and arr.shape[2] == 4:
+        arr = arr[..., :3]              # drop alpha
+    if arr.ndim == 3 and arr.shape[2] == 3:
+        arr = arr[..., ::-1]            # RGB -> BGR, dtype-agnostic
+    return np.ascontiguousarray(arr)
+
+
+def _to_uint16_full_range(img: np.ndarray) -> np.ndarray:
+    """Normalize a decoded image to the pipeline's uint16 full-range
+    contract. Scanner TIFFs arrive in many sample formats; float (0..1) and
+    wide/signed integer data previously passed through untouched and
+    rendered black or half-range downstream."""
+    if img.dtype == np.uint16:
+        return img
+    if img.dtype == np.uint8:
+        return img.astype(np.uint16) * 257
+    if np.issubdtype(img.dtype, np.floating):
+        return np.clip(img.astype(np.float32) * 65535.0 + 0.5,
+                       0, 65535).astype(np.uint16)
+    info = np.iinfo(img.dtype)
+    scale = 65535.0 / float(max(int(info.max), 1))
+    return np.clip(img.astype(np.float64) * scale, 0, 65535).astype(np.uint16)
+
+
 class CCRImage:
     def __init__(
         self,
@@ -650,26 +688,43 @@ class CCRImage:
         else:
             # Handle Unicode file paths and OpenCV TIFF issues properly
             img = None
-            
+            is_tiff = file_path.lower().endswith(('.tif', '.tiff'))
+
+            # Scanner TIFFs (Pakon, Nikon Coolscan) often use PLANAR storage
+            # (PlanarConfiguration=2, RRR..GGG..BBB). OpenCV misreads those
+            # into scrambled channels WITHOUT failing, so sniff the tag first
+            # and route them straight to tifffile (issues #86/#87). The sniff
+            # reads only the TIFF header, not the pixel data.
+            if is_tiff and TIFFFILE_AVAILABLE:
+                try:
+                    with tifffile.TiffFile(file_path) as tf:
+                        planar = getattr(tf.pages[0], "planarconfig", 1)
+                        planar = int(getattr(planar, "value", planar) or 1)
+                    if planar == 2:
+                        img = _read_tiff_bgr(file_path)
+                        print(f"Planar TIFF read via tifffile: "
+                              f"{os.path.basename(file_path)}")
+                except Exception as e:
+                    logging.warning(
+                        f"TIFF planar sniff failed for {file_path}: {e}")
+                    img = None
+
             # Try multiple reading methods for better compatibility
-            try:
-                # Method 1: Try OpenCV imread first (handles most formats)
-                img = cv2.imread(file_path, cv2.IMREAD_UNCHANGED)
-                
-            except Exception as e:
-                logging.warning(f"OpenCV imread failed for {file_path}: {e}")
-                img = None
-            
+            if img is None:
+                try:
+                    # Method 1: Try OpenCV imread first (handles most formats)
+                    img = cv2.imread(file_path, cv2.IMREAD_UNCHANGED)
+
+                except Exception as e:
+                    logging.warning(f"OpenCV imread failed for {file_path}: {e}")
+                    img = None
+
             # Method 2: If OpenCV fails or returns None, try alternative methods
             if img is None:
                 try:
                     # For TIFF files, try using tifffile library which is more robust
-                    if file_path.lower().endswith(('.tif', '.tiff')) and TIFFFILE_AVAILABLE:
-                        img = tifffile.imread(file_path)
-                        # Convert to OpenCV format (BGR if color, grayscale if mono)
-                        if len(img.shape) == 3 and img.shape[2] == 3:
-                            # RGB to BGR conversion for OpenCV compatibility
-                            img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+                    if is_tiff and TIFFFILE_AVAILABLE:
+                        img = _read_tiff_bgr(file_path)
                         print(f"Successfully read TIFF using tifffile: {os.path.basename(file_path)}")
                     else:
                         # For other formats, try binary reading with cv2.imdecode
@@ -713,6 +768,10 @@ class CCRImage:
             if img is None:
                 logging.error(f"All reading methods failed for: {file_path}")
                 return None
+            # Normalize the sample format FIRST (cvtColor can't take
+            # float64/int16 input, and float 0..1 data used to slip through
+            # unconverted and render black).
+            img = _to_uint16_full_range(img)
             # Convert grayscale to RGB
             if len(img.shape) == 2:
                 img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
@@ -720,9 +779,6 @@ class CCRImage:
                 img = cv2.cvtColor(img, cv2.COLOR_BGRA2RGB)
             else:
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-            # Convert to 16-bit if needed
-            if img.dtype != np.uint16:
-                img = img.astype(np.uint16) * 257 if img.dtype == np.uint8 else img
             # Sliced images read only their region of the source
             img = self._apply_source_ops(img)
             # This branch always reads at full resolution regardless of `preview`
@@ -1167,29 +1223,31 @@ class CCRImage:
         """
         Display-only auto-brightness for the un-converted negative preview.
 
-        Linearly stretches the tonal range so the central 90% of pixel values
-        (5th-95th percentile) is spread across the full 0-65535 range. A single
-        global map is applied to all channels so the colour balance of the scan
-        is preserved (no per-channel white balancing).
+        Applies a pure GAIN that places the 95th-percentile value at full
+        scale. Gain-only on purpose: the previous version also subtracted a
+        per-frame black offset, and subtracting a constant from RGB shifts
+        hue — mostly-blank frames (lots of film base) rendered their base
+        orange/red while exposed frames stayed pink, which read as the app
+        corrupting scans on import (GitHub issue #86). A gain preserves
+        channel ratios, so the film base looks the same on every frame.
 
-        Returns a new array; the input (resized_raw) is never modified, so this
-        has no effect on conversion, export, or any other processing.
+        Returns a new array; the input (resized_raw) is never modified, so
+        this has no effect on conversion, export, or any other processing.
         """
         if image is None:
             return image
 
-        # Estimate percentiles on a 4x4-subsampled view (16x fewer pixels,
-        # visually identical anchors) and stretch in place — this runs on
-        # every preview refresh of an un-converted image.
+        # Estimate the anchor on a 4x4-subsampled view (16x fewer pixels,
+        # visually identical) — this runs on every preview refresh of an
+        # un-converted image.
         sample = image[::4, ::4]
-        lo, hi = (float(v) for v in np.percentile(sample, (5.0, 95.0)))
-        if hi <= lo:
-            # Degenerate (flat) image — nothing meaningful to stretch.
+        hi = float(np.percentile(sample, 95.0))
+        if hi <= 0:
+            # Degenerate (black) image — nothing meaningful to brighten.
             return image
 
         img = image.astype(np.float32)
-        np.subtract(img, lo, out=img)
-        np.multiply(img, 65535.0 / (hi - lo), out=img)
+        np.multiply(img, 65535.0 / hi, out=img)
         np.clip(img, 0, 65535, out=img)
         return img.astype(np.uint16)
 

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -1403,8 +1403,10 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
         ccr_image.temperature_base = 0
         ccr_image._ws_windowed = ws
     if ws:
+        # ASCII only: this prints during EVERY B/W-point conversion, and an
+        # em dash here crashed converts on macOS (ASCII stdout, issue #86).
         print(f"[working-space] windowed base: ~{_WS_HEADROOM_STOPS:.1f} stops "
-              f"highlight headroom — recover with White Point (drag negative)")
+              f"highlight headroom - recover with White Point (drag negative)")
 
     # Auto-exposure (default-slope mode only): compute once from the preview and
     # store as a non-destructive uniform-gain base; export/zoom reuse it. With a

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,12 @@
 import sys
 import os
 
+# FIRST: make print() unable to crash the app (a macOS .app launches with an
+# ASCII stdout; any logged non-ASCII character raised UnicodeEncodeError mid-
+# operation and aborted it — GitHub issue #86). Everything below prints.
+from utils.stream_hardening import harden_std_streams
+harden_std_streams()
+
 # Make onnxruntime usable for AI dust detection, then pre-load it BEFORE Qt.
 # Two Windows gotchas this handles (see spec/dust-removal.md §8):
 #  1) Nuitka standalone build: the bundled onnxruntime .pyd is loaded without

--- a/src/utils/stream_hardening.py
+++ b/src/utils/stream_hardening.py
@@ -1,0 +1,23 @@
+"""print() must never crash the app.
+
+A macOS .app launched from Finder gets no locale environment, so Python's
+stdout/stderr can be ASCII-encoded; a console-less Windows exe can have no
+streams at all. Any diagnostic print containing a non-ASCII character (an em
+dash in a log line, say) then raises UnicodeEncodeError in the MIDDLE of
+whatever operation logged it — on macOS this aborted every B/W-point
+conversion (GitHub issue #86). Reconfigure both streams to replace
+unencodable characters instead of raising.
+"""
+import sys
+
+
+def harden_std_streams() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        if stream is None:
+            continue
+        try:
+            stream.reconfigure(errors="backslashreplace")
+        except Exception:
+            # A wrapped/frozen stream without reconfigure — leave it be; the
+            # worst case is the old behaviour for that stream only.
+            pass

--- a/tests/test_scanner_tiff.py
+++ b/tests/test_scanner_tiff.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Scanner-TIFF loading + macOS report regressions (GitHub issues #86 / #87).
+
+Pakon / Nikon Coolscan TIFFs exposed three classes of bug:
+- PLANAR TIFFs (PlanarConfiguration=2) were misread by OpenCV into scrambled
+  channels without failing; LZW-compressed files needed imagecodecs; float
+  and wide-integer sample formats slipped through un-normalized.
+- The un-converted preview's auto-brightness subtracted a per-frame black
+  offset, shifting the film base's hue differently on every frame.
+- A print() containing an em dash crashed every B/W-point conversion on
+  macOS, where the .app's stdout is ASCII (UnicodeEncodeError).
+"""
+import io
+import os
+import sys
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+import tifffile  # noqa: E402
+from core.ccr_image import (CCRImage, _read_tiff_bgr,  # noqa: E402
+                            _to_uint16_full_range)
+
+
+def _rgb_ramp(h=64, w=96):
+    """16-bit RGB with distinct per-channel content (means far apart)."""
+    img = np.zeros((h, w, 3), np.uint16)
+    img[..., 0] = 50000   # R
+    img[..., 1] = 30000   # G
+    img[..., 2] = 10000   # B
+    img[: h // 4, : w // 4] = (60000, 40000, 20000)  # some structure
+    return img
+
+
+def _assert_channels(loaded, expected_means, tol=1500):
+    got = loaded.astype(np.float64).reshape(-1, 3).mean(axis=0)
+    for g, e in zip(got, expected_means):
+        assert abs(g - e) < tol, f"channel means {got} != {expected_means}"
+
+
+# --- TIFF layouts through the real load path ---------------------------------
+class TestScannerTiffLoading:
+    def test_planar_tiff_channels_not_scrambled(self, tmp_path):
+        # Pakon-style: 16-bit, PlanarConfiguration=2 (RRR..GGG..BBB).
+        src = _rgb_ramp()
+        path = str(tmp_path / "planar.tif")
+        tifffile.imwrite(path, src, planarconfig="separate")
+        img = CCRImage(path)
+        assert img.resized_raw is not None
+        _assert_channels(img.resized_raw,
+                         src.reshape(-1, 3).mean(axis=0))
+
+    def test_interleaved_tiff_still_loads(self, tmp_path):
+        src = _rgb_ramp()
+        path = str(tmp_path / "contig.tif")
+        tifffile.imwrite(path, src, planarconfig="contig")
+        img = CCRImage(path)
+        _assert_channels(img.resized_raw,
+                         src.reshape(-1, 3).mean(axis=0))
+
+    def test_lzw_tiff_loads(self, tmp_path):
+        # VueScan/NikonScan-style compressed output (needs imagecodecs).
+        src = _rgb_ramp()
+        path = str(tmp_path / "lzw.tif")
+        tifffile.imwrite(path, src, compression="lzw")
+        img = CCRImage(path)
+        _assert_channels(img.resized_raw,
+                         src.reshape(-1, 3).mean(axis=0))
+
+    def test_lzw_planar_tiff_loads(self, tmp_path):
+        src = _rgb_ramp()
+        path = str(tmp_path / "lzw_planar.tif")
+        tifffile.imwrite(path, src, compression="lzw", planarconfig="separate")
+        img = CCRImage(path)
+        _assert_channels(img.resized_raw,
+                         src.reshape(-1, 3).mean(axis=0))
+
+    def test_float_tiff_normalizes(self, tmp_path):
+        # Float TIFFs (0..1) previously slipped through un-normalized and
+        # rendered black.
+        src = np.zeros((32, 48, 3), np.float32)
+        src[..., 0], src[..., 1], src[..., 2] = 0.75, 0.5, 0.25
+        path = str(tmp_path / "float.tif")
+        tifffile.imwrite(path, src)
+        img = CCRImage(path)
+        _assert_channels(img.resized_raw,
+                         (0.75 * 65535, 0.5 * 65535, 0.25 * 65535))
+
+
+# --- helpers ------------------------------------------------------------------
+class TestHelpers:
+    def test_read_tiff_bgr_moves_planar_axis(self, tmp_path):
+        src = _rgb_ramp()
+        path = str(tmp_path / "p.tif")
+        tifffile.imwrite(path, src, planarconfig="separate")
+        bgr = _read_tiff_bgr(path)
+        assert bgr.shape == src.shape
+        assert bgr[0, -1, 0] == src[0, -1, 2]   # B plane in slot 0
+        assert bgr[0, -1, 2] == src[0, -1, 0]   # R plane in slot 2
+
+    def test_to_uint16_full_range(self):
+        u8 = np.array([[0, 255]], np.uint8)
+        assert _to_uint16_full_range(u8).tolist() == [[0, 65535]]
+        f32 = np.array([[0.0, 0.5, 1.0]], np.float32)
+        out = _to_uint16_full_range(f32)
+        assert out.dtype == np.uint16
+        assert abs(int(out[0, 1]) - 32768) <= 1 and out[0, 2] == 65535
+        i16 = np.array([[0, 32767]], np.int16)
+        out = _to_uint16_full_range(i16)
+        assert out[0, 1] == 65535
+        u16 = np.array([[123]], np.uint16)
+        assert _to_uint16_full_range(u16) is u16
+
+
+# --- preview auto-brightness is hue-preserving --------------------------------
+class TestPreviewAutoBrightness:
+    def _panel_img(self, base, blank_fraction):
+        h, w = 64, 64
+        img = np.zeros((h, w, 3), np.uint16)
+        rows = int(h * blank_fraction)
+        img[:rows] = base
+        return img
+
+    def test_base_colour_identical_across_frames(self, tmp_path):
+        # A mostly-blank frame and a mostly-exposed frame must render the
+        # film base with the SAME colour (the old offset subtraction turned
+        # pink base orange/red on blank frames — issue #86).
+        import cv2
+        base = (48000, 32000, 36000)
+        path = str(tmp_path / "x.png")
+        cv2.imwrite(path, np.zeros((8, 8, 3), np.uint8))
+        img = CCRImage(path)
+        mostly_blank = img._auto_brightness_for_preview(
+            self._panel_img(base, 0.9))
+        mostly_exposed = img._auto_brightness_for_preview(
+            self._panel_img(base, 0.2))
+        a = mostly_blank[0, 0].astype(np.float64)
+        b = mostly_exposed[0, 0].astype(np.float64)
+        assert np.allclose(a, b, atol=2.0)
+        # Channel ratios (hue) match the source base.
+        src = np.array(base, np.float64)
+        assert np.allclose(a / a.max(), src / src.max(), atol=0.01)
+
+
+# --- print() must survive an ASCII stdout (macOS .app) ------------------------
+class TestStreamHardening:
+    def test_em_dash_print_survives_ascii_stdout(self, monkeypatch):
+        from utils.stream_hardening import harden_std_streams
+        raw = io.BytesIO()
+        stream = io.TextIOWrapper(raw, encoding="ascii", write_through=True)
+        monkeypatch.setattr(sys, "stdout", stream)
+        with pytest.raises(UnicodeEncodeError):
+            print("highlight headroom — recover")
+        harden_std_streams()
+        print("highlight headroom — recover")   # must not raise
+        stream.flush()
+        assert b"highlight headroom" in raw.getvalue()
+
+    def test_none_streams_are_tolerated(self, monkeypatch):
+        from utils.stream_hardening import harden_std_streams
+        monkeypatch.setattr(sys, "stdout", None)
+        harden_std_streams()   # must not raise
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes #86 and addresses #87 (the two macOS scanner-TIFF reports). Root causes were pinned down from the screenshot in #86.

## 1. The conversion crash (#86) — an em dash

The dialog reads `'ascii' codec can't encode character '—' in position 61`. The working-space diagnostic print fires on **every B/W-point conversion** and contains an em dash at **exactly position 61**:

```
[working-space] windowed base: ~2.0 stops highlight headroom — recover...
                                                             ^ position 61
```

A macOS `.app` launched from Finder has no locale environment, so Python's stdout is ASCII — the `print` raises `UnicodeEncodeError` mid-conversion. **Convert Current** surfaces it as the error dialog; **Convert All** catches it per image, so nothing inverts while partial state was already mutated ("runs but looks weird").

Fix: `main.py` hardens stdout/stderr at startup (`errors=backslashreplace`) so `print()` can never crash the app again, and the specific print is ASCII-only now.

## 2. Scanner TIFF decode (#86 / #87)

- **Planar TIFFs** (PlanarConfiguration=2 — Pakon exports): OpenCV misreads them into scrambled channels *without failing*. The loader now sniffs the tag (header-only) and routes planar files to tifffile.
- **imagecodecs** added to requirements + all three Nuitka builds: without it, tifffile can't decode LZW/deflate TIFFs, so compressed scans that OpenCV rejected took forever or never loaded — likely the #87 slowness/hang.
- **Sample-format bug**: float / int16 / uint32 TIFFs slipped through the `uint8-else-nothing` conversion untouched and rendered black or half-range. All formats now normalize to uint16, before `cvtColor` (which rejects float64).

## 3. Frame-to-frame colour shifts on import (#86)

Not a decode bug: the un-converted preview's auto-brightness subtracted a per-frame black offset, and subtracting a constant from RGB **shifts hue** — mostly-blank frames rendered their film base orange/red while exposed frames stayed pink (the thumbnails in the screenshot). It's now a pure gain (95th percentile → full scale), which preserves channel ratios: the base looks identical on every frame. Display-only; conversion and export are untouched.

## Tests

New `tests/test_scanner_tiff.py`: planar / LZW / LZW+planar / float TIFFs through the real `CCRImage` load path; helper units; base-colour-identical-across-frames; em-dash print survives an ASCII stdout. 80 tests pass across the touched areas.

Note: `imagecodecs` is new in the bundled builds — worth watching the first release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
