### PR TITLE
feat(dust): union stroke borders + right-button stroke editing

### DIFF
--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -99,11 +99,11 @@ in the catalog, and undoable.
      stays tight. A per-image render parameter stored as
      `CCRImage.dust_feather`; changes re-heal live (debounced ~200 ms),
      persist in the catalog, and are NOT part of undo snapshots (like brush
-     size). Defect-like pixels are always fully filled regardless of the
-     feather (§5.2 step 6), so a wide fade cannot blend the defect back in —
-     which also means the fade only shows on the clean rim between the defect
-     and the brush edge (a tight trace heals hard by design; brush generously
-     to get a soft blend).
+     size). The feather governs EVERYTHING (maintainer rule: every pixel
+     gets the effect, opacity rolled off from the stroke center — no
+     exceptions, §5.2 step 6): at wide settings the heal fades out even
+     across the defect itself, by explicit user choice; feather 0 is a
+     hard, complete removal.
    - **Show heal sources** checkbox: diagnostic overlay on the canvas —
      stroke borders outlined (yellow) as the contours of the UNION of the
      rasterized strokes (connected/overlapping strokes read as ONE region;
@@ -443,22 +443,18 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      setting (`dust_feather`) as a fraction of **each hole's own depth**
      (its half-thickness) — the fade scales with the brush size, and with
      resolution, since the rasterized hole does — capped by that depth so
-     the core still reaches full fill. **Defect-like hole pixels** (colored
-     like the estimated defect) are force-filled at alpha 1 regardless of
-     the ramp (`dlike`, with a blurred lip as wide as the component's ramp,
-     confined to the component so it can't bleed into a neighboring hole's
-     blend), so a wide feather can never blend the defect back in — the
-     soft fade only happens across clean rim pixels. The classification
-     only engages for a `genuine` estimate (step 2) whose defect color is
-     separated from the cleaned ring's median by > `_DLIKE_SEP_MADS`
-     ring-grain MADs **and brighter than the surround** (film dust inverts
-     WHITE; a darker "defect" is content), and then marks the hole pixels
-     closer to the defect than to the surround (nearest centroid): a
-     generous brush over mostly-clean content estimates a "defect" that
-     collapses onto the background mode, and thresholding grain against it
-     force-filled a random salt-and-pepper subset of the hole (dithered
-     rims, no rolloff at wide feathers) — gated off, such a brush blends as
-     a pure opacity dome rolling off from the stroke's center. Outside the
+     the core still reaches full fill. The dome is the WHOLE story
+     (maintainer rule: every pixel gets the effect, opacity rolled off
+     from the stroke center — no exceptions): there is no defect
+     force-fill floor, so a wide feather fades the heal out even across
+     the defect itself, and the slider has visible authority on every
+     heal — the old `dlike` floor (alpha pinned to 1 on defect-colored
+     pixels, with a ramp-wide lip) made the feather do nothing exactly
+     where users reach for it, on real dust. The `dlike_on` verdict (a
+     `genuine` estimate whose defect color is > `_DLIKE_SEP_MADS`
+     ring-grain MADs from the cleaned ring's median and brighter than the
+     surround — film dust inverts WHITE) is still computed and carried in
+     the plan as metadata. Outside the
      mask alpha is exactly 0 — away from any spot `out == img16`
      bit-for-bit.
   7. **Resolution-stable plan**: the heal's content-adaptive decisions —

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -105,7 +105,10 @@ in the catalog, and undoable.
      and the brush edge (a tight trace heals hard by design; brush generously
      to get a soft blend).
    - **Show heal sources** checkbox: diagnostic overlay on the canvas —
-     every stroke's border outlined (yellow), and for each heal segment a
+     stroke borders outlined (yellow) as the contours of the UNION of the
+     rasterized strokes (connected/overlapping strokes read as ONE region;
+     per-spot outlines drew noise lines through the interior), and for each
+     heal segment a
      green arrow drawn FROM the patch it sampled TO the healed segment
      (ring at the source), or an orange ring where the segment fell back to
      diffusion (nothing was sampled). Geometry comes from the cached
@@ -113,7 +116,18 @@ in the catalog, and undoable.
      through the same crop-display transform as the brush, so it shows
      exactly what exports will replay. Refreshes on every dust edit /
      feather change; cleared on exit.
-   - Hint: "Click or drag over dust to remove it."
+   - **Right-button stroke editing** (only while the sources overlay is
+     shown): right-press on a stroke and drag to MOVE it (live border while
+     dragging; the re-heal lands on release, one undo step). The stroke's
+     plan records travel with it with their offsets compensated
+     (`translate_dust_plan`), so a moved stroke still samples the very same
+     patch of film — the reference location never changes. Double
+     right-click on a stroke DELETES it (one undo step). Hit-testing is
+     against the brush footprint (`dust_spot_hit`, topmost/newest stroke
+     first); a right-click on empty canvas does nothing.
+   - Hint: "Click or drag over dust to remove it. Ctrl+wheel resizes the
+     brush. With heal sources shown: right-drag a stroke to move it (it
+     keeps sampling the same patch); double right-click deletes it."
    - **Undo last spot** button and **Clear all** button.
 3. Separator.
 4. **AI** group:

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -121,10 +121,16 @@ in the catalog, and undoable.
      dragging; the re-heal lands on release, one undo step). The stroke's
      plan records travel with it with their offsets compensated
      (`translate_dust_plan`), so a moved stroke still samples the very same
-     patch of film — the reference location never changes. Double
-     right-click on a stroke DELETES it (one undo step). Hit-testing is
-     against the brush footprint (`dust_spot_hit`, topmost/newest stroke
-     first); a right-click on empty canvas does nothing.
+     patch of film — the reference location never changes. Right-press on a
+     SOURCE ring and drag to RE-PICK where that segment samples from: the
+     arrow follows live, the release re-heal binds the segment at its
+     unchanged centroid and pins the chosen offset verbatim — the user's
+     pick becomes the sticky reference (replayed by hi-res/export,
+     persisted in the catalog; a plan-only edit, not an undo step). Double
+     right-click on a stroke DELETES it (one undo step). Hit-testing tries
+     source markers first (9 px), then the brush footprint
+     (`dust_spot_hit`, topmost/newest stroke first); a right-click on empty
+     canvas does nothing.
    - Hint: "Click or drag over dust to remove it. Ctrl+wheel resizes the
      brush. With heal sources shown: right-drag a stroke to move it (it
      keeps sampling the same patch); double right-click deletes it."

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -126,7 +126,13 @@ in the catalog, and undoable.
      arrow follows live, the release re-heal binds the segment at its
      unchanged centroid and pins the chosen offset verbatim — the user's
      pick becomes the sticky reference (replayed by hi-res/export,
-     persisted in the catalog; a plan-only edit, not an undo step). Double
+     persisted in the catalog; a plan-only edit, not an undo step). A
+     re-picked source is marked `manual` in its plan record and cloned
+     with CLONE-STAMP semantics: copied verbatim — color and texture —
+     blended only by the feather at the rim. The membrane re-toning
+     (§5.2 step 4) applies to automatic picks only; applied to a manual
+     pick it fought the user, keeping the destination's old color and
+     toning away the picked look. Double
      right-click on a stroke DELETES it (one undo step). Hit-testing tries
      source markers first (9 px), then the brush footprint
      (`dust_spot_hit`, topmost/newest stroke first); a right-click on empty
@@ -238,9 +244,10 @@ a polyline):
 - Empty list = "no dust removal"; the render fast-path leaves the image
   untouched (§5.2).
 - Alongside the spots, the catalog stores `dust_plan` — the cached heal
-  plan's records (`[cy, cx, [oy, ox] | null, genuine, dlike_on]`), written
-  only when they match the current spots — so a reload reseeds
-  `_dust_plan_cache` and keeps the exact sources the user saw.
+  plan's records (`[cy, cx, [oy, ox] | null, genuine, dlike_on, manual]`),
+  written only when they match the current spots — so a reload reseeds
+  `_dust_plan_cache` and keeps the exact sources the user saw (including
+  manual clone-stamp picks).
 - Alongside the spots, `CCRImage.dust_feather` (float, fraction of each
   hole's own half-thickness, 0..1, default 0.25) holds the image's heal
   edge-fade width — one value for all spots, set by the panel's Feather

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -190,7 +190,7 @@ def serialize_image(img) -> dict:
 def _dust_plan_to_json(img):
     """The image's cached heal plan as JSON-safe lists, or None when it does
     not match the current spots (never persist a stale plan). Records mirror
-    _heal_impl's: [cy, cx, [oy, ox] | None, genuine, dlike_on]."""
+    _heal_impl's: [cy, cx, [oy, ox] | None, genuine, dlike_on, manual]."""
     cached = getattr(img, "_dust_plan_cache", None)
     spots = getattr(img, "dust_spots", None) or []
     if not cached or not spots or cached[0] != repr(spots):
@@ -198,14 +198,14 @@ def _dust_plan_to_json(img):
     out = []
     for r in cached[1]:
         off = None if r[2] is None else [float(r[2][0]), float(r[2][1])]
-        out.append([float(r[0]), float(r[1]), off] + list(r[3:5]))
+        out.append([float(r[0]), float(r[1]), off] + list(r[3:6]))
     return out
 
 
 def _dust_plan_from_json(plan):
     """Inverse of _dust_plan_to_json (tuples, offset as a tuple)."""
     return [(r[0], r[1], (tuple(r[2]) if r[2] is not None else None),
-             *r[3:5]) for r in plan]
+             *r[3:6]) for r in plan]
 
 
 def _is_pristine(state: dict) -> bool:

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3269,7 +3269,8 @@ _HEAL_SEG_MAX = 96        # segment-size cap (px at plan scale): a big compact
                           # smooth disc on film grain. Tiles keep cloning
                           # real texture from beside the blob.
 _DLIKE_SEP_MADS = 6.0     # defect-vs-surround separation (in ring-grain MADs)
