### PR TITLE
fix: reference-frame exports replay the convert-time frame snapshot (#94)

### DIFF
--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -421,18 +421,11 @@ def _replay_conversion(img, ci) -> None:
                                     apply_reference_normalization)
     mode = ci.get("mode")
     if mode == "ref":
-        saved_fine = img.fine_rotation_angle
-        saved_ref = img.reference_frame
-        img.fine_rotation_angle = ci.get("fine_rot", 0)
-        img.reference_frame = ci["ref"]
-        try:
-            processed = ccr_normalize_with_reference(img)
-        finally:
-            img.fine_rotation_angle = saved_fine
-            # Unconditionally: the user may have deleted the frame after
-            # converting, and a restore must reproduce exactly that state.
-            img.reference_frame = saved_ref
-        img.resized_raw = processed
+        # Snapshot passed as parameters — the live reference_frame /
+        # fine_rotation_angle stay whatever the stored state restored them
+        # to (the user may have deleted the frame after converting).
+        img.resized_raw = ccr_normalize_with_reference(
+            img, reference_rect=ci["ref"], fine_rot=ci.get("fine_rot", 0))
     elif mode == "ref_params":
         img.resized_raw = apply_reference_normalization(
             img.resized_raw, ci["p_lo"], ci["p_hi"], ci["od"])

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -769,6 +769,12 @@ class CCRBackend:
             elif ci is not None and ci.get("mode") == "ref_params":
                 processed = ccr_normalize_with_refparams(
                     image_obj, ci["p_lo"], ci["p_hi"], ci["od"])
+            elif ci is not None and ci.get("mode") == "ref":
+                # Convert-time frame snapshot — survives a cleared/redrawn
+                # live reference_frame (issue #94).
+                processed = ccr_normalize_with_reference(
+                    image_obj, reference_rect=ci["ref"],
+                    fine_rot=ci.get("fine_rot", 0))
             elif image_obj.reference_frame is not None:
                 processed = ccr_normalize_with_reference(image_obj)
             else:
@@ -1309,6 +1315,21 @@ class CCRBackend:
                                                output_colorspace=output_colorspace,
                                                density=ci.get("density", False),
                                                slopes_bgr=ci.get("slopes"))
+                elif ci is not None and ci.get("mode") == "ref":
+                    # Reference-frame conversion: replay with the frame BAKED at
+                    # convert time. The live reference_frame must not be trusted —
+                    # a stray right-click clears it (leaving the converted preview
+                    # intact) and a redrawn frame would change the export away
+                    # from the preview (issue #94). The pixel data is still a
+                    # fresh full-quality decode of the original file; only the
+                    # rectangle coordinates come from the snapshot.
+                    ccr_normalize_with_reference(image_obj, output_path=output_path,
+                                                 jpg_out=jpg_output,
+                                                 jpg_quality=jpg_quality,
+                                                 max_long_side=max_long_side,
+                                                 output_colorspace=output_colorspace,
+                                                 reference_rect=ci["ref"],
+                                                 fine_rot=ci.get("fine_rot", 0))
                 elif image_obj.reference_frame is None and self.black_point_bgr is not None:
                     # Legacy/un-snapshotted B/W point conversion — global anchors.
                     # white_point_bgr may be None → default-slope mode (with the
@@ -1329,6 +1350,12 @@ class CCRBackend:
                                                  output_colorspace=output_colorspace)
                 return True
             except Exception as e:
+                # Keep the real reason: the bundled app has no visible stdout,
+                # so export_items/the result dialog surface this per image.
+                # Distinct-key dict writes are safe from the export pool threads.
+                if not hasattr(self, "_export_errors"):
+                    self._export_errors = {}
+                self._export_errors[idx] = f"{type(e).__name__}: {e}"
                 print(f"Failed to export image at index {idx}: {e}")
         return False
 
@@ -1357,6 +1384,7 @@ class CCRBackend:
         total_items = len(items)
         if total_items == 0:
             return result
