### PR TITLE
feat(dust): edit the cropped frame + resolution-stable heal (export matches preview)

### DIFF
--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -370,10 +370,19 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      different patches than the preview the user approved ("the preview and
      the final don't look the same"). Buffers at or below the canonical
      scale (the preview itself, thumbnails, the detect source) plan on
-     themselves — their behavior is unchanged. A replayed offset that no
-     longer lands on a clean window (mask-raster rounding — rare) falls back
-     to the local search for that segment; the tone membrane and feather
-     composite always run natively, so fills stay 16-bit sharp.
+     themselves — their behavior is unchanged.
+     **The preview's plan is the source of truth**: `CCRImage`'s preview
+     render caches its plan (`_dust_plan_cache`, keyed by the spots'
+     content; feather excluded — it shapes the blend, not the plan), and
+     hi-res/export renders replay THAT plan via `apply_dust_removal(plan=)`
+     — a fresh plan from the export's own re-decoded/downscaled pixels can
+     still flip near-tie source choices ("it sampled different spots than
+     the preview"). A replayed offset that lands on dust or out of bounds
+     after scaling (mask-raster rounding — rare) is rescued by the nearest
+     clean offset within a ≤4 px Chebyshev spiral (essentially the same
+     patch); only if that fails does the local search run. The tone
+     membrane and feather composite always run natively, so fills stay
+     16-bit sharp.
   - Identity fast-path: empty `spots` or all-zero mask → return `img16` unchanged.
   - Returns a new `uint16` RGB array; `img16` is never mutated (non-destructive).
   - Residual preview↔export differences are grain/resampling plus a ≤1 px rim

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -349,11 +349,14 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      to the old 8-bit `cv2.inpaint(..., inpaint_radius, INPAINT_TELEA)` fill.
   6. **Feathered composite**: alpha rises 0 → 1 from each hole's boundary
      inward over a smoothstep ramp (`_feather_alpha`), `out = img16*(1-a) +
-     filled*a` computed inside the mask's bbox only. The ramp width is the
-     image's **Feather** setting (`dust_feather`, a fraction of image width —
-     default 0.3%, so it covers the same image fraction at preview and
-     export), capped per hole by its depth so the core still reaches full
-     fill. **Defect-like hole pixels** (colored like the estimated defect)
+     filled*a` computed inside each **component's own padded window** (one
+     global mask bbox degenerates to nearly the whole frame when spots are
+     scattered, and the full-frame float blend then dominates the heal —
+     ~0.9 s at 6000 px; components never touch, so per-component alpha is
+     exactly the global answer). The ramp width is the image's **Feather**
+     setting (`dust_feather`, a fraction of image width — default 0.3%, so
+     it covers the same image fraction at preview and export), capped per
+     hole by its depth so the core still reaches full fill. **Defect-like hole pixels** (colored like the estimated defect)
      are force-filled at alpha 1 regardless of the ramp (`dlike`, with a
      light blurred lip), so a wide feather can never blend the defect back
      in — the soft fade only happens across clean rim pixels. Outside the
@@ -391,7 +394,12 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
   - Cost: per-component window work only (no full-frame 8-bit convert unless a
     fallback fires). Planning searches at 1080 px and native execution only
     validates + clones, so a full-res export heals FASTER than the old
-    native-resolution search (+ one INTER_AREA downscale of the frame).
+    native-resolution search. Every heal logs its step timing
+    (`Dust heal WxH: setup …, N segments …, telea …, composite …` plus a
+    `Dust heal total` line with the plan provenance) — measured at
+    6000×4000 / 40 spots: preview 0.08 s; export 0.65 s with the cached
+    preview plan (was 1.79 s before the plan replay + per-component
+    composite).
 
 ### 5.3 AI detection (`src/core/dust_detect.py`)
 A self-contained module wrapping the ONNX BOPBTL detector. **`onnxruntime` is

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -73,15 +73,16 @@ in the catalog, and undoable.
 - **Entering** dust mode (`ImagePreview.enter_dust_mode()`):
   1. Exit any other canvas mode (crop / slice / area / bw-point / wb-pick).
   2. Set `self.dust_mode = True`; reset zoom to fit and `_release_hires`.
-  3. `update_preview(idx)` now shows the **full, un-cropped** working positive
-     with **coarse rotation/flip only** (no fine rotation, no displayed crop) —
-     mirroring crop mode — so canvas pixels map 1:1 to `resized_raw` (§5.5).
+  3. `update_preview(idx)` keeps the **normal display framing** — the confirmed
+     crop (when one is set) with **coarse rotation/flip only** (no fine
+     rotation) — so the brush works on exactly the frame the user keeps;
+     strokes are mapped back to full-frame coords (§5.5).
   4. Set a brush-circle cursor and draw the red mask overlay for the image's
      stored spots.
   5. Call `self.window().toggle_dust_removal(True)` so `MainWindow` swaps panels.
 - **Exiting** dust mode (the **Done** button, the toggled-off toolbar action, or
   `Esc`): hide the red mask overlay, clear `dust_mode`, restore the normal
-  (cropped, fine-rotated) preview, restore the sliders panel, and re-enable the
+  (fine-rotated) preview, restore the sliders panel, and re-enable the
   toolbar actions. **Previously applied dust edits remain on the image.**
 
 ### 3.2 DustRemovalPanel layout (top → bottom)
@@ -140,8 +141,9 @@ reference to `MainWindow` and `ImagePreview` passed at construction (it does
     only the brush moves to Ctrl + wheel.)
   - **Hi-res detail loads on entry** (and refines on zoom) so dust is visible at
     full sharpness. The hi-res render reproduces `resized_raw`'s orientation and
-    goes through `apply_adjustments` (so it shows the dust-removed result); the
-    dust-mode display stays full / un-fine-rotated, so spots stay aligned.
+    goes through `apply_adjustments` (so it shows the dust-removed result); its
+    display layer is crop-matched exactly like the preview, so spots stay
+    aligned.
   - A **brush-circle cursor** tracks the pointer; its on-screen radius is
     `r_norm * W * view_scale` display pixels (§5.5).
 - Coordinate mapping reuses the existing inverse-`base_transform` +
@@ -418,22 +420,26 @@ manual brush (a stroke = many dabs) is the tool for those. Keeps the stored mode
 uniform and resolution-independent. (Future: component polygons / multi-circle.)
 
 ### 5.5 Coordinate mapping (canvas → normalized spot)
-Dust mode shows the working positive with **coarse rotation/flip only** — no
-displayed crop (the `not self.dust_mode` guard is added to update_preview's
-crop-display branch, image_preview.py:951) and no fine rotation (mirroring crop
-mode's `apply_transformations`). Therefore canvas pixels map **exactly** to
-`resized_raw` pixels via:
+Dust mode shows the working positive with the **normal display framing** — the
+confirmed crop (when one is set) with **coarse rotation/flip only**, no fine
+rotation (mirroring crop mode's `apply_transformations`). Spots are stored
+normalized against the **full un-cropped frame** — they are healed in
+`apply_adjustments` **before** crop and fine rotation (§5.1) — so canvas points
+map back via:
 1. `scene = view.mapToScene(event.pos())` (auto-accounts for zoom/pan).
 2. Invert the display `base_transform` (coarse 90°/180°/270° + H/V flips) → local
-   pixmap coords.
-3. `map_displayed_to_full(x, y)` — **identity** in dust mode (no crop shown).
+   (possibly cropped) pixmap coords.
+3. `map_displayed_to_full(x, y)` — identity with no crop displayed; under a
+   confirmed crop it applies `_crop_display_transform` (a translation, plus a
+   rotation for an angled crop) into full-frame pixel coords.
 4. Normalize: `H, W = resized_raw.shape[:2]`; `x_n = px/W`, `y_n = py/H`,
    `r_n = r_px/W`.
 
-Because spots are applied in `apply_adjustments` **before** crop and fine rotation
-(§5.1), and dust mode shows the image **without** those, mapping is exact — no
-sub-pixel fine-rotation error. The on-canvas brush radius is `r_n*W*view_scale`
-display pixels.
+No fine rotation is displayed, and the crop extraction is isometric
+(translate/rotate only) so lengths are preserved: the on-canvas brush radius is
+`r_n*W*view_scale` display pixels with `W` the **full-frame** width, and the
+live stroke overlay maps its stored full-frame points back through the inverse
+crop transform for drawing (`_draw_dust_stroke`).
 
 ## 6. Integration points
 
@@ -443,7 +449,7 @@ display pixels.
 | `src/core/ccr_processor.py` | `rasterize_dust_mask`, `apply_dust_removal`, feathered-composite helper. |
 | `src/core/dust_detect.py` (new) | ONNX detector: availability, model path/download/verify, `detect`, `prob_to_spots`, constants. `onnxruntime` imported only inside functions. |
 | `src/core/catalog.py` | Serialize/restore `dust_spots`; add `not state.get("dust_spots")` to `_is_pristine`. |
-| `src/widgets/image_preview.py` | Toolbar **Dust Removal** checkable action (after Gradient, with separator) + gating in `_update_unconvert_action_state`; `dust_mode` flag; `enter_dust_mode`/`exit_dust_mode`; canvas press/move/release + brush cursor + red mask overlay; `_scene_to_norm_spot()`; `and not self.dust_mode` in the crop-display branch + clear_preview/Esc routing; `dust_sig` in `_current_adj_sig`. |
+| `src/widgets/image_preview.py` | Toolbar **Dust Removal** checkable action (after Gradient, with separator) + gating in `_update_unconvert_action_state`; `dust_mode` flag; `enter_dust_mode`/`exit_dust_mode`; canvas press/move/release + brush cursor + red mask overlay; crop-aware stroke mapping (`_dust_scene_to_norm` via `map_displayed_to_full`, normalized by the full frame) + clear_preview/Esc routing; `dust_sig` in `_current_adj_sig`. |
 | `src/widgets/dust_panel.py` (new) | `DustRemovalPanel(QWidget)` (manual + AI sections, Done); QThread workers for model download and detection; explicit MainWindow/ImagePreview refs. |
 | `src/ui/main_window.py` | Add `dust_panel` as a **direct child** of `central_widget`'s layout (fixed 300 px, hidden); `toggle_dust_removal(on)` toggles `sliders_panel`/`dust_panel` visibility (no `QStackedWidget` — preserves `SlidersPanel`'s `parent().parent()` chains) and drives canvas enter/exit + toolbar action state. |
 | `requirements.txt` | Add `onnxruntime` (CPU). Manual path needs nothing new (`cv2`, `requests` already present). |
@@ -533,9 +539,10 @@ The lazy in-function import still means a build *without* onnxruntime runs fine
 3. **Esc / exit** routes through `_on_escape_key` (`elif self.dust_mode:
    self.exit_dust_mode()`) and `clear_preview` also exits dust mode, alongside
    the existing crop/slice/area handling.
-4. **Exact rendering in dust mode**: full image, coarse rotation/flip only, no
-   crop, no fine rotation → exact 1:1 canvas↔`resized_raw` mapping (§5.5). This
-   removes the fine-rotation sub-pixel error entirely.
+4. **Exact rendering in dust mode**: the normal display framing (incl. the
+   confirmed crop), coarse rotation/flip only, no fine rotation → exact
+   canvas↔`resized_raw` mapping through the isometric crop transform (§5.5).
+   This removes the fine-rotation sub-pixel error entirely.
 5. **Single-funnel verified** against the real export paths (§5.1 line refs); a
    single insertion at the top of `apply_adjustments` covers preview, zoom, and
    all export modes.

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -359,13 +359,30 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      in — the soft fade only happens across clean rim pixels. Outside the
      mask alpha is exactly 0 — away from any spot `out == img16`
      bit-for-bit.
+  7. **Resolution-stable plan**: the heal's content-adaptive decisions —
+     stroke segmentation, each segment's chosen source offset, and the
+     diffusion-fallback verdicts — are computed ONCE at the canonical
+     preview scale (`_DUST_PLAN_LONG` = 1080 long side) and REPLAYED on
+     larger buffers with all pixel geometry scaled (segment size, Telea
+     radius, offsets normalized over width/height; segments matched by
+     nearest normalized centroid). Re-deriving the plan per resolution let
+     the SSD argmin flip between scales, so the export healed from visibly
+     different patches than the preview the user approved ("the preview and
+     the final don't look the same"). Buffers at or below the canonical
+     scale (the preview itself, thumbnails, the detect source) plan on
+     themselves — their behavior is unchanged. A replayed offset that no
+     longer lands on a clean window (mask-raster rounding — rare) falls back
+     to the local search for that segment; the tone membrane and feather
+     composite always run natively, so fills stay 16-bit sharp.
   - Identity fast-path: empty `spots` or all-zero mask → return `img16` unchanged.
   - Returns a new `uint16` RGB array; `img16` is never mutated (non-destructive).
-  - The chosen source patch may differ between preview and export resolution
-    (scoring at different scales); both are plausible clean fills, and tone is
-    anchored to the same ring either way.
+  - Residual preview↔export differences are grain/resampling plus a ≤1 px rim
+    registration from mask rounding at hard edges — the healed structure is
+    identical (regression-tested in `TestResolutionConsistency`).
   - Cost: per-component window work only (no full-frame 8-bit convert unless a
-    fallback fires); ≤ the old Telea path even at export res with 100 spots.
+    fallback fires). Planning searches at 1080 px and native execution only
+    validates + clones, so a full-res export heals FASTER than the old
+    native-resolution search (+ one INTER_AREA downscale of the frame).
 
 ### 5.3 AI detection (`src/core/dust_detect.py`)
 A self-contained module wrapping the ONNX BOPBTL detector. **`onnxruntime` is

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -15,6 +15,7 @@ from core.ccr_processor import (adjust_image, adjust_image_opencl,
                                 apply_gamma_curve, apply_cineon_to_rec709,
                                 apply_area_layers, apply_crop_to_image,
                                 apply_dust_removal, DUST_FEATHER_DEFAULT,
+                                _DUST_PLAN_LONG,
                                 _apply_working_space_recovery,
                                 compute_auto_gain_offset)
 from core import color_management
@@ -194,6 +195,10 @@ class CCRImage:
         # (user-set via the dust panel's Feather slider; render parameter,
         # deliberately NOT in undo snapshots — like brush size).
         self.dust_feather: float = DUST_FEATHER_DEFAULT
+        # (spots_key, plan) captured from the last PREVIEW-scale heal, replayed
+        # by hi-res/export renders so they sample exactly the patches shown on
+        # screen. Session cache only — rebuilt by the next preview render.
+        self._dust_plan_cache = None
         # Which layer the adjustment panel currently edits: None = global
         # (whole image); otherwise the id of an area in area_layers. Session
         # state only — never persisted; always defaults to global on load.
@@ -917,14 +922,29 @@ class CCRImage:
     def _apply_dust_removal(self, image: np.ndarray) -> np.ndarray:
         """Inpaint stored dust spots out of the working image (no-op when there
         are none). Spots are normalized, so this scales to whatever resolution
-        is being processed — preview, hi-res zoom, or full-res export. See
-        spec/dust-removal.md."""
+        is being processed — preview, hi-res zoom, or full-res export.
+
+        WYSIWYG plan sharing: a preview-scale heal caches its plan (segments +
+        chosen source patches) keyed by the spots' content; hi-res and export
+        renders replay THAT plan, so they sample exactly the patches the user
+        approved on screen — a fresh plan from the export's own re-decoded
+        pixels can flip near-tie source choices. Feather is excluded from the
+        key (it shapes the blend, not the plan). See spec/dust-removal.md."""
         spots = getattr(self, "dust_spots", None)
         if not spots:
             return image
-        return apply_dust_removal(
-            image, spots,
-            feather=getattr(self, "dust_feather", DUST_FEATHER_DEFAULT))
+        feather = getattr(self, "dust_feather", DUST_FEATHER_DEFAULT)
+        key = repr(spots)
+        h, w = image.shape[:2]
+        if max(h, w) <= _DUST_PLAN_LONG:
+            plan_out = []
+            out = apply_dust_removal(image, spots, feather=feather,
+                                     collect_plan=plan_out)
+            self._dust_plan_cache = (key, plan_out)
+            return out
+        cached = getattr(self, "_dust_plan_cache", None)
+        plan = cached[1] if (cached is not None and cached[0] == key) else None
+        return apply_dust_removal(image, spots, feather=feather, plan=plan)
 
     def apply_adjustments(self, image: np.ndarray, settings=None, contrast_base=None,
                           temperature_base=None, brightness_base=None,

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -933,6 +933,7 @@ class CCRImage:
         spots = getattr(self, "dust_spots", None)
         if not spots:
             return image
+        t0 = time.time()
         feather = getattr(self, "dust_feather", DUST_FEATHER_DEFAULT)
         key = repr(spots)
         h, w = image.shape[:2]
@@ -941,10 +942,16 @@ class CCRImage:
             out = apply_dust_removal(image, spots, feather=feather,
                                      collect_plan=plan_out)
             self._dust_plan_cache = (key, plan_out)
+            print(f"Dust heal total ({len(spots)} spots, preview scale, "
+                  f"plan cached): {time.time() - t0:.3f}s")
             return out
         cached = getattr(self, "_dust_plan_cache", None)
         plan = cached[1] if (cached is not None and cached[0] == key) else None
-        return apply_dust_removal(image, spots, feather=feather, plan=plan)
+        out = apply_dust_removal(image, spots, feather=feather, plan=plan)
+        print(f"Dust heal total ({len(spots)} spots, "
+              f"preview plan {'reused' if plan is not None else 'MISSING'}): "
+              f"{time.time() - t0:.3f}s")
+        return out
 
     def apply_adjustments(self, image: np.ndarray, settings=None, contrast_base=None,
                           temperature_base=None, brightness_base=None,

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3263,7 +3263,7 @@ def _feather_alpha(mask: np.ndarray, fmap: np.ndarray) -> np.ndarray:
 def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
                 filled: np.ndarray, fmap: np.ndarray, feather_px: int,
-                dlike: np.ndarray) -> bool:
+                dlike: np.ndarray, src_off=None):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
 
@@ -3274,9 +3274,14 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     so gradients continue through the patch while its grain is kept verbatim).
     `bbox` = (bx0, by0, bx1, by1) tight bounds of THIS patch's hole pixels;
     `half_th` = the component's half-thickness (max distance transform), its
-    local scale. Writes the healed hole pixels into `filled` and returns True,
-    or returns False when no fully clean, in-bounds source window exists
-    (caller falls back to diffusion inpaint for this patch).
+    local scale. Writes the healed hole pixels into `filled` and returns the
+    chosen source-window offset `(dy, dx)` (relative to the match window, in
+    this buffer's pixels), or None when no fully clean, in-bounds source
+    window exists (caller falls back to diffusion inpaint for this patch).
+    `src_off`: a pre-planned offset to REUSE (the resolution-stable replay,
+    see apply_dust_removal); taken verbatim when it still lands on a clean
+    in-bounds window, otherwise the normal search runs (plan drift from
+    mask-raster rounding — rare).
 
     Everything local is keyed off the thickness, never the bbox: a traced
     hair's bbox can span half the frame while the stroke is a few px wide.
@@ -3313,7 +3318,7 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     ring = ((away > guard) & (away <= pad)
             & (mask_pad[wy0:wy1, wx0:wx1] == 0))
     if int(ring.sum()) < _HEAL_MIN_RING_PX:
-        return False  # boxed in by other spots — no context to match against
+        return None  # boxed in by other spots — no context to match against
 
     dst = img16[wy0:wy1, wx0:wx1].astype(np.float32)
 
@@ -3341,38 +3346,52 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     thr = 0.5 * float(np.percentile(d_def, 95.0))
     keep = d_def >= thr
     if int(keep.sum()) < _HEAL_MIN_RING_PX:
-        return False
+        return None
     ring[:] = False
     ring[ry[keep], rx[keep]] = True
     dst_ring = dst[ring]
 
-    # Candidate source offsets: rings of directions at thickness-scaled
-    # distances. The integral-image check rejects any source that touches
-    # dust, so offsets need only clear the local thickness — a long stroke
-    # heals from the clean strip right beside it (requiring bbox-diagonal
-    # clearance forced long strokes into the ghost-prone diffusion fallback).
-    # The window diagonal stays as a last-resort ring for compact spots.
-    d_base = 2.0 * half_th + pad + 2.0
-    d0 = float(np.hypot(wy1 - wy0, wx1 - wx0))
-    best_score, best_src = None, None
-    for fi, d in enumerate((d_base, 2.0 * d_base, 4.0 * d_base, d0)):
-        for k in range(_HEAL_ANGLES):
-            ang = 2.0 * np.pi * (k + 0.35 * fi) / _HEAL_ANGLES
-            dy = int(round(d * np.sin(ang)))
-            dx = int(round(d * np.cos(ang)))
-            sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
-            if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
-                continue
-            if _box_sum(integ, sy0, sx0, sy1, sx1) != 0:
-                continue  # source window touches dust (this or another spot)
-            src = img16[sy0:sy1, sx0:sx1].astype(np.float32)
-            diff = src[ring] - dst_ring
-            score = float(np.mean(diff * diff))
-            if best_score is None or score < best_score:
-                best_score, best_src = score, src
+    def _source_at(dy, dx):
+        sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
+        if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
+            return None
+        if _box_sum(integ, sy0, sx0, sy1, sx1) != 0:
+            return None  # source window touches dust (this or another spot)
+        return img16[sy0:sy1, sx0:sx1].astype(np.float32)
+
+    best_score, best_src, best_off = None, None, None
+    if src_off is not None:
+        # Resolution-stable replay: reuse the offset the plan chose at the
+        # canonical scale instead of re-searching on this buffer's pixels.
+        src = _source_at(int(src_off[0]), int(src_off[1]))
+        if src is not None:
+            best_src = src
+            best_off = (int(src_off[0]), int(src_off[1]))
+    if best_src is None:
+        # Candidate source offsets: rings of directions at thickness-scaled
+        # distances. The integral-image check rejects any source that touches
+        # dust, so offsets need only clear the local thickness — a long stroke
+        # heals from the clean strip right beside it (requiring bbox-diagonal
+        # clearance forced long strokes into the ghost-prone diffusion
+        # fallback). The window diagonal stays as a last-resort ring for
+        # compact spots.
+        d_base = 2.0 * half_th + pad + 2.0
+        d0 = float(np.hypot(wy1 - wy0, wx1 - wx0))
+        for fi, d in enumerate((d_base, 2.0 * d_base, 4.0 * d_base, d0)):
+            for k in range(_HEAL_ANGLES):
+                ang = 2.0 * np.pi * (k + 0.35 * fi) / _HEAL_ANGLES
+                dy = int(round(d * np.sin(ang)))
+                dx = int(round(d * np.cos(ang)))
+                src = _source_at(dy, dx)
+                if src is None:
+                    continue
+                diff = src[ring] - dst_ring
+                score = float(np.mean(diff * diff))
+                if best_score is None or score < best_score:
+                    best_score, best_src, best_off = score, src, (dy, dx)
 
     if best_src is None:
-        return False
+        return None
 
     # Smooth per-channel tone correction from the ring differences: normalized
     # Gaussian convolution interpolates (dst - src) on the ring into the hole,
@@ -3405,7 +3424,26 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     if like.any():
         hy, hx = np.nonzero(hole)
         dlike[wy0:wy1, wx0:wx1][hy[like], hx[like]] = 255
-    return True
+    return best_off
+
+
+# Canonical planning scale for the heal = the preview's long side. Buffers at
+# or below it (preview, thumbnails) plan on themselves; larger buffers (hi-res
+# zoom, export) REPLAY the plan computed at this scale so they reproduce the
+# preview's healing structure. See apply_dust_removal.
+_DUST_PLAN_LONG = 1080
+
+
+def _nearest_plan_record(plan, cyn, cxn, tol=0.06):
+    """The plan record whose segment centroid is nearest to (cyn, cxn) in
+    normalized coords, or None when nothing lies within `tol` (a component
+    that only rasterizes at the finer scale — sub-pixel at plan resolution)."""
+    best, best_d = None, tol
+    for rec in plan:
+        d = ((rec[0] - cyn) ** 2 + (rec[1] - cxn) ** 2) ** 0.5
+        if d < best_d:
+            best, best_d = rec, d
+    return best
 
 
 def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
@@ -3432,7 +3470,43 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     masked pixels change, the rest of the frame is bit-for-bit untouched.
     Returns a NEW uint16 array; img16 is never mutated. No-op (returns img16
     unchanged) when there are no spots or the rasterized mask is empty.
+
+    Resolution consistency: the heal PLAN — stroke segmentation, each
+    segment's chosen source window, and the diffusion-fallback decisions —
+    is content-adaptive, so re-deriving it independently per resolution
+    picked visibly different fills at the 1080px preview vs the full-res
+    export ("the preview and the final don't look the same"). Buffers larger
+    than the canonical scale therefore plan on an INTER_AREA downscale at
+    _DUST_PLAN_LONG (matching the preview) and replay that plan with all
+    geometry scaled: same segments, same source patches, same fallbacks —
+    the export heals with the same structure the user approved on screen.
     """
+    if not spots:
+        return img16
+    h, w = img16.shape[:2]
+    long_side = max(h, w)
+    if long_side <= _DUST_PLAN_LONG:
+        return _heal_impl(img16, spots, inpaint_radius, feather)
+    scale = long_side / float(_DUST_PLAN_LONG)
+    pw = max(2, int(round(w / scale)))
+    ph = max(2, int(round(h / scale)))
+    small = cv2.resize(img16, (pw, ph), interpolation=cv2.INTER_AREA)
+    plan = []
+    _heal_impl(small, spots, inpaint_radius, feather, collect=plan)
+    return _heal_impl(img16, spots, inpaint_radius, feather,
+                      plan=plan, scale_up=scale)
+
+
+def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
+               feather: float, plan=None, collect=None,
+               scale_up: float = 1.0) -> np.ndarray:
+    """apply_dust_removal's engine at ONE resolution. With `collect` (a list),
+    appends a plan record per heal segment: (cy_norm, cx_norm, offset) where
+    offset is the chosen source displacement normalized over (h, w), or None
+    for a diffusion fallback. With `plan` (+ `scale_up` = this buffer's size
+    over the plan scale), segments reuse the planned offsets/fallbacks
+    instead of re-searching, and the pixel-based geometry (segment size,
+    Telea radius) scales by `scale_up` so segmentation matches the plan's."""
     if not spots:
         return img16
     h, w = img16.shape[:2]
@@ -3453,6 +3527,11 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     feather_px = max(1, int(round(float(feather) * w)))
     fmap = np.ones((h, w), np.uint8)
     dlike = np.zeros((h, w), np.uint8)
+    # Pixel-based knobs scale with the buffer (relative to the plan scale) so
+    # a stroke splits into the SAME segments here as it did in the plan, and
+    # the diffusion fallback blurs over the same image fraction.
+    seg_min = max(8, int(round(_HEAL_SEG_MIN * max(1.0, scale_up))))
+    telea_r = max(1, int(round(inpaint_radius * max(1.0, scale_up))))
     for i in range(1, n):  # 0 is background
         x0 = int(stats[i, cv2.CC_STAT_LEFT])
         y0 = int(stats[i, cv2.CC_STAT_TOP])
@@ -3464,7 +3543,7 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
         hole0 = np.zeros((ch + 2, cw + 2), np.uint8)
         hole0[1:-1, 1:-1] = comp_win
         half_th = float(cv2.distanceTransform(hole0, cv2.DIST_L2, 3).max())
-        seg = max(_HEAL_SEG_MIN, int(round(_HEAL_SEG_THICKNESS * half_th)))
+        seg = max(seg_min, int(round(_HEAL_SEG_THICKNESS * half_th)))
         for ty in range(y0, y0 + ch, seg):
             for tx in range(x0, x0 + cw, seg):
                 sub = comp_win[ty - y0:ty - y0 + seg, tx - x0:tx - x0 + seg]
@@ -3473,8 +3552,26 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
                 ys, xs = np.nonzero(sub)
                 bbox = (tx + int(xs.min()), ty + int(ys.min()),
                         tx + int(xs.max()) + 1, ty + int(ys.max()) + 1)
-                if not _heal_patch(img16, labels, i, bbox, half_th, mask_pad,
-                                   integ, filled, fmap, feather_px, dlike):
+                cyn = (ty + float(ys.mean())) / h
+                cxn = (tx + float(xs.mean())) / w
+                src_off, forced_fb = None, False
+                if plan is not None:
+                    rec = _nearest_plan_record(plan, cyn, cxn)
+                    if rec is not None:
+                        if rec[2] is None:
+                            forced_fb = True  # the plan chose diffusion here
+                        else:
+                            src_off = (int(round(rec[2][0] * h)),
+                                       int(round(rec[2][1] * w)))
+                off = None
+                if not forced_fb:
+                    off = _heal_patch(img16, labels, i, bbox, half_th,
+                                      mask_pad, integ, filled, fmap,
+                                      feather_px, dlike, src_off=src_off)
+                if collect is not None:
+                    collect.append((cyn, cxn, None if off is None
+                                    else (off[0] / h, off[1] / w)))
+                if off is None:
                     fallback[ty:ty + sub.shape[0],
                              tx:tx + sub.shape[1]][sub] = 255
                     # No defect estimate on this path — cap the fade by the
@@ -3486,7 +3583,7 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
         # Diffusion fallback (cv2.inpaint supports 8-bit only).
         bgr8 = cv2.cvtColor(cv2.convertScaleAbs(img16, alpha=255.0 / 65535.0),
                             cv2.COLOR_RGB2BGR)
-        telea8 = cv2.inpaint(bgr8, fallback, inpaint_radius, cv2.INPAINT_TELEA)
+        telea8 = cv2.inpaint(bgr8, fallback, telea_r, cv2.INPAINT_TELEA)
         telea16 = cv2.cvtColor(telea8, cv2.COLOR_BGR2RGB).astype(np.uint16) * 257
         fb = fallback > 0
         filled[fb] = telea16[fb]

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3513,27 +3513,35 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
                           collect=collect_plan)
     scale = long_side / float(_DUST_PLAN_LONG)
     if plan is None:
+        # No preview plan supplied — derive one from this buffer's own
+        # downscale (plan-only: the healed small buffer would be discarded).
+        t0 = time.time()
         pw = max(2, int(round(w / scale)))
         ph = max(2, int(round(h / scale)))
         small = cv2.resize(img16, (pw, ph), interpolation=cv2.INTER_AREA)
         plan = []
-        _heal_impl(small, spots, inpaint_radius, feather, collect=plan)
+        _heal_impl(small, spots, inpaint_radius, feather, collect=plan,
+                   plan_only=True)
+        print(f"Dust plan (no cached preview plan): {time.time() - t0:.3f}s")
     return _heal_impl(img16, spots, inpaint_radius, feather,
                       plan=plan, scale_up=scale)
 
 
 def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                feather: float, plan=None, collect=None,
-               scale_up: float = 1.0) -> np.ndarray:
+               scale_up: float = 1.0, plan_only: bool = False) -> np.ndarray:
     """apply_dust_removal's engine at ONE resolution. With `collect` (a list),
     appends a plan record per heal segment: (cy_norm, cx_norm, offset) where
     offset is the chosen source displacement normalized over (h, w), or None
     for a diffusion fallback. With `plan` (+ `scale_up` = this buffer's size
     over the plan scale), segments reuse the planned offsets/fallbacks
     instead of re-searching, and the pixel-based geometry (segment size,
-    Telea radius) scales by `scale_up` so segmentation matches the plan's."""
+    Telea radius) scales by `scale_up` so segmentation matches the plan's.
+    `plan_only` skips the Telea fill and the feathered composite (the caller
+    only wants the collected plan, not the healed buffer) and returns img16."""
     if not spots:
         return img16
+    t0 = time.time()
     h, w = img16.shape[:2]
     mask = rasterize_dust_mask(spots, h, w)
     if not mask.any():
@@ -3557,6 +3565,9 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     # the diffusion fallback blurs over the same image fraction.
     seg_min = max(8, int(round(_HEAL_SEG_MIN * max(1.0, scale_up))))
     telea_r = max(1, int(round(inpaint_radius * max(1.0, scale_up))))
+    t_setup = time.time() - t0
+    t0 = time.time()
+    n_segs = 0
     for i in range(1, n):  # 0 is background
         x0 = int(stats[i, cv2.CC_STAT_LEFT])
         y0 = int(stats[i, cv2.CC_STAT_TOP])
@@ -3574,6 +3585,7 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                 sub = comp_win[ty - y0:ty - y0 + seg, tx - x0:tx - x0 + seg]
                 if not sub.any():
                     continue
+                n_segs += 1
                 ys, xs = np.nonzero(sub)
                 bbox = (tx + int(xs.min()), ty + int(ys.min()),
                         tx + int(xs.max()) + 1, ty + int(ys.max()) + 1)
@@ -3604,6 +3616,17 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                     fmap[ty:ty + sub.shape[0], tx:tx + sub.shape[1]][sub] = \
                         max(1, min(feather_px, int(round(0.5 * half_th))))
 
+    t_segs = time.time() - t0
+    mode = (" [plan-only]" if plan_only
+            else (" [replay]" if plan is not None else ""))
+    if plan_only:
+        # The caller only wants the collected plan — the fill/composite work
+        # below would be thrown away with the buffer.
+        print(f"Dust heal {w}x{h}: setup {t_setup:.3f}s, "
+              f"{n_segs} segments {t_segs:.3f}s{mode}")
+        return img16
+
+    t0 = time.time()
     if fallback.any():
         # Diffusion fallback (cv2.inpaint supports 8-bit only).
         bgr8 = cv2.cvtColor(cv2.convertScaleAbs(img16, alpha=255.0 / 65535.0),
@@ -3612,28 +3635,47 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         telea16 = cv2.cvtColor(telea8, cv2.COLOR_BGR2RGB).astype(np.uint16) * 257
         fb = fallback > 0
         filled[fb] = telea16[fb]
+    t_telea = time.time() - t0
 
     # Feathered composite: alpha rises 0 -> 1 from each hole's boundary inward
     # over its feather ramp (resolution-scaled, capped by the hole's
     # defect-free rim), so the fill cross-fades into the original instead of
     # cutting hard at the mask edge. OUTSIDE the mask alpha is exactly 0 —
-    # those pixels are kept bit-for-bit. The float blend only runs inside the
-    # mask's bounding box (padded 1 px so the cropped distance transform still
-    # sees the zeros surrounding boundary pixels).
-    bx, by, bwd, bhd = cv2.boundingRect(mask)
-    ys = slice(max(0, by - 1), min(h, by + bhd + 1))
-    xs = slice(max(0, bx - 1), min(w, bx + bwd + 1))
-    a = _feather_alpha(mask[ys, xs], fmap[ys, xs])
-    # Defect-like pixels get the fill at full strength whatever the feather;
-    # the max with a light blur adds a soft lip around the forced region
-    # without weakening its interior.
-    dl = dlike[ys, xs]
-    forced = np.maximum(dl, cv2.blur(dl, (3, 3))).astype(np.float32) / 255.0
-    a = np.maximum(a, forced)[..., None]
+    # those pixels are kept bit-for-bit. The float blend runs per COMPONENT
+    # window (padded 2 px): one global mask bbox degenerates to nearly the
+    # whole frame when spots are scattered, and the full-frame float blend
+    # then dominates the heal (~0.9 s at 6000 px for 40 spots). Components
+    # never touch (8-connectivity merges adjacent pixels), so each one's
+    # alpha computed from its own labels is exactly the global answer.
+    t0 = time.time()
     out = img16.copy()
-    blend = (img16[ys, xs].astype(np.float32) * (1.0 - a)
-             + filled[ys, xs].astype(np.float32) * a)
-    out[ys, xs] = np.clip(np.rint(blend), 0, 65535).astype(np.uint16)
+    for i in range(1, n):
+        bx0 = int(stats[i, cv2.CC_STAT_LEFT])
+        by0 = int(stats[i, cv2.CC_STAT_TOP])
+        bw_ = int(stats[i, cv2.CC_STAT_WIDTH])
+        bh_ = int(stats[i, cv2.CC_STAT_HEIGHT])
+        ys = slice(max(0, by0 - 2), min(h, by0 + bh_ + 2))
+        xs = slice(max(0, bx0 - 2), min(w, bx0 + bw_ + 2))
+        comp = labels[ys, xs] == i
+        a = _feather_alpha(comp.astype(np.uint8) * 255, fmap[ys, xs])
+        # Defect-like pixels get the fill at full strength whatever the
+        # feather; the max with a light blur adds a soft lip around the
+        # forced region without weakening its interior. (The lip's 1 px
+        # leak past the hole blends filled==img16 — a no-op.)
+        dl = np.where(comp, dlike[ys, xs], 0)
+        forced = np.maximum(dl, cv2.blur(dl, (3, 3))).astype(np.float32) / 255.0
+        a = np.maximum(a, forced)
+        write = a > 0.0
+        if not write.any():
+            continue
+        a3 = a[..., None]
+        blend = (img16[ys, xs].astype(np.float32) * (1.0 - a3)
+                 + filled[ys, xs].astype(np.float32) * a3)
+        out[ys, xs][write] = np.clip(
+            np.rint(blend[write]), 0, 65535).astype(np.uint16)
+    print(f"Dust heal {w}x{h}: setup {t_setup:.3f}s, "
+          f"{n_segs} segments {t_segs:.3f}s, telea {t_telea:.3f}s, "
+          f"composite {time.time() - t0:.3f}s{mode}")
     return out
 
 

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3363,10 +3363,25 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     if src_off is not None:
         # Resolution-stable replay: reuse the offset the plan chose at the
         # canonical scale instead of re-searching on this buffer's pixels.
-        src = _source_at(int(src_off[0]), int(src_off[1]))
-        if src is not None:
-            best_src = src
-            best_off = (int(src_off[0]), int(src_off[1]))
+        # If scaling rounded the offset onto dust or out of bounds, rescue
+        # with the nearest clean offset (Chebyshev spiral, <= 4 px) — still
+        # essentially the SAME source patch. Only when that fails too does
+        # the local search run below (it may pick a visibly different patch,
+        # so it is the last resort).
+        base_dy, base_dx = int(src_off[0]), int(src_off[1])
+        for rad in range(0, 5):
+            ring_offs = [(jy, jx)
+                         for jy in range(-rad, rad + 1)
+                         for jx in range(-rad, rad + 1)
+                         if max(abs(jy), abs(jx)) == rad]
+            for jy, jx in ring_offs:
+                src = _source_at(base_dy + jy, base_dx + jx)
+                if src is not None:
+                    best_src = src
+                    best_off = (base_dy + jy, base_dx + jx)
+                    break
+            if best_src is not None:
+                break
     if best_src is None:
         # Candidate source offsets: rings of directions at thickness-scaled
         # distances. The integral-image check rejects any source that touches
@@ -3447,7 +3462,8 @@ def _nearest_plan_record(plan, cyn, cxn, tol=0.06):
 
 
 def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
-                       feather: float = DUST_FEATHER_DEFAULT) -> np.ndarray:
+                       feather: float = DUST_FEATHER_DEFAULT,
+                       plan=None, collect_plan=None) -> np.ndarray:
     """Heal the dust spots out of a 16-bit RGB image, non-destructively.
 
     `feather` is the edge fade width as a fraction of image width (the user's
@@ -3476,23 +3492,32 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     is content-adaptive, so re-deriving it independently per resolution
     picked visibly different fills at the 1080px preview vs the full-res
     export ("the preview and the final don't look the same"). Buffers larger
-    than the canonical scale therefore plan on an INTER_AREA downscale at
-    _DUST_PLAN_LONG (matching the preview) and replay that plan with all
-    geometry scaled: same segments, same source patches, same fallbacks —
-    the export heals with the same structure the user approved on screen.
+    than the canonical scale therefore replay a plan computed at
+    _DUST_PLAN_LONG (matching the preview) with all geometry scaled: same
+    segments, same source patches, same fallbacks — the export heals with
+    the same structure the user approved on screen.
+
+    `collect_plan` (a list): on a canonical-scale buffer, receives that
+    heal's plan records — CCRImage caches the PREVIEW render's plan this way.
+    `plan`: replay the given plan instead of self-planning on a downscale,
+    so exports/hi-res sample exactly the patches the on-screen preview did
+    (self-planning re-decodes/resizes and near-tie source choices can flip
+    on real content). Ignored on canonical-scale buffers.
     """
     if not spots:
         return img16
     h, w = img16.shape[:2]
     long_side = max(h, w)
     if long_side <= _DUST_PLAN_LONG:
-        return _heal_impl(img16, spots, inpaint_radius, feather)
+        return _heal_impl(img16, spots, inpaint_radius, feather,
+                          collect=collect_plan)
     scale = long_side / float(_DUST_PLAN_LONG)
-    pw = max(2, int(round(w / scale)))
-    ph = max(2, int(round(h / scale)))
-    small = cv2.resize(img16, (pw, ph), interpolation=cv2.INTER_AREA)
-    plan = []
-    _heal_impl(small, spots, inpaint_radius, feather, collect=plan)
+    if plan is None:
+        pw = max(2, int(round(w / scale)))
+        ph = max(2, int(round(h / scale)))
+        small = cv2.resize(img16, (pw, ph), interpolation=cv2.INTER_AREA)
+        plan = []
+        _heal_impl(small, spots, inpaint_radius, feather, collect=plan)
     return _heal_impl(img16, spots, inpaint_radius, feather,
                       plan=plan, scale_up=scale)
 

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -843,11 +843,13 @@ class ImagePreview(QWidget):
         self._slice_drag = None          # line dict being dragged, or None
         self._slice_worker = None
 
-        # Dust removal mode. Like crop, dust mode shows the FULL un-cropped
-        # image with coarse rotation/flip only (no fine rotation) so canvas
-        # pixels map 1:1 to resized_raw. Spots are stored on the image; the
-        # brush only draws a live overlay + commits on release. See
-        # spec/dust-removal.md.
+        # Dust removal mode. The canvas keeps the normal display framing (the
+        # confirmed crop, when one is set) with coarse rotation/flip only (no
+        # fine rotation). Spots are stored in FULL-frame normalized coords —
+        # the heal replays on the un-cropped buffer at every resolution — so
+        # strokes painted on a cropped display are mapped back through
+        # _crop_display_transform. The brush only draws a live overlay +
+        # commits on release. See spec/dust-removal.md.
         self.dust_mode = False
         self._dust_painting = False
         self._dust_pts = []              # current stroke, normalized [[x,y],...]
@@ -1054,6 +1056,9 @@ class ImagePreview(QWidget):
 
         # Display-level crop: show only the cropped region, except in crop
         # mode where the full image is shown so the user can adjust/regret.
+        # Dust mode keeps the cropped display (spots are painted on the frame
+        # the user actually keeps); strokes map back to full-frame coords via
+        # _crop_display_transform in _dust_scene_to_norm.
         # Skipped for un-converted images: the crop tool is disabled there,
         # and the full negative (incl. film base) is needed to draw frames.
         prev_display_transform = self._crop_display_transform
@@ -1063,7 +1068,7 @@ class ImagePreview(QWidget):
         crop_angle = getattr(ccr_backend.images[idx], "crop_angle", 0.0) or 0.0
         if (preview_img is not None and not preview_img.isNull()
                 and crop is not None and not self.crop_mode and not self.slice_mode
-                and not self.area_mode and not self.dust_mode
+                and not self.area_mode
                 and (ccr_backend.images[idx].converted or ccr_backend.positive_mode)):
             if crop_angle:
                 extracted = self._extract_rotated_crop(preview_img, crop, crop_angle)
@@ -1592,8 +1597,8 @@ class ImagePreview(QWidget):
         the fitted zoom)."""
         # Dust mode always wants the sharpest pixels for precise spotting, so
         # load hi-res detail even at the fitted view (and on zoom-in). The
-        # display path already shows the full, un-fine-rotated image in dust
-        # mode, so the hi-res lines up with the normalized dust spots.
+        # hi-res display layer is crop-matched exactly like the preview
+        # (_hires_display_pixmap), so it lines up with the dust overlay.
         if self.dust_mode:
             return True
         if self._view_scale() <= 1.05:
@@ -1828,8 +1833,13 @@ class ImagePreview(QWidget):
             return None
         crop = getattr(img, "crop_rect", None)
         angle = getattr(img, "crop_angle", 0.0) or 0.0
+        # Area mode displays the FULL un-cropped frame (its normalized mask
+        # geometry maps directly), so the hi-res layer must not swap cropped
+        # pixels in under it — same mode exclusions as update_preview's
+        # crop-display branch. Dust mode is NOT excluded: it shows the cropped
+        # preview and maps strokes back through the crop transform.
         crop_active = (crop is not None and not self.crop_mode
-                       and not self.slice_mode
+                       and not self.slice_mode and not self.area_mode
                        and (img.converted or ccr_backend.positive_mode))
         crop_sig = (crop, angle) if crop_active else None
         if cache.get("display_pm") is not None and cache.get("crop_sig") == crop_sig:
@@ -2357,12 +2367,14 @@ class ImagePreview(QWidget):
         return t if t.isInvertible() else None
 
     # --- Dust removal mode -------------------------------------------------
-    # Paint over dust to inpaint it (cv2.inpaint), or AI-detect it. Edits are
-    # stored as normalized spots on the image and replayed in the render
-    # pipeline at every resolution. See spec/dust-removal.md.
+    # Paint over dust to heal it (clone fill, see apply_dust_removal), or
+    # AI-detect it. Edits are stored as normalized spots on the image and
+    # replayed in the render pipeline at every resolution. See
+    # spec/dust-removal.md.
     def enter_dust_mode(self) -> bool:
-        """Show the full un-cropped image (coarse rotation/flip only, no fine
-        rotation) so canvas pixels map 1:1 to resized_raw, ready for painting."""
+        """Show the normal display framing (incl. any confirmed crop; coarse
+        rotation/flip only, no fine rotation), ready for painting. Strokes are
+        mapped back to full-frame coords so stored spots stay crop-independent."""
         if self.current_idx is None:
             return False
         img_obj = ccr_backend.get_image_by_index(self.current_idx)
@@ -2382,16 +2394,17 @@ class ImagePreview(QWidget):
         self._dust_pts = []
         self._zoom = 1.0
         self._release_hires(refresh=False)
-        # dust_mode is already True, so update_preview shows the full un-cropped
-        # image (its crop-display branch checks `not self.dust_mode`).
+        # Re-render with dust_mode set: the crop display (if any) is kept —
+        # only the fine rotation is suppressed (apply_transformations), so the
+        # brush works on exactly the framing the user keeps.
         self.update_preview(self.current_idx)
         self._sync_zoom_combo()
         self.view.setCursor(Qt.CrossCursor)
         return True
 
     def exit_dust_mode(self):
-        """Tear down the brush overlay and restore the normal (cropped,
-        fine-rotated) preview. Stored dust edits remain on the image."""
+        """Tear down the brush overlay and restore the normal (fine-rotated)
+        preview. Stored dust edits remain on the image."""
         if not self.dust_mode:
             return
         self.dust_mode = False
@@ -2423,9 +2436,26 @@ class ImagePreview(QWidget):
             self.dust_panel.sync_brush_size(self._dust_brush_r)
         self._update_dust_cursor(anchor_scene)
 
+    def _dust_full_frame_size(self):
+        """(w, h) of the FULL un-cropped frame dust spots are normalized
+        against — resized_raw's size when a crop display is active, else the
+        displayed pixmap's own size (the two coincide with no crop shown)."""
+        if self._crop_display_transform is None:
+            if self.current_pixmap is None:
+                return None
+            return self.current_pixmap.width(), self.current_pixmap.height()
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        raw = getattr(img, "resized_raw", None) if img is not None else None
+        if raw is None:
+            return None
+        h, w = raw.shape[:2]
+        return w, h
+
     def _dust_scene_to_norm(self, scene_pos):
-        """Scene point -> normalized (x over width, y over height) in the
-        displayed (= resized_raw, un-cropped, un-fine-rotated) pixmap."""
+        """Scene point -> normalized (x over width, y over height) in the FULL
+        un-cropped frame (= resized_raw). The displayed pixmap may be the
+        confirmed crop; map_displayed_to_full undoes it (incl. a rotated one)
+        so the stored spot replays correctly on the un-cropped buffer."""
         t = self._base_transform()
         if t is None or self.current_pixmap is None:
             return None
@@ -2433,11 +2463,11 @@ class ImagePreview(QWidget):
         if not ok:
             return None
         local = inv.map(scene_pos)
-        w = self.current_pixmap.width()
-        h = self.current_pixmap.height()
-        if w <= 0 or h <= 0:
+        fx, fy = self.map_displayed_to_full(local.x(), local.y())
+        size = self._dust_full_frame_size()
+        if size is None or size[0] <= 0 or size[1] <= 0:
             return None
-        return [local.x() / w, local.y() / h]
+        return [fx / size[0], fy / size[1]]
 
     def dust_press(self, scene_pos):
         if not self.dust_mode:
@@ -2569,7 +2599,9 @@ class ImagePreview(QWidget):
                 setattr(self, attr, None)
 
     def _draw_dust_stroke(self):
-        """Draw/refresh the live red overlay for the in-progress stroke."""
+        """Draw/refresh the live red overlay for the in-progress stroke.
+        Stroke points are full-frame normalized; map them back into the
+        displayed (possibly cropped) pixmap before the scene transform."""
         if self._dust_stroke_item is not None:
             try:
                 self.scene.removeItem(self._dust_stroke_item)
@@ -2579,18 +2611,32 @@ class ImagePreview(QWidget):
         if not self._dust_pts or self.current_pixmap is None:
             return
         t = self._base_transform()
-        if t is None:
+        size = self._dust_full_frame_size()
+        if t is None or size is None:
             return
-        w = self.current_pixmap.width()
-        h = self.current_pixmap.height()
+        w, h = size
+        to_display = None
+        if self._crop_display_transform is not None:
+            to_display, ok = self._crop_display_transform.inverted()
+            if not ok:
+                return
+
+        def scene_pt(p):
+            pt = QPointF(p[0] * w, p[1] * h)
+            if to_display is not None:
+                pt = to_display.map(pt)
+            return t.map(pt)
+
         path = QPainterPath()
-        first = t.map(QPointF(self._dust_pts[0][0] * w, self._dust_pts[0][1] * h))
+        first = scene_pt(self._dust_pts[0])
         path.moveTo(first)
         for p in self._dust_pts[1:]:
-            path.lineTo(t.map(QPointF(p[0] * w, p[1] * h)))
+            path.lineTo(scene_pt(p))
         if len(self._dust_pts) == 1:
             path.lineTo(first)  # a single dab
         item = QGraphicsPathItem(path)
+        # The crop extraction is isometric (translate/rotate only), so a
+        # brush width in full-frame pixels is the same length on the display.
         pen = QPen(QColor(255, 40, 40, 150), 2.0 * self._dust_brush_r * w,
                    Qt.SolidLine, Qt.RoundCap, Qt.RoundJoin)
         item.setPen(pen)
@@ -2608,7 +2654,12 @@ class ImagePreview(QWidget):
         if (scene_pos is None or self.current_pixmap is None
                 or not self.dust_mode or self.pixmap_item is None):
             return
-        r = self._dust_brush_r * self.current_pixmap.width()
+        # Brush radius is a fraction of the FULL frame width (what the heal
+        # uses); with a cropped display that differs from the pixmap's width.
+        size = self._dust_full_frame_size()
+        if size is None:
+            return
+        r = self._dust_brush_r * size[0]
         item = QGraphicsEllipseItem(scene_pos.x() - r, scene_pos.y() - r,
                                     2 * r, 2 * r)
         pen = QPen(QColor(255, 255, 255, 220), 1)

--- a/tests/test_crop_hires.py
+++ b/tests/test_crop_hires.py
@@ -127,6 +127,50 @@ class TestCropWantsHires:
         assert ip._crop_wants_hires() is False
 
 
+class TestHiresDisplayModeGuards:
+    """_hires_display_pixmap must match what each mode DISPLAYS. Dust mode
+    shows the cropped preview (strokes map back through the crop transform),
+    so its hi-res is crop-matched like normal display. Area mode shows the
+    full un-cropped frame (normalized mask geometry maps directly), so
+    cropped hi-res pixels under it would misregister the overlay."""
+
+    @staticmethod
+    def _inject_hires(ip, img, w=1080, h=720):
+        full_pm = QPixmap(w, h)
+        full_pm.fill(QColor(64, 64, 64))
+        ip._hires = {"img": img, "sig": ip._hires_signature(img),
+                     "adj_sig": None, "base": None, "full_pm": full_pm,
+                     "display_pm": None, "crop_sig": None}
+        return full_pm
+
+    def test_dust_mode_gets_cropped_hires(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.25, 0.25, 0.75, 0.75)))
+        self._inject_hires(ip, ccr_backend.images[0])
+        ip.dust_mode = True                 # cropped preview shown; match it
+        pm = ip._hires_display_pixmap()
+        assert pm is not None
+        assert (pm.width(), pm.height()) == (540, 360)
+
+    def test_area_mode_gets_full_frame(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.25, 0.25, 0.75, 0.75)), zoom=2.0)
+        self._inject_hires(ip, ccr_backend.images[0])
+        ip.area_mode = True                 # full image shown; hires must match
+        pm = ip._hires_display_pixmap()
+        assert pm is not None
+        assert (pm.width(), pm.height()) == (1080, 720)
+
+    def test_normal_display_gets_cropped(self):
+        ip = _make_preview()
+        _setup(ip, _ImgStub((0.25, 0.25, 0.75, 0.75)))
+        pm_full = self._inject_hires(ip, ccr_backend.images[0])
+        pm = ip._hires_display_pixmap()     # no mode active -> crop applies
+        assert pm is not None
+        assert (pm.width(), pm.height()) == (540, 360)
+        assert pm is not pm_full
+
+
 class TestZoomedInEnoughWithCrop:
     def test_heavy_crop_at_fit_is_enough(self):
         ip = _make_preview()

--- a/tests/test_dust_crop_display.py
+++ b/tests/test_dust_crop_display.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Dust mode displays the CROPPED frame (the normal display framing) and maps
+strokes back to full-frame coordinates.
+
+Spots are stored normalized against the full un-cropped frame — the heal
+replays on the un-cropped buffer before the crop at every resolution
+(preview / zoom / export) — so with a confirmed crop on screen the canvas
+mapping must go displayed → full via _crop_display_transform:
+
+- update_preview keeps the crop display in dust mode (no full-frame swap);
+- _dust_scene_to_norm returns full-frame normalized coords;
+- the live stroke overlay and brush ring map back into display space and are
+  sized by the FULL frame width (the crop extraction is isometric);
+- a committed stroke stores full-frame normalized points on the image.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import cv2  # noqa: E402
+from PySide6.QtCore import QPointF  # noqa: E402
+from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+from widgets.image_preview import ImagePreview  # noqa: E402
+
+
+def _scan_png(tmp_path, name="negative.png", w=600, h=400, seed=21):
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:h, 0:w]
+    base = 20000 + 25000 * (xx / w) + 10000 * (yy / h)
+    img = np.stack([base * 1.2, base, base * 0.7], axis=-1)
+    img += rng.normal(0, 1500, img.shape)
+    img = np.clip(img, 1000, 64000).astype(np.uint16)
+    path = str(tmp_path / name)
+    cv2.imwrite(path, cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+    return path
+
+
+class _StubPanel:
+    def set_sliders_enabled(self, *a):
+        pass
+
+    def set_current_idx(self, *a):
+        pass
+
+    def set_histogram(self, *a):
+        pass
+
+    def set_hint(self, *a, **kw):
+        pass
+
+
+class _Host(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.sliders_panel = _StubPanel()
+        self.mid = QWidget(self)
+
+
+_HOSTS = []
+
+
+def _converted_preview(tmp_path, crop_rect=(0.25, 0.25, 0.75, 0.75),
+                       crop_angle=0.0):
+    """Real CCRImage (600x400) converted through the backend, displayed in a
+    real ImagePreview via the real update_preview, with the given crop."""
+    path = _scan_png(tmp_path)
+    img = CCRImage(path)
+    img.reference_frame = (20, 20, 580, 380)
+    ccr_backend.images = [img]
+    ccr_backend.file_paths = [path]
+    ccr_backend.convert_negative_by_index(0)
+    img.crop_rect = crop_rect
+    img.crop_angle = crop_angle
+
+    host = _Host()
+    _HOSTS.append(host)  # keep alive
+    layout = QVBoxLayout(host)
+    layout.addWidget(host.mid)
+    mid_layout = QVBoxLayout(host.mid)
+    ip = ImagePreview(host.mid)
+    mid_layout.addWidget(ip)
+    ip.update_preview(0)
+    return ip, img
+
+
+class TestDustModeShowsCrop:
+    def test_dust_mode_keeps_cropped_display(self, tmp_path):
+        ip, img = _converted_preview(tmp_path)
+        assert ip.current_pixmap.width() == 300   # crop displayed before entry
+        assert ip.enter_dust_mode() is True
+        # Entering dust mode must KEEP the cropped framing, not swap to the
+        # full frame (the old behavior).
+        assert ip.dust_mode is True
+        assert (ip.current_pixmap.width(), ip.current_pixmap.height()) == (300, 200)
+        assert ip._crop_display_transform is not None
+
+    def test_no_crop_shows_full_frame(self, tmp_path):
+        ip, img = _converted_preview(tmp_path, crop_rect=None)
+        assert ip.enter_dust_mode() is True
+        assert (ip.current_pixmap.width(), ip.current_pixmap.height()) == (600, 400)
+        assert ip._crop_display_transform is None
+
+
+class TestSceneToNormThroughCrop:
+    def test_center_of_crop_maps_to_crop_center(self, tmp_path):
+        ip, img = _converted_preview(tmp_path)
+        ip.enter_dust_mode()
+        # Displayed pixmap is the (150,100)-(450,300) region of the 600x400
+        # frame; its center must normalize to the crop's full-frame center.
+        n = ip._dust_scene_to_norm(QPointF(150, 100))
+        assert n == pytest.approx([0.5, 0.5], abs=1e-6)
+
+    def test_display_origin_maps_to_crop_origin(self, tmp_path):
+        ip, img = _converted_preview(tmp_path)
+        ip.enter_dust_mode()
+        n = ip._dust_scene_to_norm(QPointF(0, 0))
+        assert n == pytest.approx([0.25, 0.25], abs=1e-6)
+
+    def test_rotated_crop_center_maps_to_crop_center(self, tmp_path):
+        ip, img = _converted_preview(tmp_path, crop_angle=10.0)
+        ip.enter_dust_mode()
+        w = ip.current_pixmap.width()
+        h = ip.current_pixmap.height()
+        # A rotated crop rotates about its center, so the display center maps
+        # to the crop center regardless of the angle.
+        n = ip._dust_scene_to_norm(QPointF(w / 2.0, h / 2.0))
+        assert n == pytest.approx([0.5, 0.5], abs=1e-3)
+
+    def test_no_crop_is_identity(self, tmp_path):
+        ip, img = _converted_preview(tmp_path, crop_rect=None)
+        ip.enter_dust_mode()
+        n = ip._dust_scene_to_norm(QPointF(150, 100))
+        assert n == pytest.approx([0.25, 0.25], abs=1e-6)
+
+
+class TestOverlayMapsBack:
+    def test_stroke_overlay_lands_on_display_position(self, tmp_path):
+        ip, img = _converted_preview(tmp_path)
+        ip.enter_dust_mode()
+        # Full-frame stroke from the crop center to 0.05 to its right; on the
+        # displayed (cropped) pixmap that is (150,100) -> (180,100). (Two
+        # distinct points — Qt drops a lineTo onto the current position.)
+        ip._dust_pts = [[0.5, 0.5], [0.55, 0.5]]
+        ip._draw_dust_stroke()
+        assert ip._dust_stroke_item is not None
+        r = ip._dust_stroke_item.path().boundingRect()
+        assert (r.left(), r.top()) == pytest.approx((150.0, 100.0), abs=1e-6)
+        assert (r.right(), r.bottom()) == pytest.approx((180.0, 100.0), abs=1e-6)
+
+    def test_stroke_pen_width_uses_full_frame_width(self, tmp_path):
+        ip, img = _converted_preview(tmp_path)
+        ip.enter_dust_mode()
+        ip._dust_pts = [[0.5, 0.5]]
+        ip._draw_dust_stroke()
+        # 600 = full-frame width; the cropped pixmap is only 300 wide.
+        assert ip._dust_stroke_item.pen().widthF() == pytest.approx(
+            2.0 * ip._dust_brush_r * 600)
+
+    def test_cursor_ring_uses_full_frame_width(self, tmp_path):
+        ip, img = _converted_preview(tmp_path)
+        ip.enter_dust_mode()
+        ip._update_dust_cursor(QPointF(50, 50))
+        assert ip._dust_cursor_item is not None
+        assert ip._dust_cursor_item.rect().width() == pytest.approx(
+            2.0 * ip._dust_brush_r * 600)
+
+
+class TestCommittedSpotIsFullFrame:
+    def test_press_release_stores_full_frame_norm(self, tmp_path):
+        ip, img = _converted_preview(tmp_path)
+        ip.enter_dust_mode()
+        ip._maybe_request_hires = lambda: None   # keep the test threadless
+        ip.dust_press(QPointF(150, 100))         # display center of the crop
+        ip.dust_release()
+        assert len(img.dust_spots) == 1
+        spot = img.dust_spots[0]
+        assert spot["kind"] == "brush"
+        assert spot["pts"][0] == pytest.approx([0.5, 0.5], abs=1e-6)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -558,5 +558,76 @@ class TestUndoRouting:
         assert stub.dust_panel.called is True
 
 
+# --- Resolution consistency (preview heal == export heal) --------------------
+class TestResolutionConsistency:
+    """The heal PLAN (segmentation, source patches, fallbacks) is computed at
+    the canonical preview scale and replayed on larger buffers, so the
+    full-res export reproduces the preview's healing structure. Re-deriving
+    the plan per resolution picked visibly different source patches ("the
+    preview and the final don't look the same")."""
+
+    W, H = 3000, 2000
+
+    @classmethod
+    def _scene(cls):
+        """Structured content where source-patch flips are visible: a strong
+        diagonal edge, a striped band, and film grain (deterministic)."""
+        rng = np.random.default_rng(11)
+        yy, xx = np.mgrid[0:cls.H, 0:cls.W].astype(np.float32)
+        base = 22000 + 18000 * (xx / cls.W)
+        base = np.where(yy > 0.30 * cls.H + 0.25 * xx, base * 0.55, base)
+        stripes = 12000 * np.sin(2 * np.pi * xx / 60.0)
+        band = (yy > 0.55 * cls.H) & (yy < 0.70 * cls.H)
+        img = np.stack([base + np.where(band, stripes, 0)] * 3, axis=-1)
+        img += rng.normal(0, 3000, img.shape)
+        return np.clip(img, 0, 65535).astype(np.uint16)
+
+    # A hair stroke crossing the striped band and a speck on the diagonal
+    # edge — the cases where independent per-resolution planning visibly
+    # diverged (different segment sources at preview vs export).
+    SPOTS = [{"kind": "brush",
+              "pts": [[0.48 + t * 0.04, 0.56 + t * 0.13]
+                      for t in np.linspace(0, 1, 30)],
+              "r": 0.004},
+             {"kind": "brush", "pts": [[0.40, 0.43]], "r": 0.009}]
+
+    def test_export_heal_matches_preview_heal(self):
+        big = self._scene()
+        # The preview is a downscale of the same content (long side 1080).
+        small = cv2.resize(big, (1080, 720), interpolation=cv2.INTER_AREA)
+        healed_small = apply_dust_removal(small, self.SPOTS)
+        healed_big = apply_dust_removal(big, self.SPOTS)
+        big_ds = cv2.resize(healed_big, (1080, 720),
+                            interpolation=cv2.INTER_AREA)
+
+        a8 = cv2.convertScaleAbs(healed_small, alpha=255.0 / 65535.0)
+        b8 = cv2.convertScaleAbs(big_ds, alpha=255.0 / 65535.0)
+        # Windows around the healed hair and the edge speck (1080x720 space).
+        # Calibrated: re-planning per resolution measures p99 = 14 / 10 and
+        # mean = 0.64 / 0.42 here; the replayed plan sits at 4 / 4 (grain +
+        # resampling + the 1-px rim registration inherent to mask rounding).
+        for (y0, y1, x0, x1), p99_lim, mean_lim in (
+                ((390, 510, 490, 590), 6.0, 0.40),   # hair
+                ((270, 350, 390, 480), 6.0, 0.40)):  # edge speck
+            d = np.abs(a8[y0:y1, x0:x1].astype(np.float32)
+                       - b8[y0:y1, x0:x1].astype(np.float32))
+            assert np.percentile(d, 99) <= p99_lim
+            assert d.mean() <= mean_lim
+
+    def test_planned_heal_still_removes_dust_at_full_res(self):
+        big = self._scene()
+        healed = apply_dust_removal(big, self.SPOTS)
+        # The dark hair is gone: no strong dark outlier remains along the
+        # stroke's path (compare against the local median).
+        ys = slice(int(0.54 * self.H), int(0.72 * self.H))
+        xs = slice(int(0.46 * self.W), int(0.54 * self.W))
+        wnd = healed[ys, xs].astype(np.float32).mean(axis=2)
+        med = np.median(wnd)
+        mad = np.median(np.abs(wnd - med)) + 1e-3
+        assert (med - wnd.min()) / (1.4826 * mad) < 8.0
+        # And pixels away from the mask are bit-for-bit untouched.
+        assert np.array_equal(healed[:100, :100], big[:100, :100])
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -628,6 +628,58 @@ class TestResolutionConsistency:
         # And pixels away from the mask are bit-for-bit untouched.
         assert np.array_equal(healed[:100, :100], big[:100, :100])
 
+    @staticmethod
+    def _bare_image(spots):
+        """CCRImage skeleton carrying only what _apply_dust_removal reads —
+        no file decode, so the plan-cache plumbing is tested hermetically."""
+        img = CCRImage.__new__(CCRImage)
+        img.dust_spots = spots
+        img.dust_feather = 0.003
+        img._dust_plan_cache = None
+        return img
+
+    def test_image_render_replays_the_preview_plan(self):
+        """A preview-scale heal caches its plan; larger renders (hi-res,
+        export) must sample what THAT plan says — not a fresh self-plan from
+        their own re-decoded pixels (near-tie source flips = "it sampled
+        different spots than the preview")."""
+        big = self._scene()
+        small = cv2.resize(big, (1080, 720), interpolation=cv2.INTER_AREA)
+        img = self._bare_image(list(self.SPOTS))
+
+        img._apply_dust_removal(small)                # preview render
+        key, plan = img._dust_plan_cache
+        assert key == repr(img.dust_spots)
+        assert any(off is not None for _, _, off in plan)
+
+        out_cached = img._apply_dust_removal(big)     # export render
+        # Tamper with the cached plan (shift the source offsets): the export
+        # output must follow the cache — proof it replays the preview's plan
+        # rather than planning for itself.
+        img._dust_plan_cache = (key, [
+            (cy, cx, None if off is None else (off[0] + 0.02, off[1]))
+            for cy, cx, off in plan])
+        out_tampered = img._apply_dust_removal(big)
+        assert not np.array_equal(out_cached, out_tampered)
+
+        # A stale key (spots changed since the cached preview) self-plans.
+        img.dust_spots = img.dust_spots + [
+            {"kind": "brush", "pts": [[0.2, 0.85]], "r": 0.004}]
+        out_stale = img._apply_dust_removal(big)
+        assert out_stale.shape == big.shape
+
+    def test_explicit_plan_drives_the_sources(self):
+        big = self._scene()
+        small = cv2.resize(big, (1080, 720), interpolation=cv2.INTER_AREA)
+        plan = []
+        apply_dust_removal(small, self.SPOTS, collect_plan=plan)
+        assert plan
+        # Replaying the collected plan reproduces the self-planned result
+        # (the self-plan derives from the same content here).
+        a = apply_dust_removal(big, self.SPOTS, plan=plan)
+        b = apply_dust_removal(big, self.SPOTS)
+        assert np.array_equal(a, b)
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Two user-requested dust-removal changes, making the tool fully WYSIWYG on cropped images. (Combined into one PR per user request; previously #97 + #98.)

# 1. Dust mode edits the cropped frame

Per user request: dust removal should **use the cropped image as its canvas** and respect the crop — instead of swapping to the full un-cropped frame (the original design, which is also what made the coordinate-offset bug in #92 possible).

**Display** — `update_preview`'s crop-display branch no longer excludes `dust_mode`: entering Dust Removal keeps exactly the framing you see normally (confirmed crop, coarse rotation/flip, no fine rotation). The hi-res detail layer stays crop-matched under dust mode, so preview and hi-res always share the same geometry.

**Coordinates** — spot storage is untouched (full-frame normalized), because the heal replays on the un-cropped buffer *before* the crop at every resolution — preview, hi-res zoom, and export all keep working unchanged. The canvas mapping became crop-aware instead:

- `_dust_scene_to_norm` routes through the existing `map_displayed_to_full` chain (same as the WB picker and B/W-point sampling), handling both the plain translation crop and the rotated-crop transform, then normalizes by the full frame (`resized_raw`) via the new `_dust_full_frame_size`.
- `_draw_dust_stroke` maps the stored full-frame stroke points back through the inverse crop transform for drawing, and the stroke pen + brush ring are sized by the **full-frame** width (the crop extraction is isometric, so full-frame lengths equal display lengths).

**Area mode guard** — `_hires_display_pixmap` now excludes `area_mode` (which still displays the full frame): previously a cropped hi-res render could silently swap in under the area overlay and misregister it — the same latent bug #92 found.

**Supersedes #92**, which fixed the same user-visible symptom by restoring the full-frame display instead; this goes the direction the user asked for and carries over #92's still-valid parts. #92 should be closed unmerged.

# 2. The heal is resolution-stable: the export matches the preview

Fixes the follow-up report: **"the preview and the final does not look the same in dust removal"** — healed areas in the exported file visibly differed from the in-app preview.

**Reproduction** (dust on structure: a speck straddling a strong diagonal edge, a hair crossing a striped band; preview 1080 vs real export path 3000):

| window | mean diff | p99 | max |
|---|---|---|---|
| edge speck | 2.60 | 8 | **129** |
| stripes hair | 3.71 | 12 | **61** |
| dust-free control | — | 2 | 11 |

**Root cause** — `apply_dust_removal` re-derived all content-adaptive decisions independently per buffer: the best-match source window is an SSD argmin over 64 candidates and the winner flips between scales; `_HEAL_SEG_MIN` and the Telea radius were absolute pixels, so strokes even segmented differently at 1080 vs 6000. The spec carried the caveat "the chosen source patch may differ between preview and export; both are plausible clean fills" — this report is that caveat being visibly wrong in practice.

**Fix — plan once, replay everywhere**:

- Buffers larger than the canonical scale (`_DUST_PLAN_LONG` = 1080, the preview's long side) first run the heal on an INTER_AREA downscale to produce a **plan**: per segment, its normalized centroid and chosen source offset (normalized over w/h), or a fallback verdict.
- The native pass **replays** the plan: segments matched by nearest normalized centroid reuse the planned offset (validated in-bounds/clean; rare rounding drift falls back to the local search), planned fallbacks stay fallbacks. Segment size and Telea radius scale with the buffer so segmentation structure matches the plan.
- Buffers at or below the canonical scale — the preview itself, thumbnails, the AI-detect source — plan on themselves: **byte-identical to the old behavior**.
- Tone membrane and feathered composite still run natively (16-bit sharp). Full-res exports get **faster**: the expensive candidate search now runs at 1080px.

After the fix, preview vs downscaled export sits at grain level (hair p99 12→7, max 61→25; the remaining edge-speck max is a ≤1px rim registration from mask rounding at a 100%-contrast edge — diff heatmap confirms the heal interior is identical).

# Tests

- New `tests/test_dust_crop_display.py` drives the **real** `update_preview` on a real converted `CCRImage`: cropped framing kept in dust mode, scene→norm mapping through plain and rotated crops, overlay position/pen/ring sizing by full-frame width, committed strokes storing full-frame points.
- `TestHiresDisplayModeGuards` in `tests/test_crop_hires.py` pins the display contract: dust = cropped, area = full frame, normal = cropped.
- New `TestResolutionConsistency` in `tests/test_dust_removal.py`: heals a calibrated structured scene at 1080 and 3000 wide from the same spots and asserts the downscaled full-res heal matches the preview heal (p99 ≤ 6 where unfixed code measures 14/10) — **verified to fail before the fix** — plus full-res dust-gone and untouched-pixels-bit-for-bit checks.
- Ran (grouped, per the known full-suite hang): `test_dust_removal.py`, `test_dust_crop_display.py`, `test_crop_hires.py`, `test_zoom_hires.py`, `test_crop_overlay.py`, `test_crop_panel.py`, `test_histogram_crop.py`, `test_area_editing.py`, `test_sub_saturation_crop_undo.py`, `test_wrong_output_fixes.py` — all pass.
- Verified visually (offscreen capture): dust mode shows the cropped frame, the brush ring lands on a synthetic speck, the committed stroke heals it cleanly; preview-vs-export side-by-sides match after the fix.
- `spec/dust-removal.md` updated throughout (§3.1, §3.3, §5.2 step 7, §5.5, §6, §8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
