### PR TITLE
fix(dust): heal plan is resolution-stable so the export matches the preview

### DIFF
--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -357,13 +357,30 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      in — the soft fade only happens across clean rim pixels. Outside the
      mask alpha is exactly 0 — away from any spot `out == img16`
      bit-for-bit.
+  7. **Resolution-stable plan**: the heal's content-adaptive decisions —
+     stroke segmentation, each segment's chosen source offset, and the
+     diffusion-fallback verdicts — are computed ONCE at the canonical
+     preview scale (`_DUST_PLAN_LONG` = 1080 long side) and REPLAYED on
+     larger buffers with all pixel geometry scaled (segment size, Telea
+     radius, offsets normalized over width/height; segments matched by
+     nearest normalized centroid). Re-deriving the plan per resolution let
+     the SSD argmin flip between scales, so the export healed from visibly
+     different patches than the preview the user approved ("the preview and
+     the final don't look the same"). Buffers at or below the canonical
+     scale (the preview itself, thumbnails, the detect source) plan on
+     themselves — their behavior is unchanged. A replayed offset that no
+     longer lands on a clean window (mask-raster rounding — rare) falls back
+     to the local search for that segment; the tone membrane and feather
+     composite always run natively, so fills stay 16-bit sharp.
   - Identity fast-path: empty `spots` or all-zero mask → return `img16` unchanged.
   - Returns a new `uint16` RGB array; `img16` is never mutated (non-destructive).
-  - The chosen source patch may differ between preview and export resolution
-    (scoring at different scales); both are plausible clean fills, and tone is
-    anchored to the same ring either way.
+  - Residual preview↔export differences are grain/resampling plus a ≤1 px rim
+    registration from mask rounding at hard edges — the healed structure is
+    identical (regression-tested in `TestResolutionConsistency`).
   - Cost: per-component window work only (no full-frame 8-bit convert unless a
-    fallback fires); ≤ the old Telea path even at export res with 100 spots.
+    fallback fires). Planning searches at 1080 px and native execution only
+    validates + clones, so a full-res export heals FASTER than the old
+    native-resolution search (+ one INTER_AREA downscale of the frame).
 
 ### 5.3 AI detection (`src/core/dust_detect.py`)
 A self-contained module wrapping the ONNX BOPBTL detector. **`onnxruntime` is

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3263,7 +3263,7 @@ def _feather_alpha(mask: np.ndarray, fmap: np.ndarray) -> np.ndarray:
 def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
                 filled: np.ndarray, fmap: np.ndarray, feather_px: int,
-                dlike: np.ndarray) -> bool:
+                dlike: np.ndarray, src_off=None):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
 
@@ -3274,9 +3274,14 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     so gradients continue through the patch while its grain is kept verbatim).
     `bbox` = (bx0, by0, bx1, by1) tight bounds of THIS patch's hole pixels;
     `half_th` = the component's half-thickness (max distance transform), its