+        self._export_errors = {}   # per-index failure reasons for this run
 
         print(f"Starting export of {total_items} images...")
 
@@ -1377,7 +1405,7 @@ class CCRBackend:
                 print(f"Export completed for {base_name} in {elapsed:.2f}s")
                 return idx, True, None
             print(f"Export failed for image {idx} after {elapsed:.2f}s")
-            return idx, False, "export failed (see log)"
+            return idx, False, self._export_errors.get(idx, "export failed (see log)")
 
         # Use parallel processing for exports
         max_workers = min(4, os.cpu_count() or 1)  # Use very few workers for export to avoid I/O contention

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -610,13 +610,22 @@ def _load_export_source(ccr_image, output_path, max_long_side):
     return ccr_image.read_image(ccr_image.file_path, preview=False)
 
 
-def ccr_normalize_with_reference(ccr_image,output_path=None,jpg_out=False,jpg_quality=95,max_long_side=None,output_colorspace="srgb") -> np.ndarray:
+def ccr_normalize_with_reference(ccr_image,output_path=None,jpg_out=False,jpg_quality=95,max_long_side=None,output_colorspace="srgb",reference_rect=None,fine_rot=None) -> np.ndarray:
     """
     Normalize and align the image using the CCR algorithm, using a reference rectangle
     for percentile calculations instead of a crop factor.
 
     Args:
         ccr_image: CCRImage object
+        reference_rect: (x1, y1, x2, y2) in resized_raw coordinates. When given
+            (the conversion_inputs snapshot from convert time) it is used instead
+            of the live ccr_image.reference_frame, so a replay reproduces the
+            conversion even after the on-canvas frame was cleared or redrawn.
+            Coordinates only — the pixel data is always re-read from the file.
+        fine_rot: fine rotation angle (hundredths of a degree) to apply to the
+            reference image before the percentile crop, as at convert time.
+            None falls back to the live angle. The final output orientation
+            warp always uses the live angle (it must match the preview).
 
     Returns:
         np.ndarray: CCR-normalized and inverted image, dtype uint16
@@ -631,9 +640,12 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,jpg_out=False,jpg_qu
         raise ValueError("CCRImage.resized_raw is None")
     print(f"Image loading: {time.time() - step_start:.3f}s")
 
-    # Apply fine rotation rotation 
+    # Apply fine rotation rotation
     step_start = time.time()
     fine_angle = ccr_image.fine_rotation_angle / 100.0
+    # The reference-crop warp reproduces convert time; the final output warp
+    # (fine_angle) tracks the live angle so the export matches the preview.
+    ref_fine_angle = fine_angle if fine_rot is None else fine_rot / 100.0
     h_flip = ccr_image.horizontal_mirrored
     v_flip = ccr_image.vertical_mirrored
 
@@ -648,10 +660,10 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,jpg_out=False,jpg_qu
         img_ref = ccr_image.resized_raw
     
     # fine Rotation
-    if fine_angle != 0:
+    if ref_fine_angle != 0:
         center_ref = (img_ref.shape[1] // 2, img_ref.shape[0] // 2)
         w_ref, h_ref = img_ref.shape[1], img_ref.shape[0]
-        rot_mat = cv2.getRotationMatrix2D(center_ref, -fine_angle, 1.0)
+        rot_mat = cv2.getRotationMatrix2D(center_ref, -ref_fine_angle, 1.0)
         img_ref = cv2.warpAffine(img_ref, rot_mat, (w_ref, h_ref), flags=cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT,borderValue=0)
         # Clean up rotation matrix as it's no longer needed
         del rot_mat
@@ -662,9 +674,11 @@ def ccr_normalize_with_reference(ccr_image,output_path=None,jpg_out=False,jpg_qu
         #     img = cv2.warpAffine(img, rot_mat, (w, h), flags=cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT,borderValue=0)
     print(f"Image setup and rotation: {time.time() - step_start:.3f}s")
 
-    # Reference frame
+    # Reference frame — the caller's snapshot wins over the live frame (a
+    # right-click clears the live frame without touching the conversion).
     step_start = time.time()
-    reference_rect = ccr_image.reference_frame
+    if reference_rect is None:
+        reference_rect = ccr_image.reference_frame
     if reference_rect is None:
         raise ValueError("CCRImage.reference_frame is None")
 

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -3826,6 +3826,16 @@ class ImagePreview(QWidget):
             lines.append(f"Skipped (already exist): {plan.skipped}")
         if result.get("failed"):
             lines.append(f"Failed: {result['failed']}")
+            # Show the first few real reasons — without them a failure is
+            # undiagnosable from the bundled app (no visible console).
+            for idx, msg in result.get("failures", [])[:5]:
+                img = (ccr_backend.images[idx]
+                       if 0 <= idx < len(ccr_backend.images) else None)
+                name = (os.path.basename(getattr(img, "file_path", ""))
+                        if img is not None else f"image {idx}")
+                lines.append(f"  {name}: {msg}")
+            if len(result.get("failures", [])) > 5:
+                lines.append(f"  … and {len(result['failures']) - 5} more")
         if result.get("cancelled"):
             lines.append("Export was stopped before completion.")
         lines.append(f"\nFolder: {plan.destination}")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -92,6 +92,74 @@ class TestExportDimensions:
         assert arr is not None and max(arr.shape[:2]) == 800
 
 
+class TestRefExportSnapshotReplay:
+    """Issue #94: the reference-frame export must replay the frame BAKED at
+    convert time (conversion_inputs["ref"]), not the live reference_frame —
+    a stray right-click clears the live frame while the converted preview
+    stays intact, and every export then failed."""
+
+    def test_export_survives_cleared_reference_frame(self, tmp_path):
+        img, _ = _converted(tmp_path)
+        img.reference_frame = None      # right-click without a drag clears it
+        out = str(tmp_path / "cleared.tiff")
+        assert ccr_backend.export_image_by_index(0, out, max_long_side=1080)
+        long_side, arr = _long_side(out)
+        assert long_side == 1080
+        assert int(arr.max()) > 0
+
+    def test_full_export_survives_cleared_reference_frame(self, tmp_path):
+        img, _ = _converted(tmp_path)
+        img.reference_frame = None
+        out = str(tmp_path / "cleared_full.tiff")
+        assert ccr_backend.export_image_by_index(0, out, max_long_side=None)
+        long_side, _ = _long_side(out)
+        assert long_side == 2400
+
+    def test_cleared_frame_with_black_point_still_uses_ref_recipe(self, tmp_path):
+        # A sampled global black point must NOT hijack a reference-converted
+        # image's export onto the B/W-point pipeline when the live frame is
+        # gone — the snapshot branch matches first.
+        img, _ = _converted(tmp_path)
+        baseline = str(tmp_path / "ref_baseline.tiff")
+        assert ccr_backend.export_image_by_index(0, baseline, max_long_side=800)
+        img.reference_frame = None
+        ccr_backend.black_point_bgr = (40000.0, 40000.0, 40000.0)
+        try:
+            out = str(tmp_path / "cleared_bp.tiff")
+            assert ccr_backend.export_image_by_index(0, out, max_long_side=800)
+            _, base_arr = _long_side(baseline)
+            _, arr = _long_side(out)
+            assert np.array_equal(base_arr, arr)
+        finally:
+            ccr_backend.black_point_bgr = None
+
+    def test_export_uses_convert_time_frame_not_redrawn_one(self, tmp_path):
+        # Redrawing the frame AFTER converting must not change the export —
+        # the file must match the conversion the preview shows.
+        img, _ = _converted(tmp_path)
+        baseline = str(tmp_path / "frame_baseline.tiff")
+        assert ccr_backend.export_image_by_index(0, baseline, max_long_side=800)
+        img.reference_frame = (10, 10, 200, 150)   # new frame, not converted yet
+        out = str(tmp_path / "frame_redrawn.tiff")
+        assert ccr_backend.export_image_by_index(0, out, max_long_side=800)
+        _, base_arr = _long_side(baseline)
+        _, arr = _long_side(out)
+        assert np.array_equal(base_arr, arr)
+
+    def test_export_items_reports_real_failure_reason(self, tmp_path):
+        # The failures list must carry the actual exception text — the bundled
+        # app has no visible console, so this is the only diagnostic channel.
+        img, _ = _converted(tmp_path)
+        img.conversion_inputs = None    # un-snapshotted legacy state
+        img.reference_frame = None      # → live-frame replay must raise
+        result = ccr_backend.export_items([(0, str(tmp_path / "fail.tiff"))])
+        assert result["failed"] == 1
+        assert result["failures"], "failure reason missing"
+        idx, msg = result["failures"][0]
+        assert idx == 0
+        assert "reference_frame is None" in msg
+
+
 class TestLoadExportSource:
     def test_processing_path_uses_resized_raw(self, tmp_path):
         img, _ = _converted(tmp_path)


### PR DESCRIPTION
Fixes #94 (export fails for reference-frame-converted images).

## Root cause

The legacy (toolbar) reference conversion snapshots its inputs into `conversion_inputs = {"mode": "ref", "ref": (...), "fine_rot": ...}` at convert time, but `export_image_by_index` had no branch for mode `"ref"` — it fell through to `ccr_normalize_with_reference()`, which read the **live** `reference_frame`.

A right-click on the canvas without a drag **clears the live reference frame** (`image_preview.py`, the "right-click without a real drag" handler) while the converted preview stays intact. After that:

- with no black point sampled (the reporter's exact workflow — their film holders hide the rebate), every export of that image raised `ValueError("CCRImage.reference_frame is None")`, surfaced only as **"Exported: 0, Failed: 1"**;
- with a black point sampled, it was worse: the routing silently fell into the global-B/W-point branch and exported a **different conversion than the preview**.

This also explains why it never reproduced on the maintainer's machine: convert → export with no right-click in between works fine. File size, filename, and OS were red herrings.

## Fix

- `ccr_normalize_with_reference` accepts optional `reference_rect` / `fine_rot` overrides. **Coordinates only** — the export still re-reads the original file at full quality via `_load_export_source` and recomputes the percentiles from that fresh decode; no preview/half-res pixel data is ever reused. The final orientation warp keeps using the live fine-rotation angle so the export matches the on-screen straightening.
- `export_image_by_index` and `_reconvert_in_place` (profile re-grade) get an explicit mode-`"ref"` branch that replays `ci["ref"]` / `ci["fine_rot"]`, placed **before** the global-black-point fallback. The zoom hi-res path and catalog restore already replayed from the snapshot; export was the odd one out.
- Catalog `_replay_conversion` now passes the snapshot as parameters instead of temporarily mutating and restoring live image state.
- Export failures now carry the real exception text (`type: message`) into `export_items`' `failures` list, and the *Export Complete* dialog lists per-file reasons (first 5). The bundled app has no visible console, which is why #94 could not be diagnosed from screenshots.

## Tests

New `TestRefExportSnapshotReplay` in `tests/test_export.py`:

- export succeeds (1080 px and full size) after the live frame is cleared
- with a black point sampled and the frame cleared, the export is byte-identical to the pure reference export (no recipe hijack)
- redrawing a frame after converting does not change the export (byte-identical to the convert-time frame)
- `export_items` failure entries contain the real exception message

`tests/test_export.py` (13), `test_catalog.py` + `test_zoom_hires.py` (22), `test_slice.py` + `test_positive_mode.py` + `test_linear_merge_export.py` (78) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