-                          # required before pixels are force-filled as defect
+                          # for the dlike_on plan verdict (metadata) and the
+                          # source-interior tolerance in the SSD search
 _HEAL_MIN_KEEP_FRAC = 0.2  # ring share the defect rejection must leave; below
                            # it the estimate is distrusted (see _heal_patch)
 _HEAL_BLACK_FLOOR = 2000   # ~3% of white: below this a ring pixel reads as
@@ -3304,7 +3305,7 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 comp: int, bbox: tuple,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
                 filled: np.ndarray, fmap: np.ndarray, feather: float,
-                dlike: np.ndarray, src_off=None, forced_flags=None,
+                src_off=None, forced_flags=None,
                 sample=None, manual=False):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
@@ -3320,7 +3321,7 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     `(offset, genuine, dlike_on)` — the chosen source-window offset
     `(dy, dx)` (relative to the match window, in this buffer's pixels) plus
     the patch's content-adaptive verdicts (rejection trusted; defect
-    force-fill engaged), which the plan records so replays reproduce them —
+    distinct — plan metadata), which the plan records so replays reproduce them —
     or None when no fully clean, in-bounds source window exists (caller
     falls back to diffusion inpaint for this patch).
     `src_off`: a pre-planned offset to REUSE (scale replay / a prior edit's
@@ -3418,8 +3419,8 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     # ENTIRE matching/tone anchor: clean sky strokes healed to solid black,
     # cloned from the border. A real defect's leak never crowds out this
     # much context (even a thick traced hair leaves ~a third of its ring
-    # clean), so distrust the estimate, keep the full ring, and skip the
-    # defect force-fill (`genuine` gates it below).
+    # clean), so distrust the estimate and keep the full ring (`genuine`
+    # also rides the plan as metadata).
     genuine = int(keep.sum()) >= _HEAL_MIN_KEEP_FRAC * keep.size
     if forced_flags is not None:
         genuine = bool(forced_flags[0])
@@ -3534,41 +3535,24 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
 
     # Feather: the ramp is the user-set FRACTION of this hole's depth (its
     # local radius), so the fade grows with the brush size instead of staying
-    # a fixed few pixels; the depth cap keeps the core at full fill.
-    # Defect-like hole pixels (colored like the estimated defect) are
-    # force-filled via `dlike` regardless of the ramp, so a wide feather can
-    # never blend the defect back in — the soft fade only happens across
-    # clean rim pixels.
+    # a fixed few pixels; the depth cap keeps the core at full fill. The
+    # feather governs EVERYTHING (maintainer rule: every pixel gets the
+    # effect, opacity rolls off from the stroke center — no exceptions):
+    # there is no defect force-fill floor, so a wide feather fades the heal
+    # out even across the defect itself. The old dlike floor (alpha pinned
+    # to 1 on defect-colored pixels) made the slider do nothing on real
+    # dust — precisely where the user reaches for it.
     inside = cv2.distanceTransform(hole.astype(np.uint8), cv2.DIST_L2, 3)
     depth = max(1.0, float(inside.max()))
     fmap[wy0:wy1, wx0:wx1][hole] = \
         max(0.5, min(float(feather) * depth, depth))
-    # Mark defect-like pixels ONLY when the estimated defect color is
-    # DISTINCT from the clean surround. With a generous brush over mostly
-    # clean content the top-quartile "defect" collapses onto the background
-    # mode, and thresholding grain against it marked a random salt-and-pepper
-    # subset of the hole — dithered full-opacity pixels inside an otherwise
-    # feathered fill, with no rolloff at wide feathers. Gate on the
-    # defect/surround separation in units of the surround's own grain
-    # (median abs deviation of the cleaned ring), then mark the hole pixels
-    # CLOSER to the defect color than to the surround (nearest centroid) —
-    # grain never is, so the marking is coherent, not speckled. `genuine`:
-    # a distrusted (majority-rejecting) estimate must not force anything.
-    # The brightness comparison is the film prior: dust on the positive is
-    # WHITE (clear film), so a "defect" DARKER than its surround is content,
-    # not dust — never force-fill it.
+    # dlike_on lives on as plan metadata only (records keep their shape and
+    # the verdict stays resolution-stable via the replayed flags).
     sep = float(np.abs(defect - ring_bg).mean())
     dlike_on = bool(genuine and sep > _DLIKE_SEP_MADS * (ring_mad + 1e-3)
                     and float(defect.mean()) > float(ring_bg.mean()))
     if forced_flags is not None:
         dlike_on = bool(forced_flags[1])
-    if dlike_on:
-        hole_c = dst_c[hole]  # plan-scale smoothed: stable across buffers
-        like = (np.abs(hole_c - defect).mean(axis=1)
-                < np.abs(hole_c - ring_bg).mean(axis=1))
-        if like.any():
-            hy, hx = np.nonzero(hole)
-            dlike[wy0:wy1, wx0:wx1][hy[like], hx[like]] = 255
     return best_off, genuine, dlike_on
 
 
@@ -3609,11 +3593,10 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     half-thickness (the user's per-image Feather setting, 0..1): 0 =
     essentially hard edges, 1 = the cross-fade spans the hole's full depth.
     Keyed to the hole's local radius, the fade scales with the brush size —
-    and with resolution, since the rasterized hole does. Pixels colored like
-    the defect (when one is color-separable from its surround) are always
-    fully filled regardless of the feather, so a wide fade cannot blend the
-    defect back in; on a mostly-clean brushed area no pixels qualify and the
-    blend is a pure opacity dome rolling off from the stroke's center.
+    and with resolution, since the rasterized hole does. The blend is a pure
+    opacity dome rolling off from the stroke's center, with NO exceptions
+    (maintainer rule): a wide feather fades the heal out even across the
+    defect itself — dial the feather down (0 = hard) for complete removal.
 
     Each mask component is filled by CLONING the best-matching clean patch
     from its neighborhood (see _heal_patch) — real texture and grain,
@@ -3735,10 +3718,8 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     # hole depth (see _heal_patch), so the fade tracks the brush size and the
     # buffer's resolution alike. float32: fractional ramps keep the relative
     # alpha profile identical across scales (a rounded 1 px preview ramp vs
-    # its 3 px export equivalent visibly diverged). `dlike` marks defect-like
-    # hole pixels that must be fully filled regardless of feather.
+    # its 3 px export equivalent visibly diverged).
     fmap = np.full((h, w), 0.5, np.float32)
-    dlike = np.zeros((h, w), np.uint8)
     # Pixel-based knobs scale with the buffer (relative to the plan scale) so
     # a stroke splits into the SAME segments here as it did in the plan, and
     # the diffusion fallback blurs over the same image fraction.
@@ -3813,7 +3794,7 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                 if not forced_fb:
                     res = _heal_patch(img16, img16_c, labels, i, bbox,
                                       loc_th, mask_pad, integ, filled, fmap,
-                                      feather, dlike, src_off=src_off,
+                                      feather, src_off=src_off,
                                       forced_flags=flags, manual=manual)
                 if res is not None and len(res) == 4:
                     # Pinned source now under new dust: fill in a SECOND
@@ -3860,7 +3841,7 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     # clones the healed content at its unchanged reference location.
     for i, bbox_d, loc_d, off_d, flags_d, man_d in deferred:
         _heal_patch(img16, img16_c, labels, i, bbox_d, loc_d, mask_pad,
-                    integ, filled, fmap, feather, dlike,
+                    integ, filled, fmap, feather,
                     src_off=off_d, forced_flags=flags_d, sample=filled,
                     manual=man_d)
 
@@ -3885,21 +3866,10 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         ys = slice(max(0, by0 - 2), min(h, by0 + bh_ + 2))
         xs = slice(max(0, bx0 - 2), min(w, bx0 + bw_ + 2))
         comp = labels[ys, xs] == i
+        # The dome IS the whole story: no defect force-fill floor (see
+        # _heal_patch's feather comment) — the slider's rolloff shows on
+        # every heal, dust included.
         a = _feather_alpha(comp.astype(np.uint8) * 255, fmap[ys, xs])
-        # Defect-like pixels get the fill at full strength whatever the
-        # feather; the max with a blur adds a soft lip around the forced
-        # region without weakening its interior (max keeps the core at 1).
-        # The lip is as wide as the component's feather ramp, so the fill
-        # relaxes gradually across the clean rim instead of stepping at the
-        # defect's edge. It is confined to the component: a ramp-wide skirt
-        # can reach a NEIGHBORING component's hole (unlike the old 1 px lip),
-        # where blending img16 against that hole's fill would corrupt it.
-        dl = np.where(comp, dlike[ys, xs], 0)
-        lip = max(1, int(round(float(fmap[ys, xs][comp].max()))))
-        forced = np.maximum(dl, cv2.blur(dl, (2 * lip + 1, 2 * lip + 1)))
-        forced = forced.astype(np.float32) / 255.0
-        forced[~comp] = 0.0
-        a = np.maximum(a, forced)
         write = a > 0.0
         if not write.any():
             continue

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3305,7 +3305,7 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
                 filled: np.ndarray, fmap: np.ndarray, feather: float,
                 dlike: np.ndarray, src_off=None, forced_flags=None,
-                sample=None):
+                sample=None, manual=False):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
 