-    local scale. Writes the healed hole pixels into `filled` and returns True,
-    or returns False when no fully clean, in-bounds source window exists
-    (caller falls back to diffusion inpaint for this patch).
+    local scale. Writes the healed hole pixels into `filled` and returns the
+    chosen source-window offset `(dy, dx)` (relative to the match window, in
+    this buffer's pixels), or None when no fully clean, in-bounds source
+    window exists (caller falls back to diffusion inpaint for this patch).
+    `src_off`: a pre-planned offset to REUSE (the resolution-stable replay,
+    see apply_dust_removal); taken verbatim when it still lands on a clean
+    in-bounds window, otherwise the normal search runs (plan drift from
+    mask-raster rounding — rare).
 
     Everything local is keyed off the thickness, never the bbox: a traced
     hair's bbox can span half the frame while the stroke is a few px wide.
@@ -3313,7 +3318,7 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     ring = ((away > guard) & (away <= pad)
             & (mask_pad[wy0:wy1, wx0:wx1] == 0))
     if int(ring.sum()) < _HEAL_MIN_RING_PX:
-        return False  # boxed in by other spots — no context to match against
+        return None  # boxed in by other spots — no context to match against
 
     dst = img16[wy0:wy1, wx0:wx1].astype(np.float32)
 
@@ -3341,38 +3346,52 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     thr = 0.5 * float(np.percentile(d_def, 95.0))
     keep = d_def >= thr
     if int(keep.sum()) < _HEAL_MIN_RING_PX:
-        return False
+        return None
     ring[:] = False
     ring[ry[keep], rx[keep]] = True
     dst_ring = dst[ring]
 
-    # Candidate source offsets: rings of directions at thickness-scaled
-    # distances. The integral-image check rejects any source that touches
-    # dust, so offsets need only clear the local thickness — a long stroke
-    # heals from the clean strip right beside it (requiring bbox-diagonal
-    # clearance forced long strokes into the ghost-prone diffusion fallback).
-    # The window diagonal stays as a last-resort ring for compact spots.
-    d_base = 2.0 * half_th + pad + 2.0
-    d0 = float(np.hypot(wy1 - wy0, wx1 - wx0))
-    best_score, best_src = None, None
-    for fi, d in enumerate((d_base, 2.0 * d_base, 4.0 * d_base, d0)):
-        for k in range(_HEAL_ANGLES):
-            ang = 2.0 * np.pi * (k + 0.35 * fi) / _HEAL_ANGLES
-            dy = int(round(d * np.sin(ang)))
-            dx = int(round(d * np.cos(ang)))
-            sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
-            if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
-                continue
-            if _box_sum(integ, sy0, sx0, sy1, sx1) != 0:
-                continue  # source window touches dust (this or another spot)
-            src = img16[sy0:sy1, sx0:sx1].astype(np.float32)
-            diff = src[ring] - dst_ring
-            score = float(np.mean(diff * diff))
-            if best_score is None or score < best_score:
-                best_score, best_src = score, src
+    def _source_at(dy, dx):
+        sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
+        if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
+            return None
+        if _box_sum(integ, sy0, sx0, sy1, sx1) != 0:
+            return None  # source window touches dust (this or another spot)
+        return img16[sy0:sy1, sx0:sx1].astype(np.float32)
+
+    best_score, best_src, best_off = None, None, None
+    if src_off is not None:
+        # Resolution-stable replay: reuse the offset the plan chose at the
+        # canonical scale instead of re-searching on this buffer's pixels.
+        src = _source_at(int(src_off[0]), int(src_off[1]))
+        if src is not None:
+            best_src = src
+            best_off = (int(src_off[0]), int(src_off[1]))
+    if best_src is None:
+        # Candidate source offsets: rings of directions at thickness-scaled
+        # distances. The integral-image check rejects any source that touches
+        # dust, so offsets need only clear the local thickness — a long stroke
+        # heals from the clean strip right beside it (requiring bbox-diagonal
+        # clearance forced long strokes into the ghost-prone diffusion
+        # fallback). The window diagonal stays as a last-resort ring for
+        # compact spots.
+        d_base = 2.0 * half_th + pad + 2.0
+        d0 = float(np.hypot(wy1 - wy0, wx1 - wx0))
+        for fi, d in enumerate((d_base, 2.0 * d_base, 4.0 * d_base, d0)):
+            for k in range(_HEAL_ANGLES):
+                ang = 2.0 * np.pi * (k + 0.35 * fi) / _HEAL_ANGLES
+                dy = int(round(d * np.sin(ang)))
+                dx = int(round(d * np.cos(ang)))
+                src = _source_at(dy, dx)
+                if src is None:
+                    continue
+                diff = src[ring] - dst_ring
+                score = float(np.mean(diff * diff))
+                if best_score is None or score < best_score:
+                    best_score, best_src, best_off = score, src, (dy, dx)
 
     if best_src is None:
-        return False
+        return None
 
     # Smooth per-channel tone correction from the ring differences: normalized
     # Gaussian convolution interpolates (dst - src) on the ring into the hole,
@@ -3405,7 +3424,26 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     if like.any():
         hy, hx = np.nonzero(hole)
         dlike[wy0:wy1, wx0:wx1][hy[like], hx[like]] = 255
-    return True
+    return best_off
+
+
+# Canonical planning scale for the heal = the preview's long side. Buffers at
+# or below it (preview, thumbnails) plan on themselves; larger buffers (hi-res
+# zoom, export) REPLAY the plan computed at this scale so they reproduce the
+# preview's healing structure. See apply_dust_removal.
+_DUST_PLAN_LONG = 1080
+
+
+def _nearest_plan_record(plan, cyn, cxn, tol=0.06):
+    """The plan record whose segment centroid is nearest to (cyn, cxn) in
+    normalized coords, or None when nothing lies within `tol` (a component
+    that only rasterizes at the finer scale — sub-pixel at plan resolution)."""
+    best, best_d = None, tol
+    for rec in plan:
+        d = ((rec[0] - cyn) ** 2 + (rec[1] - cxn) ** 2) ** 0.5
+        if d < best_d:
+            best, best_d = rec, d
+    return best
 
 
 def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
@@ -3432,7 +3470,43 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     masked pixels change, the rest of the frame is bit-for-bit untouched.
     Returns a NEW uint16 array; img16 is never mutated. No-op (returns img16
     unchanged) when there are no spots or the rasterized mask is empty.
+
+    Resolution consistency: the heal PLAN — stroke segmentation, each
+    segment's chosen source window, and the diffusion-fallback decisions —
+    is content-adaptive, so re-deriving it independently per resolution
+    picked visibly different fills at the 1080px preview vs the full-res
+    export ("the preview and the final don't look the same"). Buffers larger
+    than the canonical scale therefore plan on an INTER_AREA downscale at
+    _DUST_PLAN_LONG (matching the preview) and replay that plan with all
+    geometry scaled: same segments, same source patches, same fallbacks —
+    the export heals with the same structure the user approved on screen.
     """
+    if not spots:
+        return img16
+    h, w = img16.shape[:2]
+    long_side = max(h, w)
+    if long_side <= _DUST_PLAN_LONG:
+        return _heal_impl(img16, spots, inpaint_radius, feather)
+    scale = long_side / float(_DUST_PLAN_LONG)
+    pw = max(2, int(round(w / scale)))
+    ph = max(2, int(round(h / scale)))
+    small = cv2.resize(img16, (pw, ph), interpolation=cv2.INTER_AREA)
+    plan = []
+    _heal_impl(small, spots, inpaint_radius, feather, collect=plan)
+    return _heal_impl(img16, spots, inpaint_radius, feather,
+                      plan=plan, scale_up=scale)
+
+
+def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
+               feather: float, plan=None, collect=None,
+               scale_up: float = 1.0) -> np.ndarray:
+    """apply_dust_removal's engine at ONE resolution. With `collect` (a list),
+    appends a plan record per heal segment: (cy_norm, cx_norm, offset) where
+    offset is the chosen source displacement normalized over (h, w), or None
+    for a diffusion fallback. With `plan` (+ `scale_up` = this buffer's size
+    over the plan scale), segments reuse the planned offsets/fallbacks
+    instead of re-searching, and the pixel-based geometry (segment size,
+    Telea radius) scales by `scale_up` so segmentation matches the plan's."""
     if not spots:
         return img16
     h, w = img16.shape[:2]
@@ -3453,6 +3527,11 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     feather_px = max(1, int(round(float(feather) * w)))
     fmap = np.ones((h, w), np.uint8)
     dlike = np.zeros((h, w), np.uint8)
+    # Pixel-based knobs scale with the buffer (relative to the plan scale) so
+    # a stroke splits into the SAME segments here as it did in the plan, and
+    # the diffusion fallback blurs over the same image fraction.
+    seg_min = max(8, int(round(_HEAL_SEG_MIN * max(1.0, scale_up))))
+    telea_r = max(1, int(round(inpaint_radius * max(1.0, scale_up))))
     for i in range(1, n):  # 0 is background
         x0 = int(stats[i, cv2.CC_STAT_LEFT])
         y0 = int(stats[i, cv2.CC_STAT_TOP])
@@ -3464,7 +3543,7 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
         hole0 = np.zeros((ch + 2, cw + 2), np.uint8)
         hole0[1:-1, 1:-1] = comp_win
         half_th = float(cv2.distanceTransform(hole0, cv2.DIST_L2, 3).max())
-        seg = max(_HEAL_SEG_MIN, int(round(_HEAL_SEG_THICKNESS * half_th)))
+        seg = max(seg_min, int(round(_HEAL_SEG_THICKNESS * half_th)))
         for ty in range(y0, y0 + ch, seg):
             for tx in range(x0, x0 + cw, seg):
                 sub = comp_win[ty - y0:ty - y0 + seg, tx - x0:tx - x0 + seg]
@@ -3473,8 +3552,26 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
                 ys, xs = np.nonzero(sub)
                 bbox = (tx + int(xs.min()), ty + int(ys.min()),
                         tx + int(xs.max()) + 1, ty + int(ys.max()) + 1)
-                if not _heal_patch(img16, labels, i, bbox, half_th, mask_pad,
-                                   integ, filled, fmap, feather_px, dlike):
+                cyn = (ty + float(ys.mean())) / h
+                cxn = (tx + float(xs.mean())) / w
+                src_off, forced_fb = None, False
+                if plan is not None:
+                    rec = _nearest_plan_record(plan, cyn, cxn)
+                    if rec is not None:
+                        if rec[2] is None:
+                            forced_fb = True  # the plan chose diffusion here
+                        else:
+                            src_off = (int(round(rec[2][0] * h)),
+                                       int(round(rec[2][1] * w)))
+                off = None
+                if not forced_fb:
+                    off = _heal_patch(img16, labels, i, bbox, half_th,
+                                      mask_pad, integ, filled, fmap,
+                                      feather_px, dlike, src_off=src_off)
+                if collect is not None:
+                    collect.append((cyn, cxn, None if off is None
+                                    else (off[0] / h, off[1] / w)))
+                if off is None:
                     fallback[ty:ty + sub.shape[0],
                              tx:tx + sub.shape[1]][sub] = 255
                     # No defect estimate on this path — cap the fade by the
@@ -3486,7 +3583,7 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
         # Diffusion fallback (cv2.inpaint supports 8-bit only).
         bgr8 = cv2.cvtColor(cv2.convertScaleAbs(img16, alpha=255.0 / 65535.0),
                             cv2.COLOR_RGB2BGR)
-        telea8 = cv2.inpaint(bgr8, fallback, inpaint_radius, cv2.INPAINT_TELEA)
+        telea8 = cv2.inpaint(bgr8, fallback, telea_r, cv2.INPAINT_TELEA)
         telea16 = cv2.cvtColor(telea8, cv2.COLOR_BGR2RGB).astype(np.uint16) * 257
         fb = fallback > 0
         filled[fb] = telea16[fb]

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -558,5 +558,76 @@ class TestUndoRouting:
         assert stub.dust_panel.called is True
 
 
+# --- Resolution consistency (preview heal == export heal) --------------------
+class TestResolutionConsistency:
+    """The heal PLAN (segmentation, source patches, fallbacks) is computed at
+    the canonical preview scale and replayed on larger buffers, so the
+    full-res export reproduces the preview's healing structure. Re-deriving
+    the plan per resolution picked visibly different source patches ("the
+    preview and the final don't look the same")."""
+
+    W, H = 3000, 2000
+
+    @classmethod
+    def _scene(cls):
+        """Structured content where source-patch flips are visible: a strong
+        diagonal edge, a striped band, and film grain (deterministic)."""
+        rng = np.random.default_rng(11)
+        yy, xx = np.mgrid[0:cls.H, 0:cls.W].astype(np.float32)
+        base = 22000 + 18000 * (xx / cls.W)
+        base = np.where(yy > 0.30 * cls.H + 0.25 * xx, base * 0.55, base)
+        stripes = 12000 * np.sin(2 * np.pi * xx / 60.0)
+        band = (yy > 0.55 * cls.H) & (yy < 0.70 * cls.H)
+        img = np.stack([base + np.where(band, stripes, 0)] * 3, axis=-1)
+        img += rng.normal(0, 3000, img.shape)
+        return np.clip(img, 0, 65535).astype(np.uint16)
+
+    # A hair stroke crossing the striped band and a speck on the diagonal
+    # edge — the cases where independent per-resolution planning visibly
+    # diverged (different segment sources at preview vs export).
+    SPOTS = [{"kind": "brush",
+              "pts": [[0.48 + t * 0.04, 0.56 + t * 0.13]
+                      for t in np.linspace(0, 1, 30)],
+              "r": 0.004},
+             {"kind": "brush", "pts": [[0.40, 0.43]], "r": 0.009}]
+
+    def test_export_heal_matches_preview_heal(self):
+        big = self._scene()
+        # The preview is a downscale of the same content (long side 1080).
+        small = cv2.resize(big, (1080, 720), interpolation=cv2.INTER_AREA)
+        healed_small = apply_dust_removal(small, self.SPOTS)
+        healed_big = apply_dust_removal(big, self.SPOTS)
+        big_ds = cv2.resize(healed_big, (1080, 720),
+                            interpolation=cv2.INTER_AREA)
+
+        a8 = cv2.convertScaleAbs(healed_small, alpha=255.0 / 65535.0)
+        b8 = cv2.convertScaleAbs(big_ds, alpha=255.0 / 65535.0)
+        # Windows around the healed hair and the edge speck (1080x720 space).
+        # Calibrated: re-planning per resolution measures p99 = 14 / 10 and
+        # mean = 0.64 / 0.42 here; the replayed plan sits at 4 / 4 (grain +
+        # resampling + the 1-px rim registration inherent to mask rounding).
+        for (y0, y1, x0, x1), p99_lim, mean_lim in (
+                ((390, 510, 490, 590), 6.0, 0.40),   # hair
+                ((270, 350, 390, 480), 6.0, 0.40)):  # edge speck
+            d = np.abs(a8[y0:y1, x0:x1].astype(np.float32)
+                       - b8[y0:y1, x0:x1].astype(np.float32))
+            assert np.percentile(d, 99) <= p99_lim
+            assert d.mean() <= mean_lim
+
+    def test_planned_heal_still_removes_dust_at_full_res(self):
+        big = self._scene()
+        healed = apply_dust_removal(big, self.SPOTS)
+        # The dark hair is gone: no strong dark outlier remains along the
+        # stroke's path (compare against the local median).
+        ys = slice(int(0.54 * self.H), int(0.72 * self.H))
+        xs = slice(int(0.46 * self.W), int(0.54 * self.W))
+        wnd = healed[ys, xs].astype(np.float32).mean(axis=2)
+        med = np.median(wnd)
+        mad = np.median(np.abs(wnd - med)) + 1e-3
+        assert (med - wnd.min()) / (1.4826 * mad) < 8.0
+        # And pixels away from the mask are bit-for-bit untouched.
+        assert np.array_equal(healed[:100, :100], big[:100, :100])
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes the user report: **"the preview and the final does not look the same in dust removal"** — the healed areas in the exported file visibly differed from what the in-app preview showed.

## Reproduction

Synthetic scan with dust on structure (a speck straddling a strong diagonal edge; a hair crossing a striped band), healed via stored spots, rendered at preview resolution (1080) and through the real export path (3000):

| window | mean diff | p99 | max |
|---|---|---|---|
| edge speck | 2.60 | 8 | **129** |
| stripes hair | 3.71 | 12 | **61** |
| dust-free control | — | 2 | 11 |

The two heals filled the holes with visibly different content (different shape/tone of the healed notch, different smudges along the hair).

## Root cause

`apply_dust_removal` is deliberately replayed per resolution (normalized spots), but ALL of its content-adaptive decisions were re-derived independently on each buffer:

- the best-match **source window** is an SSD argmin over 64 candidates — the winner flips between scales;
- `_HEAL_SEG_MIN` (32) and the Telea radius (3) are **absolute pixels**, so a stroke even segments differently at 1080 vs 6000;
- the diffusion-**fallback** verdict could differ per scale.

The spec even carried the caveat "the chosen source patch may differ between preview and export resolution; both are plausible clean fills" — this report is that caveat being visibly wrong in practice.

## Fix — plan once, replay everywhere

- Buffers larger than the canonical scale (`_DUST_PLAN_LONG` = 1080, the preview's long side) first run the heal on an INTER_AREA downscale to produce a **plan**: per segment, its normalized centroid and the chosen source offset (normalized over w/h), or a fallback verdict.
- The native pass **replays** the plan: segments matched by nearest normalized centroid reuse the planned offset (validated in-bounds/clean; rare rounding drift falls back to the local search), planned fallbacks stay fallbacks. Segment size and Telea radius scale with the buffer so segmentation structure matches the plan.
- Buffers at or below the canonical scale — the preview itself, thumbnails, the AI-detect source — plan on themselves: **byte-identical to the old behavior**.
- The tone membrane and feathered composite still run natively, so fills stay 16-bit sharp. Full-res exports get **faster**: the expensive candidate search now runs at 1080px.

After the fix, preview vs downscaled export sits at grain level (hair p99 12→7, max 61→25; cluster max 19→11). The remaining edge-speck max is a ≤1px rim registration from mask rounding at a 100%-contrast edge (diff heatmap confirms: heal interior identical, one-pixel rim only) — the healed structure is identical.

## Tests

- New `TestResolutionConsistency` in `tests/test_dust_removal.py`: heals a calibrated structured scene (diagonal edge + striped band + grain, deterministic) at 1080 and 3000 wide from the same spots; asserts the downscaled full-res heal matches the preview heal (p99 ≤ 6, mean ≤ 0.4 per window, where unfixed code measures p99 = 14 / 10). **Verified to fail on unfixed code** (`git stash` run: p99 = 14 > 6). Plus a full-res dust-gone check and a masked-pixels-only (bit-for-bit untouched elsewhere) check.
- `test_dust_removal.py` (41), `test_wrong_output_fixes.py`, `test_area_editing.py`, `test_histogram_crop.py`, `test_crop_hires.py` — all pass.
- `spec/dust-removal.md` §5.2 updated: new step 7 (resolution-stable plan) replaces the outdated caveat.

Independent of #97 (dust mode cropped canvas) — no file overlap conflicts; both can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
