### PR TITLE
feat(dust): nearest-first, pattern-matched source search

### DIFF
--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -406,18 +406,27 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      become the entire anchor (clean sky strokes healed to solid black,
      cloned from the border). The estimate is distrusted (`genuine=False`):
      full ring, no defect force-fill.
-  3. **Search**: candidate source windows on `_HEAL_ANGLES` (16) directions ×
-     thickness-scaled distances (`2·half_th + pad + 2`, ×1/2/4, plus the
-     window diagonal as a last resort). A candidate must be in-bounds and
-     fully clean (checked O(1) against `cv2.integral` of the padded mask), so
-     a long stroke heals from the clean strip right beside it. Score = SSD
-     between source and destination **kept ring** pixels — plus, only past a
-     ring-MAD-scaled tolerance, the candidate's interior-tone excess vs the
-     ring background (the ring SSD never looks inside the window: a source
-     whose ring matches but whose hole area holds a black border edge clones
-     the border into the fill; within tolerance the ring SSD alone ranks, an
-     always-on interior term re-ranked near-ties by texture phase and made
-     preview/export tone drift). Best wins.
+  3. **Search**: candidate source windows on rings of directions at
+     thickness-scaled distances (`d_base = 2·half_th + pad + 2`,
+     ×1/1.5/2.25/3.5, plus the window diagonal as a last resort),
+     **nearest first**: the stroke's own surroundings are the most likely
+     to carry the same pattern, so the two nearest rings sample at DOUBLE
+     angular density (2×`_HEAL_ANGLES`), near-ties fall to the closer
+     patch (`_HEAL_DIST_W` per-ring score penalty), and the sweep STOPS at
+     the first ring whose best raw match reaches the grain floor
+     (`_HEAL_ACCEPT_MADS` × sigma², sigma estimated from the CLEANEST
+     QUARTILE of the 3×3-detrended ring residual — the raw ring MAD
+     inflates on structure and the residual's median inflates under edge
+     bleed, and an inflated floor early-accepts a bad near patch; an
+     underestimated floor only costs a longer sweep). A candidate must be
+     in-bounds and fully clean (checked O(1) against `cv2.integral` of the
+     padded mask), so a long stroke heals from the clean strip right beside
+     it. Score = SSD between source and destination **kept ring** pixels —
+     plus, only past a ring-MAD-scaled tolerance, the candidate's
+     interior-tone excess vs the ring background (the ring SSD never looks
+     inside the window: a source whose ring matches but whose hole area
+     holds a black border edge clones the border into the fill; within
+     tolerance the ring SSD alone ranks). Best adjusted score wins.
   4. **Clone + membrane tone correction**: hole pixels are copied from the
      best source, plus a smooth per-channel correction field interpolated
      from the kept-ring differences (normalized Gaussian convolution,

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3258,6 +3258,13 @@ def _crop_keep_mask(rect, angle, h: int, w: int):
 _HEAL_RING = 3            # min ring width of clean context (matching + tone)
 _HEAL_GUARD = 2           # min gap (px) between the hole and its context ring
 _HEAL_ANGLES = 16         # candidate source directions searched around a spot
+                          # (the two NEAREST rings sample at double density)
+_HEAL_DIST_W = 0.15       # per-ring score penalty: near-ties go to the CLOSER
+                          # patch — the stroke's surroundings first
+_HEAL_ACCEPT_MADS = 4.0   # accept a ring once its best raw match reaches the
+                          # grain floor (~2 sigma^2, sigma from the detrended
+                          # ring residual): farther candidates could only
+                          # swap the local pattern for a lucky remote one
 _HEAL_MIN_RING_PX = 8     # need at least this much clean ring to heal
 _HEAL_SEG_MIN = 32        # min heal-segment size (px) for long strokes
 _HEAL_SEG_THICKNESS = 6.0  # segment size as a multiple of hole thickness
@@ -3466,39 +3473,62 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
             return best_off, g0, d0, "defer"
     if best_src is None:
         # Candidate source offsets: rings of directions at thickness-scaled
-        # distances. The integral-image check rejects any source that touches
-        # dust, so offsets need only clear the local thickness — a long stroke
-        # heals from the clean strip right beside it (requiring bbox-diagonal
-        # clearance forced long strokes into the ghost-prone diffusion
-        # fallback). The window diagonal stays as a last-resort ring for
-        # compact spots.
+        # distances, NEAREST FIRST — the stroke's own surroundings are the
+        # most likely to carry the same pattern, so the near rings are
+        # sampled at double angular density, near-ties fall to the closer
+        # patch (a mild per-ring penalty), and the sweep STOPS at the first
+        # ring whose best raw match reaches the grain floor: once a
+        # candidate matches as well as two clean patches of the same
+        # texture can, farther candidates could only trade the local
+        # pattern for a lucky remote one. The integral-image check rejects
+        # any source that touches dust/outside-crop, so offsets need only
+        # clear the local thickness — a long stroke heals from the clean
+        # strip right beside it. The window diagonal stays as a last-resort
+        # ring for compact spots.
         d_base = 2.0 * half_th + pad + 2.0
         d0 = float(np.hypot(wy1 - wy0, wx1 - wx0))
-        for fi, d in enumerate((d_base, 2.0 * d_base, 4.0 * d_base, d0)):
-            for k in range(_HEAL_ANGLES):
-                ang = 2.0 * np.pi * (k + 0.35 * fi) / _HEAL_ANGLES
+        # Grain floor: E[SSD] between two clean patches of the same texture
+        # is ~2*sigma^2 per channel, with sigma the GRAIN — estimated from
+        # the CLEANEST QUARTILE of the 3x3-detrended ring residual. Anything
+        # less robust inflates the floor and early-accepts a bad near patch:
+        # raw ring MAD inflates on structure (stripes), and the residual's
+        # MEDIAN inflates when a high-contrast edge hugs most of the ring
+        # (edge bleed); contamination is never the cleanest quarter. An
+        # underestimated floor only costs a longer sweep, never a worse
+        # pick. (1.8: p25 of a 3-channel half-normal mean ~ 0.56 sigma.)
+        resid = np.abs((dst - cv2.blur(dst, (3, 3)))[ring]).mean(axis=1)
+        sigma = 1.8 * float(np.percentile(resid, 25.0))
+        floor = _HEAL_ACCEPT_MADS * sigma ** 2 + 1e-3
+        tol = (_DLIKE_SEP_MADS * (ring_mad + 1e-3)) ** 2
+        best_raw = None
+        for fi, (d, n_ang) in enumerate(
+                ((d_base, 2 * _HEAL_ANGLES), (1.5 * d_base, 2 * _HEAL_ANGLES),
+                 (2.25 * d_base, _HEAL_ANGLES), (3.5 * d_base, _HEAL_ANGLES),
+                 (d0, _HEAL_ANGLES))):
+            for k in range(n_ang):
+                ang = 2.0 * np.pi * (k + 0.35 * fi) / n_ang
                 dy = int(round(d * np.sin(ang)))
                 dx = int(round(d * np.cos(ang)))
                 src = _source_at(dy, dx)
                 if src is None:
                     continue
                 diff = src[ring] - dst_ring
-                score = float(np.mean(diff * diff))
+                ssd = float(np.mean(diff * diff))
                 # The ring SSD never looks INSIDE the candidate window: a
                 # source whose ring matches but whose hole area holds
                 # something foreign (a black border edge, an object) clones
-                # that thing into the fill. Penalize interior tone far from
-                # the destination ring's background — but only the EXCESS
-                # past the ring's own variability: within it the ring SSD
-                # alone must rank candidates (an always-on penalty re-ranked
-                # near-ties by interior phase on textured content, growing
-                # the membrane correction and with it the preview/export
-                # tone drift).
+                # that thing into the fill. Penalize interior tone past the
+                # ring's own variability (the EXCESS only: an always-on
+                # penalty re-ranked near-ties by interior phase on textured
+                # content and drifted preview/export tone).
                 i_diff = np.median(src[hole], axis=0) - ring_bg
-                tol = (_DLIKE_SEP_MADS * (ring_mad + 1e-3)) ** 2
-                score += max(0.0, float(np.mean(i_diff * i_diff)) - tol)
+                raw = ssd + max(0.0, float(np.mean(i_diff * i_diff)) - tol)
+                score = raw * (1.0 + _HEAL_DIST_W * fi)
                 if best_score is None or score < best_score:
                     best_score, best_src, best_off = score, src, (dy, dx)
+                    best_raw = raw
+            if best_raw is not None and best_raw <= floor:
+                break  # the surroundings already match at the grain floor
 
     if best_src is None:
         return None

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -345,6 +345,42 @@ class TestApplyDustRemoval:
         assert recs, "first stroke's segment disappeared"
         assert recs[0][2] == off, "first stroke's source moved"
 
+    def test_search_prefers_the_strokes_surroundings(self):
+        # On content where every direction matches equally well (uniform
+        # grain), the pick must come from the NEAREST candidate ring: the
+        # sweep runs nearest-first and stops once the best match reaches the
+        # grain floor, instead of letting a lucky far patch win the SSD by
+        # noise.
+        rng = np.random.default_rng(3)
+        img = np.clip(rng.normal(30000, 3000, (400, 400, 3)), 0,
+                      65535).astype(np.uint16)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}
+        plan = []
+        apply_dust_removal(img, [spot], collect_plan=plan)
+        (cy, cx, off, *_), = plan
+        assert off is not None
+        # r = 12 px -> guard 6, ring 9, pad 15 -> d_base = 41 px.
+        dist = float(np.hypot(off[0] * 400, off[1] * 400))
+        assert dist <= 1.6 * 41
+
+    def test_stripes_pattern_heals_phase_aligned(self):
+        # On patterned content the match must pick a phase-aligned patch —
+        # the healed hole continues the stripes, not a misphased smear (and
+        # the early-accept must NOT trip on a misphased near candidate: the
+        # grain floor is estimated from the detrended residual, not the
+        # ring's structure).
+        yy, xx = np.mgrid[0:200, 0:200]
+        base = 30000 + 12000 * np.sin(2 * np.pi * xx / 24.0)
+        img = np.stack([base] * 3, axis=-1).astype(np.uint16)
+        expected = img.copy()
+        cv2.circle(img, (100, 100), 5, (62000, 62000, 62000), -1)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.05}
+        out = apply_dust_removal(img, [spot], feather=0.0)
+        hole = np.hypot(yy - 100, xx - 100) <= 10
+        err = np.abs(out[hole].astype(np.float32)
+                     - expected[hole].astype(np.float32))
+        assert float(err.mean()) < 1500
+
     def test_manual_source_pick_clones_verbatim(self):
         # A USER-PICKED source (overlay ring drag, manual=True in the plan)
         # is cloned verbatim — color AND texture. The membrane re-toning is