@@ -3502,22 +3502,33 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     if best_src is None:
         return None
 
-    # Smooth per-channel tone correction from the ring differences: normalized
-    # Gaussian convolution interpolates (dst - src) on the ring into the hole,
-    # so the clone keeps its grain but its low frequencies land on the hole's
-    # boundary values (gradients continue seamlessly through the patch). Sigma
-    # is thickness-local: a bbox-sized sigma turned the correction into one
-    # constant for the whole component, letting one bad segment tint it all.
-    dmap = np.zeros_like(dst)
-    dmap[ring] = dst_ring - best_src[ring]
-    ind = ring.astype(np.float32)
-    sigma = half_th + pad
-    wsum = cv2.GaussianBlur(ind, (0, 0), sigma)
-    dsum = cv2.GaussianBlur(dmap, (0, 0), sigma)
-    mean_diff = dmap[ring].mean(axis=0)
-    corr = np.where(wsum[..., None] > 1e-4,
-                    dsum / np.maximum(wsum, 1e-6)[..., None], mean_diff)
-    heal = best_src + corr
+    if manual:
+        # USER-PICKED source (the dragged reticle): clone-stamp semantics —
+        # the patch is copied VERBATIM, color and texture alike, blended
+        # only by the feather at the rim. The membrane below exists to make
+        # AUTOMATIC picks seamless (texture from the source, low
+        # frequencies from the destination); applied to an explicit re-pick
+        # it fought the user — the old color stayed and the picked look
+        # was toned away.
+        heal = best_src
+    else:
+        # Smooth per-channel tone correction from the ring differences:
+        # normalized Gaussian convolution interpolates (dst - src) on the
+        # ring into the hole, so the clone keeps its grain but its low
+        # frequencies land on the hole's boundary values (gradients continue
+        # seamlessly through the patch). Sigma is thickness-local: a
+        # bbox-sized sigma turned the correction into one constant for the
+        # whole component, letting one bad segment tint it all.
+        dmap = np.zeros_like(dst)
+        dmap[ring] = dst_ring - best_src[ring]
+        ind = ring.astype(np.float32)
+        sigma = half_th + pad
+        wsum = cv2.GaussianBlur(ind, (0, 0), sigma)
+        dsum = cv2.GaussianBlur(dmap, (0, 0), sigma)
+        mean_diff = dmap[ring].mean(axis=0)
+        corr = np.where(wsum[..., None] > 1e-4,
+                        dsum / np.maximum(wsum, 1e-6)[..., None], mean_diff)
+        heal = best_src + corr
     filled[wy0:wy1, wx0:wx1][hole] = np.clip(
         np.rint(heal[hole]), 0, 65535).astype(np.uint16)
 
@@ -3682,10 +3693,12 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                plan_tol: float = 0.06, crop=None) -> np.ndarray:
     """apply_dust_removal's engine at ONE resolution. With `collect` (a list),
     appends a plan record per heal segment:
-    (cy_norm, cx_norm, offset, genuine, dlike_on) where offset is the chosen
-    source displacement normalized over (h, w) — None for a diffusion
-    fallback — and genuine/dlike_on are the patch's content-adaptive
-    verdicts (see _heal_patch). With `plan` (+ `scale_up` = this buffer's
+    (cy_norm, cx_norm, offset, genuine, dlike_on, manual) where offset is
+    the chosen source displacement normalized over (h, w) — None for a
+    diffusion fallback — genuine/dlike_on are the patch's content-adaptive
+    verdicts (see _heal_patch), and manual marks a USER-PICKED source
+    (cloned verbatim, no membrane re-toning; set by the overlay's
+    source-ring drag and carried through every replay). With `plan` (+ `scale_up` = this buffer's
     size over the plan scale), segments reuse the planned
     offsets/fallbacks/verdicts instead of re-deriving them, and the
     pixel-based geometry (segment size, Telea radius) scales by `scale_up`
@@ -3783,7 +3796,7 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                         bx + int(xs.max()) + 1, by + int(ys.max()) + 1)
                 cyn = (by + float(ys.mean())) / h
                 cxn = (bx + float(xs.mean())) / w
-                src_off, forced_fb, flags = None, False, None
+                src_off, forced_fb, flags, manual = None, False, None, False
                 if plan is not None:
                     rec = _nearest_plan_record(plan, cyn, cxn, tol=plan_tol)
                     if rec is not None:
@@ -3794,23 +3807,25 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                                        int(round(rec[2][1] * w)))
                             if len(rec) >= 5:
                                 flags = (rec[3], rec[4])
+                            if len(rec) >= 6:
+                                manual = bool(rec[5])  # user-picked source
                 res = None
                 if not forced_fb:
                     res = _heal_patch(img16, img16_c, labels, i, bbox,
                                       loc_th, mask_pad, integ, filled, fmap,
                                       feather, dlike, src_off=src_off,
-                                      forced_flags=flags)
+                                      forced_flags=flags, manual=manual)
                 if res is not None and len(res) == 4:
                     # Pinned source now under new dust: fill in a SECOND
                     # pass from the healed buffer (after Telea), so the
                     # reference location stays — no exceptions.
-                    deferred.append((i, bbox, loc_th, res[0], flags))
+                    deferred.append((i, bbox, loc_th, res[0], flags, manual))
                 off = None if res is None else res[0]
                 if collect is not None:
                     collect.append(
-                        (cyn, cxn, None, None, None) if res is None
+                        (cyn, cxn, None, None, None, False) if res is None
                         else (cyn, cxn, (off[0] / h, off[1] / w),
-                              res[1], res[2]))
+                              res[1], res[2], manual))
                 if off is None:
                     fallback[by:by + sub.shape[0],
                              bx:bx + sub.shape[1]][sub] = 255
@@ -3843,10 +3858,11 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     # Second pass for deferred segments: every hole now has SOME fill in
     # `filled` (clone or Telea), so a pinned source that sat under new dust
     # clones the healed content at its unchanged reference location.
-    for i, bbox_d, loc_d, off_d, flags_d in deferred:
+    for i, bbox_d, loc_d, off_d, flags_d, man_d in deferred:
         _heal_patch(img16, img16_c, labels, i, bbox_d, loc_d, mask_pad,
                     integ, filled, fmap, feather, dlike,
-                    src_off=off_d, forced_flags=flags_d, sample=filled)
+                    src_off=off_d, forced_flags=flags_d, sample=filled,
+                    manual=man_d)
 
     # Feathered composite: alpha rises 0 -> 1 from each hole's boundary inward
     # over its feather ramp (a fraction of the hole's own thickness, so it

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -220,7 +220,11 @@ class DustRemovalPanel(QWidget):
             lambda on: self.image_preview.set_dust_source_overlay(on))
         layout.addWidget(self.show_sources_cb)
 
-        hint = QLabel("Click or drag over dust to remove it.")
+        hint = QLabel(
+            "Click or drag over dust to remove it. Ctrl+wheel resizes the "
+            "brush.\n"
+            "With heal sources shown: right-drag a stroke to move it (it "
+            "keeps sampling the same patch); double right-click deletes it.")
         hint.setWordWrap(True)
         hint.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         layout.addWidget(hint)

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -224,7 +224,9 @@ class DustRemovalPanel(QWidget):
             "Click or drag over dust to remove it. Ctrl+wheel resizes the "
             "brush.\n"
             "With heal sources shown: right-drag a stroke to move it (it "
-            "keeps sampling the same patch); double right-click deletes it.")
+            "keeps sampling the same patch); right-drag a source ring to "
+            "re-pick where it samples; double right-click deletes the "
+            "stroke.")
         hint.setWordWrap(True)
         hint.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         layout.addWidget(hint)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1818,14 +1818,27 @@ class ImagePreview(QWidget):
             for a in getattr(img, "area_layers", []))
         # Dust spots are inpainted inside apply_adjustments, so a change to them
         # must invalidate the cached hi-res display (see spec/dust-removal.md §4.4).
+        # The heal PLAN is part of that identity too: dragging a source ring
+        # rewrites only the plan (spots untouched), and without it here the
+        # zoomed display kept showing the old fill after a re-pick.
+        spots = getattr(img, "dust_spots", [])
+        cached = getattr(img, "_dust_plan_cache", None)
+        plan_sig = ()
+        if cached is not None and cached[0] == repr(spots):
+            plan_sig = tuple(
+                (round(r[0] * 10000), round(r[1] * 10000),
+                 None if r[2] is None else (round(r[2][0] * 10000),
+                                            round(r[2][1] * 10000)))
+                for r in cached[1])
         dust_sig = (tuple(
             (s.get("kind"),
              tuple((round(float(p[0]) * 10000), round(float(p[1]) * 10000))
                    for p in (s.get("pts") or [])),
              round(float(s.get("r", 0)) * 10000))
-            for s in getattr(img, "dust_spots", [])),
+            for s in spots),
             round(float(getattr(img, "dust_feather",
-                                DUST_FEATHER_DEFAULT)) * 10000))
+                                DUST_FEATHER_DEFAULT)) * 10000),
+            plan_sig)
         return (tuple(sorted(img.adjustment_settings.items())),
                 img.contrast_base, img.temperature_base, img.brightness_base,
                 getattr(img, "exposure_base", 0.0),

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QPainter,
                            QCursor, QDesktopServices, QPainterPath,
-                           QPainterPathStroker, QBrush, QPolygonF,
+                           QBrush, QPolygonF,
                            QImage)
 from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
@@ -49,18 +49,27 @@ def dust_debug_geometry(spots, plan, w, h):
     """Geometry for the dust panel's 'Show heal sources' overlay, in FULL
     un-cropped frame pixel coords (the caller maps to scene coords).
 
