### PR TITLE
revert: default auto-AWB after conversion back to OFF

### DIFF
--- a/spec/auto-white-balance.md
+++ b/spec/auto-white-balance.md
@@ -12,10 +12,8 @@ toggle + post-conversion hook pattern), `spec/settings-page.md`.
 - **Q1 — Button label**: "AWB"; the eyedropper's label is shortened
   "Auto WB Picker" → **"WB Picker"** ("Auto" now belongs to the new button; four
   buttons `WB Picker | AWB | Crop | Slice` share the row at equal stretch).
-- **Q2 — Auto-AWB default ON (revised per user).** Auto-AWB is an on-by-default
-  convenience like Auto Gain; the already-saved guard keeps it from touching any
-  image with an existing temperature/tint, and Settings → General turns it off.
-  The algorithm dropdown defaults to Gray World.
+- **Q2 — Auto-AWB default OFF.** A newly automatic behavior must not change
+  existing users' conversions; the algorithm dropdown defaults to Gray World.
 - **Q3 — Crop-aware (revised per user).** With a crop set, only the kept region
   drives the estimate: `compute_awb_temp_tint` passes the base through
   `apply_crop_to_image(base, crop_rect, crop_angle)` (normalized rect in
@@ -80,7 +78,7 @@ correct it.
   (`resized_raw`), not the adjusted preview, so clicking AWB twice yields the same
   slider values.
 - Settings → General: "Auto white balance after conversion" checkbox
-  (default **ON**) + "AWB algorithm" dropdown (default **Gray World**), both
+  (default **OFF**) + "AWB algorithm" dropdown (default **Gray World**), both
   QSettings-persisted, staged-and-applied-on-Done like the other General toggles.
 - The post-conversion hook fires only on **fresh conversions**
   (`convert_negative_by_index`, the B/W-point batch), never on replay/reconvert
@@ -277,9 +275,9 @@ New `QGroupBox("White balance")` in `_build_general_page`
   `userData`), muted help naming the default.
 
 Wiring (the Auto Gain 4-point pattern):
-- Backend flags (`ccr_backend.py` flag block): `self.auto_awb: bool = True`,
+- Backend flags (`ccr_backend.py` flag block): `self.auto_awb: bool = False`,
   `self.awb_algorithm: str = "gray_world"`.
-- QSettings: `adjust/auto_awb` (bool, default True), `adjust/awb_algorithm`
+- QSettings: `adjust/auto_awb` (bool, default False), `adjust/awb_algorithm`
   (string id, default `"gray_world"`), restored in `main_window.__init__`
   alongside `adjust/auto_gain`. Unknown stored ids fall back to the default.
 - `main_window.on_auto_awb_toggled(checked)` / `on_awb_algorithm_changed(algo)`:

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -70,12 +70,11 @@ class CCRBackend:
         # (hue-preserving). Global display mode, persisted by MainWindow. See
         # spec/gamma-luminance-mode.md.
         self.gamma_luminance: bool = False
-        # Auto white balance: when True (default), a fresh conversion writes
-        # AWB-estimated temperature/tint into the image's sliders — only when
-        # neither is already set. The algorithm id selects the estimator
-        # (core/awb.py). Global, persisted by MainWindow. See
-        # spec/auto-white-balance.md.
-        self.auto_awb: bool = True
+        # Auto white balance: when True, a fresh conversion writes AWB-estimated
+        # temperature/tint into the image's sliders — only when neither is
+        # already set. The algorithm id selects the estimator (core/awb.py).
+        # Global, persisted by MainWindow. See spec/auto-white-balance.md.
+        self.auto_awb: bool = False
         self.awb_algorithm: str = "gray_world"
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -208,13 +208,13 @@ class MainWindow(QMainWindow):
         # midtone moves don't shift hue. See spec/gamma-luminance-mode.md.
         ccr_backend.gamma_luminance = self._settings.value(
             "adjust/gamma_luminance", False, type=bool)
-        # Restore the Auto WB toggle + algorithm (defaults ON / Gray World).
+        # Restore the Auto WB toggle + algorithm (defaults OFF / Gray World).
         # When on, a fresh conversion writes AWB-estimated temperature/tint into
         # the image's sliders — only when neither is already set. Affects only
         # FUTURE conversions and the AWB button. See spec/auto-white-balance.md.
         from core.awb import AWB_ALGORITHMS, AWB_DEFAULT
         ccr_backend.auto_awb = self._settings.value(
-            "adjust/auto_awb", True, type=bool)
+            "adjust/auto_awb", False, type=bool)
         stored_algo = self._settings.value("adjust/awb_algorithm", AWB_DEFAULT)
         ccr_backend.awb_algorithm = (
             stored_algo if any(a == stored_algo for a, _ in AWB_ALGORITHMS)

--- a/tests/test_awb.py
+++ b/tests/test_awb.py
@@ -240,7 +240,7 @@ def test_hook_never_clobbers_saved_wb(backend, preset):
     assert img.adjustment_settings == preset
 
 
-def test_hook_inert_when_off(backend):
+def test_hook_off_by_default_and_inert_when_off(backend):
     backend.auto_awb = False
     img = _StubImage(_u16(_cast_scene(np.random.default_rng(8))))
     backend.maybe_auto_awb(img)
@@ -266,8 +266,8 @@ def test_algorithm_registry():
 
 def test_backend_defaults(backend):
     """Constructor defaults (the fixture restores any earlier mutation, so the
-    singleton still carries them here): auto-AWB ON, Gray World."""
-    assert backend.auto_awb is True
+    singleton still carries them here): auto-AWB opt-in, Gray World."""
+    assert backend.auto_awb is False
     assert backend.awb_algorithm == AWB_DEFAULT
 
 


### PR DESCRIPTION
## Summary

Reverts 78a6783 ("feat: default auto-AWB after conversion to ON"): **auto white balance after conversion defaults to OFF again** (opt-in via Settings → General, like before).

- `ccr_backend.auto_awb` constructor default: `True` → `False`
- `adjust/auto_awb` QSettings fallback in `main_window.__init__`: `True` → `False`
- Spec Q2 restored to the original "default OFF" rationale
- Tests: `test_backend_defaults` asserts `False` again; `test_hook_inert_when_off` regains its off-by-default name/coverage

The AWB button, algorithm dropdown, already-saved guard, and the Settings toggle itself are all unchanged — only the default flips.

Note for users who already ran a build with the ON default: QSettings persists the stored value, so anyone who opened Settings and hit Done (or toggled anything) may have `adjust/auto_awb=true` saved and will keep it until they turn it off. Fresh installs and untouched settings get OFF.

## Test plan

- [x] `pytest tests/test_awb.py -q` — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
