### PR TITLE
feat: Auto White Balance (AWB button, auto-apply after conversion, algorithm choice)

### DIFF
--- a/spec/auto-white-balance.md
+++ b/spec/auto-white-balance.md
@@ -14,8 +14,13 @@ toggle + post-conversion hook pattern), `spec/settings-page.md`.
   buttons `WB Picker | AWB | Crop | Slice` share the row at equal stretch).
 - **Q2 — Auto-AWB default OFF.** A newly automatic behavior must not change
   existing users' conversions; the algorithm dropdown defaults to Gray World.
-- **Q3 — Full frame.** The estimate uses the whole converted frame; the in-bound
-  mask rejects holder/headroom extremes. Crop-aware sampling is a follow-up.
+- **Q3 — Crop-aware (revised per user).** With a crop set, only the kept region
+  drives the estimate: `compute_awb_temp_tint` passes the base through
+  `apply_crop_to_image(base, crop_rect, crop_angle)` (normalized rect in
+  resized_raw space; None → unchanged, so uncropped images are the full frame).
+  A rotated crop's black corner fill de-windows below `AWB_LO` and is discarded
+  by the in-bound mask — no special-casing. The content-fraction gate is
+  relative to the cropped pixel count, so small crops still estimate.
 - **Q4 — Active-image access**: `sliders_panel` already imports `ccr_backend`
   and reads the active image via `ccr_backend.get_image_by_index(self.current_idx)`
   throughout — the button handler does the same. No routing through
@@ -87,9 +92,6 @@ correct it.
   (`_white_balance_gains` / `compute_neutral_temp_tint`) are unchanged.
 - No per-channel gain channel separate from the sliders (unlike Auto Gain's
   invisible offset — AWB *must* be visible on the sliders per the requirement).