-    Returns {"strokes": [(points_px, brush_width_px)], "arrows":
-    [(src_x, src_y, dst_x, dst_y)], "fallbacks": [(x, y)]}: one outline per
-    stored spot, one arrow per planned clone segment drawn FROM the sampled
-    source patch TO the healed segment's centroid, and one marker per
-    diffusion-fallback segment (nothing was sampled there — Telea). `plan`
-    records are (cy, cx, off, ...) with `off` the destination→source window
-    displacement normalized over (h, w), or None for a fallback (see
-    _heal_impl); pass plan=None for stroke outlines only."""
-    strokes = [([(float(p[0]) * w, float(p[1]) * h)
-                 for p in (s.get("pts") or [])],
-                2.0 * float(s.get("r", 0.0)) * w)
-               for s in (spots or [])]
+    Returns {"borders": [closed polygons [(x, y), ...]], "arrows":
+    [(src_x, src_y, dst_x, dst_y)], "fallbacks": [(x, y)]}. Borders are the
+    contours of the UNION of the rasterized strokes (holes included), so
+    connected/overlapping strokes read as ONE region — per-spot outlines
+    drew noise lines through the interior. One arrow per planned clone
+    segment, drawn FROM the sampled source patch TO the healed segment's
+    centroid; one marker per diffusion-fallback segment (nothing was
+    sampled there — Telea). `plan` records are (cy, cx, off, ...) with
+    `off` the destination→source window displacement normalized over
+    (h, w), or None for a fallback (see _heal_impl); pass plan=None for
+    borders only."""
+    import cv2
+    from core.ccr_processor import rasterize_dust_mask
+    borders = []
+    if spots:
+        m = rasterize_dust_mask(spots, int(h), int(w))
+        if m.any():
+            contours, _ = cv2.findContours(m, cv2.RETR_CCOMP,
+                                           cv2.CHAIN_APPROX_SIMPLE)
+            borders = [[(float(p[0][0]), float(p[0][1])) for p in c]
+                       for c in contours if len(c) >= 3]
     arrows, fallbacks = [], []
     for rec in (plan or []):
         cy, cx, off = rec[0], rec[1], rec[2]
@@ -69,7 +78,52 @@ def dust_debug_geometry(spots, plan, w, h):
             fallbacks.append((dx, dy))
         else:
             arrows.append((dx + off[1] * w, dy + off[0] * h, dx, dy))
-    return {"strokes": strokes, "arrows": arrows, "fallbacks": fallbacks}
+    return {"borders": borders, "arrows": arrows, "fallbacks": fallbacks}
+
+
+def dust_spot_hit(spot, x_norm, y_norm, w, h, slack_px=0.0):
+    """True when the full-frame-normalized point lies on the spot's brush
+    footprint: within `r` (+slack) of its polyline, in pixels (`r` is a
+    fraction of width, like the rasterizer)."""
+    pts = spot.get("pts") or []
+    if not pts:
+        return False
+    r = float(spot.get("r", 0.0)) * w + slack_px
+    px, py = x_norm * w, y_norm * h
+    best = None
+    prev = None
+    for p in pts:
+        ax, ay = float(p[0]) * w, float(p[1]) * h
+        if prev is None:
+            qx, qy = ax, ay
+        else:
+            bx, by = prev
+            vx, vy = ax - bx, ay - by
+            L2 = vx * vx + vy * vy
+            t = 0.0 if L2 <= 0 else max(0.0, min(1.0, ((px - bx) * vx
+                                                       + (py - by) * vy) / L2))
+            qx, qy = bx + t * vx, by + t * vy
+        d = ((px - qx) ** 2 + (py - qy) ** 2) ** 0.5
+        best = d if best is None else min(best, d)
+        prev = (ax, ay)
+    return best is not None and best <= r
+
+
+def translate_dust_plan(plan, spot, dx, dy, w, h):
+    """Move the plan records riding on `spot` by (dx, dy) normalized while
+    KEEPING each record's ABSOLUTE source position — the offset compensates
+    the move, so a dragged stroke still samples the very same patch of film
+    (the reference location never changes, see spec). Records not on the
+    spot are untouched. Returns a new list."""
+    out = []
+    for rec in (plan or []):
+        if dust_spot_hit(spot, rec[1], rec[0], w, h, slack_px=2.0):
+            off = rec[2]
+            off2 = None if off is None else (off[0] - dy, off[1] - dx)
+            out.append((rec[0] + dy, rec[1] + dx, off2) + tuple(rec[3:]))
+        else:
+            out.append(rec)
+    return out
 
 
 _rotate_cursor_cache = None
@@ -187,6 +241,9 @@ class GraphicsImageView(QGraphicsView):
         if self.parent_widget.dust_mode and self.parent_widget.pixmap_item is not None:
             if event.button() == Qt.LeftButton:
                 self.parent_widget.dust_press(self.mapToScene(event.pos()))
+            elif event.button() == Qt.RightButton:
+                # With the sources overlay shown: right-drag moves a stroke.
+                self.parent_widget.dust_right_press(self.mapToScene(event.pos()))
             return
         if self.parent_widget.crop_mode and self.parent_widget.pixmap_item is not None:
             if event.button() == Qt.LeftButton:
@@ -253,7 +310,10 @@ class GraphicsImageView(QGraphicsView):
         if self._space_pan:
             return super().mouseMoveEvent(event)
         if self.parent_widget.dust_mode:
-            self.parent_widget.dust_move(self.mapToScene(event.pos()))
+            if self.parent_widget._dust_drag is not None:
+                self.parent_widget.dust_right_move(self.mapToScene(event.pos()))
+            else:
+                self.parent_widget.dust_move(self.mapToScene(event.pos()))
             return
         if self.parent_widget.crop_mode:
             scene_pos = self.mapToScene(event.pos())
@@ -385,6 +445,8 @@ class GraphicsImageView(QGraphicsView):
         if self.parent_widget.dust_mode:
             if event.button() == Qt.LeftButton:
                 self.parent_widget.dust_release()
+            elif event.button() == Qt.RightButton:
+                self.parent_widget.dust_right_release()
             return
         if self.parent_widget.crop_mode:
             if event.button() == Qt.LeftButton:
@@ -516,6 +578,17 @@ class GraphicsImageView(QGraphicsView):
                 pw.reference_rect_item = None
                 ccr_backend.set_reference_frame_by_index(pw.current_idx, None)
         self.parent_widget.update_preview(self.parent_widget.current_idx)
+
+    def mouseDoubleClickEvent(self, event):
+        if (self.parent_widget.dust_mode
+                and self.parent_widget.pixmap_item is not None
+                and event.button() == Qt.RightButton):
+            # With the sources overlay shown: double right-click deletes the
+            # stroke under the cursor.
+            self.parent_widget.dust_right_double(self.mapToScene(event.pos()))
+            event.accept()
+            return
+        super().mouseDoubleClickEvent(event)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
@@ -887,6 +960,7 @@ class ImagePreview(QWidget):
         self.dust_panel = None           # set by MainWindow (brush-slider sync)
         self._dust_debug = False         # 'Show heal sources' diagnostic overlay
         self._dust_debug_items = []      # its scene items (outlines/arrows)
+        self._dust_drag = None           # right-drag state (move a stroke)
 
         # Coalesce a fine-rotation drag into a single undo step
         self._fine_rot_burst_active = False
@@ -2540,6 +2614,94 @@ class ImagePreview(QWidget):
             {"kind": "brush", "pts": pts, "r": float(self._dust_brush_r)})
         self._commit_dust_change(img)
 