@@ -951,13 +987,17 @@ class TestResolutionConsistency:
         b8 = cv2.convertScaleAbs(big_ds, alpha=255.0 / 65535.0)
         # Windows around the healed hair and the edge speck (1080x720 space).
         # Calibrated: re-planning per resolution measures p99 = 14 / 10 and
-        # mean = 0.64 / 0.42 here; the replayed plan sits at 4 / 8 (grain +
-        # resampling + the 1-px rim registration inherent to mask rounding —
-        # the speck's rim rides the feather dome over a high-contrast defect
-        # since the force-fill floor was removed, so a 1-px raster shift is
-        # worth more diff there; the sources themselves are identical).
+        # mean = 0.64 / 0.42 here; the replayed plan sits at 10 / 8. The
+        # residuals are NOT source flips (those are what the guard is for —
+        # the offsets replay verbatim): the speck's rim rides the feather
+        # dome over a high-contrast defect (a 1-px raster shift is worth
+        # more diff there), and the hair's nearest-first search now picks
+        # phase-aligned patches in the striped band whose INTEGER offsets
+        # quantize differently at export scale (sub-pixel pattern phase,
+        # bounded by ±0.5 px). The means stay far below the re-planning
+        # 0.64/0.42 and carry the structure-flip discrimination.
         for (y0, y1, x0, x1), p99_lim, mean_lim in (
-                ((390, 510, 490, 590), 6.0, 0.40),   # hair
+                ((390, 510, 490, 590), 11.0, 0.40),  # hair
                 ((270, 350, 390, 480), 9.0, 0.40)):  # edge speck
             d = np.abs(a8[y0:y1, x0:x1].astype(np.float32)
                        - b8[y0:y1, x0:x1].astype(np.float32))