-- No crop-awareness in v1: the estimate uses the full converted frame (the
-  in-bound mask already rejects holder/border extremes). Crop-aware sampling is a
-  possible follow-up.
 - No AWB for un-converted negatives or positive-mode identity frames beyond the
   existing picker gate (button shares the picker's enable state).
 - No live "AWB mode" that re-estimates on every render (it writes sliders once).
@@ -185,7 +187,8 @@ def estimate_neutral_rgb(base_u16, ws_windowed: bool, algorithm: str
     Unknown algorithm ids fall back to gray_world (forward-compat settings)."""
 
 def compute_awb_temp_tint(ccr_image) -> tuple | None:
-    """estimate_neutral_rgb(ccr_image.resized_raw, ccr_image._ws_windowed,
+    """apply_crop_to_image(resized_raw, crop_rect, crop_angle) →
+    estimate_neutral_rgb(cropped, ccr_image._ws_windowed,
     ccr_backend.awb_algorithm) → compute_neutral_temp_tint(r, g, b,
     ccr_image.tint_balance_factor). Returns (temp:int, tint:int) or None."""
 ```
@@ -329,6 +332,9 @@ Wiring (the Auto Gain 4-point pattern):
   conversion itself.
 - **Stored algorithm id unknown** (future rename/downgrade): fall back to
   `gray_world` silently.
+- **Cropped image**: only the kept region is sampled (§0-Q3). A rotated crop's
+  out-of-source black fill is masked out by `AWB_LO`; a degenerate/absent rect
+  falls back to the full frame (`apply_crop_to_image` returns the input).
 - **Area layers**: AWB writes the whole-image layer (`adjustment_settings`),
   never an area layer — the button uses `on_wb_sampled`, which already targets
   the whole-image sliders; the hook writes `adjustment_settings` directly.
@@ -356,6 +362,9 @@ Wiring (the Auto Gain 4-point pattern):
 - **Hook guard**: fake image with `{"temperature": 5}` (or `{"tint": -3}`) →
   hook leaves settings unchanged; with both 0/absent → keys written; with
   `auto_awb=False` → untouched.
+- **Crop-aware**: cast-A content inside the crop rect, cast-B junk outside →
+  the estimate matches cast A (and differs from the uncropped estimate); a
+  rotated crop's black fill does not skew the estimate.
 - **Unknown algorithm id** → gray_world result.
 - **Settings round-trip** (GUI-light or mocked): backend defaults
   (False, "gray_world"); toggling handlers persist and update flags.

--- a/spec/auto-white-balance.md
+++ b/spec/auto-white-balance.md
@@ -12,8 +12,10 @@ toggle + post-conversion hook pattern), `spec/settings-page.md`.
 - **Q1 — Button label**: "AWB"; the eyedropper's label is shortened
   "Auto WB Picker" → **"WB Picker"** ("Auto" now belongs to the new button; four
   buttons `WB Picker | AWB | Crop | Slice` share the row at equal stretch).
-- **Q2 — Auto-AWB default OFF.** A newly automatic behavior must not change
-  existing users' conversions; the algorithm dropdown defaults to Gray World.
+- **Q2 — Auto-AWB default ON (revised per user).** Auto-AWB is an on-by-default
+  convenience like Auto Gain; the already-saved guard keeps it from touching any
+  image with an existing temperature/tint, and Settings → General turns it off.
+  The algorithm dropdown defaults to Gray World.
 - **Q3 — Crop-aware (revised per user).** With a crop set, only the kept region
   drives the estimate: `compute_awb_temp_tint` passes the base through
   `apply_crop_to_image(base, crop_rect, crop_angle)` (normalized rect in
@@ -78,7 +80,7 @@ correct it.
   (`resized_raw`), not the adjusted preview, so clicking AWB twice yields the same
   slider values.
 - Settings → General: "Auto white balance after conversion" checkbox
-  (default **OFF**) + "AWB algorithm" dropdown (default **Gray World**), both
+  (default **ON**) + "AWB algorithm" dropdown (default **Gray World**), both
   QSettings-persisted, staged-and-applied-on-Done like the other General toggles.
 - The post-conversion hook fires only on **fresh conversions**
   (`convert_negative_by_index`, the B/W-point batch), never on replay/reconvert
@@ -275,9 +277,9 @@ New `QGroupBox("White balance")` in `_build_general_page`
   `userData`), muted help naming the default.
 
 Wiring (the Auto Gain 4-point pattern):
-- Backend flags (`ccr_backend.py` flag block): `self.auto_awb: bool = False`,
+- Backend flags (`ccr_backend.py` flag block): `self.auto_awb: bool = True`,
   `self.awb_algorithm: str = "gray_world"`.
-- QSettings: `adjust/auto_awb` (bool, default False), `adjust/awb_algorithm`
+- QSettings: `adjust/auto_awb` (bool, default True), `adjust/awb_algorithm`
   (string id, default `"gray_world"`), restored in `main_window.__init__`
   alongside `adjust/auto_gain`. Unknown stored ids fall back to the default.
 - `main_window.on_auto_awb_toggled(checked)` / `on_awb_algorithm_changed(algo)`:

--- a/spec/auto-white-balance.md
+++ b/spec/auto-white-balance.md
@@ -1,0 +1,363 @@
+# Spec: Auto White Balance (AWB)
+
+Status: REFINED v2 (open questions resolved — ready to implement)
+Owner: FreeCCR
+Feature branch: `feature/awb`
+Related: [`spec/working-space-white-balance.md`](working-space-white-balance.md) (the
+flat WB gain model this inverts), [`spec/auto-gain.md`](auto-gain.md) (the Settings
+toggle + post-conversion hook pattern), `spec/settings-page.md`.
+
+## 0. Decisions (locked)
+
+- **Q1 — Button label**: "AWB"; the eyedropper's label is shortened
+  "Auto WB Picker" → **"WB Picker"** ("Auto" now belongs to the new button; four
+  buttons `WB Picker | AWB | Crop | Slice` share the row at equal stretch).
+- **Q2 — Auto-AWB default OFF.** A newly automatic behavior must not change
+  existing users' conversions; the algorithm dropdown defaults to Gray World.
+- **Q3 — Full frame.** The estimate uses the whole converted frame; the in-bound
+  mask rejects holder/headroom extremes. Crop-aware sampling is a follow-up.
+- **Q4 — Active-image access**: `sliders_panel` already imports `ccr_backend`
+  and reads the active image via `ccr_backend.get_image_by_index(self.current_idx)`
+  throughout — the button handler does the same. No routing through
+  `image_preview`.
+- **Q5 — One backend choke point.** A new `ccr_backend.maybe_auto_awb(image_obj)`
+  carries the toggle + already-saved guard; it is called from the **three** fresh-
+  conversion sites (§4.5). `convert_negative_by_index` transitively covers the
+  single ref-mode convert (`image_preview.convert_ccr`), `convert_all_images`,
+  and `auto_frame_all_images`.
+- **Slider re-sync is automatic**: every conversion path ends in
+  `image_preview.update_preview(idx)`, which calls
+  `sliders_panel.set_current_idx(idx)` (`image_preview.py:1114`) →
+  `_load_active_layer` re-reads the settings dict — the AWB-written temp/tint
+  appear on the sliders with no new wiring.
+- **Windowing is self-consistent**: the converters set `_ws_windowed` before
+  returning (`ccr_processor.py:1404` bwpoint = windowed when enabled, `:1573`
+  reference = full-range), so the hook and the button always read the correct
+  flag for the base in `resized_raw`.
+- **Thread-safety**: `auto_frame_all_images` calls `convert_negative_by_index`
+  from `ThreadPoolExecutor` workers; the hook is pure numpy + a dict write on
+  that image's own settings (no Qt) — safe.
+
+## 1. Summary
+
+Add a fully automatic white balance:
+
+1. An **"AWB" button** next to the existing WB eyedropper ("Auto WB Picker") in the
+   sliders panel. One click — no grey-spot picking — estimates the neutral color of
+   the whole converted frame with a classical, learning-free illuminant-estimation
+   algorithm and sets the **Temperature / Tint sliders** to neutralize it. The
+   result is visible on the sliders, undoable, and persisted exactly like an
+   eyedropper pick.
+2. A **Settings → General** checkbox — **"Auto white balance after conversion"** —
+   that applies the same estimate automatically when a negative is converted,
+   **only if the image has no temperature/tint already saved** (both at 0).
+3. A **Settings → General dropdown** to choose the AWB **algorithm**: Gray World,
+   White Patch, Shades of Gray, Gray Edge. The button and the auto-hook both use
+   the selected algorithm.
+
+This is deliberately NOT the abandoned deep-learning AWB (PR #52, `net_awb.onnx`,
+judged not useful on film positives). These are transparent statistics on the
+converted base, and the result lands on the sliders where the user can see and
+correct it.
+
+## 2. Goals / Non-goals
+
+### Goals
+- "AWB" button in the same button row as the WB picker, enabled under the same
+  conditions (converted image active).
+- The estimate rides the **existing picker math**: algorithm → estimated neutral
+  RGB → `compute_neutral_temp_tint()` → `on_wb_sampled()`. AWB behaves exactly as
+  if the user had clicked a perfectly chosen grey spot: sliders move, hint shows
+  the values, undo burst, catalog persistence — all for free.
+- **Idempotent**: the estimate is computed from the converted *base*
+  (`resized_raw`), not the adjusted preview, so clicking AWB twice yields the same
+  slider values.
+- Settings → General: "Auto white balance after conversion" checkbox
+  (default **OFF**) + "AWB algorithm" dropdown (default **Gray World**), both
+  QSettings-persisted, staged-and-applied-on-Done like the other General toggles.
+- The post-conversion hook fires only on **fresh conversions**
+  (`convert_negative_by_index`, the B/W-point batch), never on replay/reconvert
+  paths, and only when `temperature == 0 and tint == 0` in the image's saved
+  adjustments.
+- Pure-numpy core (`src/core/awb.py`), unit-testable headless.
+
+### Non-goals
+- No neural / learned estimator (explicitly rejected previously).
+- No new WB math: the flat per-channel gain model and its inverse
+  (`_white_balance_gains` / `compute_neutral_temp_tint`) are unchanged.
+- No per-channel gain channel separate from the sliders (unlike Auto Gain's
+  invisible offset — AWB *must* be visible on the sliders per the requirement).
+- No crop-awareness in v1: the estimate uses the full converted frame (the
+  in-bound mask already rejects holder/border extremes). Crop-aware sampling is a
+  possible follow-up.
+- No AWB for un-converted negatives or positive-mode identity frames beyond the
+  existing picker gate (button shares the picker's enable state).
+- No live "AWB mode" that re-estimates on every render (it writes sliders once).
+
+## 3. Current behaviour (as-is)
+
+- The WB eyedropper (`sliders_panel.py:493` "Auto WB Picker") samples a 7×7 patch
+  of `resized_raw` (`image_preview._sample_wb_point`, `image_preview.py:304`),
+  de-windows it when the base is working-space windowed, and calls
+  `compute_neutral_temp_tint(r, g, b, tint_balance_factor)`
+  (`ccr_processor.py:2261`) — the exact inverse of the flat WB gains
+  (`_white_balance_gains`, `ccr_processor.py:1012`):
+  - temperature: `s = (slider/100)·0.40` → `R·(1+s)`, `B·(1−s)`
+  - tint: `t = tanh(slider·0.02)·0.26·balance` → `G·(1−t)`, `R·(1+0.3t)`, `B·(1+0.3t)`
+- The result is applied by `sliders_panel.on_wb_sampled(temp, tint)`
+  (`sliders_panel.py:1527`): blockSignals slider set + label update +
+  `on_slider_changed()` (stores into `adjustment_settings`, reprocesses, hint).
+- `compute_neutral_temp_tint` is **scale-invariant** (it only uses channel
+  ratios), so any positive-scaled RGB triple works as input.
+- Auto Gain (`spec/auto-gain.md`) established: backend flag + QSettings key +
+  Settings→General checkbox staged via `_init_toggles`/`_apply_pending` +
+  `main_window.on_*_toggled` handler.
+- Temperature/tint are stored in `CCRImage.adjustment_settings` under
+  `"temperature"` / `"tint"`; missing keys mean 0. `temperature_base` is zeroed at
+  conversion (`ccr_processor.py:1403`) and tint has no base channel, so
+  `ci.get("temperature", 0) == 0 and ci.get("tint", 0) == 0` is exactly
+  "no temp/tint saved".
+
+## 4. Design
+
+### 4.1 Estimation domain
+
+All algorithms run on the converted base `CCRImage.resized_raw` (16-bit RGB,
+~1080 px long side), converted to float and **de-windowed** when
+`_ws_windowed` (mirroring `compute_auto_gain_offset`, `ccr_processor.py:1181`):
+
+```
+d = base.astype(float32)
+d = (d - WS_B) * _WS_INV_WIDTH        if ws_windowed else d / 65535.0
+```
+
+**Valid-pixel mask** (applied per pixel, all three channels must pass):
+
+```
+valid = all_channels(d >= AWB_LO) & all_channels(d <= AWB_HI)
+AWB_LO = 0.02      # noise floor / sub-black & holder rejection
+AWB_HI = 0.98      # near-clip & headroom rejection
+```
+
+If `valid.sum() < MIN_CONTENT_FRACTION · N` (reuse 0.005), the estimate is
+`None` → the button shows a hint ("AWB: not enough usable image content") and the
+auto-hook is a silent no-op.
+
+### 4.2 Algorithms (all return an estimated neutral RGB triple)
+
+Each algorithm estimates the color that *should* be neutral — the illuminant/cast
+color. That triple is exactly what a perfect grey-spot pick would sample, so it
+feeds `compute_neutral_temp_tint` unchanged. Working set `V` = valid pixels of
+`d` (float, linear working domain).
+
+| id | label | estimate per channel c |
+|---|---|---|
+| `gray_world` | Gray World | `mean(V_c)` |
+| `white_patch` | White Patch | `percentile(V_c, 99)` |
+| `shades_of_gray` | Shades of Gray | `mean(V_c ** 6) ** (1/6)` (Minkowski p=6) |
+| `gray_edge` | Gray Edge | `mean(|∇(G_σ * d_c)| ** 6) ** (1/6)` over valid, p=6, σ=1 |
+
+Notes:
+- `gray_world` assumes the scene averages to grey — the classical default, robust
+  on varied film scenes.
+- `white_patch` is the robust max-RGB variant (99th percentile instead of max, on
+  already near-clip-masked data).
+- `shades_of_gray` (Finlayson & Trezzi) generalizes both; p=6 is the literature
+  default.
+- `gray_edge` (van de Weijer et al.): Gaussian-smooth each channel (σ=1), take the
+  gradient magnitude `sqrt(gx²+gy²)` (numpy `np.gradient`), then the Minkowski
+  p=6 mean over pixels whose source pixel is valid. Uses `cv2.GaussianBlur` if
+  available (cv2 is already a dependency), else a small numpy separable blur.
+- Degenerate guard: if any channel estimate ≤ `AWB_EPS` (1e-6), return `None`.
+
+### 4.3 New module `src/core/awb.py`
+
+```python
+AWB_ALGORITHMS = [("gray_world", "Gray World"),
+                  ("white_patch", "White Patch"),
+                  ("shades_of_gray", "Shades of Gray"),
+                  ("gray_edge", "Gray Edge")]        # (id, UI label), ordered
+AWB_DEFAULT = "gray_world"
+
+def estimate_neutral_rgb(base_u16, ws_windowed: bool, algorithm: str
+                         ) -> tuple | None:
+    """De-window, mask, run the selected estimator; None if not enough content.
+    Unknown algorithm ids fall back to gray_world (forward-compat settings)."""
+
+def compute_awb_temp_tint(ccr_image) -> tuple | None:
+    """estimate_neutral_rgb(ccr_image.resized_raw, ccr_image._ws_windowed,
+    ccr_backend.awb_algorithm) → compute_neutral_temp_tint(r, g, b,
+    ccr_image.tint_balance_factor). Returns (temp:int, tint:int) or None."""
+```
+
+`compute_awb_temp_tint` imports `ccr_backend` lazily (deferred import, same
+pattern as `ccr_image.py`) to read the selected algorithm.
+
+### 4.4 The AWB button
+
+- `self.auto_wb_btn = QPushButton("AWB")` in `sliders_panel`, inserted in
+  `wb_crop_row` immediately after `wb_picker_btn` (`sliders_panel.py:516-520`),
+  `setFixedHeight(theme.CONTROL_H)`, stretch 1. The picker's label is shortened
+  from "Auto WB Picker" to **"WB Picker"** so the four buttons
+  (`WB Picker | AWB | Crop | Slice`) fit; "Auto" now unambiguously belongs to the
+  new button. Tooltip: "Automatic white balance — estimates the neutral color
+  from the whole image and sets Temperature and Tint."
+- Enable gate: same line as the picker (`sliders_panel.py:867`).
+- Handler `_on_auto_wb()`:
+  ```python
+  img = ccr_backend.get_image_by_index(self.current_idx)
+  if img is None or not img.converted:
+      return
+  res = compute_awb_temp_tint(img)
+  if res is None:
+      self.set_temporary_hint("AWB: not enough usable image content.", 5000)
+      return
+  self.on_wb_sampled(*res)
+  ```
+  Everything downstream (undo burst, slider set, store, reprocess, hint) is the
+  existing `on_wb_sampled` path.
+
+### 4.5 The post-conversion hook
+
+One backend method carries the whole policy:
+
+```python
+def maybe_auto_awb(self, image_obj):            # ccr_backend
+    """One-shot AWB at conversion: writes temperature/tint into the image's
+    whole-image settings when the toggle is on and neither is already set."""
+    if not self.auto_awb or not image_obj.converted:
+        return
+    ci = image_obj.adjustment_settings
+    if ci.get("temperature", 0) or ci.get("tint", 0):
+        return                                   # already saved → never clobber
+    res = compute_awb_temp_tint(image_obj)       # from core.awb (lazy import)
+    if res is not None and any(res):
+        ci["temperature"], ci["tint"] = res
+```
+
+Called from the **three fresh-conversion sites**, always after the
+`conversion_inputs` snapshot and **before** `update_thumbnail_and_preview()` so
+the first render already includes the WB:
+
+1. `ccr_backend.convert_negative_by_index` (`ccr_backend.py:798`) — covers the
+   single ref-mode convert (`image_preview.convert_ccr`), `convert_all_images`,
+   and `auto_frame_all_images` (worker threads — hook is thread-safe, §0).
+2. `ccr_backend.apply_bwpoint_to_all_images` (`ccr_backend.py:1929`) — the
+   B/W-point batch loop.
+3. `sliders_panel._on_convert_current_bwpoint` (`sliders_panel.py:1740`) — the
+   single B/W-point convert (GUI-side; calls
+   `ccr_backend.maybe_auto_awb(img)`).
+
+- Backend-side (no GUI dependency) so batch conversion just works; the render
+  that already follows conversion picks the values up, and the panel re-sync is
+  automatic (§0).
+- **Not** fired from `_reconvert_in_place` / replay / reload paths: reconversion
+  preserves the user's adjustments, and a global-mode reconvert must not
+  surprise-move sliders. (For images whose temp/tint were AWB-written earlier,
+  the guard also skips them — the values are now "saved".)
+- The guard condition is the user requirement verbatim: apply only when the image
+  does **not** have a temp and tint already saved. `0/absent` = not saved; any
+  non-zero value (user- or AWB-written, catalog-restored) = saved → skip. An
+  all-zero estimate is not written (no pointless dict pollution).
+
+### 4.6 Settings → General
+
+New `QGroupBox("White balance")` in `_build_general_page`
+(`settings_dialog.py:93`), after the "Exposure" group:
+
+- `QCheckBox("Auto white balance after conversion")` — muted help: "When a
+  negative is converted, automatically estimate and set Temperature/Tint —
+  only for images with no white balance already set."
+- Row: `QLabel("Algorithm")` + `QComboBox` with the four labels (ids as
+  `userData`), muted help naming the default.
+
+Wiring (the Auto Gain 4-point pattern):
+- Backend flags (`ccr_backend.py` flag block): `self.auto_awb: bool = False`,
+  `self.awb_algorithm: str = "gray_world"`.
+- QSettings: `adjust/auto_awb` (bool, default False), `adjust/awb_algorithm`
+  (string id, default `"gray_world"`), restored in `main_window.__init__`
+  alongside `adjust/auto_gain`. Unknown stored ids fall back to the default.
+- `main_window.on_auto_awb_toggled(checked)` / `on_awb_algorithm_changed(algo)`:
+  set flag + persist. **No rerender/reprocess** — these affect only future
+  conversions and button presses, not existing renders.
+- Dialog staging: seed both in `_init_toggles`; commit in `_apply_pending` only
+  on change (checkbox → toggled handler; combo → algorithm handler).
+
+## 5. Data model
+
+- No new per-image fields, no catalog change: AWB writes the existing
+  `"temperature"` / `"tint"` keys in `adjustment_settings`.
+- Two new global backend flags (`auto_awb`, `awb_algorithm`) + two QSettings keys
+  (`adjust/auto_awb`, `adjust/awb_algorithm`).
+
+## 6. Integration points
+
+- **new** `src/core/awb.py` — algorithms + `compute_awb_temp_tint` (pure numpy;
+  imports `compute_neutral_temp_tint`, `WS_B`, `_WS_INV_WIDTH`,
+  `MIN_CONTENT_FRACTION` from `ccr_processor`; `ccr_backend` lazily).
+- `src/widgets/sliders_panel.py` — button creation (~:493), row insert
+  (~:516-520), picker label "WB Picker", click connect (~:719), enable gate
+  (~:867), `_on_auto_wb` handler near `_on_pick_neutral_point` (~:1492),
+  `maybe_auto_awb` call in `_on_convert_current_bwpoint` (~:1774).
+- `src/core/ccr_backend.py` — flags in the flag block (~:67);
+  `maybe_auto_awb()`; calls in `convert_negative_by_index` (after ~:818) and
+  `apply_bwpoint_to_all_images` (after ~:1968).
+- `src/ui/main_window.py` — QSettings restore (~:204), two handlers near
+  `on_auto_gain_toggled` (~:687).
+- `src/widgets/settings_dialog.py` — General page group (~:93), `_init_toggles`
+  (~:264), `_apply_pending` (~:282).
+
+## 7. Edge cases
+
+- **Not enough valid pixels** (< 0.5%: nearly all holder/headroom/blown):
+  estimate `None` → button hints, auto-hook no-ops. The image is left untouched.
+- **Monochrome/neutral frame**: all channel stats equal → temp=0, tint=0 —
+  harmless no-op write.
+- **Extreme cast beyond slider range**: `compute_neutral_temp_tint` already
+  clamps to ±100; the hint shows the (clamped) values, user sees the sliders
+  pegged — honest behavior.
+- **Auto-AWB + Auto Gain together**: independent — Auto Gain is a uniform gain
+  offset (never touches sliders), AWB is per-channel via the sliders. Order
+  irrelevant (both multiplicative, and AWB estimates from the base, not the
+  gained render).
+- **User undoes an auto-AWB'd conversion**: conversion undo restores the
+  pre-conversion state snapshot; the AWB-written keys are inside
+  `adjustment_settings`, captured by the same `to_state` deep-copy — verify the
+  conversion undo snapshot ordering at implementation.
+- **Batch conversion cost**: gray_world/white_patch/shades ≈ a few ms per ~1080px
+  frame; gray_edge ~10-20 ms (blur + gradient). Negligible next to the
+  conversion itself.
+- **Stored algorithm id unknown** (future rename/downgrade): fall back to
+  `gray_world` silently.
+- **Area layers**: AWB writes the whole-image layer (`adjustment_settings`),
+  never an area layer — the button uses `on_wb_sampled`, which already targets
+  the whole-image sliders; the hook writes `adjustment_settings` directly.
+  (If an area layer is active when the button is clicked, `on_wb_sampled`'s
+  behavior is the eyedropper's — identical semantics, no new rules.)
+
+## 8. Test plan (`tests/test_awb.py`, pure numpy + GUI-light)
+
+- **Gray-world recovery**: synthetic neutral-scene base × illuminant
+  (1.25, 1.0, 0.8); estimate ∝ illuminant; applying the returned temp/tint
+  through `_white_balance_gains` equalizes the valid-pixel channel means within
+  slider-int quantization (~1%).
+- **White patch**: base with a near-white patch tinted by the cast → estimate
+  matches the patch color, not the scene mean.
+- **Shades of Gray**: on a uniform image equals gray_world; on a skewed image
+  lies between gray_world and white_patch.
+- **Gray edge**: cast applied to an edge-rich synthetic → recovers the cast.
+- **Mask**: headroom pixels (d > 0.98) and sub-black (d < 0.02) excluded —
+  adding a blown region does not change the gray_world estimate.
+- **Insufficient content**: 99.9% out-of-bounds → `None`.
+- **De-window correctness**: same scene encoded windowed vs plain, ws flag set
+  respectively → same slider values.
+- **Idempotence**: estimate from `resized_raw` is independent of current
+  temp/tint settings.
+- **Hook guard**: fake image with `{"temperature": 5}` (or `{"tint": -3}`) →
+  hook leaves settings unchanged; with both 0/absent → keys written; with
+  `auto_awb=False` → untouched.
+- **Unknown algorithm id** → gray_world result.
+- **Settings round-trip** (GUI-light or mocked): backend defaults
+  (False, "gray_world"); toggling handlers persist and update flags.
+
+## 9. Open questions — RESOLVED (see §0 for the locked answers)

--- a/src/core/awb.py
+++ b/src/core/awb.py
@@ -1,0 +1,92 @@
+"""Classical auto-white-balance (AWB) illuminant estimation.
+
+Learning-free estimators over the converted base (spec/auto-white-balance.md).
+Each algorithm returns the RGB triple that *should* be neutral — exactly what a
+perfect grey-spot pick would sample — so the result feeds
+compute_neutral_temp_tint unchanged and lands on the Temperature/Tint sliders
+through the same inverse the WB eyedropper uses.
+"""
+
+import numpy as np
+
+from core.ccr_processor import (MIN_CONTENT_FRACTION, WS_B, _WS_INV_WIDTH,
+                                compute_neutral_temp_tint)
+
+# (id, UI label) — ordered as shown in the Settings dropdown.
+AWB_ALGORITHMS = [
+    ("gray_world", "Gray World"),
+    ("white_patch", "White Patch"),
+    ("shades_of_gray", "Shades of Gray"),
+    ("gray_edge", "Gray Edge"),
+]
+AWB_DEFAULT = "gray_world"
+
+AWB_LO = 0.02          # noise floor: sub-black / film-holder rejection
+AWB_HI = 0.98          # near-clip / headroom rejection
+AWB_EPS = 1e-6
+_WP_PERCENTILE = 99.0  # white_patch: robust max-RGB
+_MINK_P = 6.0          # Minkowski norm for shades_of_gray / gray_edge
+_GE_SIGMA = 1.0        # gray_edge pre-smoothing
+
+
+def _gray_edge_estimate(d, valid_mask):
+    """van de Weijer gray-edge: Minkowski p-mean of the smoothed per-channel
+    gradient magnitude, over pixels whose source value is in-bound."""
+    import cv2
+    sm = cv2.GaussianBlur(d, (0, 0), _GE_SIGMA)
+    gy, gx = np.gradient(sm, axis=(0, 1))
+    mag = np.sqrt(gx * gx + gy * gy)
+    m = mag.reshape(-1, 3)[valid_mask.reshape(-1)]
+    if m.shape[0] == 0:
+        return None
+    return np.mean(m ** _MINK_P, axis=0) ** (1.0 / _MINK_P)
+
+
+def estimate_neutral_rgb(base_u16, ws_windowed=False, algorithm=AWB_DEFAULT):
+    """Estimated neutral (cast) RGB triple of a converted base, or None when
+    there is not enough usable content. The scale is arbitrary —
+    compute_neutral_temp_tint only uses channel ratios. Index 0=R, 1=G, 2=B.
+    Unknown algorithm ids fall back to gray_world (forward-compat settings)."""
+    if base_u16 is None or getattr(base_u16, "size", 0) == 0:
+        return None
+    d = base_u16.astype(np.float32)
+    if ws_windowed:
+        d -= np.float32(WS_B)
+        d *= np.float32(_WS_INV_WIDTH)     # de-window; headroom masked below
+    else:
+        d *= np.float32(1.0 / 65535.0)
+    flat = d.reshape(-1, 3)
+    valid = np.all((flat >= AWB_LO) & (flat <= AWB_HI), axis=1)
+    if valid.sum() < MIN_CONTENT_FRACTION * flat.shape[0]:
+        return None
+    if algorithm == "white_patch":
+        est = np.percentile(flat[valid], _WP_PERCENTILE, axis=0)
+    elif algorithm == "shades_of_gray":
+        est = np.mean(flat[valid] ** _MINK_P, axis=0) ** (1.0 / _MINK_P)
+    elif algorithm == "gray_edge":
+        est = _gray_edge_estimate(d, valid.reshape(d.shape[:2]))
+    else:                                  # gray_world + unknown-id fallback
+        est = np.mean(flat[valid], axis=0)
+    if est is None or not np.all(np.isfinite(est)) or np.any(est <= AWB_EPS):
+        return None
+    return float(est[0]), float(est[1]), float(est[2])
+
+
+def compute_awb_temp_tint(ccr_image, algorithm=None):
+    """(temperature, tint) slider ints that neutralize the image's estimated
+    cast, or None. Runs on the converted base (resized_raw), so the result is
+    independent of the current slider values (idempotent). Uses the
+    backend-selected algorithm when none is given."""
+    if ccr_image is None or getattr(ccr_image, "resized_raw", None) is None:
+        return None
+    if algorithm is None:
+        from core.ccr_backend import ccr_backend   # deferred: circular at load
+        algorithm = getattr(ccr_backend, "awb_algorithm", AWB_DEFAULT)
+    est = estimate_neutral_rgb(ccr_image.resized_raw,
+                               getattr(ccr_image, "_ws_windowed", False),
+                               algorithm)
+    if est is None:
+        return None
+    return compute_neutral_temp_tint(
+        est[0], est[1], est[2],
+        getattr(ccr_image, "tint_balance_factor", 1.0))

--- a/src/core/awb.py
+++ b/src/core/awb.py
@@ -10,7 +10,7 @@ through the same inverse the WB eyedropper uses.
 import numpy as np
 
 from core.ccr_processor import (MIN_CONTENT_FRACTION, WS_B, _WS_INV_WIDTH,
-                                compute_neutral_temp_tint)
+                                apply_crop_to_image, compute_neutral_temp_tint)
 
 # (id, UI label) — ordered as shown in the Settings dropdown.
 AWB_ALGORITHMS = [
@@ -75,14 +75,19 @@ def estimate_neutral_rgb(base_u16, ws_windowed=False, algorithm=AWB_DEFAULT):
 def compute_awb_temp_tint(ccr_image, algorithm=None):
     """(temperature, tint) slider ints that neutralize the image's estimated
     cast, or None. Runs on the converted base (resized_raw), so the result is
-    independent of the current slider values (idempotent). Uses the
+    independent of the current slider values (idempotent). Crop-aware: with a
+    crop set, only the kept region drives the estimate (a rotated crop's black
+    corner fill sits below AWB_LO, so the mask discards it). Uses the
     backend-selected algorithm when none is given."""
     if ccr_image is None or getattr(ccr_image, "resized_raw", None) is None:
         return None
     if algorithm is None:
         from core.ccr_backend import ccr_backend   # deferred: circular at load
         algorithm = getattr(ccr_backend, "awb_algorithm", AWB_DEFAULT)
-    est = estimate_neutral_rgb(ccr_image.resized_raw,
+    base = apply_crop_to_image(ccr_image.resized_raw,
+                               getattr(ccr_image, "crop_rect", None),
+                               getattr(ccr_image, "crop_angle", 0.0) or 0.0)
+    est = estimate_neutral_rgb(base,
                                getattr(ccr_image, "_ws_windowed", False),
                                algorithm)
     if est is None:

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -70,6 +70,12 @@ class CCRBackend:
         # (hue-preserving). Global display mode, persisted by MainWindow. See
         # spec/gamma-luminance-mode.md.
         self.gamma_luminance: bool = False
+        # Auto white balance: when True, a fresh conversion writes AWB-estimated
+        # temperature/tint into the image's sliders — only when neither is
+        # already set. The algorithm id selects the estimator (core/awb.py).
+        # Global, persisted by MainWindow. See spec/auto-white-balance.md.
+        self.auto_awb: bool = False
+        self.awb_algorithm: str = "gray_world"
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area
         # Selected film-stock preset for the black-point-only conversion:
@@ -795,6 +801,23 @@ class CCRBackend:
             img.update_thumbnail_and_preview()
         return True
 
+    def maybe_auto_awb(self, image_obj):
+        """One-shot auto white balance at conversion: writes the AWB-estimated
+        temperature/tint into the image's whole-image settings when the toggle
+        is on and neither is already set (never clobbers a saved value). Called
+        only from fresh-conversion sites, not replay/reconvert paths. Pure
+        numpy + a dict write, so it is safe from the auto-frame worker threads.
+        See spec/auto-white-balance.md."""
+        if not self.auto_awb or not image_obj.converted:
+            return
+        ci = image_obj.adjustment_settings
+        if ci.get("temperature", 0) or ci.get("tint", 0):
+            return
+        from core.awb import compute_awb_temp_tint
+        res = compute_awb_temp_tint(image_obj)
+        if res is not None and any(res):
+            ci["temperature"], ci["tint"] = res
+
     def convert_negative_by_index(self, idx: int):
         """
         Converts the negative image at the given index using CCR normalization with reference.
@@ -816,6 +839,7 @@ class CCRBackend:
                     "ref": tuple(image_obj.reference_frame),
                     "fine_rot": image_obj.fine_rotation_angle,
                 }
+                self.maybe_auto_awb(image_obj)
                 image_obj.update_thumbnail_and_preview()
             except Exception as e:
                 print(f"Failed to convert image at index {idx}: {e}")
@@ -1966,6 +1990,7 @@ class CCRBackend:
                     "density": bool(self.density_bwpoint),
                     "slopes": slopes,
                 }
+                self.maybe_auto_awb(img)
                 img.update_thumbnail_and_preview()
             except Exception as e:
                 print(f"B/W point conversion failed for image {i}: {e}")

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -70,11 +70,12 @@ class CCRBackend:
         # (hue-preserving). Global display mode, persisted by MainWindow. See
         # spec/gamma-luminance-mode.md.
         self.gamma_luminance: bool = False
-        # Auto white balance: when True, a fresh conversion writes AWB-estimated
-        # temperature/tint into the image's sliders — only when neither is
-        # already set. The algorithm id selects the estimator (core/awb.py).
-        # Global, persisted by MainWindow. See spec/auto-white-balance.md.
-        self.auto_awb: bool = False
+        # Auto white balance: when True (default), a fresh conversion writes
+        # AWB-estimated temperature/tint into the image's sliders — only when
+        # neither is already set. The algorithm id selects the estimator
+        # (core/awb.py). Global, persisted by MainWindow. See
+        # spec/auto-white-balance.md.
+        self.auto_awb: bool = True
         self.awb_algorithm: str = "gray_world"
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -208,13 +208,13 @@ class MainWindow(QMainWindow):
         # midtone moves don't shift hue. See spec/gamma-luminance-mode.md.
         ccr_backend.gamma_luminance = self._settings.value(
             "adjust/gamma_luminance", False, type=bool)
-        # Restore the Auto WB toggle + algorithm (defaults OFF / Gray World).
+        # Restore the Auto WB toggle + algorithm (defaults ON / Gray World).
         # When on, a fresh conversion writes AWB-estimated temperature/tint into
         # the image's sliders — only when neither is already set. Affects only
         # FUTURE conversions and the AWB button. See spec/auto-white-balance.md.
         from core.awb import AWB_ALGORITHMS, AWB_DEFAULT
         ccr_backend.auto_awb = self._settings.value(
-            "adjust/auto_awb", False, type=bool)
+            "adjust/auto_awb", True, type=bool)
         stored_algo = self._settings.value("adjust/awb_algorithm", AWB_DEFAULT)
         ccr_backend.awb_algorithm = (
             stored_algo if any(a == stored_algo for a, _ in AWB_ALGORITHMS)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -208,6 +208,17 @@ class MainWindow(QMainWindow):
         # midtone moves don't shift hue. See spec/gamma-luminance-mode.md.
         ccr_backend.gamma_luminance = self._settings.value(
             "adjust/gamma_luminance", False, type=bool)
+        # Restore the Auto WB toggle + algorithm (defaults OFF / Gray World).
+        # When on, a fresh conversion writes AWB-estimated temperature/tint into
+        # the image's sliders — only when neither is already set. Affects only
+        # FUTURE conversions and the AWB button. See spec/auto-white-balance.md.
+        from core.awb import AWB_ALGORITHMS, AWB_DEFAULT
+        ccr_backend.auto_awb = self._settings.value(
+            "adjust/auto_awb", False, type=bool)
+        stored_algo = self._settings.value("adjust/awb_algorithm", AWB_DEFAULT)
+        ccr_backend.awb_algorithm = (
+            stored_algo if any(a == stored_algo for a, _ in AWB_ALGORITHMS)
+            else AWB_DEFAULT)
         # Reflect the restored mode in the toolbar/slider gating right away
         # (no images yet, but the negative-only actions should already grey out).
         self.image_preview._update_unconvert_action_state()
@@ -719,6 +730,23 @@ class MainWindow(QMainWindow):
         self.sliders_panel.set_temporary_hint(hint, duration=5000)
 
     # --- Gamma application mode (global, persistent) ----------------------
+    def on_auto_awb_toggled(self, checked: bool):
+        """Flip the global Auto WB flag and persist it. No re-render: the flag
+        only affects FUTURE conversions (and never images with a saved
+        temperature/tint). See spec/auto-white-balance.md."""
+        ccr_backend.auto_awb = bool(checked)
+        self._settings.setValue("adjust/auto_awb", bool(checked))
+        self.sliders_panel.set_temporary_hint(
+            "Auto white balance on — new conversions get an automatic "
+            "Temperature/Tint estimate." if checked else
+            "Auto white balance off.", duration=4000)
+
+    def on_awb_algorithm_changed(self, algorithm: str):
+        """Persist the AWB algorithm choice. Used by the AWB button and the
+        post-conversion hook; existing images are untouched."""
+        ccr_backend.awb_algorithm = str(algorithm)
+        self._settings.setValue("adjust/awb_algorithm", str(algorithm))
+
     def on_gamma_mode_toggled(self, checked: bool):
         """Flip the global Gamma mode (per-channel vs hue-preserving luminance),
         persist it, and re-render all loaded images. Gamma is a display-domain

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
 )
 
 from core import color_management
+from core.awb import AWB_ALGORITHMS, AWB_DEFAULT
 from core.ccr_backend import ccr_backend
 from ui import theme
 
@@ -120,6 +121,31 @@ class SettingsDialog(QDialog):
             "little saturation as it brightens/darkens. Highlights that would "
             "exceed white still clip."))
         lay.addWidget(grp_gamma)
+
+        grp_wb = QGroupBox("White balance")
+        gw = QVBoxLayout(grp_wb)
+        gw.setSpacing(theme.GAP_ROW)
+        self._cb_auto_awb = QCheckBox("Auto white balance after conversion")
+        gw.addWidget(self._cb_auto_awb)
+        gw.addWidget(self._muted(
+            "When a negative is converted, automatically estimate the color "
+            "cast and set the Temperature/Tint sliders — only for images with "
+            "no white balance already set. The AWB button applies the same "
+            "estimate on demand."))
+        algo_row = QHBoxLayout()
+        algo_row.setSpacing(theme.GAP_ROW)
+        algo_row.addWidget(QLabel("Algorithm"))
+        self._combo_awb_algo = QComboBox()
+        for algo_id, label in AWB_ALGORITHMS:
+            self._combo_awb_algo.addItem(label, algo_id)
+        algo_row.addWidget(self._combo_awb_algo, 1)
+        gw.addLayout(algo_row)
+        gw.addWidget(self._muted(
+            "Gray World (default) assumes the scene averages to gray. White "
+            "Patch balances on the brightest content. Shades of Gray weights "
+            "bright areas more than Gray World. Gray Edge balances on edge "
+            "colors — robust when large areas share one color."))
+        lay.addWidget(grp_wb)
 
         lay.addStretch(1)
         return page
@@ -269,6 +295,7 @@ class SettingsDialog(QDialog):
                         (self._cb_rgb_merge, ccr_backend.rgb_merge_mode),
                         (self._cb_density, ccr_backend.density_bwpoint),
                         (self._cb_auto_gain, ccr_backend.auto_gain),
+                        (self._cb_auto_awb, ccr_backend.auto_awb),
                         (self._cb_gamma_lum, ccr_backend.gamma_luminance)):
             cb.blockSignals(True)
             cb.setChecked(bool(val))
@@ -278,6 +305,12 @@ class SettingsDialog(QDialog):
             self._combo_merge_detail.findData(
                 bool(getattr(ccr_backend, "rgb_merge_demosaic", True))))
         self._combo_merge_detail.blockSignals(False)
+        self._combo_awb_algo.blockSignals(True)
+        idx = self._combo_awb_algo.findData(
+            getattr(ccr_backend, "awb_algorithm", AWB_DEFAULT))
+        self._combo_awb_algo.setCurrentIndex(
+            idx if idx >= 0 else self._combo_awb_algo.findData(AWB_DEFAULT))
+        self._combo_awb_algo.blockSignals(False)
 
     def _apply_pending(self):
         """Apply only the toggles whose checkbox differs from the live backend
@@ -295,6 +328,11 @@ class SettingsDialog(QDialog):
             self._mw.on_density_bwpoint_toggled(bool(self._cb_density.isChecked()))
         if bool(self._cb_auto_gain.isChecked()) != bool(ccr_backend.auto_gain):
             self._mw.on_auto_gain_toggled(bool(self._cb_auto_gain.isChecked()))
+        if bool(self._cb_auto_awb.isChecked()) != bool(ccr_backend.auto_awb):
+            self._mw.on_auto_awb_toggled(bool(self._cb_auto_awb.isChecked()))
+        staged_algo = self._combo_awb_algo.currentData()
+        if staged_algo != getattr(ccr_backend, "awb_algorithm", AWB_DEFAULT):
+            self._mw.on_awb_algorithm_changed(staged_algo)
         if bool(self._cb_gamma_lum.isChecked()) != bool(ccr_backend.gamma_luminance):
             self._mw.on_gamma_mode_toggled(bool(self._cb_gamma_lum.isChecked()))
 

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -488,12 +488,19 @@ class SlidersPanel(QWidget):
         # Separator between B/W Point tools and the adjustment sliders
         scroll_layout.addWidget(theme.section_separator())
 
-        # Auto white balance: pick a neutral point with an eyedropper.
+        # White balance: pick a neutral point with an eyedropper.
         # Enabled only for converted images (same gating as the sliders).
-        self.wb_picker_btn = QPushButton("Auto WB Picker")
+        self.wb_picker_btn = QPushButton("WB Picker")
         self.wb_picker_btn.setToolTip(
             "Click, then pick a neutral gray/white point on the image "
             "to auto-set Temperature and Tint.")
+        # Fully automatic white balance: no picking — estimates the neutral
+        # from the whole image and sets the Temperature/Tint sliders.
+        self.auto_wb_btn = QPushButton("AWB")
+        self.auto_wb_btn.setToolTip(
+            "Automatic white balance — estimates the neutral color from the "
+            "whole image and sets Temperature and Tint. The algorithm is "
+            "chosen in Settings → General.")
         # Crop: non-destructive crop of the preview/export (same gating).
         self.crop_btn = QPushButton("Crop")
         self.crop_btn.setToolTip(
@@ -511,10 +518,12 @@ class SlidersPanel(QWidget):
             "drag to adjust, right-click to delete, Enter to slice, "
             "Esc to cancel.")
         self.wb_picker_btn.setFixedHeight(theme.CONTROL_H)
+        self.auto_wb_btn.setFixedHeight(theme.CONTROL_H)
         self.crop_btn.setFixedHeight(theme.CONTROL_H)
         self.slice_btn.setFixedHeight(theme.CONTROL_H)
         wb_crop_row = theme.apply_button_row(QHBoxLayout())
         wb_crop_row.addWidget(self.wb_picker_btn, 1)
+        wb_crop_row.addWidget(self.auto_wb_btn, 1)
         wb_crop_row.addWidget(self.crop_btn, 1)
         wb_crop_row.addWidget(self.slice_btn, 1)
         scroll_layout.addLayout(wb_crop_row)
@@ -717,6 +726,7 @@ class SlidersPanel(QWidget):
         self.compare_button.setCheckable(False)
         self.sync_to_all_button.clicked.connect(self.on_sync_to_all_clicked)
         self.wb_picker_btn.clicked.connect(self._on_pick_neutral_point)
+        self.auto_wb_btn.clicked.connect(self._on_auto_wb)
         self.crop_btn.clicked.connect(self._on_crop_clicked)
         self.slice_btn.clicked.connect(self._on_slice_clicked)
         self.white_point_btn.clicked.connect(self._on_set_white_point)
@@ -865,6 +875,7 @@ class SlidersPanel(QWidget):
     def set_sliders_enabled(self, enabled: bool):
         print(f"Setting sliders enabled: {enabled}")
         self.wb_picker_btn.setEnabled(enabled)
+        self.auto_wb_btn.setEnabled(enabled)
         self.crop_btn.setEnabled(enabled)
         self.color_profile_combo.setEnabled(enabled)
         self.curve_editor.setEnabled(enabled)
@@ -1524,6 +1535,21 @@ class SlidersPanel(QWidget):
                 "line, drag = adjust, right-click = delete, <b>Enter</b> = "
                 "slice, <b>Esc</b> = cancel.", duration=12000)
 
+    def _on_auto_wb(self):
+        """Fully automatic white balance: estimate the neutral from the whole
+        converted frame (Settings → General algorithm) and set the sliders via
+        the same path as an eyedropper pick."""
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None or not img.converted:
+            return
+        from core.awb import compute_awb_temp_tint
+        res = compute_awb_temp_tint(img)
+        if res is None:
+            self.set_temporary_hint(
+                "<b>AWB:</b> not enough usable image content.", duration=5000)
+            return
+        self.on_wb_sampled(*res)
+
     def on_wb_sampled(self, temp_value, tint_value):
         """Apply the auto-computed temperature/tint from the WB eyedropper."""
         # The WB pick is its own undo step — don't merge it into a slider burst
@@ -1772,6 +1798,7 @@ class SlidersPanel(QWidget):
                 "density": bool(ccr_backend.density_bwpoint),
                 "slopes": slopes,
             }
+            ccr_backend.maybe_auto_awb(img)
             img.update_thumbnail_and_preview()
             mw = self.parent().parent()
             mw.thumbnail_list.update_all_thumbnails()

--- a/tests/test_awb.py
+++ b/tests/test_awb.py
@@ -240,7 +240,7 @@ def test_hook_never_clobbers_saved_wb(backend, preset):
     assert img.adjustment_settings == preset
 
 
-def test_hook_off_by_default_and_inert_when_off(backend):
+def test_hook_inert_when_off(backend):
     backend.auto_awb = False
     img = _StubImage(_u16(_cast_scene(np.random.default_rng(8))))
     backend.maybe_auto_awb(img)
@@ -266,8 +266,8 @@ def test_algorithm_registry():
 
 def test_backend_defaults(backend):
     """Constructor defaults (the fixture restores any earlier mutation, so the
-    singleton still carries them here): auto-AWB opt-in, Gray World."""
-    assert backend.auto_awb is False
+    singleton still carries them here): auto-AWB ON, Gray World."""
+    assert backend.auto_awb is True
     assert backend.awb_algorithm == AWB_DEFAULT
 
 

--- a/tests/test_awb.py
+++ b/tests/test_awb.py
@@ -148,12 +148,14 @@ def test_estimate_is_scale_invariant():
 # --- compute_awb_temp_tint on an image-like object ---------------------------
 
 class _StubImage:
-    def __init__(self, base, ws=False, converted=True):
+    def __init__(self, base, ws=False, converted=True, crop=None, angle=0.0):
         self.resized_raw = base
         self._ws_windowed = ws
         self.converted = converted
         self.tint_balance_factor = 1.0
         self.adjustment_settings = {}
+        self.crop_rect = crop
+        self.crop_angle = angle
 
 
 def test_compute_awb_temp_tint_stub_image():
@@ -167,6 +169,46 @@ def test_compute_awb_temp_tint_stub_image():
 
 def test_compute_awb_temp_tint_no_base():
     assert compute_awb_temp_tint(_StubImage(None), algorithm="gray_world") is None
+
+
+# --- crop awareness -----------------------------------------------------------
+
+def test_crop_region_drives_the_estimate():
+    """Cast-A content inside the crop, strongly different cast-B junk outside:
+    the cropped estimate matches the interior content, not the whole frame."""
+    rng = np.random.default_rng(10)
+    inside = _cast_scene(rng, cast=CAST, shape=(64, 64))
+    d = _cast_scene(rng, cast=(0.7, 1.0, 1.3), shape=(128, 128))   # cool junk
+    d[32:96, 32:96, :] = inside                                     # centered 50%
+    crop = (0.25, 0.25, 0.75, 0.75)
+    cropped = compute_awb_temp_tint(
+        _StubImage(_u16(d), crop=crop), algorithm="gray_world")
+    interior_only = compute_awb_temp_tint(
+        _StubImage(_u16(inside)), algorithm="gray_world")
+    full = compute_awb_temp_tint(_StubImage(_u16(d)), algorithm="gray_world")
+    assert cropped == interior_only
+    assert cropped != full
+
+
+def test_rotated_crop_black_fill_is_masked():
+    """An angled crop samples outside the source (black fill); those pixels
+    sit below AWB_LO and must not skew the estimate toward neutral-dark."""
+    d = _cast_scene(np.random.default_rng(11), shape=(96, 96))
+    straight = compute_awb_temp_tint(
+        _StubImage(_u16(d), crop=(0.1, 0.1, 0.9, 0.9)), algorithm="gray_world")
+    angled = compute_awb_temp_tint(
+        _StubImage(_u16(d), crop=(0.1, 0.1, 0.9, 0.9), angle=8.0),
+        algorithm="gray_world")
+    # same scene statistics → within a slider unit of the straight crop
+    assert abs(angled[0] - straight[0]) <= 1
+    assert abs(angled[1] - straight[1]) <= 1
+
+
+def test_stub_without_crop_attrs_still_works():
+    """The hook may see images predating the crop feature — getattr defaults."""
+    img = _StubImage(_u16(_cast_scene(np.random.default_rng(12))))
+    del img.crop_rect, img.crop_angle
+    assert compute_awb_temp_tint(img, algorithm="gray_world") is not None
 
 
 # --- the post-conversion hook (backend policy) --------------------------------

--- a/tests/test_awb.py
+++ b/tests/test_awb.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Tests for Auto White Balance (spec/auto-white-balance.md).
+
+AWB estimates the neutral (cast) color of the converted base with a classical,
+learning-free algorithm and feeds it through compute_neutral_temp_tint — the
+same inverse the WB eyedropper uses — so the result lands on the
+Temperature/Tint sliders. Pure numpy core, runs headless.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.awb import (  # noqa: E402
+    AWB_ALGORITHMS, AWB_DEFAULT, AWB_LO, AWB_HI,
+    estimate_neutral_rgb, compute_awb_temp_tint,
+)
+from core.ccr_processor import (  # noqa: E402
+    _white_balance_gains, compute_neutral_temp_tint, encode_window,
+)
+
+CAST = (1.25, 1.0, 0.8)          # warm illuminant (R high, B low)
+
+
+def _u16(d):
+    """Full-range uint16 base from a display array in [0, 1]."""
+    return (np.clip(np.asarray(d, dtype=np.float32), 0, 1) * 65535).astype(np.uint16)
+
+
+def _cast_scene(rng, cast=CAST, shape=(64, 64), lo=0.15, hi=0.75):
+    """A neutral random scene tinted by `cast` (channel means ∝ cast)."""
+    g = rng.uniform(lo, hi, size=shape).astype(np.float32)
+    return np.stack([g * c for c in cast], axis=-1)
+
+
+def _ratios(triple):
+    r, g, b = triple
+    return r / g, b / g
+
+
+# --- the estimators ---------------------------------------------------------
+
+def test_gray_world_recovers_cast():
+    d = _cast_scene(np.random.default_rng(0))
+    est = estimate_neutral_rgb(_u16(d), ws_windowed=False, algorithm="gray_world")
+    rg, bg = _ratios(est)
+    assert rg == pytest.approx(CAST[0] / CAST[1], rel=0.01)
+    assert bg == pytest.approx(CAST[2] / CAST[1], rel=0.01)
+
+
+def test_white_patch_balances_on_brightest_content():
+    """A bright cast-colored patch drives white_patch, not the dim scene mean."""
+    cast = (1.1, 1.0, 0.85)
+    d = np.full((100, 100, 3), 0.3, dtype=np.float32)
+    d[..., 0] *= 0.9                                   # dim content: different cast
+    patch = np.array([0.85 * c for c in cast], dtype=np.float32)   # all <= 0.98
+    d[:5, :, :] = patch                                # 5% brightest rows
+    est = estimate_neutral_rgb(_u16(d), ws_windowed=False, algorithm="white_patch")
+    rg, bg = _ratios(est)
+    assert rg == pytest.approx(cast[0] / cast[1], rel=0.02)
+    assert bg == pytest.approx(cast[2] / cast[1], rel=0.02)
+
+
+def test_shades_of_gray_equals_gray_world_on_uniform():
+    d = np.full((32, 32, 3), 0.5, dtype=np.float32) * np.array(
+        [1.1, 1.0, 0.9], dtype=np.float32)
+    gw = estimate_neutral_rgb(_u16(d), algorithm="gray_world")
+    sog = estimate_neutral_rgb(_u16(d), algorithm="shades_of_gray")
+    assert np.allclose(gw, sog, rtol=1e-4)
+
+
+def test_gray_edge_recovers_cast_from_edges():
+    """Luminance stripes tinted by the cast: every edge gradient carries the
+    cast's channel ratios."""
+    stripes = np.tile(
+        np.repeat(np.array([0.3, 0.6], dtype=np.float32), 8), 4)   # 64 cols
+    d = np.stack([np.tile(stripes * c, (64, 1)) for c in CAST], axis=-1)
+    est = estimate_neutral_rgb(_u16(d), ws_windowed=False, algorithm="gray_edge")
+    rg, bg = _ratios(est)
+    assert rg == pytest.approx(CAST[0] / CAST[1], rel=0.03)
+    assert bg == pytest.approx(CAST[2] / CAST[1], rel=0.03)
+
+
+def test_unknown_algorithm_falls_back_to_gray_world():
+    d = _cast_scene(np.random.default_rng(1))
+    got = estimate_neutral_rgb(_u16(d), algorithm="not_a_real_algorithm")
+    gw = estimate_neutral_rgb(_u16(d), algorithm="gray_world")
+    assert got == gw
+
+
+# --- masking ----------------------------------------------------------------
+
+def test_out_of_bound_pixels_excluded():
+    """Near-clip and near-black pixels must not skew the estimate: the dirty
+    image's estimate equals the estimate over just its in-bound interior."""
+    d = _cast_scene(np.random.default_rng(2), shape=(80, 80))
+    dirty = d.copy()
+    dirty[:4, :, :] = 0.995        # blown row block (> AWB_HI)
+    dirty[-4:, :, :] = 0.005       # holder-black block (< AWB_LO)
+    interior = estimate_neutral_rgb(_u16(d[4:-4]), algorithm="gray_world")
+    got = estimate_neutral_rgb(_u16(dirty), algorithm="gray_world")
+    assert np.allclose(interior, got, rtol=1e-4)
+
+
+def test_insufficient_content_returns_none():
+    d = np.full((100, 100, 3), 0.995, dtype=np.float32)   # all above AWB_HI
+    assert estimate_neutral_rgb(_u16(d), algorithm="gray_world") is None
+
+
+def test_windowed_and_full_range_agree():
+    """The same display-domain scene, encoded windowed vs full-range, yields
+    the same channel ratios (de-windowing is correct)."""
+    d = _cast_scene(np.random.default_rng(3))
+    ws = estimate_neutral_rgb(encode_window(d.copy()), ws_windowed=True,
+                              algorithm="gray_world")
+    full = estimate_neutral_rgb(_u16(d), ws_windowed=False,
+                                algorithm="gray_world")
+    assert _ratios(ws) == pytest.approx(_ratios(full), rel=5e-3)
+
+
+# --- estimate → sliders → gains round-trip -----------------------------------
+
+def test_roundtrip_neutralizes_the_cast():
+    """Applying the AWB-computed temp/tint through the real WB gain stage makes
+    the scene's channel means meet (within int-slider quantization)."""
+    d = _cast_scene(np.random.default_rng(4))
+    est = estimate_neutral_rgb(_u16(d), algorithm="gray_world")
+    temp, tint = compute_neutral_temp_tint(*est)
+    gr, gg, gb = _white_balance_gains(temp, tint)
+    means = d.reshape(-1, 3).mean(axis=0) * (gr, gg, gb)
+    # one temp slider unit moves R/B by 0.4% each → ~1.6% worst-case spread
+    assert means.max() / means.min() == pytest.approx(1.0, abs=0.02)
+
+
+def test_estimate_is_scale_invariant():
+    """compute_neutral_temp_tint sees ratios only — the estimate's scale (0-1
+    vs 0-65535 domain) must not change the slider result."""
+    est = (0.55, 0.47, 0.40)
+    a = compute_neutral_temp_tint(*est)
+    b = compute_neutral_temp_tint(*(v * 65535.0 for v in est))
+    assert a == b
+
+
+# --- compute_awb_temp_tint on an image-like object ---------------------------
+
+class _StubImage:
+    def __init__(self, base, ws=False, converted=True):
+        self.resized_raw = base
+        self._ws_windowed = ws
+        self.converted = converted
+        self.tint_balance_factor = 1.0
+        self.adjustment_settings = {}
+
+
+def test_compute_awb_temp_tint_stub_image():
+    d = _cast_scene(np.random.default_rng(5))
+    res = compute_awb_temp_tint(_StubImage(_u16(d)), algorithm="gray_world")
+    assert res is not None
+    temp, tint = res
+    assert temp < -20            # warm cast → cool correction, well off zero
+    assert -100 <= temp <= 100 and -100 <= tint <= 100
+
+
+def test_compute_awb_temp_tint_no_base():
+    assert compute_awb_temp_tint(_StubImage(None), algorithm="gray_world") is None
+
+
+# --- the post-conversion hook (backend policy) --------------------------------
+
+@pytest.fixture
+def backend():
+    from core.ccr_backend import ccr_backend
+    saved = (ccr_backend.auto_awb, ccr_backend.awb_algorithm)
+    yield ccr_backend
+    ccr_backend.auto_awb, ccr_backend.awb_algorithm = saved
+
+
+def test_hook_writes_when_unset(backend):
+    backend.auto_awb = True
+    backend.awb_algorithm = "gray_world"
+    img = _StubImage(_u16(_cast_scene(np.random.default_rng(6))))
+    backend.maybe_auto_awb(img)
+    assert img.adjustment_settings.get("temperature", 0) != 0
+    assert "tint" in img.adjustment_settings
+
+
+@pytest.mark.parametrize("preset", [{"temperature": 5}, {"tint": -3},
+                                    {"temperature": 2, "tint": 1}])
+def test_hook_never_clobbers_saved_wb(backend, preset):
+    backend.auto_awb = True
+    img = _StubImage(_u16(_cast_scene(np.random.default_rng(7))))
+    img.adjustment_settings = dict(preset)
+    backend.maybe_auto_awb(img)
+    assert img.adjustment_settings == preset
+
+
+def test_hook_off_by_default_and_inert_when_off(backend):
+    backend.auto_awb = False
+    img = _StubImage(_u16(_cast_scene(np.random.default_rng(8))))
+    backend.maybe_auto_awb(img)
+    assert img.adjustment_settings == {}
+
+
+def test_hook_skips_unconverted(backend):
+    backend.auto_awb = True
+    img = _StubImage(_u16(_cast_scene(np.random.default_rng(9))),
+                     converted=False)
+    backend.maybe_auto_awb(img)
+    assert img.adjustment_settings == {}
+
+
+# --- registry / defaults -------------------------------------------------------
+
+def test_algorithm_registry():
+    ids = [a for a, _ in AWB_ALGORITHMS]
+    assert ids == ["gray_world", "white_patch", "shades_of_gray", "gray_edge"]
+    assert AWB_DEFAULT in ids
+    assert 0.0 < AWB_LO < AWB_HI < 1.0
+
+
+def test_backend_defaults(backend):
+    """Constructor defaults (the fixture restores any earlier mutation, so the
+    singleton still carries them here): auto-AWB opt-in, Gray World."""
+    assert backend.auto_awb is False
+    assert backend.awb_algorithm == AWB_DEFAULT
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Fully automatic white balance, three ways in (spec: `spec/auto-white-balance.md`, REFINED v2):

1. **AWB button** in the sliders panel, right next to the WB eyedropper (now labeled "WB Picker" — the row is `WB Picker | AWB | Crop | Slice`). One click, no grey-spot picking: a classical illuminant-estimation algorithm computes the neutral color of the whole converted frame and **sets the Temperature/Tint sliders** — undoable, persisted, and idempotent (the estimate runs on the converted base, so re-clicking gives the same result).
2. **Settings → General → "Auto white balance after conversion"** (default **ON**, like Auto Gain): fresh conversions get the same estimate automatically — **only when the image has no temperature/tint already saved** (both 0/absent). Replay/reconvert paths never fire it, so existing edits are never touched.
3. **Settings → General → Algorithm dropdown**: Gray World (default), White Patch, Shades of Gray, Gray Edge. Used by both the button and the auto-hook. Persisted as `adjust/awb_algorithm`; unknown stored ids fall back to Gray World.

Deliberately **not** the abandoned deep-learning AWB (PR #52): these are transparent, learning-free statistics, and the result lands on the sliders where the user can see and correct it.

## How it works

- New pure-numpy `src/core/awb.py`: de-window the converted base (mirroring `compute_auto_gain_offset`), mask to in-bound pixels (all channels in **[0.02, 0.98]** — rejects holder black, headroom, near-clip), run the selected estimator, and feed the estimated neutral through the **existing** `compute_neutral_temp_tint` — the exact inverse of the flat WB gain model. AWB behaves precisely like a perfectly chosen eyedropper pick, reusing `on_wb_sampled` (undo burst, slider set, store, reprocess, hint).
- `ccr_backend.maybe_auto_awb(img)` carries the whole auto-hook policy, called from the three fresh-conversion sites: `convert_negative_by_index` (covers single ref convert, Convert All, auto-frame — thread-safe from its worker pool), `apply_bwpoint_to_all_images`, and the panel's single B/W-point convert. Placed before `update_thumbnail_and_preview()` so the first render already includes the WB; slider re-sync is automatic via the existing `update_preview → set_current_idx` path.
- **Crop-aware**: with a crop set, only the kept region drives the estimate (`apply_crop_to_image` on the base; a rotated crop's black corner fill sits below the noise floor and is masked out; no crop → full frame).
- `< 0.5%` usable pixels → estimate is `None`: button shows a hint, hook is a silent no-op.

## Screenshots

Button row and Settings page verified offscreen (qt-testing skill): four buttons fit at panel width; the White balance group shows checkbox + algorithm dropdown seeded from the backend.

## Tests

`tests/test_awb.py` — 23 headless tests: cast recovery per algorithm, white-patch vs mean behavior, mask exclusion, insufficient content, windowed/full-range agreement, estimate→gains round-trip (neutralizes within slider quantization), scale invariance, crop-awareness (crop drives the estimate; angled-crop fill masked; crop-less images fine), hook guards (never clobbers saved temp/tint, off-by-default, unconverted skip), registry/defaults.

Ran green alongside neighbors: `test_auto_gain`, `test_white_balance_ws`, `test_settings_dialog`, `test_film_stock_ui`, `test_density_bwpoint`, `test_default_slope`, `test_film_stocks`, `test_positive_mode` (full suite not run — known pre-existing order-dependent hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