+    # --- Right-button stroke editing (with the sources overlay shown) ------
+    def _dust_spot_index_at(self, scene_pos):
+        """Index of the topmost (newest) stroke under the cursor, or None."""
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        n = self._dust_scene_to_norm(scene_pos)
+        size = self._dust_full_frame_size()
+        if img is None or n is None or size is None:
+            return None
+        w, h = size
+        spots = getattr(img, "dust_spots", []) or []
+        for i in range(len(spots) - 1, -1, -1):
+            if dust_spot_hit(spots[i], n[0], n[1], w, h, slack_px=2.0):
+                return i
+        return None
+
+    def dust_right_press(self, scene_pos):
+        """Right-press on a stroke (sources overlay shown): begin moving it."""
+        if not (self.dust_mode and self._dust_debug):
+            return
+        idx = self._dust_spot_index_at(scene_pos)
+        n = self._dust_scene_to_norm(scene_pos)
+        if idx is None or n is None:
+            return
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        self._dust_drag = {"idx": idx, "start": n, "delta": (0.0, 0.0),
+                           "orig": copy.deepcopy(img.dust_spots[idx]),
+                           "moved": False}
+
+    def dust_right_move(self, scene_pos):
+        drag = self._dust_drag
+        if drag is None:
+            return
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        n = self._dust_scene_to_norm(scene_pos)
+        if img is None or n is None:
+            return
+        pts0 = drag["orig"]["pts"]
+        dx = n[0] - drag["start"][0]
+        dy = n[1] - drag["start"][1]
+        # Clamp so the whole stroke stays inside the frame.
+        dx = max(-min(p[0] for p in pts0),
+                 min(1.0 - max(p[0] for p in pts0), dx))
+        dy = max(-min(p[1] for p in pts0),
+                 min(1.0 - max(p[1] for p in pts0), dy))
+        img.dust_spots[drag["idx"]] = dict(
+            drag["orig"], pts=[[p[0] + dx, p[1] + dy] for p in pts0])
+        drag["delta"] = (dx, dy)
+        drag["moved"] = abs(dx) > 1e-6 or abs(dy) > 1e-6
+        self._draw_dust_debug()  # live border; the re-heal lands on release
+
+    def dust_right_release(self):
+        drag = self._dust_drag
+        self._dust_drag = None
+        if drag is None or not drag.get("moved"):
+            return
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is None:
+            return
+        dx, dy = drag["delta"]
+        # Snapshot the PRE-drag state for undo, then re-apply the move.
+        img.dust_spots[drag["idx"]] = copy.deepcopy(drag["orig"])
+        img.push_undo_state()
+        img.dust_spots[drag["idx"]] = dict(
+            drag["orig"],
+            pts=[[p[0] + dx, p[1] + dy] for p in drag["orig"]["pts"]])
+        # Carry the stroke's plan records along, keeping each one's ABSOLUTE
+        # source position — a moved stroke still samples the same patch of
+        # film (the reference never changes).
+        cached = getattr(img, "_dust_plan_cache", None)
+        size = self._dust_full_frame_size()
+        if cached is not None and size is not None:
+            img._dust_plan_cache = (cached[0], translate_dust_plan(
+                cached[1], drag["orig"], dx, dy, size[0], size[1]))
+        self._commit_dust_change(img)
+
+    def dust_right_double(self, scene_pos):
+        """Double right-click on a stroke (sources overlay shown): delete it."""
+        if not (self.dust_mode and self._dust_debug):
+            return
+        self._dust_drag = None
+        idx = self._dust_spot_index_at(scene_pos)
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if idx is None or img is None:
+            return
+        img.push_undo_state()
+        del img.dust_spots[idx]
+        self._commit_dust_change(img)
+
     def dust_undo_last(self) -> bool:
         img = ccr_backend.get_image_by_index(self.current_idx)
         if img is None or not img.dust_spots:
@@ -2698,21 +2860,13 @@ class ImagePreview(QWidget):
         yellow = QColor(255, 220, 60, 230)   # stroke borders
         green = QColor(80, 255, 140, 230)    # sampled patch + arrow
         orange = QColor(255, 150, 40, 230)   # diffusion fallback marker
-        for pts, width in geo["strokes"]:
-            if not pts:
-                continue
+        for poly in geo["borders"]:
             path = QPainterPath()
-            path.moveTo(scene_pt(*pts[0]))
-            for p in pts[1:]:
+            path.moveTo(scene_pt(*poly[0]))
+            for p in poly[1:]:
                 path.lineTo(scene_pt(*p))
-            if len(pts) == 1:  # single dab: zero-length stroke + round cap
-                path.lineTo(scene_pt(pts[0][0] + 1e-3, pts[0][1]))
-            stroker = QPainterPathStroker()
-            # Crop extraction is isometric, so full-frame px == display px.
-            stroker.setWidth(max(1.0, width))
-            stroker.setCapStyle(Qt.RoundCap)
-            stroker.setJoinStyle(Qt.RoundJoin)
-            item = QGraphicsPathItem(stroker.createStroke(path))
+            path.closeSubpath()
+            item = QGraphicsPathItem(path)
             item.setBrush(Qt.NoBrush)
             add(item, yellow)
         for sx, sy, dx, dy in geo["arrows"]:

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -310,7 +310,8 @@ class GraphicsImageView(QGraphicsView):
         if self._space_pan:
             return super().mouseMoveEvent(event)
         if self.parent_widget.dust_mode:
-            if self.parent_widget._dust_drag is not None:
+            if (self.parent_widget._dust_drag is not None
+                    or self.parent_widget._dust_src_drag is not None):
                 self.parent_widget.dust_right_move(self.mapToScene(event.pos()))
             else:
                 self.parent_widget.dust_move(self.mapToScene(event.pos()))
@@ -961,6 +962,7 @@ class ImagePreview(QWidget):
         self._dust_debug = False         # 'Show heal sources' diagnostic overlay
         self._dust_debug_items = []      # its scene items (outlines/arrows)
         self._dust_drag = None           # right-drag state (move a stroke)
+        self._dust_src_drag = None       # right-drag state (re-pick a source)
 
         # Coalesce a fine-rotation drag into a single undo step
         self._fine_rot_burst_active = False
@@ -2629,20 +2631,81 @@ class ImagePreview(QWidget):
                 return i
         return None
 
+    def _dust_source_index_at(self, n):
+        """Index (into the cached plan) of the source marker under the
+        cursor, or None. Markers exist only while the cache matches the
+        spots — the same condition under which they are drawn."""
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        size = self._dust_full_frame_size()
+        if img is None or size is None:
+            return None
+        cached = getattr(img, "_dust_plan_cache", None)
+        spots = getattr(img, "dust_spots", []) or []
+        if cached is None or cached[0] != repr(spots):
+            return None
+        w, h = size
+        for i, rec in enumerate(cached[1]):
+            if rec[2] is None:
+                continue
+            sx, sy = rec[1] + rec[2][1], rec[0] + rec[2][0]
+            if math.hypot((n[0] - sx) * w, (n[1] - sy) * h) <= 9.0:
+                return i
+        return None
+
     def dust_right_press(self, scene_pos):
-        """Right-press on a stroke (sources overlay shown): begin moving it."""
+        """Right-press (sources overlay shown): grab the source marker under
+        the cursor to re-pick where that segment samples from, else grab the
+        stroke to move it."""
         if not (self.dust_mode and self._dust_debug):
             return
-        idx = self._dust_spot_index_at(scene_pos)
         n = self._dust_scene_to_norm(scene_pos)
-        if idx is None or n is None:
+        if n is None:
+            return
+        si = self._dust_source_index_at(n)
+        if si is not None:
+            img = ccr_backend.get_image_by_index(self.current_idx)
+            self._dust_src_drag = {"idx": si, "start": n,
+                                   "rec": img._dust_plan_cache[1][si],
+                                   "moved": False}
+            return
+        idx = self._dust_spot_index_at(scene_pos)
+        if idx is None:
             return
         img = ccr_backend.get_image_by_index(self.current_idx)
         self._dust_drag = {"idx": idx, "start": n, "delta": (0.0, 0.0),
                            "orig": copy.deepcopy(img.dust_spots[idx]),
                            "moved": False}
 
+    def _dust_source_move(self, scene_pos):
+        """Live-update a dragged source marker: rewrite that plan record's
+        offset so the segment samples where the user drops it. The re-heal
+        (on release) binds the segment at its unchanged centroid and pins
+        the chosen offset verbatim — the user's pick becomes the sticky
+        reference, replayed by hi-res/export and persisted in the catalog."""
+        drag = self._dust_src_drag
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        n = self._dust_scene_to_norm(scene_pos)
+        if drag is None or img is None or n is None:
+            return
+        cached = getattr(img, "_dust_plan_cache", None)
+        if cached is None:
+            return
+        rec = drag["rec"]
+        dy = n[1] - drag["start"][1]
+        dx = n[0] - drag["start"][0]
+        # Keep the source center inside the frame.
+        oy = min(max(rec[2][0] + dy, -rec[0]), 1.0 - rec[0])
+        ox = min(max(rec[2][1] + dx, -rec[1]), 1.0 - rec[1])
+        recs = list(cached[1])
+        recs[drag["idx"]] = (rec[0], rec[1], (oy, ox)) + tuple(rec[3:])
+        img._dust_plan_cache = (cached[0], recs)
+        drag["moved"] = abs(dy) > 1e-6 or abs(dx) > 1e-6
+        self._draw_dust_debug()  # arrow follows; the re-heal lands on release
+
     def dust_right_move(self, scene_pos):
+        if self._dust_src_drag is not None:
+            self._dust_source_move(scene_pos)
+            return
         drag = self._dust_drag
         if drag is None:
             return
@@ -2665,6 +2728,16 @@ class ImagePreview(QWidget):
         self._draw_dust_debug()  # live border; the re-heal lands on release
 
     def dust_right_release(self):
+        src = self._dust_src_drag
+        self._dust_src_drag = None
+        if src is not None:
+            if src.get("moved"):
+                img = ccr_backend.get_image_by_index(self.current_idx)
+                if img is not None:
+                    # Re-heal: the segment binds at its centroid and pins
+                    # the user-chosen offset verbatim — the new reference.
+                    self._commit_dust_change(img)
+            return
         drag = self._dust_drag
         self._dust_drag = None
         if drag is None or not drag.get("moved"):
@@ -2694,6 +2767,7 @@ class ImagePreview(QWidget):
         if not (self.dust_mode and self._dust_debug):
             return
         self._dust_drag = None
