### PR TITLE
fix(dust): coordinates off after cropping - hi-res layer cropped the canvas under dust/area mode

### DIFF
--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1828,8 +1828,15 @@ class ImagePreview(QWidget):
             return None
         crop = getattr(img, "crop_rect", None)
         angle = getattr(img, "crop_angle", 0.0) or 0.0
+        # Dust and area modes display the FULL un-cropped frame and normalize
+        # their stored coordinates against it, so the hi-res layer must not
+        # swap cropped pixels in under them (same mode exclusions as
+        # update_preview's crop-display branch) — otherwise strokes painted
+        # after the hi-res lands map to crop-relative positions and heal the
+        # wrong pixels.
         crop_active = (crop is not None and not self.crop_mode
                        and not self.slice_mode
+                       and not self.dust_mode and not self.area_mode
                        and (img.converted or ccr_backend.positive_mode))
         crop_sig = (crop, angle) if crop_active else None
         if cache.get("display_pm") is not None and cache.get("crop_sig") == crop_sig:
@@ -2357,9 +2364,10 @@ class ImagePreview(QWidget):
         return t if t.isInvertible() else None
 
     # --- Dust removal mode -------------------------------------------------
-    # Paint over dust to inpaint it (cv2.inpaint), or AI-detect it. Edits are
-    # stored as normalized spots on the image and replayed in the render
-    # pipeline at every resolution. See spec/dust-removal.md.
+    # Paint over dust to heal it (clone fill, see apply_dust_removal), or
+    # AI-detect it. Edits are stored as normalized spots on the image and
+    # replayed in the render pipeline at every resolution. See
+    # spec/dust-removal.md.
     def enter_dust_mode(self) -> bool:
         """Show the full un-cropped image (coarse rotation/flip only, no fine
         rotation) so canvas pixels map 1:1 to resized_raw, ready for painting."""

--- a/tests/test_crop_hires.py
+++ b/tests/test_crop_hires.py
@@ -127,6 +127,48 @@ class TestCropWantsHires:
         assert ip._crop_wants_hires() is False
 
 
+class TestHiresDisplayModeGuards:
+    """_hires_display_pixmap must NOT apply the display crop in dust/area
+    modes: both show the full un-cropped frame and normalize coordinates
+    against it, so cropped hi-res pixels under them would make strokes heal
+    the wrong place (the 'dust coordinates off after cropping' bug)."""
+
+    @staticmethod
+    def _inject_hires(ip, img, w=1080, h=720):
+        full_pm = QPixmap(w, h)
+        full_pm.fill(QColor(64, 64, 64))
+        ip._hires = {"img": img, "sig": ip._hires_signature(img),
+                     "adj_sig": None, "base": None, "full_pm": full_pm,
+                     "display_pm": None, "crop_sig": None}
+        return full_pm
+
+    def test_dust_mode_gets_full_frame(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.25, 0.25, 0.75, 0.75)))
+        self._inject_hires(ip, ccr_backend.images[0])
+        ip.dust_mode = True                 # full image shown; hires must match
+        pm = ip._hires_display_pixmap()
+        assert pm is not None
+        assert (pm.width(), pm.height()) == (1080, 720)
+
+    def test_area_mode_gets_full_frame(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.25, 0.25, 0.75, 0.75)), zoom=2.0)
+        self._inject_hires(ip, ccr_backend.images[0])
+        ip.area_mode = True                 # full image shown; hires must match
+        pm = ip._hires_display_pixmap()
+        assert pm is not None
+        assert (pm.width(), pm.height()) == (1080, 720)
+
+    def test_normal_display_still_gets_cropped(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.25, 0.25, 0.75, 0.75)))
+        self._inject_hires(ip, ccr_backend.images[0])
+        pm = ip._hires_display_pixmap()     # no mode active -> crop applies
+        assert pm is not None
+        assert (pm.width(), pm.height()) == (540, 360)
+
+
 class TestZoomedInEnoughWithCrop:
     def test_heavy_crop_at_fit_is_enough(self):
         ip = _make_preview()


### PR DESCRIPTION
Fixes the user-reported "after cropping, dust removal coordinates are off".

## Root cause

Dust mode deliberately shows the **full un-cropped frame** and stores spots normalized against it (spec/dust-removal.md §5.5) — `update_preview`'s crop-display branch excludes `dust_mode`/`area_mode` for exactly that reason. But dust mode also always requests hi-res detail (`_zoomed_in_enough()` is unconditionally `True` there), and **`_hires_display_pixmap` applied the display crop with no dust/area-mode guard**.

So on a cropped image:

1. Open Dust Removal → canvas correctly shows the full frame.
2. ~1 s later the hi-res render lands and silently swaps the canvas to the **cropped region scaled into the full-frame footprint**.
3. `_dust_scene_to_norm` still normalizes clicks against the full frame → every stroke painted after the swap is stored at crop-relative positions read as full-frame positions → the heal lands offset (and scale-warped) from the dust.

It looks intermittent because strokes painted in the first second (before the hi-res swap) are correct. Area/gradient painting while zoomed had the same latent mismatch.

## Fix

One condition: `_hires_display_pixmap`'s `crop_active` now carries the same mode exclusions as `update_preview`'s crop-display branch (`not self.dust_mode and not self.area_mode`). Dust/area modes get the intended **full-frame** hi-res; normal display still gets the crop-matched hi-res.

Also updates a stale comment claiming the heal is `cv2.inpaint` (it's the clone fill since #81/#82).

## Tests

New `TestHiresDisplayModeGuards` in `tests/test_crop_hires.py`:
- dust mode + crop → hi-res display is the full frame
- area mode + crop (zoomed) → full frame
- normal display + crop → still cropped (existing behavior)

Verified the dust/area cases **fail on unfixed code** and pass with the fix. Ran `test_crop_hires.py`, `test_zoom_hires.py`, `test_dust_removal.py` (62 passed), plus `test_crop_overlay.py`, `test_histogram_crop.py`, `test_sub_saturation_crop_undo.py`, `test_crop_panel.py`, `test_area_editing.py` — the single failure there (`test_area_editing.py::TestBackend::test_add_select_enable_remove`) is pre-existing: it fails identically on unmodified `main`, run alone or in a group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