### PR DESCRIPTION
## What

Redesigns the heal's source-window search per the maintainer's direction: **prioritize the stroke's surroundings, choose the matching pattern.** Planning-time only — sticky/pinned sources and the replay contract are untouched.

- **Nearest first, denser close in.** Rings run at 1 / 1.5 / 2.25 / 3.5 × `d_base` (window diagonal last), and the two nearest rings sample 32 directions instead of 16 — the stroke's own surroundings are the most likely to carry the same pattern.
- **Near-ties go to the closer patch** (`_HEAL_DIST_W` per-ring score penalty).
- **Early accept at the grain floor.** The sweep stops at the first ring whose best raw match is as good as two clean patches of the same texture can be (~2σ²) — searching farther could only swap the local pattern for a lucky remote one. Also an average speedup: most segments accept on the first ring.
- **Robust floor estimate.** σ comes from the *cleanest quartile* of the 3×3-detrended ring residual. The raw ring MAD inflates on structure (stripes → a misphased near patch would be accepted over a phase-aligned far one) and the residual's median inflates when a high-contrast edge hugs the ring (edge bleed → a leak-poisoned near candidate got accepted, and its contaminated ring drove the membrane to black-clip the fill — caught by the traced-hair regression test during development). Contamination is never the cleanest quarter; an underestimated floor only lengthens the sweep.

## Consistency recalibration

The hair window's p99 limit moves 6 → 11: the search now legitimately picks phase-aligned patches inside the striped band, and their **integer** offsets quantize differently at export scale (sub-pixel pattern phase, bounded by ±0.5 px). The offsets themselves replay verbatim — this is not a source flip (those measure p99 14 / mean 0.64) — and the window means (0.33 / 0.30 vs limits 0.40) keep the structure discrimination.

## Tests

New: on uniform grain the pick must come from the nearest ring; on striped content the heal must be phase-aligned (guards both the pattern matching and the floor robustness). Full dust/crop/catalog suite: 103 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mARQRfzeYh6SZz2id9AM4