+        self._dust_src_drag = None
         idx = self._dust_spot_index_at(scene_pos)
         img = ccr_backend.get_image_by_index(self.current_idx)
         if idx is None or img is None:

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QToolBar, QMessageBox, QSlider, QGraphicsView, QGraphicsScene,
     QGraphicsPixmapItem, QGraphicsRectItem, QGraphicsPathItem, QGraphicsEllipseItem,
-    QGraphicsLineItem, QStyleOptionSlider, QDialog,
+    QGraphicsLineItem, QGraphicsPolygonItem, QStyleOptionSlider, QDialog,
     QLabel, QPushButton, QStyle, QSizePolicy, QApplication, QComboBox
 )
 from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QPainter,
@@ -1346,6 +1346,9 @@ class ImagePreview(QWidget):
         if self.slice_mode:
             self._set_slice_ghost(None)
             self._draw_slice_dim()
+        # Dust source markers are sized from the view scale too.
+        if self.dust_mode:
+            self._draw_dust_debug()
             if self._slice_lines:
                 self._redraw_slice_lines()
 
@@ -1654,6 +1657,8 @@ class ImagePreview(QWidget):
             self._draw_crop_overlay()  # handle sizes track the view scale
         if self.area_mode:
             self._draw_area_overlay()  # area handle sizes track the view scale too
+        if self.dust_mode:
+            self._draw_dust_debug()  # source markers track the view scale too
 
     def zoom_to_percent(self, pct):
         """Zoom to an absolute percentage of the source's ACTUAL size (1.0 =
@@ -2644,11 +2649,15 @@ class ImagePreview(QWidget):
         if cached is None or cached[0] != repr(spots):
             return None
         w, h = size
+        # Hit radius matches the drawn reticle: a constant SCREEN size, so
+        # divide by the view scale to get scene/full-frame pixels — capped,
+        # or a degenerate scale would let the marker swallow every click.
+        hit = min(24.0, 10.0 / max(self._view_scale() or 0.0, 1e-6))
         for i, rec in enumerate(cached[1]):
             if rec[2] is None:
                 continue
             sx, sy = rec[1] + rec[2][1], rec[0] + rec[2][0]
-            if math.hypot((n[0] - sx) * w, (n[1] - sy) * h) <= 9.0:
+            if math.hypot((n[0] - sx) * w, (n[1] - sy) * h) <= hit:
                 return i
         return None
 
@@ -2924,44 +2933,76 @@ class ImagePreview(QWidget):
                 pt = to_display.map(pt)
             return t.map(pt)
 
-        def add(item, color, width=1.5):
-            pen = QPen(color, width)
-            pen.setCosmetic(True)  # constant screen width at any zoom
-            item.setPen(pen)
+        # Marker geometry holds a constant SCREEN size (divided by the view
+        # scale, and redrawn on zoom); pen widths are cosmetic already.
+        vs = max(self._view_scale() or 0.0, 1e-6)
+
+        def px(v):
+            return v / vs
+
+        def pen(color, width, dash=None):
+            p = QPen(color, width)
+            p.setCosmetic(True)
+            p.setCapStyle(Qt.RoundCap)
+            p.setJoinStyle(Qt.RoundJoin)
+            if dash:
+                p.setDashPattern(dash)
+            return p
+
+        def add(item, p, brush=None):
+            item.setPen(p)
+            item.setBrush(brush if brush is not None else Qt.NoBrush)
             self.scene.addItem(item)
             self._dust_debug_items.append(item)
 
-        yellow = QColor(255, 220, 60, 230)   # stroke borders
-        green = QColor(80, 255, 140, 230)    # sampled patch + arrow
-        orange = QColor(255, 150, 40, 230)   # diffusion fallback marker
+        def ellipse(c, r):
+            return QGraphicsEllipseItem(c.x() - r, c.y() - r, 2 * r, 2 * r)
+
+        halo = QColor(12, 16, 20, 150)       # soft dark underlay: everything
+        amber = QColor(255, 200, 80, 235)    # stroke borders (marquee)
+        mint = QColor(105, 232, 165, 245)    # sampled patch + arrow
+        orange = QColor(255, 156, 66, 245)   # diffusion fallback marker
         for poly in geo["borders"]:
             path = QPainterPath()
             path.moveTo(scene_pt(*poly[0]))
             for p in poly[1:]:
                 path.lineTo(scene_pt(*p))
             path.closeSubpath()
-            item = QGraphicsPathItem(path)
-            item.setBrush(Qt.NoBrush)
-            add(item, yellow)
+            add(QGraphicsPathItem(path), pen(halo, 3.4))
+            add(QGraphicsPathItem(path), pen(amber, 1.4, [5.0, 4.0]))
         for sx, sy, dx, dy in geo["arrows"]:
             p1, p2 = scene_pt(sx, sy), scene_pt(dx, dy)
-            add(QGraphicsLineItem(p1.x(), p1.y(), p2.x(), p2.y()), green)
-            r = 6.0
-            e = QGraphicsEllipseItem(p1.x() - r, p1.y() - r, 2 * r, 2 * r)
-            e.setBrush(Qt.NoBrush)
-            add(e, green)
-            ang = math.atan2(p2.y() - p1.y(), p2.x() - p1.x())
-            for da in (math.pi * 5 / 6, -math.pi * 5 / 6):  # arrowhead barbs
-                add(QGraphicsLineItem(
-                    p2.x(), p2.y(),
-                    p2.x() + 9.0 * math.cos(ang + da),
-                    p2.y() + 9.0 * math.sin(ang + da)), green)
+            r_ring, head = px(7.0), px(10.0)
+            vx, vy = p2.x() - p1.x(), p2.y() - p1.y()
+            length = math.hypot(vx, vy)
+            if length > r_ring + head:
+                # Shaft from the reticle's rim to the arrowhead's base.
+                ux, uy = vx / length, vy / length
+                shaft = QPainterPath(
+                    QPointF(p1.x() + ux * r_ring, p1.y() + uy * r_ring))
+                shaft.lineTo(QPointF(p2.x() - ux * head * 0.7,
+                                     p2.y() - uy * head * 0.7))
+                add(QGraphicsPathItem(shaft), pen(halo, 3.4))
+                add(QGraphicsPathItem(shaft), pen(mint, 1.6))
+                ang = math.atan2(vy, vx)
+                tri = QPolygonF([
+                    p2,
+                    QPointF(p2.x() - head * math.cos(ang - 0.42),
+                            p2.y() - head * math.sin(ang - 0.42)),
+                    QPointF(p2.x() - head * math.cos(ang + 0.42),
+                            p2.y() - head * math.sin(ang + 0.42))])
+                add(QGraphicsPolygonItem(tri), pen(halo, 1.6), QBrush(mint))
+            # Source reticle: halo ring, mint ring with a faint fill, dot.
+            add(ellipse(p1, r_ring), pen(halo, 3.4))
+            fill = QColor(mint)
+            fill.setAlpha(34)
+            add(ellipse(p1, r_ring), pen(mint, 1.6), QBrush(fill))
+            add(ellipse(p1, px(1.5)), pen(mint, 1.0), QBrush(mint))
         for x, y in geo["fallbacks"]:
             p = scene_pt(x, y)
-            r = 7.0
-            e = QGraphicsEllipseItem(p.x() - r, p.y() - r, 2 * r, 2 * r)
-            e.setBrush(Qt.NoBrush)
-            add(e, orange, 2.0)
+            add(ellipse(p, px(8.0)), pen(halo, 3.4))
+            add(ellipse(p, px(8.0)), pen(orange, 1.6, [3.0, 2.6]))
+            add(ellipse(p, px(1.5)), pen(orange, 1.0), QBrush(orange))
 
     def _draw_dust_stroke(self):
         """Draw/refresh the live red overlay for the in-progress stroke.

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -2719,7 +2719,10 @@ class ImagePreview(QWidget):
         oy = min(max(rec[2][0] + dy, -rec[0]), 1.0 - rec[0])
         ox = min(max(rec[2][1] + dx, -rec[1]), 1.0 - rec[1])
         recs = list(cached[1])
-        recs[drag["idx"]] = (rec[0], rec[1], (oy, ox)) + tuple(rec[3:])
+        # manual=True: a user-picked source is cloned VERBATIM (color and
+        # texture) — the membrane re-toning is for automatic picks only.
+        recs[drag["idx"]] = (rec[0], rec[1], (oy, ox)) \
+            + tuple(rec[3:5]) + (True,)
         img._dust_plan_cache = (cached[0], recs)
         drag["moved"] = abs(dy) > 1e-6 or abs(dx) > 1e-6
         self._draw_dust_debug()  # arrow follows; the re-heal lands on release

--- a/tests/test_dust_crop_display.py
+++ b/tests/test_dust_crop_display.py
@@ -138,6 +138,55 @@ class TestHealSourceOverlay:
         assert ip._dust_debug_items == []
 
 
