### PR TITLE
fix(dust): feather scales with the brush (fraction of hole radius)

### DIFF
--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -356,7 +356,13 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      they are its minority — the film holder / rebate inverts to near-black
      and is not scene context; letting it anchor tone painted a dark smudge
      on strokes near the frame edge. (If dark dominates, the stroke really
-     is in dark content and the ring stays.)
+     is in dark content and the ring stays.) Content OUTSIDE the image's
+     confirmed crop (`CCRImage.crop_rect`/`crop_angle`, rasterized by
+     `_crop_keep_mask` incl. rotation) is not scene either: it is merged
+     into `mask_pad` like dust, so rings never anchor on it and fresh
+     source searches never sample it — pinned sources keep their reference
+     regardless (sticky), routing through the deferred pass onto the same
+     pixels if they poke outside a newer crop.
   2. **Defect-color rejection**: the defect's color is estimated from the
      hole's own content (a tight stroke's hole IS the defect; a generous
      brush's defect is the hole's outlier mode vs the ring). Ring pixels

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -368,8 +368,17 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      the ramp (`dlike`, with a blurred lip as wide as the component's ramp,
      confined to the component so it can't bleed into a neighboring hole's
      blend), so a wide feather can never blend the defect back in — the
-     soft fade only happens across clean rim pixels. Outside the mask alpha
-     is exactly 0 — away from any spot `out == img16` bit-for-bit.
+     soft fade only happens across clean rim pixels. The classification
+     only engages when the estimated defect color is separated from the
+     cleaned ring's median by > `_DLIKE_SEP_MADS` ring-grain MADs, and then
+     marks the hole pixels closer to the defect than to the surround
+     (nearest centroid): a generous brush over mostly-clean content
+     estimates a "defect" that collapses onto the background mode, and
+     thresholding grain against it force-filled a random salt-and-pepper
+     subset of the hole (dithered rims, no rolloff at wide feathers) —
+     gated off, such a brush blends as a pure opacity dome rolling off
+     from the stroke's center. Outside the mask alpha is exactly 0 — away
+     from any spot `out == img16` bit-for-bit.
   7. **Resolution-stable plan**: the heal's content-adaptive decisions —
      stroke segmentation, each segment's chosen source offset, and the
      diffusion-fallback verdicts — are computed ONCE at the canonical

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -217,6 +217,10 @@ a polyline):
   from the component's extent.
 - Empty list = "no dust removal"; the render fast-path leaves the image
   untouched (§5.2).
+- Alongside the spots, the catalog stores `dust_plan` — the cached heal
+  plan's records (`[cy, cx, [oy, ox] | null, genuine, dlike_on]`), written
+  only when they match the current spots — so a reload reseeds
+  `_dust_plan_cache` and keeps the exact sources the user saw.
 - Alongside the spots, `CCRImage.dust_feather` (float, fraction of each
   hole's own half-thickness, 0..1, default 0.25) holds the image's heal
   edge-fade width — one value for all spots, set by the panel's Feather
@@ -444,7 +448,18 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      **The preview's plan is the source of truth**: `CCRImage`'s preview
      render caches its plan (`_dust_plan_cache`, keyed by the spots'
      content; feather excluded — it shapes the blend, not the plan), and
-     hi-res/export renders replay THAT plan via `apply_dust_removal(plan=)`
+     hi-res/export renders replay THAT plan via `apply_dust_removal(plan=)`.
+     **Sticky sources**: once a segment's source is set, nothing may move
+     it — every preview-scale re-heal is seeded with the previous plan
+     (`prior_plan`, bound tightly by `_DUST_EDIT_TOL` so a NEW stroke's
+     segments never inherit a neighbor's source unscored), and segments at
+     unchanged centroids reuse their prior offset/verdicts verbatim instead
+     of re-searching. Painting a new stroke therefore cannot re-sample the
+     strokes already on screen; only a stroke landing ON a prior source
+     (making it dust) forces that one segment to re-search. The plan
+     persists in the catalog (`dust_plan`, dropped when stale) and reseeds
+     the cache on restore, so reloads keep the exact sources the user saw —
+     a from-scratch replan of an incrementally-built plan could differ
      — a fresh plan from the export's own re-decoded/downscaled pixels can
      still flip near-tie source choices ("it sampled different spots than
      the preview"). A replayed offset that lands on dust or out of bounds

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -335,7 +335,14 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      is thickness-scaled to one giant segment whose window rarely has a
      clean home anywhere, dumping the whole blob into the flat, grainless
      diffusion fallback — a visible smooth disc on film grain. Tiles keep
-     cloning real texture from beside the blob.
+     cloning real texture from beside the blob. **Edit locality**: for
+     components spanning multiple tiles the grid anchors to the IMAGE
+     (absolute multiples of `seg`), not the component bbox, and each tile's
+     guard/ring/search geometry keys off the tile-bounded local scale
+     `min(half_th, seg/2)` (inert for uncapped components) — otherwise a
+     new dab merging into a blob shifted every tile and resized every
+     window, re-sampling segments far from the edit on each stroke.
+     Compact single-tile components keep one un-split tile at their bbox.
   1. **Window + guarded ring**: patch bbox padded by `guard + ring_w`; `ring`
      = clean known pixels at distance `(guard, guard+ring_w]` from the hole
      (`guard` ≥ 2 px, scaled to half the thickness). The gap matters: the

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -449,14 +449,18 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      render caches its plan (`_dust_plan_cache`, keyed by the spots'
      content; feather excluded — it shapes the blend, not the plan), and
      hi-res/export renders replay THAT plan via `apply_dust_removal(plan=)`.
-     **Sticky sources**: once a segment's source is set, nothing may move
+     **Sticky sources**: once a segment's source is set, NOTHING may move
      it — every preview-scale re-heal is seeded with the previous plan
      (`prior_plan`, bound tightly by `_DUST_EDIT_TOL` so a NEW stroke's
      segments never inherit a neighbor's source unscored), and segments at
      unchanged centroids reuse their prior offset/verdicts verbatim instead
      of re-searching. Painting a new stroke therefore cannot re-sample the
-     strokes already on screen; only a stroke landing ON a prior source
-     (making it dust) forces that one segment to re-search. The plan
+     strokes already on screen. A pinned offset is never re-searched, only
+     clamped into bounds (scale rounding); even a stroke landing ON a prior
+     source keeps the reference — that segment defers to a second pass
+     (after the clone/Telea fills) and clones the HEALED content at the
+     very same location, so no dust is copied and the arrow never moves.
+     The plan
      persists in the catalog (`dust_plan`, dropped when stale) and reseeds
      the cache on restore, so reloads keep the exact sources the user saw —
      a from-scratch replan of an incrementally-built plan could differ

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -104,6 +104,15 @@ in the catalog, and undoable.
      which also means the fade only shows on the clean rim between the defect
      and the brush edge (a tight trace heals hard by design; brush generously
      to get a soft blend).
+   - **Show heal sources** checkbox: diagnostic overlay on the canvas —
+     every stroke's border outlined (yellow), and for each heal segment a
+     green arrow drawn FROM the patch it sampled TO the healed segment
+     (ring at the source), or an orange ring where the segment fell back to
+     diffusion (nothing was sampled). Geometry comes from the cached
+     preview heal plan (`dust_debug_geometry` + `_dust_plan_cache`), mapped
+     through the same crop-display transform as the brush, so it shows
+     exactly what exports will replay. Refreshes on every dust edit /
+     feather change; cleared on exit.
    - Hint: "Click or drag over dust to remove it."
    - **Undo last spot** button and **Clear all** button.
 3. Separator.
@@ -321,7 +330,12 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      are healed in thickness-scaled segments, each from its own local source
      strip — one whole-stroke window would demand a clean area the size of the
      stroke's bbox, which rarely exists (a traced curl would silently fall
-     back to diffusion and ghost).
+     back to diffusion and ghost). Segments are also CAPPED at
+     `_HEAL_SEG_MAX` (96 px at plan scale, ×`scale_up`): a big compact dab
+     is thickness-scaled to one giant segment whose window rarely has a
+     clean home anywhere, dumping the whole blob into the flat, grainless
+     diffusion fallback — a visible smooth disc on film grain. Tiles keep
+     cloning real texture from beside the blob.
   1. **Window + guarded ring**: patch bbox padded by `guard + ring_w`; `ring`
      = clean known pixels at distance `(guard, guard+ring_w]` from the hole
      (`guard` ≥ 2 px, scaled to half the thickness). The gap matters: the

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -326,7 +326,12 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      = clean known pixels at distance `(guard, guard+ring_w]` from the hole
      (`guard` ≥ 2 px, scaled to half the thickness). The gap matters: the
      defect's soft edge leaks past the brushed mask, and pixels hugging the
-     hole are the most likely to be the defect itself.
+     hole are the most likely to be the defect itself. Near-black pixels
+     (`_HEAL_BLACK_FLOOR`, ~3% of white) are dropped from the ring while
+     they are its minority — the film holder / rebate inverts to near-black
+     and is not scene context; letting it anchor tone painted a dark smudge
+     on strokes near the frame edge. (If dark dominates, the stroke really
+     is in dark content and the ring stays.)
   2. **Defect-color rejection**: the defect's color is estimated from the
      hole's own content (a tight stroke's hole IS the defect; a generous
      brush's defect is the hole's outlier mode vs the ring). Ring pixels
@@ -335,13 +340,26 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      hair edge, or the hair's continuation past the stroke's end (which can
      be the ring's *majority*), cannot lift the fill into a bright ghost of
      the stroke. Legit bimodal structure survives (both modes sit far from
-     the defect color).
+     the defect color). **Sanity cap** (`_HEAL_MIN_KEEP_FRAC`): if the
+     rejection would keep < 20% of the ring, the "defect" was estimated as
+     the ring's own majority (a clean generous brush, whose top-quartile
+     estimate collapses onto the background) and whatever survives is some
+     small foreign mode — a black border, a dark roofline — that would
+     become the entire anchor (clean sky strokes healed to solid black,
+     cloned from the border). The estimate is distrusted (`genuine=False`):
+     full ring, no defect force-fill.
   3. **Search**: candidate source windows on `_HEAL_ANGLES` (16) directions ×
      thickness-scaled distances (`2·half_th + pad + 2`, ×1/2/4, plus the
      window diagonal as a last resort). A candidate must be in-bounds and
      fully clean (checked O(1) against `cv2.integral` of the padded mask), so
      a long stroke heals from the clean strip right beside it. Score = SSD
-     between source and destination **kept ring** pixels; best wins.
+     between source and destination **kept ring** pixels — plus, only past a
+     ring-MAD-scaled tolerance, the candidate's interior-tone excess vs the
+     ring background (the ring SSD never looks inside the window: a source
+     whose ring matches but whose hole area holds a black border edge clones
+     the border into the fill; within tolerance the ring SSD alone ranks, an
+     always-on interior term re-ranked near-ties by texture phase and made
+     preview/export tone drift). Best wins.
   4. **Clone + membrane tone correction**: hole pixels are copied from the
      best source, plus a smooth per-channel correction field interpolated
      from the kept-ring differences (normalized Gaussian convolution,
@@ -353,8 +371,12 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
   5. **Fallback**: a patch with no clean in-bounds source window (image
      border, dense dust) or a starved ring (< `_HEAL_MIN_RING_PX`) falls back
      to the old 8-bit `cv2.inpaint(..., inpaint_radius, INPAINT_TELEA)` fill.
-  6. **Feathered composite**: alpha rises 0 → 1 from each hole's boundary
-     inward over a smoothstep ramp (`_feather_alpha`), `out = img16*(1-a) +
+  6. **Feathered composite**: alpha rises ~0 → 1 from each hole's boundary
+     inward over a smoothstep ramp (`_feather_alpha`, evaluated at
+     pixel-center depths `inside − 0.5` with FLOAT ramp widths, so the
+     relative profile is identical at every resolution — an integer ramp
+     with a boundary lift made thin-stroke rims visibly harder at preview
+     than at export), `out = img16*(1-a) +
      filled*a` computed inside each **component's own padded window** (one
      global mask bbox degenerates to nearly the whole frame when spots are
      scattered, and the full-frame float blend then dominates the heal —
@@ -369,23 +391,30 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      confined to the component so it can't bleed into a neighboring hole's
      blend), so a wide feather can never blend the defect back in — the
      soft fade only happens across clean rim pixels. The classification
-     only engages when the estimated defect color is separated from the
-     cleaned ring's median by > `_DLIKE_SEP_MADS` ring-grain MADs, and then
-     marks the hole pixels closer to the defect than to the surround
-     (nearest centroid): a generous brush over mostly-clean content
-     estimates a "defect" that collapses onto the background mode, and
-     thresholding grain against it force-filled a random salt-and-pepper
-     subset of the hole (dithered rims, no rolloff at wide feathers) —
-     gated off, such a brush blends as a pure opacity dome rolling off
-     from the stroke's center. Outside the mask alpha is exactly 0 — away
-     from any spot `out == img16` bit-for-bit.
+     only engages for a `genuine` estimate (step 2) whose defect color is
+     separated from the cleaned ring's median by > `_DLIKE_SEP_MADS`
+     ring-grain MADs **and brighter than the surround** (film dust inverts
+     WHITE; a darker "defect" is content), and then marks the hole pixels
+     closer to the defect than to the surround (nearest centroid): a
+     generous brush over mostly-clean content estimates a "defect" that
+     collapses onto the background mode, and thresholding grain against it
+     force-filled a random salt-and-pepper subset of the hole (dithered
+     rims, no rolloff at wide feathers) — gated off, such a brush blends as
+     a pure opacity dome rolling off from the stroke's center. Outside the
+     mask alpha is exactly 0 — away from any spot `out == img16`
+     bit-for-bit.
   7. **Resolution-stable plan**: the heal's content-adaptive decisions —
-     stroke segmentation, each segment's chosen source offset, and the
-     diffusion-fallback verdicts — are computed ONCE at the canonical
+     stroke segmentation, each segment's chosen source offset, the
+     diffusion-fallback verdicts, and the per-segment `genuine`/`dlike_on`
+     verdicts — are computed ONCE at the canonical
      preview scale (`_DUST_PLAN_LONG` = 1080 long side) and REPLAYED on
      larger buffers with all pixel geometry scaled (segment size, Telea
      radius, offsets normalized over width/height; segments matched by
-     nearest normalized centroid). Re-deriving the plan per resolution let
+     nearest normalized centroid). Per-pixel threshold classifications
+     (holder-black, defect-like) read a luma smoothed to the plan scale
+     (`img16_c`, box = the scale factor; identity on canonical buffers), so
+     full-res grain crosses those thresholds no more often than the
+     preview's area-averaged pixels did. Re-deriving the plan per resolution let
      the SSD argmin flip between scales, so the export healed from visibly
      different patches than the preview the user approved ("the preview and
      the final don't look the same"). Buffers at or below the canonical

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -92,13 +92,18 @@ in the catalog, and undoable.
      specks get fine steps (0.05% ≈ 3 px radius on a 6000 px scan) while big
      scratch-covering sizes stay reachable; the label shows the size as a % of
      image width. The canvas Ctrl+wheel resize clamps to the same range.
-   - **Feather** slider (0–1.0% of image width, default 0.30%): the edge fade
-     width of every heal on the image — manual and AI spots alike. A
-     per-image render parameter stored as `CCRImage.dust_feather`; changes
-     re-heal live (debounced ~200 ms), persist in the catalog, and are NOT
-     part of undo snapshots (like brush size). Defect-like pixels are always
-     fully filled regardless of the feather (§5.2 step 6), so a wide fade
-     cannot blend the defect back in.
+   - **Feather** slider (0–100% of each spot's own radius, default 25%): the
+     edge fade width of every heal on the image — manual and AI spots alike.
+     Radius-relative, so the fade **grows with the brush size** — a big
+     scratch patch fades over a proportionally wide rim while a tiny speck
+     stays tight. A per-image render parameter stored as
+     `CCRImage.dust_feather`; changes re-heal live (debounced ~200 ms),
+     persist in the catalog, and are NOT part of undo snapshots (like brush
+     size). Defect-like pixels are always fully filled regardless of the
+     feather (§5.2 step 6), so a wide fade cannot blend the defect back in —
+     which also means the fade only shows on the clean rim between the defect
+     and the brush edge (a tight trace heals hard by design; brush generously
+     to get a soft blend).
    - Hint: "Click or drag over dust to remove it."
    - **Undo last spot** button and **Clear all** button.
 3. Separator.
@@ -203,12 +208,13 @@ a polyline):
   from the component's extent.
 - Empty list = "no dust removal"; the render fast-path leaves the image
   untouched (§5.2).
-- Alongside the spots, `CCRImage.dust_feather` (float, fraction of image
-  width, default 0.003) holds the image's heal edge-fade width — one value
-  for all spots, set by the panel's Feather slider, serialized in the catalog
-  (`dust_feather`, missing key → default), excluded from undo snapshots, and
-  part of the hi-res `dust_sig` so a feather change invalidates cached
-  renders.
+- Alongside the spots, `CCRImage.dust_feather` (float, fraction of each
+  hole's own half-thickness, 0..1, default 0.25) holds the image's heal
+  edge-fade width — one value for all spots, set by the panel's Feather
+  slider, serialized in the catalog under `dust_feather_r` (missing key →
+  legacy width-fraction `dust_feather` migrated by slider position ×100,
+  else default), excluded from undo snapshots, and part of the hi-res
+  `dust_sig` so a feather change invalidates cached renders.
 
 Rationale: mirrors openenlarge's normalized `DustStroke` model, serializes
 cleanly to JSON, deep-copies cleanly for undo, and is fully resolution
@@ -354,14 +360,16 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      scattered, and the full-frame float blend then dominates the heal —
      ~0.9 s at 6000 px; components never touch, so per-component alpha is
      exactly the global answer). The ramp width is the image's **Feather**
-     setting (`dust_feather`, a fraction of image width — default 0.3%, so
-     it covers the same image fraction at preview and export), capped per
-     hole by its depth so the core still reaches full fill. **Defect-like hole pixels** (colored like the estimated defect)
-     are force-filled at alpha 1 regardless of the ramp (`dlike`, with a
-     light blurred lip), so a wide feather can never blend the defect back
-     in — the soft fade only happens across clean rim pixels. Outside the
-     mask alpha is exactly 0 — away from any spot `out == img16`
-     bit-for-bit.
+     setting (`dust_feather`) as a fraction of **each hole's own depth**
+     (its half-thickness) — the fade scales with the brush size, and with
+     resolution, since the rasterized hole does — capped by that depth so
+     the core still reaches full fill. **Defect-like hole pixels** (colored
+     like the estimated defect) are force-filled at alpha 1 regardless of
+     the ramp (`dlike`, with a blurred lip as wide as the component's ramp,
+     confined to the component so it can't bleed into a neighboring hole's
+     blend), so a wide feather can never blend the defect back in — the
+     soft fade only happens across clean rim pixels. Outside the mask alpha
+     is exactly 0 — away from any spot `out == img16` bit-for-bit.
   7. **Resolution-stable plan**: the heal's content-adaptive decisions —
      stroke segmentation, each segment's chosen source offset, and the
      diffusion-fallback verdicts — are computed ONCE at the canonical

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -160,6 +160,13 @@ def serialize_image(img) -> dict:
         "adjustment_settings": dict(img.adjustment_settings),
         "areas": _areas_to_json(getattr(img, "area_layers", None)),
         "dust_spots": copy.deepcopy(getattr(img, "dust_spots", None) or []),
+        # The heal plan (each segment's chosen source patch + verdicts):
+        # once a source is set, nothing may move it — not even a reload, so
+        # the plan persists next to the spots and reseeds the plan cache on
+        # restore (a from-scratch replan of an incrementally-built plan can
+        # pick different sources than the user saw). None when the cache is
+        # stale or there are no spots.
+        "dust_plan": _dust_plan_to_json(img),
         # Feather as a fraction of each hole's own radius. Written under a NEW
         # key: the legacy "dust_feather" key held a fraction of image width
         # (0..0.01) and is only ever read back (migrated), never written.
@@ -178,6 +185,27 @@ def serialize_image(img) -> dict:
         "tint_balance_factor": float(getattr(img, "tint_balance_factor", 1.0)),
         "reference_frame": list(img.reference_frame) if img.reference_frame else None,
     }
+
+
+def _dust_plan_to_json(img):
+    """The image's cached heal plan as JSON-safe lists, or None when it does
+    not match the current spots (never persist a stale plan). Records mirror
+    _heal_impl's: [cy, cx, [oy, ox] | None, genuine, dlike_on]."""
+    cached = getattr(img, "_dust_plan_cache", None)
+    spots = getattr(img, "dust_spots", None) or []
+    if not cached or not spots or cached[0] != repr(spots):
+        return None
+    out = []
+    for r in cached[1]:
+        off = None if r[2] is None else [float(r[2][0]), float(r[2][1])]
+        out.append([float(r[0]), float(r[1]), off] + list(r[3:5]))
+    return out
+
+
+def _dust_plan_from_json(plan):
+    """Inverse of _dust_plan_to_json (tuples, offset as a tuple)."""
+    return [(r[0], r[1], (tuple(r[2]) if r[2] is not None else None),
+             *r[3:5]) for r in plan]
 
 
 def _is_pristine(state: dict) -> bool:
@@ -384,6 +412,13 @@ def _restore_image(file_path: str, state: dict):
     )
     img.is_duplicate = bool(state.get("is_duplicate", False))
     img.dust_spots = copy.deepcopy(state.get("dust_spots") or [])
+    plan = state.get("dust_plan")
+    if plan and img.dust_spots:
+        # Reseed the plan cache so the restored image keeps the exact
+        # sources the user saw (sticky across sessions); a missing/legacy
+        # plan just replans once and is sticky from then on.
+        img._dust_plan_cache = (repr(img.dust_spots),
+                                _dust_plan_from_json(plan))
     if "dust_feather_r" in state:
         img.dust_feather = float(state["dust_feather_r"])
     elif "dust_feather" in state:

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -160,7 +160,10 @@ def serialize_image(img) -> dict:
         "adjustment_settings": dict(img.adjustment_settings),
         "areas": _areas_to_json(getattr(img, "area_layers", None)),
         "dust_spots": copy.deepcopy(getattr(img, "dust_spots", None) or []),
-        "dust_feather": float(getattr(img, "dust_feather", 0.003)),
+        # Feather as a fraction of each hole's own radius. Written under a NEW
+        # key: the legacy "dust_feather" key held a fraction of image width
+        # (0..0.01) and is only ever read back (migrated), never written.
+        "dust_feather_r": float(getattr(img, "dust_feather", 0.25)),
         "color_profile": getattr(img, "color_profile", "color"),
         "crop_rect": list(img.crop_rect) if img.crop_rect else None,
         "crop_angle": float(img.crop_angle or 0.0),
@@ -381,7 +384,14 @@ def _restore_image(file_path: str, state: dict):
     )
     img.is_duplicate = bool(state.get("is_duplicate", False))
     img.dust_spots = copy.deepcopy(state.get("dust_spots") or [])
-    img.dust_feather = float(state.get("dust_feather", 0.003))
+    if "dust_feather_r" in state:
+        img.dust_feather = float(state["dust_feather_r"])
+    elif "dust_feather" in state:
+        # Legacy width-fraction feather (slider 0..100 -> 0..1% of image
+        # width): map the old slider position onto today's radius-fraction
+        # scale (0..100 -> 0..100% of radius) so the user's relative setting
+        # survives. Neither key present -> CCRImage's default stands.
+        img.dust_feather = min(1.0, float(state["dust_feather"]) * 100.0)
     img.color_profile = state.get("color_profile", "color")
     ref = state.get("reference_frame")
     img.reference_frame = tuple(ref) if ref else None

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -943,6 +943,11 @@ class CCRImage:
             return image
         t0 = time.time()
         feather = getattr(self, "dust_feather", DUST_FEATHER_DEFAULT)
+        # Sources must come from INSIDE the confirmed crop — outside is the
+        # holder/rebate/junk the user cut away, not scene content.
+        rect = getattr(self, "crop_rect", None)
+        crop = ((tuple(rect), float(getattr(self, "crop_angle", 0.0) or 0.0))
+                if rect else None)
         key = repr(spots)
         h, w = image.shape[:2]
         if max(h, w) <= _DUST_PLAN_LONG:
@@ -950,14 +955,16 @@ class CCRImage:
             cached = getattr(self, "_dust_plan_cache", None)
             prior = cached[1] if cached is not None else None
             out = apply_dust_removal(image, spots, feather=feather,
-                                     collect_plan=plan_out, prior_plan=prior)
+                                     collect_plan=plan_out, prior_plan=prior,
+                                     crop=crop)
             self._dust_plan_cache = (key, plan_out)
             print(f"Dust heal total ({len(spots)} spots, preview scale, "
                   f"plan cached): {time.time() - t0:.3f}s")
             return out
         cached = getattr(self, "_dust_plan_cache", None)
         plan = cached[1] if (cached is not None and cached[0] == key) else None
-        out = apply_dust_removal(image, spots, feather=feather, plan=plan)
+        out = apply_dust_removal(image, spots, feather=feather, plan=plan,
+                                 crop=crop)
         print(f"Dust heal total ({len(spots)} spots, "
               f"preview plan {'reused' if plan is not None else 'MISSING'}): "
               f"{time.time() - t0:.3f}s")

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -191,9 +191,10 @@ class CCRImage:
         # time (resolution-independent). [] = no dust removal. See
         # spec/dust-removal.md.
         self.dust_spots: List[Dict[str, Any]] = []
-        # Edge fade width for the dust heal, as a fraction of image width
-        # (user-set via the dust panel's Feather slider; render parameter,
-        # deliberately NOT in undo snapshots — like brush size).
+        # Edge fade width for the dust heal, as a fraction of each hole's own
+        # half-thickness so it scales with the brush (user-set via the dust
+        # panel's Feather slider; render parameter, deliberately NOT in undo
+        # snapshots — like brush size).
         self.dust_feather: float = DUST_FEATHER_DEFAULT
         # (spots_key, plan) captured from the last PREVIEW-scale heal, replayed
         # by hi-res/export renders so they sample exactly the patches shown on

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -930,7 +930,14 @@ class CCRImage:
         renders replay THAT plan, so they sample exactly the patches the user
         approved on screen — a fresh plan from the export's own re-decoded
         pixels can flip near-tie source choices. Feather is excluded from the
-        key (it shapes the blend, not the plan). See spec/dust-removal.md."""
+        key (it shapes the blend, not the plan).
+
+        Sticky sources: the cached plan — even one keyed to a PREVIOUS spot
+        set — seeds every preview-scale re-heal as `prior_plan`, so once a
+        segment's source patch is chosen, later strokes/edits reuse it
+        verbatim instead of re-searching (the plan is serialized in the
+        catalog, so this holds across sessions too). See
+        spec/dust-removal.md."""
         spots = getattr(self, "dust_spots", None)
         if not spots:
             return image
@@ -940,8 +947,10 @@ class CCRImage:
         h, w = image.shape[:2]
         if max(h, w) <= _DUST_PLAN_LONG:
             plan_out = []
+            cached = getattr(self, "_dust_plan_cache", None)
+            prior = cached[1] if cached is not None else None
             out = apply_dust_removal(image, spots, feather=feather,
-                                     collect_plan=plan_out)
+                                     collect_plan=plan_out, prior_plan=prior)
             self._dust_plan_cache = (key, plan_out)
             print(f"Dust heal total ({len(spots)} spots, preview scale, "
                   f"plan cached): {time.time() - t0:.3f}s")

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3283,7 +3283,8 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 comp: int, bbox: tuple,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
                 filled: np.ndarray, fmap: np.ndarray, feather: float,
-                dlike: np.ndarray, src_off=None, forced_flags=None):
+                dlike: np.ndarray, src_off=None, forced_flags=None,
+                sample=None):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
 
@@ -3301,10 +3302,13 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     force-fill engaged), which the plan records so replays reproduce them —
     or None when no fully clean, in-bounds source window exists (caller
     falls back to diffusion inpaint for this patch).
-    `src_off`: a pre-planned offset to REUSE (the resolution-stable replay,
-    see apply_dust_removal); taken verbatim when it still lands on a clean
-    in-bounds window, otherwise the normal search runs (plan drift from
-    mask-raster rounding — rare). `forced_flags`: the plan's
+    `src_off`: a pre-planned offset to REUSE (scale replay / a prior edit's
+    plan) — always taken verbatim (clamped into bounds), never re-searched:
+    once a patch's reference is set, nothing may move it. When dust has
+    landed on the pinned source and `sample` is None, the patch returns a
+    4th element "defer" instead of filling — the caller re-runs it after
+    the Telea pass with `sample` = the healed buffer, so it clones healed
+    content at the SAME location. `forced_flags`: the plan's
     (genuine, dlike_on) verdicts to reuse instead of re-deriving them from
     this buffer's pixels (grain statistics shift with resampling, and a
     flipped verdict is a visible preview/export difference). `img16_c`:
@@ -3417,27 +3421,27 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
 
     best_score, best_src, best_off = None, None, None
     if src_off is not None:
-        # Resolution-stable replay: reuse the offset the plan chose at the
-        # canonical scale instead of re-searching on this buffer's pixels.
-        # If scaling rounded the offset onto dust or out of bounds, rescue
-        # with the nearest clean offset (Chebyshev spiral, <= 4 px) — still
-        # essentially the SAME source patch. Only when that fails too does
-        # the local search run below (it may pick a visibly different patch,
-        # so it is the last resort).
-        base_dy, base_dx = int(src_off[0]), int(src_off[1])
-        for rad in range(0, 5):
-            ring_offs = [(jy, jx)
-                         for jy in range(-rad, rad + 1)
-                         for jx in range(-rad, rad + 1)
-                         if max(abs(jy), abs(jx)) == rad]
-            for jy, jx in ring_offs:
-                src = _source_at(base_dy + jy, base_dx + jx)
-                if src is not None:
-                    best_src = src
-                    best_off = (base_dy + jy, base_dx + jx)
-                    break
-            if best_src is not None:
-                break
+        # Pinned source (scale replay, or a prior edit's plan): the offset
+        # is taken VERBATIM — once a patch's reference is set, NOTHING may
+        # move it. It is only clamped into bounds (scale rounding can push
+        # the window a pixel past the frame). If dust has landed on it
+        # since (a new stroke painted over the sampled patch), the segment
+        # is DEFERRED and re-run after the Telea pass with `sample` = the
+        # healed buffer: it clones the healed content at the very same
+        # location instead of re-searching elsewhere.
+        dy = min(max(int(src_off[0]), -wy0), h - wy1)
+        dx = min(max(int(src_off[1]), -wx0), w - wx1)
+        best_off = (dy, dx)
+        if _box_sum(integ, wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx) == 0:
+            best_src = img16[wy0 + dy:wy1 + dy,
+                             wx0 + dx:wx1 + dx].astype(np.float32)
+        elif sample is not None:
+            best_src = sample[wy0 + dy:wy1 + dy,
+                              wx0 + dx:wx1 + dx].astype(np.float32)
+        else:
+            g0, d0 = forced_flags if forced_flags is not None else (True,
+                                                                    False)
+            return best_off, g0, d0, "defer"
     if best_src is None:
         # Candidate source offsets: rings of directions at thickness-scaled
         # distances. The integral-image check rejects any source that touches
@@ -3616,9 +3620,10 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     source/verdicts VERBATIM instead of re-searching, so painting a new
     stroke cannot re-sample the strokes already on screen (a fresh search
     with the new mask in place flipped near-tie sources for any segment
-    whose context ring the new stroke grazed). Only a stroke that lands ON
-    a prior source (making it dust) forces that one segment to re-search;
-    new segments match no prior record and search normally.
+    whose context ring the new stroke grazed). Even a stroke that lands ON
+    a prior source does not move it: that segment defers to a second pass
+    and clones the HEALED content at the same location (see _heal_patch).
+    New segments match no prior record and search normally.
     """
     if not spots:
         return img16
@@ -3696,6 +3701,9 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     kb = int(round(max(1.0, scale_up)))
     kb += 1 - (kb % 2)  # nearest odd
     img16_c = img16 if kb <= 1 else cv2.blur(img16, (kb, kb))
+    # Segments whose PINNED source is under newer dust: re-run after the
+    # fills below so they clone the healed content at the same location.
+    deferred = []
     t_setup = time.time() - t0
     t0 = time.time()
     n_segs = 0
@@ -3755,6 +3763,11 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                                       loc_th, mask_pad, integ, filled, fmap,
                                       feather, dlike, src_off=src_off,
                                       forced_flags=flags)
+                if res is not None and len(res) == 4:
+                    # Pinned source now under new dust: fill in a SECOND
+                    # pass from the healed buffer (after Telea), so the
+                    # reference location stays — no exceptions.
+                    deferred.append((i, bbox, loc_th, res[0], flags))
                 off = None if res is None else res[0]
                 if collect is not None:
                     collect.append(
@@ -3789,6 +3802,14 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         fb = fallback > 0
         filled[fb] = telea16[fb]
     t_telea = time.time() - t0
+
+    # Second pass for deferred segments: every hole now has SOME fill in
+    # `filled` (clone or Telea), so a pinned source that sat under new dust
+    # clones the healed content at its unchanged reference location.
+    for i, bbox_d, loc_d, off_d, flags_d in deferred:
+        _heal_patch(img16, img16_c, labels, i, bbox_d, loc_d, mask_pad,
+                    integ, filled, fmap, feather, dlike,
+                    src_off=off_d, forced_flags=flags_d, sample=filled)
 
     # Feathered composite: alpha rises 0 -> 1 from each hole's boundary inward
     # over its feather ramp (a fraction of the hole's own thickness, so it

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3240,8 +3240,10 @@ _HEAL_ANGLES = 16         # candidate source directions searched around a spot
 _HEAL_MIN_RING_PX = 8     # need at least this much clean ring to heal
 _HEAL_SEG_MIN = 32        # min heal-segment size (px) for long strokes
 _HEAL_SEG_THICKNESS = 6.0  # segment size as a multiple of hole thickness
-DUST_FEATHER_DEFAULT = 0.003  # feather ramp width, fraction of image width
-                              # (user-adjustable per image via the dust panel)
+DUST_FEATHER_DEFAULT = 0.25   # feather ramp width, fraction of each hole's
+                              # own half-thickness (its local radius), so the
+                              # fade scales with the brush size (user-adjustable
+                              # per image via the dust panel)
 
 
 def _box_sum(integ: np.ndarray, y0: int, x0: int, y1: int, x1: int) -> int:
@@ -3252,8 +3254,8 @@ def _box_sum(integ: np.ndarray, y0: int, x0: int, y1: int, x1: int) -> int:
 def _feather_alpha(mask: np.ndarray, fmap: np.ndarray) -> np.ndarray:
     """Per-pixel blend alpha for the fill: 0 at each hole's boundary rising to
     1 over `fmap` px inward (smoothstep ramp); exactly 0 outside the mask.
-    `fmap` holds each hole's feather ramp width in px (uint8; 1 = essentially
-    hard). The +1 lift keeps a 1-px-feather rim nearly fully filled while wide
+    `fmap` holds each hole's feather ramp width in px (1 = essentially hard).
+    The +1 lift keeps a 1-px-feather rim nearly fully filled while wide
     feathers still start near 0 at the very edge."""
     inside = cv2.distanceTransform((mask > 0).astype(np.uint8), cv2.DIST_L2, 3)
     f = np.maximum(fmap.astype(np.float32), 1.0)
@@ -3262,7 +3264,7 @@ def _feather_alpha(mask: np.ndarray, fmap: np.ndarray) -> np.ndarray:
 
 def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
-                filled: np.ndarray, fmap: np.ndarray, feather_px: int,
+                filled: np.ndarray, fmap: np.ndarray, feather: float,
                 dlike: np.ndarray, src_off=None):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
@@ -3427,14 +3429,17 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     filled[wy0:wy1, wx0:wx1][hole] = np.clip(
         np.rint(heal[hole]), 0, 65535).astype(np.uint16)
 
-    # Feather: the user-set ramp width, capped by the hole depth so the core
-    # still reaches full fill. Defect-like hole pixels (colored like the
-    # estimated defect) are force-filled via `dlike` regardless of the ramp,
-    # so a wide feather can never blend the defect back in — the soft fade
-    # only happens across clean rim pixels.
+    # Feather: the ramp is the user-set FRACTION of this hole's depth (its
+    # local radius), so the fade grows with the brush size instead of staying
+    # a fixed few pixels; the depth cap keeps the core at full fill.
+    # Defect-like hole pixels (colored like the estimated defect) are
+    # force-filled via `dlike` regardless of the ramp, so a wide feather can
+    # never blend the defect back in — the soft fade only happens across
+    # clean rim pixels.
     inside = cv2.distanceTransform(hole.astype(np.uint8), cv2.DIST_L2, 3)
     depth = max(1.0, float(inside.max()))
-    fmap[wy0:wy1, wx0:wx1][hole] = int(max(1.0, min(float(feather_px), depth)))
+    fmap[wy0:wy1, wx0:wx1][hole] = int(
+        max(1.0, min(round(float(feather) * depth), depth)))
     like = np.abs(hole_px - defect).mean(axis=1) < thr
     if like.any():
         hy, hx = np.nonzero(hole)
@@ -3466,11 +3471,13 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
                        plan=None, collect_plan=None) -> np.ndarray:
     """Heal the dust spots out of a 16-bit RGB image, non-destructively.
 
-    `feather` is the edge fade width as a fraction of image width (the user's
-    per-image Feather setting): 0 = essentially hard edges, larger values
-    cross-fade the fill into the surrounding original over a wider ramp.
-    Defect-like pixels are always fully filled regardless of the feather, so
-    a wide fade cannot blend the defect back in.
+    `feather` is the edge fade width as a fraction of each hole's own
+    half-thickness (the user's per-image Feather setting, 0..1): 0 =
+    essentially hard edges, 1 = the cross-fade spans the hole's full depth.
+    Keyed to the hole's local radius, the fade scales with the brush size —
+    and with resolution, since the rasterized hole does. Defect-like pixels
+    are always fully filled regardless of the feather, so a wide fade cannot
+    blend the defect back in.
 
     Each mask component is filled by CLONING the best-matching clean patch
     from its neighborhood (see _heal_patch) — real texture and grain,
@@ -3482,7 +3489,7 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     diffusion and ghost). Patches with no clean source window (image border,
     dense dust) fall back to cv2.inpaint (Telea, 8-bit). The fill is
     composited through a feathered alpha that ramps inward from each hole's
-    boundary (resolution-scaled, capped by the hole's defect-free rim); ONLY
+    boundary (thickness-relative, capped by the hole's defect-free rim); ONLY
     masked pixels change, the rest of the frame is bit-for-bit untouched.
     Returns a NEW uint16 array; img16 is never mutated. No-op (returns img16
     unchanged) when there are no spots or the rasterized mask is empty.
@@ -3553,12 +3560,12 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     integ = cv2.integral((mask_pad > 0).astype(np.uint8))
     filled = img16.copy()
     fallback = np.zeros_like(mask)
-    # Per-pixel feather ramp width (px). Normalized like the spots, so the
-    # fade covers the same image fraction at preview and export; each patch
-    # caps its own value by its hole depth (see _heal_patch). `dlike` marks
-    # defect-like hole pixels that must be fully filled regardless of feather.
-    feather_px = max(1, int(round(float(feather) * w)))
-    fmap = np.ones((h, w), np.uint8)
+    # Per-pixel feather ramp width (px): each patch writes feather × its own
+    # hole depth (see _heal_patch), so the fade tracks the brush size and the
+    # buffer's resolution alike. uint16: a 20%-of-width brush at export scale
+    # yields ramps far past 255. `dlike` marks defect-like hole pixels that
+    # must be fully filled regardless of feather.
+    fmap = np.ones((h, w), np.uint16)
     dlike = np.zeros((h, w), np.uint8)
     # Pixel-based knobs scale with the buffer (relative to the plan scale) so
     # a stroke splits into the SAME segments here as it did in the plan, and
@@ -3604,17 +3611,18 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                 if not forced_fb:
                     off = _heal_patch(img16, labels, i, bbox, half_th,
                                       mask_pad, integ, filled, fmap,
-                                      feather_px, dlike, src_off=src_off)
+                                      feather, dlike, src_off=src_off)
                 if collect is not None:
                     collect.append((cyn, cxn, None if off is None
                                     else (off[0] / h, off[1] / w)))
                 if off is None:
                     fallback[ty:ty + sub.shape[0],
                              tx:tx + sub.shape[1]][sub] = 255
-                    # No defect estimate on this path — cap the fade by the
-                    # hole thickness so thin strokes stay near-hard.
+                    # Same radius-relative ramp as the clone path, using the
+                    # component's half-thickness as the local radius.
                     fmap[ty:ty + sub.shape[0], tx:tx + sub.shape[1]][sub] = \
-                        max(1, min(feather_px, int(round(0.5 * half_th))))
+                        max(1, min(int(round(float(feather) * half_th)),
+                                   int(round(half_th))))
 
     t_segs = time.time() - t0
     mode = (" [plan-only]" if plan_only
@@ -3638,9 +3646,10 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     t_telea = time.time() - t0
 
     # Feathered composite: alpha rises 0 -> 1 from each hole's boundary inward
-    # over its feather ramp (resolution-scaled, capped by the hole's
-    # defect-free rim), so the fill cross-fades into the original instead of
-    # cutting hard at the mask edge. OUTSIDE the mask alpha is exactly 0 —
+    # over its feather ramp (a fraction of the hole's own thickness, so it
+    # scales with brush size and resolution alike), so the fill cross-fades
+    # into the original instead of cutting hard at the mask edge. OUTSIDE the
+    # mask alpha is exactly 0 —
     # those pixels are kept bit-for-bit. The float blend runs per COMPONENT
     # window (padded 2 px): one global mask bbox degenerates to nearly the
     # whole frame when spots are scattered, and the full-frame float blend
@@ -3659,11 +3668,18 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         comp = labels[ys, xs] == i
         a = _feather_alpha(comp.astype(np.uint8) * 255, fmap[ys, xs])
         # Defect-like pixels get the fill at full strength whatever the
-        # feather; the max with a light blur adds a soft lip around the
-        # forced region without weakening its interior. (The lip's 1 px
-        # leak past the hole blends filled==img16 — a no-op.)
+        # feather; the max with a blur adds a soft lip around the forced
+        # region without weakening its interior (max keeps the core at 1).
+        # The lip is as wide as the component's feather ramp, so the fill
+        # relaxes gradually across the clean rim instead of stepping at the
+        # defect's edge. It is confined to the component: a ramp-wide skirt
+        # can reach a NEIGHBORING component's hole (unlike the old 1 px lip),
+        # where blending img16 against that hole's fill would corrupt it.
         dl = np.where(comp, dlike[ys, xs], 0)
-        forced = np.maximum(dl, cv2.blur(dl, (3, 3))).astype(np.float32) / 255.0
+        lip = int(fmap[ys, xs][comp].max())
+        forced = np.maximum(dl, cv2.blur(dl, (2 * lip + 1, 2 * lip + 1)))
+        forced = forced.astype(np.float32) / 255.0
+        forced[~comp] = 0.0
         a = np.maximum(a, forced)
         write = a > 0.0
         if not write.any():

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3542,6 +3542,14 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
 # preview's healing structure. See apply_dust_removal.
 _DUST_PLAN_LONG = 1080
 
+# Centroid-match tolerance (normalized) when an EDIT re-heals with the
+# previous plan as prior (sticky sources): unchanged segments sit at
+# bit-identical centroids (the tile grid is absolute), so the bind is tight —
+# a NEW stroke's segments must never inherit a neighbor's source without
+# ever being scored. Cross-resolution replay keeps the looser default
+# (raster rounding shifts centroids across scales).
+_DUST_EDIT_TOL = 0.004
+
 
 def _nearest_plan_record(plan, cyn, cxn, tol=0.06):
     """The plan record whose segment centroid is nearest to (cyn, cxn) in
@@ -3557,7 +3565,8 @@ def _nearest_plan_record(plan, cyn, cxn, tol=0.06):
 
 def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
                        feather: float = DUST_FEATHER_DEFAULT,
-                       plan=None, collect_plan=None) -> np.ndarray:
+                       plan=None, collect_plan=None,
+                       prior_plan=None) -> np.ndarray:
     """Heal the dust spots out of a 16-bit RGB image, non-destructively.
 
     `feather` is the edge fade width as a fraction of each hole's own
@@ -3601,6 +3610,15 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     so exports/hi-res sample exactly the patches the on-screen preview did
     (self-planning re-decodes/resizes and near-tie source choices can flip
     on real content). Ignored on canonical-scale buffers.
+    `prior_plan` (canonical-scale buffers only): the PREVIOUS edit's plan.
+    Once a patch's source is set, nothing may move it — segments whose
+    centroids are unchanged (tight _DUST_EDIT_TOL bind) reuse their prior
+    source/verdicts VERBATIM instead of re-searching, so painting a new
+    stroke cannot re-sample the strokes already on screen (a fresh search
+    with the new mask in place flipped near-tie sources for any segment
+    whose context ring the new stroke grazed). Only a stroke that lands ON
+    a prior source (making it dust) forces that one segment to re-search;
+    new segments match no prior record and search normally.
     """
     if not spots:
         return img16
@@ -3608,7 +3626,8 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     long_side = max(h, w)
     if long_side <= _DUST_PLAN_LONG:
         return _heal_impl(img16, spots, inpaint_radius, feather,
-                          collect=collect_plan)
+                          collect=collect_plan, plan=prior_plan,
+                          plan_tol=_DUST_EDIT_TOL)
     scale = long_side / float(_DUST_PLAN_LONG)
     if plan is None:
         # No preview plan supplied — derive one from this buffer's own
@@ -3627,7 +3646,8 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
 
 def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                feather: float, plan=None, collect=None,
-               scale_up: float = 1.0, plan_only: bool = False) -> np.ndarray:
+               scale_up: float = 1.0, plan_only: bool = False,
+               plan_tol: float = 0.06) -> np.ndarray:
     """apply_dust_removal's engine at ONE resolution. With `collect` (a list),
     appends a plan record per heal segment:
     (cy_norm, cx_norm, offset, genuine, dlike_on) where offset is the chosen
@@ -3637,7 +3657,9 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     size over the plan scale), segments reuse the planned
     offsets/fallbacks/verdicts instead of re-deriving them, and the
     pixel-based geometry (segment size, Telea radius) scales by `scale_up`
-    so segmentation matches the plan's.
+    so segmentation matches the plan's. `plan_tol` is the centroid-match
+    tolerance: loose for cross-resolution replay (raster rounding), tight
+    (_DUST_EDIT_TOL) when a prior edit's plan pins sources at the same scale.
     `plan_only` skips the Telea fill and the feathered composite (the caller
     only wants the collected plan, not the healed buffer) and returns img16."""
     if not spots:
@@ -3718,7 +3740,7 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                 cxn = (bx + float(xs.mean())) / w
                 src_off, forced_fb, flags = None, False, None
                 if plan is not None:
-                    rec = _nearest_plan_record(plan, cyn, cxn)
+                    rec = _nearest_plan_record(plan, cyn, cxn, tol=plan_tol)
                     if rec is not None:
                         if rec[2] is None:
                             forced_fb = True  # the plan chose diffusion here

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3691,17 +3691,31 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         seg_max = max(seg_min, int(round(_HEAL_SEG_MAX * max(1.0, scale_up))))
         seg = max(seg_min, min(int(round(_HEAL_SEG_THICKNESS * half_th)),
                                seg_max))
-        for ty in range(y0, y0 + ch, seg):
-            for tx in range(x0, x0 + cw, seg):
-                sub = comp_win[ty - y0:ty - y0 + seg, tx - x0:tx - x0 + seg]
+        # Local scale for the guard/ring/search geometry: bounded by the
+        # tile, so a merged blob's growing thickness cannot resize EVERY
+        # tile's window (a new dab used to re-sample segments far from the
+        # edit). Inert for uncapped components (seg = 6·half_th there).
+        loc_th = min(half_th, 0.5 * seg)
+        # Components spanning multiple tiles anchor the grid to the IMAGE,
+        # not the bbox: a dab extending the bbox origin used to shift every
+        # tile of the blob, re-sampling segments the edit never touched.
+        # Compact components keep the single un-split tile.
+        if cw <= seg and ch <= seg:
+            gy, gx = y0, x0
+        else:
+            gy, gx = (y0 // seg) * seg, (x0 // seg) * seg
+        for ty in range(gy, y0 + ch, seg):
+            for tx in range(gx, x0 + cw, seg):
+                by, bx = max(ty, y0), max(tx, x0)
+                sub = comp_win[by - y0:ty - y0 + seg, bx - x0:tx - x0 + seg]
                 if not sub.any():
                     continue
                 n_segs += 1
                 ys, xs = np.nonzero(sub)
-                bbox = (tx + int(xs.min()), ty + int(ys.min()),
-                        tx + int(xs.max()) + 1, ty + int(ys.max()) + 1)
-                cyn = (ty + float(ys.mean())) / h
-                cxn = (tx + float(xs.mean())) / w
+                bbox = (bx + int(xs.min()), by + int(ys.min()),
+                        bx + int(xs.max()) + 1, by + int(ys.max()) + 1)
+                cyn = (by + float(ys.mean())) / h
+                cxn = (bx + float(xs.mean())) / w
                 src_off, forced_fb, flags = None, False, None
                 if plan is not None:
                     rec = _nearest_plan_record(plan, cyn, cxn)
@@ -3716,7 +3730,7 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                 res = None
                 if not forced_fb:
                     res = _heal_patch(img16, img16_c, labels, i, bbox,
-                                      half_th, mask_pad, integ, filled, fmap,
+                                      loc_th, mask_pad, integ, filled, fmap,
                                       feather, dlike, src_off=src_off,
                                       forced_flags=flags)
                 off = None if res is None else res[0]
@@ -3726,12 +3740,12 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                         else (cyn, cxn, (off[0] / h, off[1] / w),
                               res[1], res[2]))
                 if off is None:
-                    fallback[ty:ty + sub.shape[0],
-                             tx:tx + sub.shape[1]][sub] = 255
+                    fallback[by:by + sub.shape[0],
+                             bx:bx + sub.shape[1]][sub] = 255
                     # Same radius-relative ramp as the clone path, using the
-                    # component's half-thickness as the local radius.
-                    fmap[ty:ty + sub.shape[0], tx:tx + sub.shape[1]][sub] = \
-                        max(0.5, min(float(feather) * half_th, half_th))
+                    # tile-bounded half-thickness as the local radius.
+                    fmap[by:by + sub.shape[0], bx:bx + sub.shape[1]][sub] = \
+                        max(0.5, min(float(feather) * loc_th, loc_th))
 
     t_segs = time.time() - t0
     mode = (" [plan-only]" if plan_only

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3230,6 +3230,27 @@ def rasterize_dust_mask(spots, h: int, w: int) -> np.ndarray:
     return mask
 
 
+def _crop_keep_mask(rect, angle, h: int, w: int):
+    """uint8 {0,1} mask of the pixels a confirmed crop KEEPS — the crop
+    rectangle (normalized x1, y1, x2, y2 over width/height), rotated by
+    `angle` about its center (Qt clockwise convention; the raster twin of
+    _extract_rotated_crop / apply_crop_to_image). None when degenerate."""
+    x1, y1, x2, y2 = [float(v) for v in rect]
+    bw, bh = (x2 - x1) * w, (y2 - y1) * h
+    if bw <= 1 or bh <= 1:
+        return None
+    cx, cy = (x1 + x2) / 2.0 * w, (y1 + y2) / 2.0 * h
+    a = np.deg2rad(float(angle or 0.0))
+    ca, sa = float(np.cos(a)), float(np.sin(a))
+    corners = np.array(
+        [(cx + ca * ux - sa * uy, cy + sa * ux + ca * uy)
+         for ux, uy in ((-bw / 2, -bh / 2), (bw / 2, -bh / 2),
+                        (bw / 2, bh / 2), (-bw / 2, bh / 2))], np.int32)
+    keep = np.zeros((h, w), np.uint8)
+    cv2.fillPoly(keep, [corners], 1)
+    return keep
+
+
 # Clone-heal tuning. The fill copies the best-matching CLEAN patch from the
 # spot's neighborhood (real texture and grain, 16-bit native) instead of
 # diffusing an average inward — diffusion (cv2.inpaint) produces a smooth,
@@ -3570,7 +3591,7 @@ def _nearest_plan_record(plan, cyn, cxn, tol=0.06):
 def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
                        feather: float = DUST_FEATHER_DEFAULT,
                        plan=None, collect_plan=None,
-                       prior_plan=None) -> np.ndarray:
+                       prior_plan=None, crop=None) -> np.ndarray:
     """Heal the dust spots out of a 16-bit RGB image, non-destructively.
 
     `feather` is the edge fade width as a fraction of each hole's own
@@ -3624,6 +3645,12 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     a prior source does not move it: that segment defers to a second pass
     and clones the HEALED content at the same location (see _heal_patch).
     New segments match no prior record and search normally.
+    `crop`: ((x1, y1, x2, y2) normalized, angle_deg) — the image's confirmed
+    crop. Content OUTSIDE it (film holder, rebate, whatever the user cut
+    away) is not scene: it is treated like dust for context purposes, so
+    rings never anchor on it and fresh searches never sample it. Pinned
+    sources keep their reference regardless (sticky) — one outside a newer
+    crop just routes through the deferred pass onto the same pixels.
     """
     if not spots:
         return img16
@@ -3632,7 +3659,7 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     if long_side <= _DUST_PLAN_LONG:
         return _heal_impl(img16, spots, inpaint_radius, feather,
                           collect=collect_plan, plan=prior_plan,
-                          plan_tol=_DUST_EDIT_TOL)
+                          plan_tol=_DUST_EDIT_TOL, crop=crop)
     scale = long_side / float(_DUST_PLAN_LONG)
     if plan is None:
         # No preview plan supplied — derive one from this buffer's own
@@ -3643,16 +3670,16 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
         small = cv2.resize(img16, (pw, ph), interpolation=cv2.INTER_AREA)
         plan = []
         _heal_impl(small, spots, inpaint_radius, feather, collect=plan,
-                   plan_only=True)
+                   plan_only=True, crop=crop)
         print(f"Dust plan (no cached preview plan): {time.time() - t0:.3f}s")
     return _heal_impl(img16, spots, inpaint_radius, feather,
-                      plan=plan, scale_up=scale)
+                      plan=plan, scale_up=scale, crop=crop)
 
 
 def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                feather: float, plan=None, collect=None,
                scale_up: float = 1.0, plan_only: bool = False,
-               plan_tol: float = 0.06) -> np.ndarray:
+               plan_tol: float = 0.06, crop=None) -> np.ndarray:
     """apply_dust_removal's engine at ONE resolution. With `collect` (a list),
     appends a plan record per heal segment:
     (cy_norm, cx_norm, offset, genuine, dlike_on) where offset is the chosen
@@ -3678,6 +3705,16 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     n, labels, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
     # "Clean" excludes every spot plus 1 px (buries antialiased speck edges).
     mask_pad = cv2.dilate(mask, np.ones((3, 3), np.uint8))
+    if crop is not None and crop[0]:
+        keep = _crop_keep_mask(crop[0], crop[1], h, w)
+        if keep is not None and not keep.all():
+            # Outside-crop content (holder/rebate/junk the user cut away) is
+            # not scene: treat it like dust for context purposes — rings
+            # never anchor on it and fresh searches never sample it. Pinned
+            # sources keep their reference (sticky): one poking outside just
+            # routes through the deferred pass onto the same pixels.
+            mask_pad = np.maximum(
+                mask_pad, np.where(keep > 0, 0, 255).astype(np.uint8))
     integ = cv2.integral((mask_pad > 0).astype(np.uint8))
     filled = img16.copy()
     fallback = np.zeros_like(mask)

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3240,6 +3240,8 @@ _HEAL_ANGLES = 16         # candidate source directions searched around a spot
 _HEAL_MIN_RING_PX = 8     # need at least this much clean ring to heal
 _HEAL_SEG_MIN = 32        # min heal-segment size (px) for long strokes
 _HEAL_SEG_THICKNESS = 6.0  # segment size as a multiple of hole thickness
+_DLIKE_SEP_MADS = 6.0     # defect-vs-surround separation (in ring-grain MADs)
+                          # required before pixels are force-filled as defect
 DUST_FEATHER_DEFAULT = 0.25   # feather ramp width, fraction of each hole's
                               # own half-thickness (its local radius), so the
                               # fade scales with the brush size (user-adjustable
@@ -3440,10 +3442,25 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     depth = max(1.0, float(inside.max()))
     fmap[wy0:wy1, wx0:wx1][hole] = int(
         max(1.0, min(round(float(feather) * depth), depth)))
-    like = np.abs(hole_px - defect).mean(axis=1) < thr
-    if like.any():
-        hy, hx = np.nonzero(hole)
-        dlike[wy0:wy1, wx0:wx1][hy[like], hx[like]] = 255
+    # Mark defect-like pixels ONLY when the estimated defect color is
+    # DISTINCT from the clean surround. With a generous brush over mostly
+    # clean content the top-quartile "defect" collapses onto the background
+    # mode, and thresholding grain against it marked a random salt-and-pepper
+    # subset of the hole — dithered full-opacity pixels inside an otherwise
+    # feathered fill, with no rolloff at wide feathers. Gate on the
+    # defect/surround separation in units of the surround's own grain
+    # (median abs deviation of the cleaned ring), then mark the hole pixels
+    # CLOSER to the defect color than to the surround (nearest centroid) —
+    # grain never is, so the marking is coherent, not speckled.
+    ring_bg = np.median(dst_ring, axis=0)
+    mad = float(np.median(np.abs(dst_ring - ring_bg).mean(axis=1)))
+    sep = float(np.abs(defect - ring_bg).mean())
+    if sep > _DLIKE_SEP_MADS * (mad + 1e-3):
+        like = (np.abs(hole_px - defect).mean(axis=1)
+                < np.abs(hole_px - ring_bg).mean(axis=1))
+        if like.any():
+            hy, hx = np.nonzero(hole)
+            dlike[wy0:wy1, wx0:wx1][hy[like], hx[like]] = 255
     return best_off
 
 
@@ -3475,9 +3492,11 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     half-thickness (the user's per-image Feather setting, 0..1): 0 =
     essentially hard edges, 1 = the cross-fade spans the hole's full depth.
     Keyed to the hole's local radius, the fade scales with the brush size —
-    and with resolution, since the rasterized hole does. Defect-like pixels
-    are always fully filled regardless of the feather, so a wide fade cannot
-    blend the defect back in.
+    and with resolution, since the rasterized hole does. Pixels colored like
+    the defect (when one is color-separable from its surround) are always
+    fully filled regardless of the feather, so a wide fade cannot blend the
+    defect back in; on a mostly-clean brushed area no pixels qualify and the
+    blend is a pure opacity dome rolling off from the stroke's center.
 
     Each mask component is filled by CLONING the best-matching clean patch
     from its neighborhood (see _heal_patch) — real texture and grain,

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3240,6 +3240,13 @@ _HEAL_ANGLES = 16         # candidate source directions searched around a spot
 _HEAL_MIN_RING_PX = 8     # need at least this much clean ring to heal
 _HEAL_SEG_MIN = 32        # min heal-segment size (px) for long strokes
 _HEAL_SEG_THICKNESS = 6.0  # segment size as a multiple of hole thickness
+_HEAL_SEG_MAX = 96        # segment-size cap (px at plan scale): a big compact
+                          # dab otherwise becomes ONE segment whose source
+                          # window (bbox + thickness-scaled pad) rarely fits
+                          # anywhere clean, dumping the whole blob into the
+                          # flat, grainless diffusion fallback — a visible
+                          # smooth disc on film grain. Tiles keep cloning
+                          # real texture from beside the blob.
 _DLIKE_SEP_MADS = 6.0     # defect-vs-surround separation (in ring-grain MADs)
                           # required before pixels are force-filled as defect
 _HEAL_MIN_KEEP_FRAC = 0.2  # ring share the defect rejection must leave; below
@@ -3681,7 +3688,9 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         hole0 = np.zeros((ch + 2, cw + 2), np.uint8)
         hole0[1:-1, 1:-1] = comp_win
         half_th = float(cv2.distanceTransform(hole0, cv2.DIST_L2, 3).max())
-        seg = max(seg_min, int(round(_HEAL_SEG_THICKNESS * half_th)))
+        seg_max = max(seg_min, int(round(_HEAL_SEG_MAX * max(1.0, scale_up))))
+        seg = max(seg_min, min(int(round(_HEAL_SEG_THICKNESS * half_th)),
+                               seg_max))
         for ty in range(y0, y0 + ch, seg):
             for tx in range(x0, x0 + cw, seg):
                 sub = comp_win[ty - y0:ty - y0 + seg, tx - x0:tx - x0 + seg]

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3242,6 +3242,11 @@ _HEAL_SEG_MIN = 32        # min heal-segment size (px) for long strokes
 _HEAL_SEG_THICKNESS = 6.0  # segment size as a multiple of hole thickness
 _DLIKE_SEP_MADS = 6.0     # defect-vs-surround separation (in ring-grain MADs)
                           # required before pixels are force-filled as defect
+_HEAL_MIN_KEEP_FRAC = 0.2  # ring share the defect rejection must leave; below
+                           # it the estimate is distrusted (see _heal_patch)
+_HEAL_BLACK_FLOOR = 2000   # ~3% of white: below this a ring pixel reads as
+                           # film holder / rebate, not scene (dust inverts
+                           # bright; the unexposed border inverts to black)
 DUST_FEATHER_DEFAULT = 0.25   # feather ramp width, fraction of each hole's
                               # own half-thickness (its local radius), so the
                               # fade scales with the brush size (user-adjustable
@@ -3254,20 +3259,24 @@ def _box_sum(integ: np.ndarray, y0: int, x0: int, y1: int, x1: int) -> int:
 
 
 def _feather_alpha(mask: np.ndarray, fmap: np.ndarray) -> np.ndarray:
-    """Per-pixel blend alpha for the fill: 0 at each hole's boundary rising to
-    1 over `fmap` px inward (smoothstep ramp); exactly 0 outside the mask.
-    `fmap` holds each hole's feather ramp width in px (1 = essentially hard).
-    The +1 lift keeps a 1-px-feather rim nearly fully filled while wide
-    feathers still start near 0 at the very edge."""
+    """Per-pixel blend alpha for the fill: rises from ~0 at each hole's
+    boundary to 1 over `fmap` px inward (smoothstep ramp); exactly 0 outside
+    the mask. `fmap` holds each hole's feather ramp width in px (float;
+    <= 0.5 = hard fill). Depths are taken at PIXEL CENTERS (inside - 0.5) so
+    the relative alpha profile is resolution-stable: a 1 px ramp at preview
+    scale and its 3 px equivalent at export cover the same fraction of the
+    hole with the same average alpha — an integer ramp with a boundary lift
+    made thin-stroke rims visibly harder at preview than at export."""
     inside = cv2.distanceTransform((mask > 0).astype(np.uint8), cv2.DIST_L2, 3)
-    f = np.maximum(fmap.astype(np.float32), 1.0)
-    return _smoothstep((inside + 1.0) / (f + 1.0)) * (mask > 0)
+    f = np.maximum(fmap.astype(np.float32), 0.5)
+    return _smoothstep((inside - 0.5) / f) * (mask > 0)
 
 
-def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
+def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
+                comp: int, bbox: tuple,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
                 filled: np.ndarray, fmap: np.ndarray, feather: float,
-                dlike: np.ndarray, src_off=None):
+                dlike: np.ndarray, src_off=None, forced_flags=None):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
 
@@ -3278,14 +3287,24 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     so gradients continue through the patch while its grain is kept verbatim).
     `bbox` = (bx0, by0, bx1, by1) tight bounds of THIS patch's hole pixels;
     `half_th` = the component's half-thickness (max distance transform), its
-    local scale. Writes the healed hole pixels into `filled` and returns the
-    chosen source-window offset `(dy, dx)` (relative to the match window, in
-    this buffer's pixels), or None when no fully clean, in-bounds source
-    window exists (caller falls back to diffusion inpaint for this patch).
+    local scale. Writes the healed hole pixels into `filled` and returns
+    `(offset, genuine, dlike_on)` — the chosen source-window offset
+    `(dy, dx)` (relative to the match window, in this buffer's pixels) plus
+    the patch's content-adaptive verdicts (rejection trusted; defect
+    force-fill engaged), which the plan records so replays reproduce them —
+    or None when no fully clean, in-bounds source window exists (caller
+    falls back to diffusion inpaint for this patch).
     `src_off`: a pre-planned offset to REUSE (the resolution-stable replay,
     see apply_dust_removal); taken verbatim when it still lands on a clean
     in-bounds window, otherwise the normal search runs (plan drift from
-    mask-raster rounding — rare).
+    mask-raster rounding — rare). `forced_flags`: the plan's
+    (genuine, dlike_on) verdicts to reuse instead of re-deriving them from
+    this buffer's pixels (grain statistics shift with resampling, and a
+    flipped verdict is a visible preview/export difference). `img16_c`:
+    img16 smoothed to the PLAN scale (identity on canonical buffers) — all
+    PER-PIXEL threshold classifications (holder-black, defect-like) read it,
+    so full-res grain crosses those thresholds no more often than the
+    preview's area-averaged pixels did.
 
     Everything local is keyed off the thickness, never the bbox: a traced
     hair's bbox can span half the frame while the stroke is a few px wide.
@@ -3321,10 +3340,20 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
         (~hole).astype(np.uint8), cv2.DIST_L2, 3)  # px from the hole
     ring = ((away > guard) & (away <= pad)
             & (mask_pad[wy0:wy1, wx0:wx1] == 0))
-    if int(ring.sum()) < _HEAL_MIN_RING_PX:
-        return None  # boxed in by other spots — no context to match against
 
     dst = img16[wy0:wy1, wx0:wx1].astype(np.float32)
+    dst_c = img16_c[wy0:wy1, wx0:wx1].astype(np.float32)
+    # Film-holder / rebate pixels are not scene context: the unexposed
+    # border inverts to near-black, and letting it into the ring drags the
+    # membrane's tone correction toward black (a dark smudge on strokes
+    # near the frame edge) and pollutes source matching. Drop near-black
+    # pixels while they are the ring's minority; if they dominate, the
+    # stroke really is in dark content and the ring stays.
+    dark = dst_c.mean(axis=2) < _HEAL_BLACK_FLOOR
+    if int((ring & dark).sum()) < 0.5 * int(ring.sum()):
+        ring &= ~dark
+    if int(ring.sum()) < _HEAL_MIN_RING_PX:
+        return None  # boxed in by other spots — no context to match against
 
     # Robust rejection: the defect leaks past the mask into the ring — its
     # soft edge, or its whole continuation past the stroke's end, where it can
@@ -3349,11 +3378,27 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     d_def = np.abs(ring_px - defect).mean(axis=1)
     thr = 0.5 * float(np.percentile(d_def, 95.0))
     keep = d_def >= thr
-    if int(keep.sum()) < _HEAL_MIN_RING_PX:
-        return None
-    ring[:] = False
-    ring[ry[keep], rx[keep]] = True
+    # Sanity cap on the rejection: discarding nearly the whole ring means
+    # the "defect" was estimated as the ring's own MAJORITY — a generous
+    # brush over clean content, where the top-quartile estimate collapses
+    # onto the background. Whatever survives is then some small foreign
+    # mode (a black film-holder border, a dark roofline) that becomes the
+    # ENTIRE matching/tone anchor: clean sky strokes healed to solid black,
+    # cloned from the border. A real defect's leak never crowds out this
+    # much context (even a thick traced hair leaves ~a third of its ring
+    # clean), so distrust the estimate, keep the full ring, and skip the
+    # defect force-fill (`genuine` gates it below).
+    genuine = int(keep.sum()) >= _HEAL_MIN_KEEP_FRAC * keep.size
+    if forced_flags is not None:
+        genuine = bool(forced_flags[0])
+    if genuine:
+        if int(keep.sum()) < _HEAL_MIN_RING_PX:
+            return None
+        ring[:] = False
+        ring[ry[keep], rx[keep]] = True
     dst_ring = dst[ring]
+    ring_bg = np.median(dst_ring, axis=0)
+    ring_mad = float(np.median(np.abs(dst_ring - ring_bg).mean(axis=1)))
 
     def _source_at(dy, dx):
         sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
@@ -3406,6 +3451,19 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
                     continue
                 diff = src[ring] - dst_ring
                 score = float(np.mean(diff * diff))
+                # The ring SSD never looks INSIDE the candidate window: a
+                # source whose ring matches but whose hole area holds
+                # something foreign (a black border edge, an object) clones
+                # that thing into the fill. Penalize interior tone far from
+                # the destination ring's background — but only the EXCESS
+                # past the ring's own variability: within it the ring SSD
+                # alone must rank candidates (an always-on penalty re-ranked
+                # near-ties by interior phase on textured content, growing
+                # the membrane correction and with it the preview/export
+                # tone drift).
+                i_diff = np.median(src[hole], axis=0) - ring_bg
+                tol = (_DLIKE_SEP_MADS * (ring_mad + 1e-3)) ** 2
+                score += max(0.0, float(np.mean(i_diff * i_diff)) - tol)
                 if best_score is None or score < best_score:
                     best_score, best_src, best_off = score, src, (dy, dx)
 
@@ -3440,8 +3498,8 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     # clean rim pixels.
     inside = cv2.distanceTransform(hole.astype(np.uint8), cv2.DIST_L2, 3)
     depth = max(1.0, float(inside.max()))
-    fmap[wy0:wy1, wx0:wx1][hole] = int(
-        max(1.0, min(round(float(feather) * depth), depth)))
+    fmap[wy0:wy1, wx0:wx1][hole] = \
+        max(0.5, min(float(feather) * depth, depth))
     # Mark defect-like pixels ONLY when the estimated defect color is
     # DISTINCT from the clean surround. With a generous brush over mostly
     # clean content the top-quartile "defect" collapses onto the background
@@ -3451,17 +3509,24 @@ def _heal_patch(img16: np.ndarray, labels: np.ndarray, comp: int, bbox: tuple,
     # defect/surround separation in units of the surround's own grain
     # (median abs deviation of the cleaned ring), then mark the hole pixels
     # CLOSER to the defect color than to the surround (nearest centroid) —
-    # grain never is, so the marking is coherent, not speckled.
-    ring_bg = np.median(dst_ring, axis=0)
-    mad = float(np.median(np.abs(dst_ring - ring_bg).mean(axis=1)))
+    # grain never is, so the marking is coherent, not speckled. `genuine`:
+    # a distrusted (majority-rejecting) estimate must not force anything.
+    # The brightness comparison is the film prior: dust on the positive is
+    # WHITE (clear film), so a "defect" DARKER than its surround is content,
+    # not dust — never force-fill it.
     sep = float(np.abs(defect - ring_bg).mean())
-    if sep > _DLIKE_SEP_MADS * (mad + 1e-3):
-        like = (np.abs(hole_px - defect).mean(axis=1)
-                < np.abs(hole_px - ring_bg).mean(axis=1))
+    dlike_on = bool(genuine and sep > _DLIKE_SEP_MADS * (ring_mad + 1e-3)
+                    and float(defect.mean()) > float(ring_bg.mean()))
+    if forced_flags is not None:
+        dlike_on = bool(forced_flags[1])
+    if dlike_on:
+        hole_c = dst_c[hole]  # plan-scale smoothed: stable across buffers
+        like = (np.abs(hole_c - defect).mean(axis=1)
+                < np.abs(hole_c - ring_bg).mean(axis=1))
         if like.any():
             hy, hx = np.nonzero(hole)
             dlike[wy0:wy1, wx0:wx1][hy[like], hx[like]] = 255
-    return best_off
+    return best_off, genuine, dlike_on
 
 
 # Canonical planning scale for the heal = the preview's long side. Buffers at
@@ -3557,12 +3622,15 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                feather: float, plan=None, collect=None,
                scale_up: float = 1.0, plan_only: bool = False) -> np.ndarray:
     """apply_dust_removal's engine at ONE resolution. With `collect` (a list),
-    appends a plan record per heal segment: (cy_norm, cx_norm, offset) where
-    offset is the chosen source displacement normalized over (h, w), or None
-    for a diffusion fallback. With `plan` (+ `scale_up` = this buffer's size
-    over the plan scale), segments reuse the planned offsets/fallbacks
-    instead of re-searching, and the pixel-based geometry (segment size,
-    Telea radius) scales by `scale_up` so segmentation matches the plan's.
+    appends a plan record per heal segment:
+    (cy_norm, cx_norm, offset, genuine, dlike_on) where offset is the chosen
+    source displacement normalized over (h, w) — None for a diffusion
+    fallback — and genuine/dlike_on are the patch's content-adaptive
+    verdicts (see _heal_patch). With `plan` (+ `scale_up` = this buffer's
+    size over the plan scale), segments reuse the planned
+    offsets/fallbacks/verdicts instead of re-deriving them, and the
+    pixel-based geometry (segment size, Telea radius) scales by `scale_up`
+    so segmentation matches the plan's.
     `plan_only` skips the Telea fill and the feathered composite (the caller
     only wants the collected plan, not the healed buffer) and returns img16."""
     if not spots:
@@ -3581,16 +3649,24 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     fallback = np.zeros_like(mask)
     # Per-pixel feather ramp width (px): each patch writes feather × its own
     # hole depth (see _heal_patch), so the fade tracks the brush size and the
-    # buffer's resolution alike. uint16: a 20%-of-width brush at export scale
-    # yields ramps far past 255. `dlike` marks defect-like hole pixels that
-    # must be fully filled regardless of feather.
-    fmap = np.ones((h, w), np.uint16)
+    # buffer's resolution alike. float32: fractional ramps keep the relative
+    # alpha profile identical across scales (a rounded 1 px preview ramp vs
+    # its 3 px export equivalent visibly diverged). `dlike` marks defect-like
+    # hole pixels that must be fully filled regardless of feather.
+    fmap = np.full((h, w), 0.5, np.float32)
     dlike = np.zeros((h, w), np.uint8)
     # Pixel-based knobs scale with the buffer (relative to the plan scale) so
     # a stroke splits into the SAME segments here as it did in the plan, and
     # the diffusion fallback blurs over the same image fraction.
     seg_min = max(8, int(round(_HEAL_SEG_MIN * max(1.0, scale_up))))
     telea_r = max(1, int(round(inpaint_radius * max(1.0, scale_up))))
+    # Plan-scale smoothing for per-pixel threshold classifications inside
+    # _heal_patch: a box the size of the scale factor makes this buffer's
+    # pixel statistics match the preview's area-averaged ones, so the same
+    # pixels classify as holder-black / defect-like at every resolution.
+    kb = int(round(max(1.0, scale_up)))
+    kb += 1 - (kb % 2)  # nearest odd
+    img16_c = img16 if kb <= 1 else cv2.blur(img16, (kb, kb))
     t_setup = time.time() - t0
     t0 = time.time()
     n_segs = 0
@@ -3617,7 +3693,7 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                         tx + int(xs.max()) + 1, ty + int(ys.max()) + 1)
                 cyn = (ty + float(ys.mean())) / h
                 cxn = (tx + float(xs.mean())) / w
-                src_off, forced_fb = None, False
+                src_off, forced_fb, flags = None, False, None
                 if plan is not None:
                     rec = _nearest_plan_record(plan, cyn, cxn)
                     if rec is not None:
@@ -3626,22 +3702,27 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                         else:
                             src_off = (int(round(rec[2][0] * h)),
                                        int(round(rec[2][1] * w)))
-                off = None
+                            if len(rec) >= 5:
+                                flags = (rec[3], rec[4])
+                res = None
                 if not forced_fb:
-                    off = _heal_patch(img16, labels, i, bbox, half_th,
-                                      mask_pad, integ, filled, fmap,
-                                      feather, dlike, src_off=src_off)
+                    res = _heal_patch(img16, img16_c, labels, i, bbox,
+                                      half_th, mask_pad, integ, filled, fmap,
+                                      feather, dlike, src_off=src_off,
+                                      forced_flags=flags)
+                off = None if res is None else res[0]
                 if collect is not None:
-                    collect.append((cyn, cxn, None if off is None
-                                    else (off[0] / h, off[1] / w)))
+                    collect.append(
+                        (cyn, cxn, None, None, None) if res is None
+                        else (cyn, cxn, (off[0] / h, off[1] / w),
+                              res[1], res[2]))
                 if off is None:
                     fallback[ty:ty + sub.shape[0],
                              tx:tx + sub.shape[1]][sub] = 255
                     # Same radius-relative ramp as the clone path, using the
                     # component's half-thickness as the local radius.
                     fmap[ty:ty + sub.shape[0], tx:tx + sub.shape[1]][sub] = \
-                        max(1, min(int(round(float(feather) * half_th)),
-                                   int(round(half_th))))
+                        max(0.5, min(float(feather) * half_th, half_th))
 
     t_segs = time.time() - t0
     mode = (" [plan-only]" if plan_only
@@ -3695,7 +3776,7 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         # can reach a NEIGHBORING component's hole (unlike the old 1 px lip),
         # where blending img16 against that hole's fill would corrupt it.
         dl = np.where(comp, dlike[ys, xs], 0)
-        lip = int(fmap[ys, xs][comp].max())
+        lip = max(1, int(round(float(fmap[ys, xs][comp].max()))))
         forced = np.maximum(dl, cv2.blur(dl, (2 * lip + 1, 2 * lip + 1)))
         forced = forced.astype(np.float32) / 255.0
         forced[~comp] = 0.0

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -16,7 +16,7 @@ import math
 
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
                                 QPushButton, QSlider, QFrame, QProgressBar,
-                                QMessageBox)
+                                QMessageBox, QCheckBox)
 from PySide6.QtCore import Qt, QObject, QThread, QTimer, Signal
 
 from core import dust_detect
@@ -207,6 +207,18 @@ class DustRemovalPanel(QWidget):
         feather_row.addWidget(self.feather_slider)
         feather_row.addWidget(self.feather_value)
         layout.addLayout(feather_row)
+
+        # Diagnostic overlay: outline every stroke and mark where each heal
+        # segment sampled its patch from (arrow source -> segment; ring only
+        # = diffusion fallback, nothing was sampled).
+        self.show_sources_cb = QCheckBox("Show heal sources")
+        self.show_sources_cb.setToolTip(
+            "Outline each stroke and mark where every heal sampled its "
+            "patch from (green arrow: sampled patch → healed segment; "
+            "orange ring: diffusion fill, nothing sampled).")
+        self.show_sources_cb.toggled.connect(
+            lambda on: self.image_preview.set_dust_source_overlay(on))
+        layout.addWidget(self.show_sources_cb)
 
         hint = QLabel("Click or drag over dust to remove it.")
         hint.setWordWrap(True)

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
 from PySide6.QtCore import Qt, QObject, QThread, QTimer, Signal
 
 from core import dust_detect
+from core.ccr_processor import DUST_FEATHER_DEFAULT
 from ui import theme
 
 # Brush radius limits as a fraction of image width (the canvas clamps to the
@@ -186,18 +187,20 @@ class DustRemovalPanel(QWidget):
         brush_row.addWidget(self.brush_value)
         layout.addLayout(brush_row)
 
-        # Edge feather: per-image render parameter (fraction of image width)
-        # applied to ALL of the image's spots — manual and AI — live.
+        # Edge feather: per-image render parameter (fraction of each spot's
+        # own radius, so the fade scales with the brush) applied to ALL of
+        # the image's spots — manual and AI — live.
         feather_row = QHBoxLayout()
         feather_row.setSpacing(theme.GAP_TIGHT)
         feather_lbl = QLabel("Feather")
         feather_lbl.setFixedWidth(theme.LABEL_COL_W)
         self.feather_slider = QSlider(Qt.Horizontal)
-        self.feather_slider.setMinimum(0)    # f = value/10000 -> 0 .. 1.0% width
+        self.feather_slider.setMinimum(0)    # f = value/100 -> 0 .. 100% of radius
         self.feather_slider.setMaximum(100)
-        self.feather_slider.setValue(30)     # 0.30% default
+        self.feather_slider.setValue(
+            int(round(DUST_FEATHER_DEFAULT * 100)))
         self.feather_slider.setFixedHeight(theme.CONTROL_H)
-        self.feather_value = QLabel("0.30%")
+        self.feather_value = QLabel(f"{DUST_FEATHER_DEFAULT * 100:.0f}%")
         self.feather_value.setFixedWidth(theme.VALUE_COL_W)
         self.feather_slider.valueChanged.connect(self._on_feather_changed)
         feather_row.addWidget(feather_lbl)
@@ -316,11 +319,12 @@ class DustRemovalPanel(QWidget):
         self.image_preview.set_dust_brush_size(
             slider_to_brush_r(self.brush_slider.value()))
         # Reflect this image's feather without re-triggering a re-render.
-        f = getattr(img, "dust_feather", 0.003) if img is not None else 0.003
+        f = (getattr(img, "dust_feather", DUST_FEATHER_DEFAULT)
+             if img is not None else DUST_FEATHER_DEFAULT)
         self.feather_slider.blockSignals(True)
-        self.feather_slider.setValue(int(round(f * 10000)))
+        self.feather_slider.setValue(int(round(f * 100)))
         self.feather_slider.blockSignals(False)
-        self.feather_value.setText(f"{f * 100.0:.2f}%")
+        self.feather_value.setText(f"{f * 100.0:.0f}%")
         self._refresh_ai_section()
         self.status_label.setText("")
 
@@ -341,7 +345,7 @@ class DustRemovalPanel(QWidget):
         self.image_preview.set_dust_brush_size(r)
 
     def _on_feather_changed(self, value):
-        self.feather_value.setText(f"{value / 100.0:.2f}%")
+        self.feather_value.setText(f"{value}%")
         self._feather_timer.start()
 
     def _apply_feather(self):
@@ -350,7 +354,7 @@ class DustRemovalPanel(QWidget):
         img = self._current_image()
         if img is None:
             return
-        f = self.feather_slider.value() / 10000.0
+        f = self.feather_slider.value() / 100.0
         if abs(getattr(img, "dust_feather", -1.0) - f) < 1e-9:
             return
         img.dust_feather = f

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -2568,9 +2568,13 @@ class ImagePreview(QWidget):
         if img is None or raw is None:
             return None
         brush = [s for s in getattr(img, "dust_spots", []) if s.get("kind") == "brush"]
+        rect = getattr(img, "crop_rect", None)
+        crop = ((tuple(rect), float(getattr(img, "crop_angle", 0.0) or 0.0))
+                if rect else None)
         return apply_dust_removal(
             raw, brush,
-            feather=getattr(img, "dust_feather", DUST_FEATHER_DEFAULT))
+            feather=getattr(img, "dust_feather", DUST_FEATHER_DEFAULT),
+            crop=crop)
 
     def dust_detect_source(self):
         """Detection source for the current image (see dust_detect_source_for)."""

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -9,7 +9,7 @@ from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QP
                            QImage)
 from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
-from core.ccr_processor import apply_dust_removal
+from core.ccr_processor import apply_dust_removal, DUST_FEATHER_DEFAULT
 from core import crop_aspect
 from widgets.dust_panel import DUST_BRUSH_R_MIN, DUST_BRUSH_R_MAX
 from widgets.export_dialog import ExportSettingsDialog
@@ -1713,7 +1713,8 @@ class ImagePreview(QWidget):
                    for p in (s.get("pts") or [])),
              round(float(s.get("r", 0)) * 10000))
             for s in getattr(img, "dust_spots", [])),
-            round(float(getattr(img, "dust_feather", 0.003)) * 10000))
+            round(float(getattr(img, "dust_feather",
+                                DUST_FEATHER_DEFAULT)) * 10000))
         return (tuple(sorted(img.adjustment_settings.items())),
                 img.contrast_base, img.temperature_base, img.brightness_base,
                 getattr(img, "exposure_base", 0.0),
@@ -2537,7 +2538,8 @@ class ImagePreview(QWidget):
             return None
         brush = [s for s in getattr(img, "dust_spots", []) if s.get("kind") == "brush"]
         return apply_dust_removal(
-            raw, brush, feather=getattr(img, "dust_feather", 0.003))
+            raw, brush,
+            feather=getattr(img, "dust_feather", DUST_FEATHER_DEFAULT))
 
     def dust_detect_source(self):
         """Detection source for the current image (see dust_detect_source_for)."""

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -5,7 +5,8 @@ from PySide6.QtWidgets import (
     QLabel, QPushButton, QStyle, QSizePolicy, QApplication, QComboBox
 )
 from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QPainter,
-                           QCursor, QDesktopServices, QPainterPath, QBrush, QPolygonF,
+                           QCursor, QDesktopServices, QPainterPath,
+                           QPainterPathStroker, QBrush, QPolygonF,
                            QImage)
 from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
@@ -43,6 +44,33 @@ def _eyedropper_cursor():
         p.end()
         _eyedropper_cursor_cache = QCursor(pm, 3, 21)
     return _eyedropper_cursor_cache
+
+def dust_debug_geometry(spots, plan, w, h):
+    """Geometry for the dust panel's 'Show heal sources' overlay, in FULL
+    un-cropped frame pixel coords (the caller maps to scene coords).
+
+    Returns {"strokes": [(points_px, brush_width_px)], "arrows":
+    [(src_x, src_y, dst_x, dst_y)], "fallbacks": [(x, y)]}: one outline per
+    stored spot, one arrow per planned clone segment drawn FROM the sampled
+    source patch TO the healed segment's centroid, and one marker per
+    diffusion-fallback segment (nothing was sampled there — Telea). `plan`
+    records are (cy, cx, off, ...) with `off` the destination→source window
+    displacement normalized over (h, w), or None for a fallback (see
+    _heal_impl); pass plan=None for stroke outlines only."""
+    strokes = [([(float(p[0]) * w, float(p[1]) * h)
+                 for p in (s.get("pts") or [])],
+                2.0 * float(s.get("r", 0.0)) * w)
+               for s in (spots or [])]
+    arrows, fallbacks = [], []
+    for rec in (plan or []):
+        cy, cx, off = rec[0], rec[1], rec[2]
+        dx, dy = cx * w, cy * h
+        if off is None:
+            fallbacks.append((dx, dy))
+        else:
+            arrows.append((dx + off[1] * w, dy + off[0] * h, dx, dy))
+    return {"strokes": strokes, "arrows": arrows, "fallbacks": fallbacks}
+
 
 _rotate_cursor_cache = None
 
@@ -857,6 +885,8 @@ class ImagePreview(QWidget):
         self._dust_stroke_item = None    # live red stroke overlay (in-progress)
         self._dust_cursor_item = None    # brush-circle cursor following the pointer
         self.dust_panel = None           # set by MainWindow (brush-slider sync)
+        self._dust_debug = False         # 'Show heal sources' diagnostic overlay
+        self._dust_debug_items = []      # its scene items (outlines/arrows)
 
         # Coalesce a fine-rotation drag into a single undo step
         self._fine_rot_burst_active = False
@@ -2400,6 +2430,7 @@ class ImagePreview(QWidget):
         # brush works on exactly the framing the user keeps.
         self.update_preview(self.current_idx)
         self._sync_zoom_combo()
+        self._draw_dust_debug()
         self.view.setCursor(Qt.CrossCursor)
         return True
 
@@ -2581,6 +2612,9 @@ class ImagePreview(QWidget):
         """Re-bake the preview/thumbnail after a dust edit and refresh the UI."""
         img.update_thumbnail_and_preview()
         self.update_preview(self.current_idx)
+        # The preview re-heal above refreshed the plan cache — sync the
+        # 'Show heal sources' overlay with what was actually sampled.
+        self._draw_dust_debug()
         # Kick the hi-res re-render right away (instead of the debounce) so the
         # inpainted spot resolves promptly; the in-flight guard dedups it. The
         # previous sharp render stays on screen until this lands (no blur flash).
@@ -2599,6 +2633,103 @@ class ImagePreview(QWidget):
                 except (RuntimeError, ValueError):
                     pass
                 setattr(self, attr, None)
+        self._clear_dust_debug_items()
+
+    def _clear_dust_debug_items(self):
+        for item in self._dust_debug_items:
+            try:
+                self.scene.removeItem(item)
+            except (RuntimeError, ValueError):
+                pass
+        self._dust_debug_items = []
+
+    def set_dust_source_overlay(self, on: bool):
+        """Dust panel's 'Show heal sources' checkbox: outline every stroke and
+        mark where each heal segment sampled its patch from (arrow source →
+        segment; ring only = diffusion fallback, nothing was sampled)."""
+        self._dust_debug = bool(on)
+        self._draw_dust_debug()
+
+    def _draw_dust_debug(self):
+        self._clear_dust_debug_items()
+        if not (self.dust_mode and self._dust_debug):
+            return
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None or self.current_pixmap is None:
+            return
+        t = self._base_transform()
+        size = self._dust_full_frame_size()
+        if t is None or size is None:
+            return
+        w, h = size
+        spots = getattr(img, "dust_spots", []) or []
+        if not spots:
+            return
+        # The plan cache holds what the last preview-scale heal actually did
+        # (and what exports will replay): per segment, the sampled source
+        # offset or a diffusion-fallback verdict. Stale key (spots changed,
+        # preview not re-rendered yet) → outlines only.
+        cached = getattr(img, "_dust_plan_cache", None)
+        plan = cached[1] if (cached and cached[0] == repr(spots)) else None
+        geo = dust_debug_geometry(spots, plan, w, h)
+        to_display = None
+        if self._crop_display_transform is not None:
+            to_display, ok = self._crop_display_transform.inverted()
+            if not ok:
+                return
+
+        def scene_pt(x, y):
+            pt = QPointF(x, y)
+            if to_display is not None:
+                pt = to_display.map(pt)
+            return t.map(pt)
+
+        def add(item, color, width=1.5):
+            pen = QPen(color, width)
+            pen.setCosmetic(True)  # constant screen width at any zoom
+            item.setPen(pen)
+            self.scene.addItem(item)
+            self._dust_debug_items.append(item)
+
+        yellow = QColor(255, 220, 60, 230)   # stroke borders
+        green = QColor(80, 255, 140, 230)    # sampled patch + arrow
+        orange = QColor(255, 150, 40, 230)   # diffusion fallback marker
+        for pts, width in geo["strokes"]:
+            if not pts:
+                continue
+            path = QPainterPath()
+            path.moveTo(scene_pt(*pts[0]))
+            for p in pts[1:]:
+                path.lineTo(scene_pt(*p))
+            if len(pts) == 1:  # single dab: zero-length stroke + round cap
+                path.lineTo(scene_pt(pts[0][0] + 1e-3, pts[0][1]))
+            stroker = QPainterPathStroker()
+            # Crop extraction is isometric, so full-frame px == display px.
+            stroker.setWidth(max(1.0, width))
+            stroker.setCapStyle(Qt.RoundCap)
+            stroker.setJoinStyle(Qt.RoundJoin)
+            item = QGraphicsPathItem(stroker.createStroke(path))
+            item.setBrush(Qt.NoBrush)
+            add(item, yellow)
+        for sx, sy, dx, dy in geo["arrows"]:
+            p1, p2 = scene_pt(sx, sy), scene_pt(dx, dy)
+            add(QGraphicsLineItem(p1.x(), p1.y(), p2.x(), p2.y()), green)
+            r = 6.0
+            e = QGraphicsEllipseItem(p1.x() - r, p1.y() - r, 2 * r, 2 * r)
+            e.setBrush(Qt.NoBrush)
+            add(e, green)
+            ang = math.atan2(p2.y() - p1.y(), p2.x() - p1.x())
+            for da in (math.pi * 5 / 6, -math.pi * 5 / 6):  # arrowhead barbs
+                add(QGraphicsLineItem(
+                    p2.x(), p2.y(),
+                    p2.x() + 9.0 * math.cos(ang + da),
+                    p2.y() + 9.0 * math.sin(ang + da)), green)
+        for x, y in geo["fallbacks"]:
+            p = scene_pt(x, y)
+            r = 7.0
+            e = QGraphicsEllipseItem(p.x() - r, p.y() - r, 2 * r, 2 * r)
+            e.setBrush(Qt.NoBrush)
+            add(e, orange, 2.0)
 
     def _draw_dust_stroke(self):
         """Draw/refresh the live red overlay for the in-progress stroke.

--- a/tests/test_dust_crop_display.py
+++ b/tests/test_dust_crop_display.py
@@ -115,6 +115,29 @@ class TestDustModeShowsCrop:
         assert ip._crop_display_transform is None
 
 
+class TestHealSourceOverlay:
+    def test_overlay_draws_from_plan_and_clears(self, tmp_path):
+        # 'Show heal sources': stroke outline + per-segment sample markers,
+        # derived from the cached preview plan, drawn through the same
+        # crop-display mapping as the brush; toggling off removes them.
+        ip, img = _converted_preview(tmp_path)
+        ip.enter_dust_mode()
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.02}]
+        img.update_thumbnail_and_preview()   # preview heal caches the plan
+        cached = getattr(img, "_dust_plan_cache", None)
+        assert cached is not None and cached[0] == repr(img.dust_spots)
+        ip.set_dust_source_overlay(True)
+        # At least the stroke outline plus one sample arrow / fallback ring.
+        assert len(ip._dust_debug_items) >= 2
+        ip.set_dust_source_overlay(False)
+        assert ip._dust_debug_items == []
+        # Exit tears the overlay down with the other dust items.
+        ip.set_dust_source_overlay(True)
+        assert ip._dust_debug_items
+        ip.exit_dust_mode()
+        assert ip._dust_debug_items == []
+
+
 class TestSceneToNormThroughCrop:
     def test_center_of_crop_maps_to_crop_center(self, tmp_path):
         ip, img = _converted_preview(tmp_path)

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -264,6 +264,31 @@ class TestApplyDustRemoval:
         core = out[99:102, 60:140].astype(np.float32).reshape(-1, 3)
         assert float(np.abs(core.mean(axis=0) - sky).max()) < 5000
 
+    def test_big_merged_dabs_clone_texture_not_smear(self):
+        # Big overlapping dabs used to become ONE segment whose source
+        # window (bbox + thickness-scaled pad) could not fit anywhere clean,
+        # dumping the whole blob into the flat diffusion fallback — a
+        # visible grainless disc on film. The segment-size cap tiles the
+        # blob so each tile clones real texture from beside it.
+        rng = np.random.default_rng(21)
+        img = np.clip(rng.normal(32000, 3000, (640, 640, 3)), 0,
+                      65535).astype(np.uint16)
+        # A merged blob whose ONE-segment window has no clean in-bounds home
+        # in this frame, while per-tile windows do.
+        spots = [{"kind": "brush", "pts": [[0.42, 0.40]], "r": 0.075},
+                 {"kind": "brush", "pts": [[0.55, 0.38]], "r": 0.075},
+                 {"kind": "brush", "pts": [[0.48, 0.52]], "r": 0.07}]
+        out = apply_dust_removal(img, spots)
+        mask = rasterize_dust_mask(spots, 640, 640) > 0
+        core = cv2.erode(mask.astype(np.uint8), np.ones((25, 25), np.uint8)) > 0
+        healed = out[core].astype(np.float32)
+        ann = (~mask) & (cv2.dilate(mask.astype(np.uint8),
+                                    np.ones((41, 41), np.uint8)) > 0)
+        surround = out[ann].astype(np.float32)
+        # Tone lands on the surround AND grain survives (Telea ~ 0 std).
+        assert abs(float(healed.mean()) - float(surround.mean())) < 2000
+        assert float(healed.std()) > 0.5 * float(surround.std())
+
     def test_clean_stroke_near_black_border_stays_sky(self):
         # THE black-blob artifact: a generous brush over clean sky near the
         # frame's black holder border. The defect estimate collapses onto
@@ -506,9 +531,13 @@ class _StubPreview:
         self.dust_mode = True
         self.current_idx = None
         self.brush = None
+        self.source_overlay = None
 
     def set_dust_brush_size(self, r):
         self.brush = r
+
+    def set_dust_source_overlay(self, on):
+        self.source_overlay = on
 
     def dust_undo_last(self):
         return False
@@ -595,6 +624,30 @@ class TestPanelWiring:
             assert abs(img.dust_feather - 0.6) < 1e-9
         finally:
             ccr_backend.images = saved
+
+    def test_show_sources_checkbox_drives_canvas_overlay(self):
+        from widgets.dust_panel import DustRemovalPanel
+        prev = _StubPreview()
+        panel = DustRemovalPanel(_StubMain(), prev)
+        panel.show_sources_cb.setChecked(True)
+        assert prev.source_overlay is True
+        panel.show_sources_cb.setChecked(False)
+        assert prev.source_overlay is False
+
+    def test_dust_debug_geometry_maps_plan_to_arrows(self):
+        # Full-frame pixel geometry for the 'Show heal sources' overlay:
+        # spot outlines, one arrow per cloned segment (source -> segment,
+        # source = centroid + planned offset), a marker per Telea fallback.
+        from widgets.image_preview import dust_debug_geometry
+        spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.05}]
+        plan = [(0.5, 0.5, (0.1, -0.2), True, False),
+                (0.3, 0.4, None, None, None)]
+        geo = dust_debug_geometry(spots, plan, 1000, 500)
+        assert geo["strokes"] == [([(500.0, 250.0)], 100.0)]
+        (sx, sy, dx, dy), = geo["arrows"]
+        assert (dx, dy) == (500.0, 250.0)
+        assert (sx, sy) == (500.0 - 0.2 * 1000, 250.0 + 0.1 * 500)
+        assert geo["fallbacks"] == [(0.4 * 1000, 0.3 * 500)]
 
     def test_detect_all_no_targets_is_safe(self):
         from widgets.dust_panel import DustRemovalPanel, _DetectAllWorker  # noqa: F401

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -161,20 +161,20 @@ class TestApplyDustRemoval:
         assert float(err.max()) < 5000   # fill stays sky-toned along the stroke
 
     def test_feather_alpha_ramps_inward(self):
-        # The fill blends over a smooth inward ramp: 0 at the hole boundary,
-        # 1 in the core, exactly 0 outside the mask; a 1-px feather is an
-        # essentially hard (fully filled) edge for tight traces.
+        # The fill blends over a smooth inward ramp: ~0 at the hole boundary,
+        # 1 in the core, exactly 0 outside the mask; a ramp of 0.5 px (the
+        # feather-0 convention) is a hard, fully filled edge.
         from core.ccr_processor import _feather_alpha
         mask = np.zeros((60, 60), np.uint8)
         cv2.circle(mask, (30, 30), 20, 255, -1)
-        a = _feather_alpha(mask, np.full((60, 60), 8, np.uint8))
+        a = _feather_alpha(mask, np.full((60, 60), 8.0, np.float32))
         assert a[30, 30] == 1.0                    # core fully filled
         assert a[30, 51] == 0.0                    # outside untouched
         edge, mid = a[30, 49], a[30, 45]
         assert 0.0 < edge < 0.35                   # soft start at the rim
         assert edge < mid < 1.0                    # monotone ramp
-        hard = _feather_alpha(mask, np.ones((60, 60), np.uint8))
-        assert hard[30, 49] > 0.9                  # 1px feather ~ hard fill
+        hard = _feather_alpha(mask, np.full((60, 60), 0.5, np.float32))
+        assert hard[30, 49] > 0.9                  # hard fill at the rim
 
     def test_feather_param_softens_rim(self):
         # The user Feather setting widens the fill's cross-fade: with a wide
@@ -263,6 +263,27 @@ class TestApplyDustRemoval:
         out = apply_dust_removal(img, [spot], feather=1.0)
         core = out[99:102, 60:140].astype(np.float32).reshape(-1, 3)
         assert float(np.abs(core.mean(axis=0) - sky).max()) < 5000
+
+    def test_clean_stroke_near_black_border_stays_sky(self):
+        # THE black-blob artifact: a generous brush over clean sky near the
+        # frame's black holder border. The defect estimate collapses onto
+        # the sky itself, the ring rejection then discarded the whole sky
+        # ring as "leak" and kept the black border as the only matching and
+        # tone anchor — the stroke healed to solid black, cloned from a
+        # window overlapping the border.
+        rng = np.random.default_rng(9)
+        img = np.clip(rng.normal(34000, 2500, (200, 300, 3)), 0,
+                      65535).astype(np.uint16)
+        img[:14] = np.clip(rng.normal(900, 300, (14, 300, 3)), 0, 65535)
+        spot = {"kind": "brush",
+                "pts": [[0.30, 0.22], [0.40, 0.20], [0.50, 0.22]],
+                "r": 0.055}  # ~17 px dabs, ~30 px below the border
+        out = apply_dust_removal(img, [spot], feather=0.25)
+        mask = rasterize_dust_mask([spot], 200, 300) > 0
+        healed = out[mask].astype(np.float32).mean(axis=1)
+        # Nothing near black anywhere in the fill; tone stays sky-like.
+        assert float(np.percentile(healed, 1)) > 20000
+        assert abs(float(healed.mean()) - 34000) < 4000
 
     def test_underscoped_dab_keeps_tone(self):
         # A click smaller than the speck (the small dot ghost): the speck's
@@ -711,15 +732,16 @@ class TestResolutionConsistency:
         img._apply_dust_removal(small)                # preview render
         key, plan = img._dust_plan_cache
         assert key == repr(img.dust_spots)
-        assert any(off is not None for _, _, off in plan)
+        assert any(rec[2] is not None for rec in plan)
 
         out_cached = img._apply_dust_removal(big)     # export render
         # Tamper with the cached plan (shift the source offsets): the export
         # output must follow the cache — proof it replays the preview's plan
         # rather than planning for itself.
         img._dust_plan_cache = (key, [
-            (cy, cx, None if off is None else (off[0] + 0.02, off[1]))
-            for cy, cx, off in plan])
+            rec if rec[2] is None
+            else (rec[0], rec[1], (rec[2][0] + 0.02, rec[2][1])) + rec[3:]
+            for rec in plan])
         out_tampered = img._apply_dust_removal(big)
         assert not np.array_equal(out_cached, out_tampered)
 

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -198,6 +198,29 @@ class TestApplyDustRemoval:
         assert int(hard[100, 100, 0]) < 40000
         assert int(soft[100, 100, 0]) < 40000
 
+    def test_full_feather_is_smooth_dome_no_speckle(self):
+        # 100% feather on a mostly-clean brushed area must blend as a smooth
+        # opacity dome rolling off from the stroke center — not a random
+        # per-pixel subset healed at full strength (the defect classifier
+        # collapsing onto the background used to force-fill a salt-and-pepper
+        # subset of grain pixels, dithering the rim).
+        rng = np.random.default_rng(3)
+        img = np.clip(rng.normal(30000, 3000, (200, 200, 3)), 0,
+                      65535).astype(np.uint16)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.15}  # r_px = 30
+        out = apply_dust_removal(img, [spot], feather=1.0)
+        diff = np.abs(out.astype(np.float32) - img.astype(np.float32)).mean(axis=2)
+        yy, xx = np.mgrid[0:200, 0:200]
+        d = np.hypot(yy - 100, xx - 100)
+        # Mean deviation decreases monotonically outward (a dome)...
+        rings = [float(diff[(d >= a) & (d < b)].mean())
+                 for a, b in ((0, 6), (6, 12), (12, 18), (18, 24), (24, 30))]
+        assert all(rings[i] > rings[i + 1] for i in range(len(rings) - 1))
+        # ...and the outer rim has no isolated full-strength pixels: even its
+        # 99th-percentile deviation stays well below the core's mean.
+        outer = diff[(d >= 24) & (d < 29)]
+        assert float(np.percentile(outer, 99)) < 0.8 * (rings[0] + 1e-6)
+
     def test_feather_ramp_scales_with_brush_size(self):
         # The feather is a fraction of the hole's own radius: at the SAME
         # setting, ~6 px inside the boundary is still soft rim for a big

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -289,6 +289,31 @@ class TestApplyDustRemoval:
         assert abs(float(healed.mean()) - float(surround.mean())) < 2000
         assert float(healed.std()) > 0.5 * float(surround.std())
 
+    def test_new_stroke_keeps_far_samples_stable(self):
+        # Adding a dab must only re-sample segments near the edit. Tiles
+        # used to anchor to the component bbox and scale their windows by
+        # the component's thickness, so a dab merging at a blob's top-left
+        # shifted EVERY tile of the blob and re-sampled its far side too.
+        rng = np.random.default_rng(31)
+        img = np.clip(rng.normal(32000, 3000, (640, 640, 3)), 0,
+                      65535).astype(np.uint16)
+        base = [{"kind": "brush", "pts": [[0.45, 0.45]], "r": 0.075},
+                {"kind": "brush", "pts": [[0.58, 0.45]], "r": 0.075}]
+        plan1, plan2 = [], []
+        apply_dust_removal(img, base, collect_plan=plan1)
+        # A small dab overlapping the blob's top-left corner: extends the
+        # component bbox origin (0.38*640-19 px < the blob's old 240 px
+        # edge) and its thickness, touches nothing on the far (right) side.
+        added = base + [{"kind": "brush", "pts": [[0.38, 0.38]], "r": 0.03}]
+        apply_dust_removal(img, added, collect_plan=plan2)
+        far1 = [r for r in plan1 if r[1] > 0.55]
+        assert far1
+        for rec in far1:
+            match = [r for r in plan2
+                     if abs(r[0] - rec[0]) < 1e-9 and abs(r[1] - rec[1]) < 1e-9]
+            assert match, f"far segment moved: {rec[:2]}"
+            assert match[0][2] == rec[2], "far segment re-sampled"
+
     def test_clean_stroke_near_black_border_stays_sky(self):
         # THE black-blob artifact: a generous brush over clean sky near the
         # frame's black holder border. The defect estimate collapses onto

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -333,6 +333,39 @@ class TestApplyDustRemoval:
         assert recs, "first stroke's segment disappeared"
         assert recs[0][2] == off, "first stroke's source moved"
 
+    def test_stroke_on_prior_source_keeps_reference_samples_healed(self):
+        # NO exceptions: even a stroke painted directly ON a segment's
+        # source patch must not move the reference. The segment defers to a
+        # second pass and clones the HEALED content at the very same
+        # location — same offset in the plan, no dust cloned into the fill.
+        rng = np.random.default_rng(23)
+        img = np.clip(rng.normal(30000, 2500, (400, 400, 3)), 0,
+                      65535).astype(np.uint16)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}
+        plan1 = []
+        apply_dust_removal(img, [spot], collect_plan=plan1)
+        (cy, cx, off, _, _), = plan1
+        assert off is not None
+        # A bright defect appears at the chosen source and the user paints
+        # over it — the source patch is now under dust.
+        sy, sx = cy + off[0], cx + off[1]
+        img2 = img.copy()
+        cv2.circle(img2, (int(sx * 400), int(sy * 400)), 5,
+                   (62000, 62000, 62000), -1)
+        b = {"kind": "brush", "pts": [[sx, sy]], "r": 0.03}
+        plan2 = []
+        out = apply_dust_removal(img2, [spot, b], collect_plan=plan2,
+                                 prior_plan=plan1)
+        rec = [r for r in plan2
+               if abs(r[0] - cy) < 1e-9 and abs(r[1] - cx) < 1e-9]
+        assert rec, "first stroke's segment disappeared"
+        assert rec[0][2] == off, "reference moved"
+        # The fill sampled the HEALED source, not the new bright defect.
+        m = rasterize_dust_mask([spot], 400, 400) > 0
+        healed = out[m].astype(np.float32)
+        assert float(healed.mean()) < 40000
+        assert float(healed.max()) < 55000
+
     def test_new_stroke_keeps_far_samples_stable(self):
         # Adding a dab must only re-sample segments near the edit. Tiles
         # used to anchor to the component bbox and scale their windows by

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -289,6 +289,50 @@ class TestApplyDustRemoval:
         assert abs(float(healed.mean()) - float(surround.mean())) < 2000
         assert float(healed.std()) > 0.5 * float(surround.std())
 
+    def test_prior_plan_pins_sources_verbatim(self):
+        # Once a patch's source is set, nothing may move it: the previous
+        # plan seeds every re-heal and matching segments reuse its offset
+        # VERBATIM (no re-scoring). Proof by tampering: a shifted-but-clean
+        # prior offset must drive the heal and be carried into the new plan.
+        rng = np.random.default_rng(17)
+        img = np.clip(rng.normal(30000, 3000, (400, 400, 3)), 0,
+                      65535).astype(np.uint16)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}
+        plan1 = []
+        apply_dust_removal(img, [spot], collect_plan=plan1)
+        (cy, cx, off, g, d), = plan1
+        assert off is not None
+        tampered = [(cy, cx, (off[0], off[1] + 20.0 / 400.0), g, d)]
+        plan2 = []
+        apply_dust_removal(img, [spot], collect_plan=plan2,
+                           prior_plan=tampered)
+        assert plan2[0][2][1] == pytest.approx(tampered[0][2][1])
+
+    def test_new_stroke_keeps_prior_sources_even_in_its_ring(self):
+        # A stroke painted inside an existing segment's context ring used to
+        # change that segment's matching inputs and could flip its source;
+        # with the prior plan pinning sources, the first stroke's sample
+        # stays bit-identical (only a stroke ON the source itself may force
+        # a re-search).
+        rng = np.random.default_rng(17)
+        img = np.clip(rng.normal(30000, 3000, (400, 400, 3)), 0,
+                      65535).astype(np.uint16)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}
+        plan1 = []
+        apply_dust_removal(img, [spot], collect_plan=plan1)
+        (cy, cx, off, _, _), = plan1
+        # Perturb the ring on the side OPPOSITE the chosen source, so the
+        # prior source window stays clean.
+        bx = 0.44 if (cx + off[1]) >= 0.5 else 0.56
+        b = {"kind": "brush", "pts": [[bx, 0.5]], "r": 0.01}
+        plan2 = []
+        apply_dust_removal(img, [spot, b], collect_plan=plan2,
+                           prior_plan=plan1)
+        recs = [r for r in plan2
+                if abs(r[0] - cy) < 1e-9 and abs(r[1] - cx) < 1e-9]
+        assert recs, "first stroke's segment disappeared"
+        assert recs[0][2] == off, "first stroke's source moved"
+
     def test_new_stroke_keeps_far_samples_stable(self):
         # Adding a dab must only re-sample segments near the edit. Tiles
         # used to anchor to the component bbox and scale their windows by
@@ -503,6 +547,25 @@ class TestPersistence:
         img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.01}]
         state = catalog.serialize_image(img)
         assert catalog._is_pristine(state) is False
+
+    def test_dust_plan_round_trips_in_catalog(self, tmp_path):
+        # The heal plan persists with the spots and reseeds the cache on
+        # restore, so a reload keeps the exact sources the user saw (a
+        # from-scratch replan of an incrementally-built plan could differ).
+        cat = str(tmp_path / "catalog.json")
+        path = _scan_png(tmp_path)
+        img = CCRImage(path)
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.02}]
+        img.update_thumbnail_and_preview()   # preview heal caches the plan
+        cached = img._dust_plan_cache
+        assert cached is not None and cached[0] == repr(img.dust_spots)
+        assert cached[1]
+        catalog.update_for_images([img], path=cat)
+        restored = catalog.create_images_for_path(path, path=cat)[0]
+        rc = getattr(restored, "_dust_plan_cache", None)
+        assert rc is not None
+        assert rc[0] == repr(restored.dust_spots)
+        assert rc[1] == cached[1]
 
     def test_dust_feather_round_trips_and_defaults(self, tmp_path):
         cat = str(tmp_path / "catalog.json")

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -28,7 +28,7 @@ import cv2  # noqa: E402
 from core import catalog, dust_detect  # noqa: E402
 from core.ccr_image import CCRImage  # noqa: E402
 from core.ccr_processor import (apply_dust_removal,  # noqa: E402
-                                rasterize_dust_mask)
+                                rasterize_dust_mask, DUST_FEATHER_DEFAULT)
 
 
 def _flat_with_speck(h=100, w=100, base=30000, speck=60000, cx=50, cy=50, r=4):
@@ -180,13 +180,14 @@ class TestApplyDustRemoval:
         # The user Feather setting widens the fill's cross-fade: with a wide
         # feather the hole's clean rim stays close to the ORIGINAL pixels
         # (low alpha), with feather 0 the rim is the clone (hard edge).
+        # feather is a fraction of the hole's own radius (1.0 = full depth).
         rng = np.random.default_rng(5)
         img = np.clip(rng.normal(30000, 2000, (200, 200, 3)), 0,
                       65535).astype(np.uint16)
         cv2.circle(img, (100, 100), 6, (60000, 60000, 60000), -1)
         spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.08}  # mask r=16
         hard = apply_dust_removal(img, [spot], feather=0.0)
-        soft = apply_dust_removal(img, [spot], feather=0.08)
+        soft = apply_dust_removal(img, [spot], feather=1.0)
         yy, xx = np.mgrid[0:200, 0:200]
         rim = (np.hypot(yy - 100, xx - 100) > 13.5) & \
               (np.hypot(yy - 100, xx - 100) < 15.5)
@@ -197,15 +198,46 @@ class TestApplyDustRemoval:
         assert int(hard[100, 100, 0]) < 40000
         assert int(soft[100, 100, 0]) < 40000
 
+    def test_feather_ramp_scales_with_brush_size(self):
+        # The feather is a fraction of the hole's own radius: at the SAME
+        # setting, ~6 px inside the boundary is still soft rim for a big
+        # brush but near-full fill for a small one. A fixed-width ramp (the
+        # old fraction-of-image-width feather) would give the same alpha at
+        # the same absolute inset for both sizes.
+        rng = np.random.default_rng(11)
+        base = np.clip(rng.normal(30000, 3000, (300, 300, 3)), 0,
+                       65535).astype(np.uint16)
+
+        def rim_ratio(r_norm):
+            r_px = r_norm * 300
+            img = base.copy()
+            cv2.circle(img, (150, 150), max(3, int(r_px / 4)),
+                       (60000, 60000, 60000), -1)
+            spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": r_norm}
+            hard = apply_dust_removal(img, [spot], feather=0.0)
+            soft = apply_dust_removal(img, [spot], feather=0.75)
+            yy, xx = np.mgrid[0:300, 0:300]
+            d = np.hypot(yy - 150, xx - 150)
+            probe = (d > r_px - 7) & (d < r_px - 5)  # ~6 px inside the rim
+            d_hard = np.abs(hard[probe].astype(np.float32)
+                            - img[probe]).mean()
+            d_soft = np.abs(soft[probe].astype(np.float32)
+                            - img[probe]).mean()
+            return float(d_soft) / max(float(d_hard), 1e-6)
+
+        assert rim_ratio(0.12) < 0.5   # big brush: 6 px in is still soft rim
+        assert rim_ratio(0.04) > 0.5   # small brush: 6 px in is nearly core
+
     def test_wide_feather_never_blends_defect_back(self):
         # Defect-like pixels are force-filled whatever the feather: a tight
-        # hair trace with a huge feather must still remove the hair.
+        # hair trace with the feather at its maximum must still remove the
+        # hair.
         sky = np.array([20000, 25000, 40000], np.float32)
         img = np.broadcast_to(sky.astype(np.uint16), (200, 200, 3)).copy()
         cv2.line(img, (30, 100), (170, 100), (62000, 60000, 30000), 13)
         spot = {"kind": "brush",
                 "pts": [[0.2, 0.5], [0.5, 0.5], [0.8, 0.5]], "r": 2.0 / 200}
-        out = apply_dust_removal(img, [spot], feather=0.02)
+        out = apply_dust_removal(img, [spot], feather=1.0)
         core = out[99:102, 60:140].astype(np.float32).reshape(-1, 3)
         assert float(np.abs(core.mean(axis=0) - sky).max()) < 5000
 
@@ -383,15 +415,21 @@ class TestPersistence:
         path = _scan_png(tmp_path)
         img = CCRImage(path)
         img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.01}]
-        img.dust_feather = 0.007
+        img.dust_feather = 0.7
         catalog.update_for_images([img], path=cat)
         restored = catalog.create_images_for_path(path, path=cat)
-        assert abs(restored[0].dust_feather - 0.007) < 1e-9
+        assert abs(restored[0].dust_feather - 0.7) < 1e-9
         # Pre-feature catalog entries restore to the default.
         state = catalog.serialize_image(img)
-        del state["dust_feather"]
+        del state["dust_feather_r"]
         old = catalog._restore_image(path, state)
-        assert abs(old.dust_feather - 0.003) < 1e-9
+        assert abs(old.dust_feather - DUST_FEATHER_DEFAULT) < 1e-9
+        # Legacy width-fraction entries (old "dust_feather" key, 0..1% of
+        # width) migrate by slider position onto the radius-fraction scale:
+        # 0.30% of width -> 30% of radius.
+        state["dust_feather"] = 0.003
+        legacy = catalog._restore_image(path, state)
+        assert abs(legacy.dust_feather - 0.3) < 1e-9
 
 
 # --- Undo -------------------------------------------------------------------
@@ -497,7 +535,7 @@ class TestPanelWiring:
         from core.ccr_backend import ccr_backend
 
         class _Img:
-            dust_feather = 0.003
+            dust_feather = 0.25
             dust_spots = []
 
         img = _Img()
@@ -508,9 +546,9 @@ class TestPanelWiring:
             prev.current_idx = 0
             panel = DustRemovalPanel(_StubMain(), prev)
             panel.feather_slider.setValue(60)  # emits valueChanged
-            assert panel.feather_value.text() == "0.60%"
+            assert panel.feather_value.text() == "60%"
             panel._apply_feather()             # bypass the debounce timer
-            assert abs(img.dust_feather - 0.006) < 1e-9
+            assert abs(img.dust_feather - 0.6) < 1e-9
         finally:
             ccr_backend.images = saved
 
@@ -634,7 +672,7 @@ class TestResolutionConsistency:
         no file decode, so the plan-cache plumbing is tested hermetically."""
         img = CCRImage.__new__(CCRImage)
         img.dust_spots = spots
-        img.dust_feather = 0.003
+        img.dust_feather = 0.25
         img._dust_plan_cache = None
         return img
 

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -333,6 +333,28 @@ class TestApplyDustRemoval:
         assert recs, "first stroke's segment disappeared"
         assert recs[0][2] == off, "first stroke's source moved"
 
+    def test_sources_stay_inside_the_crop(self):
+        # Content outside the confirmed crop (film holder, rebate, junk the
+        # user cut away) is not scene: fresh searches must never sample it,
+        # and the context ring must not anchor on it.
+        rng = np.random.default_rng(29)
+        img = np.clip(rng.normal(30000, 2500, (400, 400, 3)), 0,
+                      65535).astype(np.uint16)
+        img[:, 260:] = 62000  # junk strip the crop removes
+        crop = ((0.0, 0.0, 0.65, 1.0), 0.0)  # keeps x < 260 px
+        spot = {"kind": "brush", "pts": [[0.60, 0.5]], "r": 0.03}
+        plan = []
+        out = apply_dust_removal(img, [spot], collect_plan=plan, crop=crop)
+        assert plan
+        # Every sampled window lies inside the crop: source-window center +
+        # its half extent (hole r 12 + guard/ring pad 15 = 27 px) fits.
+        for cy, cx, off, *_ in plan:
+            if off is not None:
+                assert (cx + off[1]) * 400 + 27 <= 260 + 1e-6
+        # The fill is sky, not the junk strip.
+        m = rasterize_dust_mask([spot], 400, 400) > 0
+        assert float(out[m].astype(np.float32).mean()) < 40000
+
     def test_stroke_on_prior_source_keeps_reference_samples_healed(self):
         # NO exceptions: even a stroke painted directly ON a segment's
         # source patch must not move the reference. The segment defers to a


### PR DESCRIPTION
## Problem

1. Dust heal strokes showed sharp edges regardless of the Feather slider, and the fade did not grow with the brush size (fixed ~3 px ramp, fraction of image width).
2. At 100% feather the blend dithered instead of rolling off: the defect classifier collapsed onto the background over mostly-clean brushes and force-filled a random salt-and-pepper subset of grain pixels.
3. Strokes near dark content (black holder border, rooflines) healed to **solid black**, cloned from windows overlapping the border ("same setting, some good, some bad" + "samples from weird spots").

## Fixes

**Feather scales with the brush.** `dust_feather` is now a fraction of each hole's own half-thickness (default 25%), like the area-mask feather. The fade grows with the brush and with resolution. Force-fill lip scales with the ramp and is confined to its component. Slider reads 0–100% of spot radius; catalog writes `dust_feather_r`, migrating legacy width-fraction values by slider position.

**Smooth opacity dome.** The defect force-fill only engages when the estimated defect is color-separable from the surround (> 6 ring-grain MADs), **brighter** than it (film dust inverts white), from a trusted estimate — and then marks pixels by nearest centroid, which grain never satisfies. A clean generous brush blends as a pure dome rolling off from the stroke center; a real hair/speck is still fully healed at any feather.

**No black fills / weird sampling.** Near-black ring pixels (< ~3% of white = holder/rebate, not scene) are dropped while a minority; a rejection that would discard > 80% of the ring is distrusted (the estimate collapsed onto the background — keeping some foreign dark mode as the only anchor is what healed strokes black); and source candidates pay a penalty for interior tone past a ring-MAD tolerance from the background (the ring SSD never looked inside the window, so a border-edge interior scored perfectly).

**Preview == export, hardened.** Per-segment `genuine`/`dlike` verdicts are recorded in the heal plan and replayed, never re-derived per buffer. `_feather_alpha` evaluates pixel-center depths with float ramp widths (the old integer ramp + boundary lift made thin rims harder at preview than export). Per-pixel threshold classifications read a plan-scale-smoothed luma so full-res grain doesn't cross thresholds more often than the preview's averaged pixels.

## Tests

New: `test_feather_ramp_scales_with_brush_size`, `test_full_feather_is_smooth_dome_no_speckle`, `test_clean_stroke_near_black_border_stays_sky`; updated feather semantics/persistence tests + legacy-key migration.
`test_dust_removal.py` (46), `test_dust_crop_display.py` + `test_crop_hires.py` (24), `test_catalog.py` (13) all pass, including the calibrated preview/export consistency thresholds, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