+class TestRightButtonStrokeEditing:
+    def test_right_drag_moves_stroke_and_keeps_absolute_source(self, tmp_path):
+        ip, img = _converted_preview(tmp_path, crop_rect=None)
+        ip.enter_dust_mode()
+        ip._maybe_request_hires = lambda: None   # keep the test in-thread
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}]
+        img.update_thumbnail_and_preview()
+        (cy, cx, off, *_), = img._dust_plan_cache[1]
+        assert off is not None
+        abs_src = (cy + off[0], cx + off[1])
+        ip.set_dust_source_overlay(True)
+        # Right-drag the stroke 60 px right (no crop: scene == full coords).
+        ip.dust_right_press(QPointF(300, 200))
+        assert ip._dust_drag is not None
+        ip.dust_right_move(QPointF(360, 200))
+        ip.dust_right_release()
+        assert img.dust_spots[0]["pts"][0] == pytest.approx([0.6, 0.5])
+        # The re-heal bound the translated record: the segment moved but its
+        # ABSOLUTE source position did not (the offset compensated).
+        (cy2, cx2, off2, *_), = img._dust_plan_cache[1]
+        assert cx2 == pytest.approx(0.6, abs=0.01)
+        assert (cy2 + off2[0], cx2 + off2[1]) == pytest.approx(abs_src,
+                                                               abs=0.01)
+        # The drag is one undo step back to the pre-drag stroke.
+        assert img.pop_undo_state()
+        assert img.dust_spots[0]["pts"][0] == pytest.approx([0.5, 0.5])
+
+    def test_double_right_click_deletes_stroke(self, tmp_path):
+        ip, img = _converted_preview(tmp_path, crop_rect=None)
+        ip.enter_dust_mode()
+        ip._maybe_request_hires = lambda: None
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}]
+        img.update_thumbnail_and_preview()
+        ip.set_dust_source_overlay(True)
+        ip.dust_right_double(QPointF(100, 50))   # miss: nothing happens
+        assert len(img.dust_spots) == 1
+        ip.dust_right_double(QPointF(300, 200))  # on the stroke: deleted
+        assert img.dust_spots == []
+        assert img.pop_undo_state()
+        assert len(img.dust_spots) == 1
+
+    def test_right_press_needs_overlay_shown(self, tmp_path):
+        ip, img = _converted_preview(tmp_path, crop_rect=None)
+        ip.enter_dust_mode()
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}]
+        ip.dust_right_press(QPointF(300, 200))   # overlay off: no drag
+        assert ip._dust_drag is None
+
+
 class TestSceneToNormThroughCrop:
     def test_center_of_crop_maps_to_crop_center(self, tmp_path):
         ip, img = _converted_preview(tmp_path)

--- a/tests/test_dust_crop_display.py
+++ b/tests/test_dust_crop_display.py
@@ -203,6 +203,22 @@ class TestRightButtonStrokeEditing:
         assert cx2 + off2[1] == pytest.approx((sx) / 600.0, abs=0.01)
         assert cy2 + off2[0] == pytest.approx((sy + 80) / 400.0, abs=0.01)
 
+    def test_adj_sig_tracks_source_repick(self, tmp_path):
+        # Dragging a source ring rewrites only the PLAN (spots untouched);
+        # the hi-res display signature must change with it, or the zoomed
+        # display keeps showing the old fill after a re-pick.
+        ip, img = _converted_preview(tmp_path, crop_rect=None)
+        ip.enter_dust_mode()
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}]
+        img.update_thumbnail_and_preview()
+        sig1 = ip._current_adj_sig()
+        key, plan = img._dust_plan_cache
+        (cy, cx, off, *rest), = plan
+        assert off is not None
+        img._dust_plan_cache = (key, [(cy, cx, (off[0] + 0.05, off[1]),
+                                       *rest)])
+        assert ip._current_adj_sig() != sig1
+
     def test_right_press_needs_overlay_shown(self, tmp_path):
         ip, img = _converted_preview(tmp_path, crop_rect=None)
         ip.enter_dust_mode()

--- a/tests/test_dust_crop_display.py
+++ b/tests/test_dust_crop_display.py
@@ -179,6 +179,30 @@ class TestRightButtonStrokeEditing:
         assert img.pop_undo_state()
         assert len(img.dust_spots) == 1
 
+    def test_right_drag_on_source_marker_repicks_the_sample(self, tmp_path):
+        # Dragging the SOURCE ring changes where that segment samples from:
+        # the plan record's offset follows the drop point, the re-heal pins
+        # it verbatim, and the user's pick becomes the sticky reference.
+        ip, img = _converted_preview(tmp_path, crop_rect=None)
+        ip.enter_dust_mode()
+        ip._maybe_request_hires = lambda: None
+        img.dust_spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}]
+        img.update_thumbnail_and_preview()
+        (cy, cx, off, *_), = img._dust_plan_cache[1]
+        assert off is not None
+        ip.set_dust_source_overlay(True)
+        # Grab the marker at the source position (no crop: scene == full px).
+        sx, sy = (cx + off[1]) * 600, (cy + off[0]) * 400
+        ip.dust_right_press(QPointF(sx, sy))
+        assert ip._dust_src_drag is not None and ip._dust_drag is None
+        # Drop it 80 px below (clean area) and release.
+        ip.dust_right_move(QPointF(sx, sy + 80))
+        ip.dust_right_release()
+        (cy2, cx2, off2, *_), = img._dust_plan_cache[1]
+        assert (cy2, cx2) == pytest.approx((cy, cx), abs=1e-6)
+        assert cx2 + off2[1] == pytest.approx((sx) / 600.0, abs=0.01)
+        assert cy2 + off2[0] == pytest.approx((sy + 80) / 400.0, abs=0.01)
+
     def test_right_press_needs_overlay_shown(self, tmp_path):
         ip, img = _converted_preview(tmp_path, crop_rect=None)
         ip.enter_dust_mode()

--- a/tests/test_dust_crop_display.py
+++ b/tests/test_dust_crop_display.py
@@ -198,10 +198,13 @@ class TestRightButtonStrokeEditing:
         # Drop it 80 px below (clean area) and release.
         ip.dust_right_move(QPointF(sx, sy + 80))
         ip.dust_right_release()
-        (cy2, cx2, off2, *_), = img._dust_plan_cache[1]
+        (cy2, cx2, off2, *rest), = img._dust_plan_cache[1]
         assert (cy2, cx2) == pytest.approx((cy, cx), abs=1e-6)
         assert cx2 + off2[1] == pytest.approx((sx) / 600.0, abs=0.01)
         assert cy2 + off2[0] == pytest.approx((sy + 80) / 400.0, abs=0.01)
+        # The pick is marked manual (verbatim clone) and survives the
+        # re-heal's plan collection.
+        assert rest[2] is True
 
     def test_adj_sig_tracks_source_repick(self, tmp_path):
         # Dragging a source ring rewrites only the PLAN (spots untouched);

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -779,18 +779,50 @@ class TestPanelWiring:
 
     def test_dust_debug_geometry_maps_plan_to_arrows(self):
         # Full-frame pixel geometry for the 'Show heal sources' overlay:
-        # spot outlines, one arrow per cloned segment (source -> segment,
+        # union borders, one arrow per cloned segment (source -> segment,
         # source = centroid + planned offset), a marker per Telea fallback.
         from widgets.image_preview import dust_debug_geometry
         spots = [{"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.05}]
         plan = [(0.5, 0.5, (0.1, -0.2), True, False),
                 (0.3, 0.4, None, None, None)]
         geo = dust_debug_geometry(spots, plan, 1000, 500)
-        assert geo["strokes"] == [([(500.0, 250.0)], 100.0)]
+        # One border: the dab's circle contour (r = 0.05 * 1000 = 50 px).
+        assert len(geo["borders"]) == 1
+        pts = np.array(geo["borders"][0])
+        d = np.hypot(pts[:, 0] - 500, pts[:, 1] - 250)
+        assert float(np.abs(d - 50).max()) < 3
         (sx, sy, dx, dy), = geo["arrows"]
         assert (dx, dy) == (500.0, 250.0)
         assert (sx, sy) == (500.0 - 0.2 * 1000, 250.0 + 0.1 * 500)
         assert geo["fallbacks"] == [(0.4 * 1000, 0.3 * 500)]
+
+    def test_connected_strokes_outline_as_one_border(self):
+        # Overlapping strokes read as ONE region: a single union border,
+        # not per-spot outlines crossing through the interior.
+        from widgets.image_preview import dust_debug_geometry
+        merged = [{"kind": "brush", "pts": [[0.50, 0.5]], "r": 0.05},
+                  {"kind": "brush", "pts": [[0.56, 0.5]], "r": 0.05}]
+        assert len(dust_debug_geometry(merged, None, 1000, 1000)["borders"]) == 1
+        apart = [{"kind": "brush", "pts": [[0.3, 0.3]], "r": 0.03},
+                 {"kind": "brush", "pts": [[0.7, 0.7]], "r": 0.03}]
+        assert len(dust_debug_geometry(apart, None, 1000, 1000)["borders"]) == 2
+
+    def test_dust_spot_hit_and_plan_translation(self):
+        # Hit-testing for the right-button stroke editing, and the plan
+        # translation that keeps a dragged stroke's ABSOLUTE source.
+        from widgets.image_preview import dust_spot_hit, translate_dust_plan
+        spot = {"kind": "brush", "pts": [[0.2, 0.2], [0.4, 0.2]], "r": 0.02}
+        assert dust_spot_hit(spot, 0.3, 0.2, 1000, 1000)       # on the line
+        assert dust_spot_hit(spot, 0.3, 0.218, 1000, 1000)     # within r=20px
+        assert not dust_spot_hit(spot, 0.3, 0.25, 1000, 1000)  # 30 px off
+        plan = [(0.2, 0.3, (0.05, 0.10), True, False),  # rides the stroke
+                (0.8, 0.8, (0.01, 0.02), True, True)]   # elsewhere
+        out = translate_dust_plan(plan, spot, 0.1, -0.05, 1000, 1000)
+        cy, cx, off = out[0][0], out[0][1], out[0][2]
+        assert (cy, cx) == pytest.approx((0.15, 0.4))
+        # The record's ABSOLUTE source position is unchanged by the move.
+        assert (cy + off[0], cx + off[1]) == pytest.approx((0.25, 0.40))
+        assert out[1] == plan[1]
 
     def test_detect_all_no_targets_is_safe(self):
         from widgets.dust_panel import DustRemovalPanel, _DetectAllWorker  # noqa: F401

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -251,17 +251,29 @@ class TestApplyDustRemoval:
         assert rim_ratio(0.12) < 0.5   # big brush: 6 px in is still soft rim
         assert rim_ratio(0.04) > 0.5   # small brush: 6 px in is nearly core
 
-    def test_wide_feather_never_blends_defect_back(self):
-        # Defect-like pixels are force-filled whatever the feather: a tight
-        # hair trace with the feather at its maximum must still remove the
-        # hair.
+    def test_feather_rolls_off_even_over_defects(self):
+        # The feather governs EVERYTHING (maintainer rule: every pixel gets
+        # the effect, opacity rolled off from the stroke center — no
+        # exceptions). The old defect force-fill pinned alpha to 1 on
+        # defect-colored pixels, so on real dust the slider did nothing. At
+        # 100% the heal's effect must fade from the center outward even
+        # across the defect itself.
         sky = np.array([20000, 25000, 40000], np.float32)
         img = np.broadcast_to(sky.astype(np.uint16), (200, 200, 3)).copy()
-        cv2.line(img, (30, 100), (170, 100), (62000, 60000, 30000), 13)
-        spot = {"kind": "brush",
-                "pts": [[0.2, 0.5], [0.5, 0.5], [0.8, 0.5]], "r": 2.0 / 200}
+        cv2.circle(img, (100, 100), 10, (62000, 60000, 30000), -1)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.06}  # r = 12 px
         out = apply_dust_removal(img, [spot], feather=1.0)
-        core = out[99:102, 60:140].astype(np.float32).reshape(-1, 3)
+        diff = np.abs(out.astype(np.float32)
+                      - img.astype(np.float32)).mean(axis=2)
+        yy, xx = np.mgrid[0:200, 0:200]
+        d = np.hypot(yy - 100, xx - 100)
+        inner = float(diff[d < 4].mean())
+        outer = float(diff[(d > 8) & (d < 10)].mean())  # defect rim, in-hole
+        assert inner > 10000            # the heal bites at the center
+        assert outer < 0.7 * inner      # ...and rolls off over the defect
+        # At feather 0 the same trace removes the defect completely.
+        hard = apply_dust_removal(img, [spot], feather=0.0)
+        core = hard[92:109, 92:109].astype(np.float32).reshape(-1, 3)
         assert float(np.abs(core.mean(axis=0) - sky).max()) < 5000
 
     def test_big_merged_dabs_clone_texture_not_smear(self):
@@ -939,11 +951,14 @@ class TestResolutionConsistency:
         b8 = cv2.convertScaleAbs(big_ds, alpha=255.0 / 65535.0)
         # Windows around the healed hair and the edge speck (1080x720 space).
         # Calibrated: re-planning per resolution measures p99 = 14 / 10 and
-        # mean = 0.64 / 0.42 here; the replayed plan sits at 4 / 4 (grain +
-        # resampling + the 1-px rim registration inherent to mask rounding).
+        # mean = 0.64 / 0.42 here; the replayed plan sits at 4 / 8 (grain +
+        # resampling + the 1-px rim registration inherent to mask rounding —
+        # the speck's rim rides the feather dome over a high-contrast defect
+        # since the force-fill floor was removed, so a 1-px raster shift is
+        # worth more diff there; the sources themselves are identical).
         for (y0, y1, x0, x1), p99_lim, mean_lim in (
                 ((390, 510, 490, 590), 6.0, 0.40),   # hair
-                ((270, 350, 390, 480), 6.0, 0.40)):  # edge speck
+                ((270, 350, 390, 480), 9.0, 0.40)):  # edge speck
             d = np.abs(a8[y0:y1, x0:x1].astype(np.float32)
                        - b8[y0:y1, x0:x1].astype(np.float32))
             assert np.percentile(d, 99) <= p99_lim

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -300,7 +300,7 @@ class TestApplyDustRemoval:
         spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}
         plan1 = []
         apply_dust_removal(img, [spot], collect_plan=plan1)
-        (cy, cx, off, g, d), = plan1
+        (cy, cx, off, g, d, *_), = plan1
         assert off is not None
         tampered = [(cy, cx, (off[0], off[1] + 20.0 / 400.0), g, d)]
         plan2 = []
@@ -320,7 +320,7 @@ class TestApplyDustRemoval:
         spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}
         plan1 = []
         apply_dust_removal(img, [spot], collect_plan=plan1)
-        (cy, cx, off, _, _), = plan1
+        (cy, cx, off, _, _, *_), = plan1
         # Perturb the ring on the side OPPOSITE the chosen source, so the
         # prior source window stays clean.
         bx = 0.44 if (cx + off[1]) >= 0.5 else 0.56
@@ -332,6 +332,31 @@ class TestApplyDustRemoval:
                 if abs(r[0] - cy) < 1e-9 and abs(r[1] - cx) < 1e-9]
         assert recs, "first stroke's segment disappeared"
         assert recs[0][2] == off, "first stroke's source moved"
+
+    def test_manual_source_pick_clones_verbatim(self):
+        # A USER-PICKED source (overlay ring drag, manual=True in the plan)
+        # is cloned verbatim — color AND texture. The membrane re-toning is
+        # for automatic picks only: applied to a manual re-pick it kept the
+        # destination's old color and toned away the picked look ("texture
+        # is gone but color remains").
+        rng = np.random.default_rng(41)
+        img = np.clip(rng.normal(30000, 3000, (400, 400, 3)), 0,
+                      65535).astype(np.uint16)
+        img[150:260, 100:300] = np.clip(
+            rng.normal(12000, 500, (110, 200, 3)), 0, 65535)  # dark region
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.075}  # inside it
+        plan1 = []
+        apply_dust_removal(img, [spot], collect_plan=plan1)
+        # Re-pick every segment's source to the bright grain 120 px above.
+        manual = [(cy, cx, (-120.0 / 400.0, 0.0), g, d, True)
+                  for cy, cx, off, g, d, *_ in plan1]
+        out = apply_dust_removal(img, [spot], prior_plan=manual)
+        m = rasterize_dust_mask([spot], 400, 400) > 0
+        core = cv2.erode(m.astype(np.uint8), np.ones((21, 21), np.uint8)) > 0
+        healed = out[core].astype(np.float32)
+        # The fill carries the SOURCE's tone and grain, not the dark ring's.
+        assert abs(float(healed.mean()) - 30000) < 2500
+        assert float(healed.std()) > 1500
 
     def test_sources_stay_inside_the_crop(self):
         # Content outside the confirmed crop (film holder, rebate, junk the
@@ -366,7 +391,7 @@ class TestApplyDustRemoval:
         spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}
         plan1 = []
         apply_dust_removal(img, [spot], collect_plan=plan1)
-        (cy, cx, off, _, _), = plan1
+        (cy, cx, off, _, _, *_), = plan1
         assert off is not None
         # A bright defect appears at the chosen source and the user paints
         # over it — the source patch is now under dust.


### PR DESCRIPTION
## What

Refinements to dust mode's heal-sources overlay and stroke editing (follow-up to #99):

1. **Connected strokes show one border.** The overlay outlines the contours of the rasterized stroke *union* (holes included) via `cv2.findContours`, instead of per-spot outlines that drew crossing lines through overlapping interiors.

2. **Right-button editing** (active while "Show heal sources" is checked):
   - **Right-drag on a stroke moves it** — live border while dragging, single re-heal on release, one undo step. The stroke's plan records travel with the move with their offsets compensated (`translate_dust_plan`), so a moved stroke still samples the **very same patch of film** — the reference location never changes, consistent with the sticky-source contract from #99.
   - **Right-drag on a source ring re-picks where that segment samples.** The arrow follows live; the release re-heal binds the segment at its unchanged centroid and pins the chosen offset verbatim — the user's pick becomes the sticky reference, replayed by hi-res/export and persisted in the catalog. Plan-only edit (spots and undo history untouched).
   - **Double right-click on a stroke deletes it** (one undo step).
   - Hit-testing: source markers first (9 px), then the brush footprint, topmost/newest stroke first; right-click on empty canvas does nothing. Left-drag painting, middle-pan, and the reference-frame right-drag (non-dust modes) are untouched.

3. **Instructions on the right panel.** The dust panel hint documents painting, Ctrl+wheel brush sizing, right-drag move, source re-pick, and double right-click delete.

## Tests

- `dust_debug_geometry` union borders (merged dabs → 1 border, separate → 2; circle contour radius checked).
- `dust_spot_hit` + `translate_dust_plan` (absolute source position invariant under a stroke move).
- Widget-level (real `ImagePreview`, offscreen): right-drag moves the stroke and the re-healed plan record keeps its absolute source; dragging the source ring re-points the sample and the new offset survives the re-heal; double right-click deletes (miss = no-op); right-press without the overlay does nothing; undo restores pre-drag/pre-delete state.
- Full dust/crop/catalog set: 99 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
