### PR TITLE
fix(dust): de-window the AI detection source (windowed base read as black)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,8 @@ imagecodecs
 requests
 nuitka
 pyopencl
-onnxruntime
+# AI dust detection. The DirectML build runs the detector on any Windows GPU
+# (~10x faster than CPU); same import name, and dust_detect falls back to CPU
+# when no usable GPU exists. Other platforms use the CPU/CoreML package.
+onnxruntime-directml; sys_platform == 'win32'
+onnxruntime; sys_platform != 'win32'

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -555,12 +555,20 @@ panel that imports it) load even when `onnxruntime` is absent.
       edge); circle-inpainting those smears real detail, so linear defects are
       left to the manual brush (§5.4).
     - **bright-speck gate**: film dust inverts to **white** specks, so a real
-      dust blob is brighter than its surroundings. Require the blob's mean luma
-      to exceed a surrounding ring by `BRIGHT_MARGIN`; this rejects normal-toned
-      content the detector wrongly fires on (a face, a dark feature — which is
-      how the AI once removed a person's head). `detect` therefore returns
-      `(prob, luma)` so `prob_to_spots` has the detection-resolution grayscale.
-      This and the aspect filter are the main guards against AI false positives.
+      dust blob is brighter than its surroundings. The gate is
+      **noise-relative** — dust sits off the focal plane, so most real specks
+      are soft-edged and faint (a fixed absolute margin missed nearly all of
+      them on smooth sky while they stood many grain-sigmas above it): the
+      blob's mean-luma lift over a surrounding ring must exceed
+      `min(BRIGHT_MARGIN, max(BRIGHT_FLOOR, BRIGHT_SNR·σ))` with σ the ring's
+      own luma std. Sharp dust (≥ `BRIGHT_MARGIN`) always passes; faint dust
+      passes where the surround is smooth; busy texture keeps the full
+      absolute bar. Normal-toned content the detector wrongly fires on (a
+      face, a dark feature — which is how the AI once removed a person's
+      head) still fails: its lift is ~0 or negative. `detect` therefore
+      returns `(prob, luma)` so `prob_to_spots` has the detection-resolution
+      grayscale. This and the aspect filter are the main guards against AI
+      false positives.
   - Each surviving (compact) component → one `auto` spot: centroid
     `(cx/prob_w, cy/prob_h)`; **area-equivalent** radius
     `r = (sqrt(area/π) + pad) / prob_w` — a tight circle matching the speck, so

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -193,9 +193,14 @@ reference to `MainWindow` and `ImagePreview` passed at construction (it does
 
 ### 3.4 AI detect & remove
 - **Detect & Remove** runs detection **off the GUI thread** on the current
-  working positive (`resized_raw` with existing spots already inpainted, so
-  already-cleaned dust is not re-flagged), at preview resolution. When the
-  base is a **windowed working-space buffer**, the detection source is
+  working positive (with existing manual spots already inpainted, so
+  already-cleaned dust is not re-flagged). The source is a **hi-res
+  conversion replay** (`render_hires_base`, the same snapshot replay the
+  zoom view uses) downscaled to `DETECT_MAX_LONG`, falling back to
+  `resized_raw` when no replay is possible — soft off-focus dust is ~1 px
+  at preview resolution and undetectable there. The source build runs
+  inside the detect worker (it decodes + converts: seconds). When the base
+  is a **windowed working-space buffer**, the detection source is
   de-windowed + window-clamped first (same as the WB picker / AWB): fed raw
   container codes the net sees a black frame and the bright-speck gate's
   absolute margin is unreachable — no dust would ever be found.
@@ -539,11 +544,19 @@ panel that imports it) load even when `onnxruntime` is absent.
   - URL: `https://github.com/MohaElder/openenlarge/releases/download/autodust-assets-v1/detector.onnx`
   - SHA‑256: `61e4a93d4e94b4fc6212e2e9b785fa12b5cbc9654724b02aaf8b212075bb729f`
   - (URL / SHA / filename are module constants so they can be repointed.)
-- **`detect(positive_rgb16) -> (prob_h, prob_w, prob: float32[0,1])`**: resize so
-  the short side is `DETECT_SHORT=512` and both dims are multiples of 16; Rec.709
-  luma; normalize to `[-1,1]`; run the session (`[1,1,dh,dw]` → logits); sigmoid.
-  CPU execution provider (matches openenlarge's Windows guidance). Returns the
-  prob map at detection resolution (cached per image for cheap Sensitivity).
+- **`detect(positive_rgb16) -> (prob_h, prob_w, prob: float32[0,1])`**: run at
+  the input's **native resolution** capped at `DETECT_MAX_LONG` (both dims
+  rounded to multiples of 16), **tiled** through the U-Net (`DETECT_TILE`,
+  `DETECT_OVERLAP` overlap, max-stitched so a seam can't split a speck);
+  Rec.709 luma; normalize to `[-1,1]`; per tile `[1,1,th,tw]` → logits →
+  sigmoid. CPU execution provider (matches openenlarge's Windows guidance).
+  Returns the prob map at detection resolution (cached per image for cheap
+  Sensitivity). **Why native/tiled:** most real film dust sits off the focal
+  plane — soft, faint blobs a few scan-pixels wide. They are ~1 px blips at
+  the 1080 preview and vanished entirely at the old fixed 512-short
+  detection downscale; recall keeps rising up to ~3.2k long side (measured
+  on the example dusty-sky scan), beyond which the time quadruples and the
+  now-huge diffuse blobs start to fragment.
 - **`prob_to_spots(prob, prob_h, prob_w, sensitivity, max_dim) -> list[spot]`**:
   - `thr = 0.85 - 0.60 * (sensitivity/100)` (0 → very selective … 100 →
     aggressive), matching openenlarge.

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -425,49 +425,38 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      become the entire anchor (clean sky strokes healed to solid black,
      cloned from the border). Either failure distrusts the estimate
      (`genuine=False`): full ring, no defect force-fill.
-  3. **Search — AUTO spots (maintainer rule, verbatim)**: (1) the sample
-     area MUST TOUCH the patch area; (2) among the touching candidates (64
-     directions at `2·half_th` + a few px to clear the mask dilation) the
+  3. **Search — THE AUTOMATIC SAMPLING RULE (maintainer, verbatim)**,
+     applied to EVERY automatically picked initial sample — AI-detected
+     spots and painted strokes alike (only the user's explicit right-drag
+     re-pick is exempt): (1) the sample area MUST TOUCH the patch area —
+     border-to-border, union contiguous (candidates: 64 directions at
+     `2·half_th` +0/+1/+2 px of raster slack, sample-area cleanliness
+     checked against the RAW mask so the dilation cannot push the sample
+     off the border it must touch); (2) among the touching candidates the
      one with the lowest combined Δhue + Δsat + ΔV — measured against the
      patch's own background, estimated as the darker half of the HOLE's
-     pixels (film dust is white; the hole is `SPOT_SCALE`× the speck core,
-     so the true background is visible inside it) — plus the lowest
-     texture wins; (3) again: the areas must touch. A TOTAL selection — no
-     distance escalation, no "good enough" gate, no fallback ranking. No
-     ring statistic participates in the choice, and the defect-leak
-     rejection (§ step 2) is disabled for auto components (a manual-stroke
-     defense; an auto spot cannot leak by construction — its misfires
-     re-anchored auto heals on foreign structure across an edge).
-     Invariant intersections: dust is never cloned (a touching window
-     overlapping another spot is excluded; a fully-encircled spot clones
-     the HEALED content at a touching offset via the deferred pass), and a
-     candidate needs ≥ 1 clean ring px for the tone membrane.
-     **Search — MANUAL strokes**: candidate source windows on rings of
-     directions at thickness-scaled distances
-     (`d_base = 2·half_th + pad + 2`,
-     ×1/1.5/2.25/3.5, plus the window diagonal as a last resort),
-     **nearest first, and the nearest ring with a USABLE candidate wins BY
-     CONSTRUCTION** (maintainer rule: the sampling point is closer the
-     better — the immediate surroundings, never across the frame). The two
-     nearest rings sample at DOUBLE angular density (2×`_HEAL_ANGLES`). A
-     candidate must be in-bounds and clean where it is READ — hole
-     projection spotless, ≥ `_SRC_RING_CLEAN_MIN` of the ring clean
-     (checked O(1) against `cv2.integral`, per-pixel only when the window
-     touches dust) — so a long stroke heals from the clean strip right
-     beside it and a speck inside a dust cluster still samples its
-     immediate area. USABLE additionally means the candidate's
-     proximity-weighted ring-mean stays within `_HEAL_TONE_TOL_MADS`
-     weighted MADs of the destination's (same chroma + brightness; ring
-     pixels are weighted toward the hole — a feature crossing the window's
-     periphery must not veto a candidate whose fill-adjacent surroundings
-     match). Within the accepted ring, candidates rank by weighted ring
-     SSD + `_HEAL_TONE_W`·(ring-mean offset)² + (only past a
-     ring-MAD-scaled tolerance) the interior-tone excess vs the ring
-     background (the ring SSD never looks inside the window: a source
-     whose ring matches but whose hole area holds a black border edge
-     clones the border into the fill). Only when NO ring holds a usable
-     candidate does the distance-penalized (`_HEAL_DIST_W`) best of the
-     wrong-tone leftovers fill instead.
+     pixels (film dust is white) — plus the lowest texture wins; (3)
+     again: the areas must touch. A TOTAL selection — no distance
+     escalation, no "good enough" gate, no fallback ranking. On a windowed
+     working-space buffer the deltas are computed on de-windowed display
+     values. No ring statistic participates in the choice, and the
+     defect-leak rejection (§ step 2) is disabled for auto components (it
+     is a manual-trace defense; an auto spot cannot leak by construction).
+     **One sample offset per patch**: the rule speaks of the patch as a
+     unit — the component's first segment runs the argmin and the rest of
+     the patch reuses its offset (nudged ≤ 4 px around raster grazes), so
+     a long stroke cannot get differently-phased clones butted together
+     mid-stroke. Known consequences, accepted with the rule: a brush
+     NARROWER than the defect it traces samples the defect's own
+     continuation (cover a defect to remove it), and on patterned content
+     the fill may land phase-shifted (the rule has no pattern-phase term;
+     the re-pick drag is the alignment tool). Invariant intersections:
+     dust is never cloned (a touching window overlapping any spot is
+     excluded; when NO in-bounds touching candidate exists at all — patch
+     at frame edge or fully encircled — the boundary-diffusion Telea fill
+     applies, growing from the patch's own touching border), and a
+     candidate needs ≥ 1 clean ring px for the tone membrane (raw-mask
+     subset, scale-stable).
   4. **Clone + membrane tone correction**: hole pixels are copied from the
      best source, plus a smooth per-channel correction field interpolated
      from the kept-ring differences (normalized Gaussian convolution,

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -194,7 +194,11 @@ reference to `MainWindow` and `ImagePreview` passed at construction (it does
 ### 3.4 AI detect & remove
 - **Detect & Remove** runs detection **off the GUI thread** on the current
   working positive (`resized_raw` with existing spots already inpainted, so
-  already-cleaned dust is not re-flagged), at preview resolution:
+  already-cleaned dust is not re-flagged), at preview resolution. When the
+  base is a **windowed working-space buffer**, the detection source is
+  de-windowed + window-clamped first (same as the WB picker / AWB): fed raw
+  container codes the net sees a black frame and the bright-speck gate's
+  absolute margin is unreachable — no dust would ever be found.
   1. If no cached probability map for this image, run the ONNX detector and cache
      it (so re-tuning Sensitivity does not re-run the net).
   2. Threshold + size-gate + dilate the prob map into a binary mask at detection

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -205,7 +205,12 @@ reference to `MainWindow` and `ImagePreview` passed at construction (it does
      resolution (§5.3).
   3. Extract connected components; convert each to one normalized `auto` spot
      (centroid + radius from component extent).
-  4. Replace any prior `auto` spots on the image with the new set (manual `brush`
+  4. With a confirmed crop, drop `auto` spots whose center falls **outside the
+     crop frame** (same rasterized geometry as the display crop): the rebate /
+     holder is not scene — it is cropped away everywhere, and its bright edge
+     printing (frame numbers, sprocket edges) reads as dust to the detector.
+     Manual `brush` spots are never filtered.
+  5. Replace any prior `auto` spots on the image with the new set (manual `brush`
      spots are untouched), `push_undo_state()` once, re-render.
 - **Sensitivity** changes re-threshold the cached prob map and refresh the
   `auto` spots live (no net re-run) unless the working buffer changed.

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -425,8 +425,26 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      become the entire anchor (clean sky strokes healed to solid black,
      cloned from the border). Either failure distrusts the estimate
      (`genuine=False`): full ring, no defect force-fill.
-  3. **Search**: candidate source windows on rings of directions at
-     thickness-scaled distances (`d_base = 2·half_th + pad + 2`,
+  3. **Search — AUTO spots (maintainer rule, verbatim)**: (1) the sample
+     area MUST TOUCH the patch area; (2) among the touching candidates (64
+     directions at `2·half_th` + a few px to clear the mask dilation) the
+     one with the lowest combined Δhue + Δsat + ΔV — measured against the
+     patch's own background, estimated as the darker half of the HOLE's
+     pixels (film dust is white; the hole is `SPOT_SCALE`× the speck core,
+     so the true background is visible inside it) — plus the lowest
+     texture wins; (3) again: the areas must touch. A TOTAL selection — no
+     distance escalation, no "good enough" gate, no fallback ranking. No
+     ring statistic participates in the choice, and the defect-leak
+     rejection (§ step 2) is disabled for auto components (a manual-stroke
+     defense; an auto spot cannot leak by construction — its misfires
+     re-anchored auto heals on foreign structure across an edge).
+     Invariant intersections: dust is never cloned (a touching window
+     overlapping another spot is excluded; a fully-encircled spot clones
+     the HEALED content at a touching offset via the deferred pass), and a
+     candidate needs ≥ 1 clean ring px for the tone membrane.
+     **Search — MANUAL strokes**: candidate source windows on rings of
+     directions at thickness-scaled distances
+     (`d_base = 2·half_th + pad + 2`,
      ×1/1.5/2.25/3.5, plus the window diagonal as a last resort),
      **nearest first, and the nearest ring with a USABLE candidate wins BY
      CONSTRUCTION** (maintainer rule: the sampling point is closer the

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -428,7 +428,12 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
   3. **Search — THE AUTOMATIC SAMPLING RULE (maintainer, verbatim)**,
      applied to EVERY automatically picked initial sample — AI-detected
      spots and painted strokes alike (only the user's explicit right-drag
-     re-pick is exempt): (1) the sample area MUST TOUCH the patch area —
+     re-pick is exempt). **Strokes are never auto-connected**: each spot is
+     its own patch with its own segments, argmin and per-patch offset even
+     when spots touch or overlap (drawing order owns shared pixels; only
+     the never-clone-dust checks and the feathered composite see the
+     union). Pinned and shared offsets validate touching against THE WHOLE
+     PATCH, at plan time and replay alike: (1) the sample area MUST TOUCH the patch area —
      border-to-border, union contiguous (candidates: 64 directions at
      `2·half_th` +0/+1/+2 px of raster slack, sample-area cleanliness
      checked against the RAW mask so the dilation cannot push the sample

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -567,6 +567,14 @@ panel that imports it) load even when `onnxruntime` is absent.
       also fires on legitimate thin LINES (a bike frame, the horizon, a path
       edge); circle-inpainting those smears real detail, so linear defects are
       left to the manual brush (§5.4).
+    - **smooth-surround rule**: auto-detection keeps spots on SMOOTH surrounds
+      only — sky, open shadow (surround-ring luma std ≤ `SMOOTH_MAX_STD`). In
+      busy texture (foliage, stucco, gravel) a compact bright glint is
+      indistinguishable from dust at this scale and healing it eats real
+      detail; textured areas are the manual brush's job. `detect()` uses the
+      same idea (windowed-std map + the confirmed crop's footprint as a
+      keep-mask) to skip whole tiles with nothing keepable — on a strip
+      cropped to one frame most tiles never hit the net (~3× faster).
     - **bright-speck gate**: film dust inverts to **white** specks, so a real
       dust blob is brighter than its surroundings. The gate is
       **noise-relative** — dust sits off the focal plane, so most real specks
@@ -583,10 +591,12 @@ panel that imports it) load even when `onnxruntime` is absent.
       grayscale. This and the aspect filter are the main guards against AI
       false positives.
   - Each surviving (compact) component → one `auto` spot: centroid
-    `(cx/prob_w, cy/prob_h)`; **area-equivalent** radius
-    `r = (sqrt(area/π) + pad) / prob_w` — a tight circle matching the speck, so
-    the inpaint stays invisible rather than leaving a smudge (the old
-    bounding-extent radius over-covered and was the artifact source).
+    `(cx/prob_w, cy/prob_h)`; **area-equivalent** radius scaled by
+    `SPOT_SCALE`: `r = (sqrt(area/π)·SPOT_SCALE + pad) / prob_w`. Area-based,
+    NOT the bounding-box extent (that over-covered and was the artifact
+    source) — but scaled up because the thresholded component is only the
+    bright CORE of a soft off-focus speck; an exact-fit circle left its faint
+    skirt unhealed.
   - `prob_to_spots` is **pure / model-free** (operates on a numpy prob map) so it
     is unit-testable without ONNX.
 - All ONNX use is guarded; any import/inference error surfaces as

--- a/spec/dust-removal.md
+++ b/spec/dust-removal.md
@@ -412,35 +412,44 @@ def apply_dust_removal(img16, spots, inpaint_radius=3) -> np.ndarray: # uint16 R
      hair edge, or the hair's continuation past the stroke's end (which can
      be the ring's *majority*), cannot lift the fill into a bright ghost of
      the stroke. Legit bimodal structure survives (both modes sit far from
-     the defect color). **Sanity cap** (`_HEAL_MIN_KEEP_FRAC`): if the
-     rejection would keep < 20% of the ring, the "defect" was estimated as
-     the ring's own majority (a clean generous brush, whose top-quartile
-     estimate collapses onto the background) and whatever survives is some
-     small foreign mode — a black border, a dark roofline — that would
+     the defect color). **The split validates itself under the white-dust
+     prior**: the rejection is trusted only when the REJECTED pixels are
+     luma-brighter than the KEPT ones by a noise margin — for a faint speck
+     or clean-ish hole the "defect" estimate collapses onto the background,
+     and the (inverted) split would strip the background and anchor the
+     entire match/tone on some foreign minority in the ring (a wall across
+     an edge), sending the source hunt far away while perfect same-tone
+     context sits beside the spot. **Sanity cap** (`_HEAL_MIN_KEEP_FRAC`):
+     if the rejection would keep < 20% of the ring, whatever survives is
+     some small foreign mode — a black border, a dark roofline — that would
      become the entire anchor (clean sky strokes healed to solid black,
-     cloned from the border). The estimate is distrusted (`genuine=False`):
-     full ring, no defect force-fill.
+     cloned from the border). Either failure distrusts the estimate
+     (`genuine=False`): full ring, no defect force-fill.
   3. **Search**: candidate source windows on rings of directions at
      thickness-scaled distances (`d_base = 2·half_th + pad + 2`,
      ×1/1.5/2.25/3.5, plus the window diagonal as a last resort),
-     **nearest first**: the stroke's own surroundings are the most likely
-     to carry the same pattern, so the two nearest rings sample at DOUBLE
-     angular density (2×`_HEAL_ANGLES`), near-ties fall to the closer
-     patch (`_HEAL_DIST_W` per-ring score penalty), and the sweep STOPS at
-     the first ring whose best raw match reaches the grain floor
-     (`_HEAL_ACCEPT_MADS` × sigma², sigma estimated from the CLEANEST
-     QUARTILE of the 3×3-detrended ring residual — the raw ring MAD
-     inflates on structure and the residual's median inflates under edge
-     bleed, and an inflated floor early-accepts a bad near patch; an
-     underestimated floor only costs a longer sweep). A candidate must be
-     in-bounds and fully clean (checked O(1) against `cv2.integral` of the
-     padded mask), so a long stroke heals from the clean strip right beside
-     it. Score = SSD between source and destination **kept ring** pixels —
-     plus, only past a ring-MAD-scaled tolerance, the candidate's
-     interior-tone excess vs the ring background (the ring SSD never looks
-     inside the window: a source whose ring matches but whose hole area
-     holds a black border edge clones the border into the fill; within
-     tolerance the ring SSD alone ranks). Best adjusted score wins.
+     **nearest first, and the nearest ring with a USABLE candidate wins BY
+     CONSTRUCTION** (maintainer rule: the sampling point is closer the
+     better — the immediate surroundings, never across the frame). The two
+     nearest rings sample at DOUBLE angular density (2×`_HEAL_ANGLES`). A
+     candidate must be in-bounds and clean where it is READ — hole
+     projection spotless, ≥ `_SRC_RING_CLEAN_MIN` of the ring clean
+     (checked O(1) against `cv2.integral`, per-pixel only when the window
+     touches dust) — so a long stroke heals from the clean strip right
+     beside it and a speck inside a dust cluster still samples its
+     immediate area. USABLE additionally means the candidate's
+     proximity-weighted ring-mean stays within `_HEAL_TONE_TOL_MADS`
+     weighted MADs of the destination's (same chroma + brightness; ring
+     pixels are weighted toward the hole — a feature crossing the window's
+     periphery must not veto a candidate whose fill-adjacent surroundings
+     match). Within the accepted ring, candidates rank by weighted ring
+     SSD + `_HEAL_TONE_W`·(ring-mean offset)² + (only past a
+     ring-MAD-scaled tolerance) the interior-tone excess vs the ring
+     background (the ring SSD never looks inside the window: a source
+     whose ring matches but whose hole area holds a black border edge
+     clones the border into the fill). Only when NO ring holds a usable
+     candidate does the distance-penalized (`_HEAL_DIST_W`) best of the
+     wrong-tone leftovers fill instead.
   4. **Clone + membrane tone correction**: hole pixels are copied from the
      best source, plus a smooth per-channel correction field interpolated
      from the kept-ring differences (normalized Gaussian convolution,

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -416,9 +416,12 @@ def _restore_image(file_path: str, state: dict):
     if plan and img.dust_spots:
         # Reseed the plan cache so the restored image keeps the exact
         # sources the user saw (sticky across sessions); a missing/legacy
-        # plan just replans once and is sticky from then on.
+        # plan just replans once and is sticky from then on. The snapshot
+        # ties the plan to THESE spots — records of spots later deleted or
+        # replaced are pruned instead of rebinding to new spots.
         img._dust_plan_cache = (repr(img.dust_spots),
                                 _dust_plan_from_json(plan))
+        img._dust_plan_spots = list(img.dust_spots)
     if "dust_feather_r" in state:
         img.dust_feather = float(state["dust_feather_r"])
     elif "dust_feather" in state:

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -955,10 +955,30 @@ class CCRImage:
             plan_out = []
             cached = getattr(self, "_dust_plan_cache", None)
             prior = cached[1] if cached is not None else None
+            # A prior record may only rebind to a spot that STILL EXISTS.
+            # The cache deliberately outlives spot edits (sticky sources),
+            # but a record whose spot was deleted/replaced must never seed
+            # a NEW spot painted or re-detected at the same place — that
+            # resurrected old sources verbatim and the sampling rule never
+            # ran for the new spot (stale catalog plans made the touch rule
+            # look permanently broken).
+            snap = getattr(self, "_dust_plan_spots", None)
+            if prior and snap is not None:
+                gone = [s for s in snap if s not in spots]
+                if gone:
+                    from core.ccr_processor import rasterize_dust_mask
+                    gm = rasterize_dust_mask(gone, h, w) > 0
+                    prior = [r for r in prior
+                             if not gm[min(h - 1, max(0, int(round(r[0] * h)))),
+                                       min(w - 1, max(0, int(round(r[1] * w))))]]
             out = apply_dust_removal(image, spots, feather=feather,
                                      collect_plan=plan_out, prior_plan=prior,
                                      crop=crop, ws_windowed=ws_windowed)
             self._dust_plan_cache = (key, plan_out)
+            # Shallow copy ON PURPOSE: a right-drag stroke MOVE mutates the
+            # spot dict in place, so the snapshot entry stays identical and
+            # the moved stroke keeps its pinned source.
+            self._dust_plan_spots = list(spots)
             print(f"Dust heal total ({len(spots)} spots, preview scale, "
                   f"plan cached): {time.time() - t0:.3f}s")
             return out

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -920,7 +920,8 @@ class CCRImage:
         gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
         return cv2.cvtColor(gray, cv2.COLOR_GRAY2RGB)
 
-    def _apply_dust_removal(self, image: np.ndarray) -> np.ndarray:
+    def _apply_dust_removal(self, image: np.ndarray,
+                            ws_windowed: bool = False) -> np.ndarray:
         """Inpaint stored dust spots out of the working image (no-op when there
         are none). Spots are normalized, so this scales to whatever resolution
         is being processed — preview, hi-res zoom, or full-res export.
@@ -956,7 +957,7 @@ class CCRImage:
             prior = cached[1] if cached is not None else None
             out = apply_dust_removal(image, spots, feather=feather,
                                      collect_plan=plan_out, prior_plan=prior,
-                                     crop=crop)
+                                     crop=crop, ws_windowed=ws_windowed)
             self._dust_plan_cache = (key, plan_out)
             print(f"Dust heal total ({len(spots)} spots, preview scale, "
                   f"plan cached): {time.time() - t0:.3f}s")
@@ -964,7 +965,7 @@ class CCRImage:
         cached = getattr(self, "_dust_plan_cache", None)
         plan = cached[1] if (cached is not None and cached[0] == key) else None
         out = apply_dust_removal(image, spots, feather=feather, plan=plan,
-                                 crop=crop)
+                                 crop=crop, ws_windowed=ws_windowed)
         print(f"Dust heal total ({len(spots)} spots, "
               f"preview plan {'reused' if plan is not None else 'MISSING'}): "
               f"{time.time() - t0:.3f}s")
@@ -982,13 +983,15 @@ class CCRImage:
         # Dust removal runs FIRST so the inpainted positive flows through the
         # rest of the adjustment stage (and so a dust-only image is still
         # cleaned even when the early-return guard below would otherwise skip).
-        image = self._apply_dust_removal(image)
+        # It runs on the (possibly WINDOWED) base, so the heal must know — the
+        # sampling rule's hue/sat/value deltas are computed on display values.
+        ws = self._ws_windowed if ws_windowed is None else ws_windowed
+        image = self._apply_dust_removal(image, ws_windowed=ws)
         s = self.adjustment_settings if settings is None else settings
         cb = self.contrast_base if contrast_base is None else contrast_base
         tb = self.temperature_base if temperature_base is None else temperature_base
         bb = self.brightness_base if brightness_base is None else brightness_base
         eb = self.exposure_base if exposure_base is None else exposure_base
-        ws = self._ws_windowed if ws_windowed is None else ws_windowed
         profile = self.color_profile if color_profile is None else color_profile
         areas = (getattr(self, "area_layers", []) if areas_override is None
                  else areas_override)

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3322,12 +3322,19 @@ def _feather_alpha(mask: np.ndarray, fmap: np.ndarray) -> np.ndarray:
     return _smoothstep((inside - 0.5) / f) * (mask > 0)
 
 
+def _hsv1(rgb):
+    """(h, s, v) of one RGB triple (float 0..65535) — all three in 0..1."""
+    px = np.asarray(rgb, np.float32).reshape(1, 1, 3) / 65535.0
+    hh, ss, vv = cv2.cvtColor(px, cv2.COLOR_RGB2HSV)[0, 0]
+    return float(hh) / 360.0, float(ss), float(vv)
+
+
 def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 comp: int, bbox: tuple,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
                 filled: np.ndarray, fmap: np.ndarray, feather: float,
                 src_off=None, forced_flags=None,
-                sample=None, manual=False):
+                sample=None, manual=False, auto=False):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
 
@@ -3465,6 +3472,13 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     # also rides the plan as metadata).
     genuine = (rejected_brighter
                and int(keep.sum()) >= _HEAL_MIN_KEEP_FRAC * keep.size)
+    if auto:
+        # The strip is a MANUAL-stroke defense (a traced hair's leak). An
+        # auto spot cannot leak — its hole is SPOT_SCALE× the speck's core,
+        # the skirt sits inside it — so the strip's misfires (anchoring the
+        # membrane tone on foreign ring structure across an edge) are its
+        # only possible effect here.
+        genuine = False
     if forced_flags is not None:
         genuine = bool(forced_flags[0])
     if genuine:
@@ -3535,6 +3549,64 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 g0, d0 = forced_flags if forced_flags is not None else (True,
                                                                         False)
                 return best_off, g0, d0, "defer"
+    if best_src is None and auto:
+        # ============== AUTO SAMPLING RULE (maintainer, verbatim) ============
+        # 1. The sample area MUST TOUCH the patch area.
+        # 2. Among the touching candidates pick the lowest combined
+        #    delta-hue + delta-saturation + delta-V (vs the patch's own
+        #    background) plus the lowest texture. This is a TOTAL selection:
+        #    the best touching candidate always wins — no distance
+        #    escalation, no "good enough" gate, no fallback.
+        # 3. (Again) the sample area and the patch area must touch.
+        # Reference = the darker half of the HOLE's own pixels (film dust is
+        # white, and the hole is SPOT_SCALE× the speck's core, so the true
+        # background is visible inside it). No ring statistic participates
+        # in the choice — a shadow band or wall crossing the ring cannot
+        # redirect the anchor (both reported failures did exactly that).
+        hl = hole_px.mean(axis=1)
+        ref = np.median(hole_px[hl <= np.median(hl)], axis=0)
+        ref_h, ref_s, ref_v = _hsv1(ref)
+        best_comb = None
+        # The mask is dilated ~1 px around every spot (plus crop padding), so
+        # the touching distance steps out a few px until the sampled area
+        # clears its own spot's dilation — all three radii border the patch.
+        for extra in (2.0, 4.0, 6.0):
+            dt = 2.0 * half_th + extra
+            for k in range(2 * _HEAL_ANGLES):
+                ang = 2.0 * np.pi * k / (2 * _HEAL_ANGLES)
+                dy = int(round(dt * np.sin(ang)))
+                dx = int(round(dt * np.cos(ang)))
+                sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
+                if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
+                    continue
+                m = mask_pad[sy0:sy1, sx0:sx1]
+                # Pre-existing invariant: dust is never cloned — a touching
+                # window whose SAMPLE AREA holds another spot is not scene.
+                if m[hole].any():
+                    continue
+                rv2 = m[ring] == 0
+                if not rv2.any():
+                    continue  # membrane needs ≥1 clean ring px (NaN guard)
+                src = img16[sy0:sy1, sx0:sx1].astype(np.float32)
+                area = src[hole]
+                ah, as_, av = _hsv1(np.median(area, axis=0))
+                dh_ = abs(ah - ref_h)
+                dh_ = min(dh_, 1.0 - dh_) * 2.0 * max(as_, ref_s)
+                tex = float(area.mean(axis=1).std()) / 65535.0
+                comb = dh_ + abs(as_ - ref_s) + abs(av - ref_v) + tex
+                if best_comb is None or comb < best_comb:
+                    best_comb = comb
+                    best_src, best_off = src, (dy, dx)
+                    best_rv = None if bool(rv2.all()) else rv2
+        if best_src is None:
+            # Every touching direction lies inside other dust (the spot is
+            # fully encircled). Dust pixels are never cloned (pre-existing
+            # invariant), so the segment defers and clones the HEALED
+            # content at a touching offset via the existing second pass —
+            # the answer still exists and still touches the patch.
+            dy = int(round(2.0 * half_th + 2.0))
+            dy = min(max(dy, -wy0), h - wy1)
+            return (dy, 0), False, False, "defer"
     if best_src is None:
         # Candidate source offsets: rings of directions at thickness-scaled
         # distances, NEAREST FIRST, near rings at double angular density.
@@ -3836,6 +3908,15 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         return img16
 
     n, labels, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    # Spot kind per component: the AUTO sampling rule (touch + HSV/texture
+    # argmin) applies only to components made purely of auto-detected spots;
+    # anything a brush touched keeps the manual machinery (hair defenses).
+    kinds = {s.get("kind") for s in spots}
+    all_auto = kinds == {"auto"}
+    brush_mask = None
+    if not all_auto and "auto" in kinds:
+        brush_mask = rasterize_dust_mask(
+            [s for s in spots if s.get("kind") != "auto"], h, w)
     # "Clean" excludes every spot plus 1 px (buries antialiased speck edges).
     mask_pad = cv2.dilate(mask, np.ones((3, 3), np.uint8))
     if crop is not None and crop[0]:
@@ -3881,6 +3962,9 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
         cw = int(stats[i, cv2.CC_STAT_WIDTH])
         ch = int(stats[i, cv2.CC_STAT_HEIGHT])
         comp_win = labels[y0:y0 + ch, x0:x0 + cw] == i
+        comp_auto = all_auto or (
+            brush_mask is not None
+            and not bool(brush_mask[y0:y0 + ch, x0:x0 + cw][comp_win].any()))
         # Half-thickness = the defect's local scale (1px zero border so a
         # component touching its bbox edge still measures correctly).
         hole0 = np.zeros((ch + 2, cw + 2), np.uint8)
@@ -3932,7 +4016,8 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                     res = _heal_patch(img16, img16_c, labels, i, bbox,
                                       loc_th, mask_pad, integ, filled, fmap,
                                       feather, src_off=src_off,
-                                      forced_flags=flags, manual=manual)
+                                      forced_flags=flags, manual=manual,
+                                      auto=comp_auto)
                 if res is not None and len(res) == 4:
                     # Pinned source now under new dust: fill in a SECOND
                     # pass from the healed buffer (after Telea), so the

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3259,6 +3259,9 @@ _HEAL_RING = 3            # min ring width of clean context (matching + tone)
 _HEAL_GUARD = 2           # min gap (px) between the hole and its context ring
 _HEAL_ANGLES = 16         # candidate source directions searched around a spot
                           # (the two NEAREST rings sample at double density)
+_SRC_RING_CLEAN_MIN = 0.6  # a candidate source window beside other dust stays
+                           # usable while at least this fraction of its ring
+                           # positions is clean (fill pixels must ALL be clean)
 _HEAL_DIST_W = 0.15       # per-ring score penalty: near-ties go to the CLOSER
                           # patch — the stroke's surroundings first
 _HEAL_ACCEPT_MADS = 4.0   # accept a ring once its best raw match reaches the
@@ -3441,36 +3444,64 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     ring_mad = float(np.median(np.abs(dst_ring - ring_bg).mean(axis=1)))
 
     def _source_at(dy, dx):
+        """Candidate source window, or (None, None). Returns (pixels, rv):
+        rv is None for a fully clean window, else the boolean CLEAN subset of
+        the ring positions. The old all-or-nothing dust check rejected any
+        window touching dust ANYWHERE — in a dusty sky (specks cluster) every
+        near window was disqualified by its neighbors and the pick leapt to
+        the far rings. Only the pixels a heal actually READS must be clean:
+        the hole projection (cloned verbatim — mandatory), and the ring
+        (matching + membrane tone), which keeps its clean subset when at
+        least _SRC_RING_CLEAN_MIN of it survives."""
         sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
         if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
-            return None
-        if _box_sum(integ, sy0, sx0, sy1, sx1) != 0:
-            return None  # source window touches dust (this or another spot)
-        return img16[sy0:sy1, sx0:sx1].astype(np.float32)
+            return None, None
+        if _box_sum(integ, sy0, sx0, sy1, sx1) == 0:
+            return img16[sy0:sy1, sx0:sx1].astype(np.float32), None
+        m = mask_pad[sy0:sy1, sx0:sx1]
+        if m[hole].any():
+            return None, None  # fill pixels would clone dust
+        rv = m[ring] == 0
+        if (float(rv.mean()) < _SRC_RING_CLEAN_MIN
+                or int(rv.sum()) < _HEAL_MIN_RING_PX):
+            return None, None  # too little clean ring to match/tone against
+        return img16[sy0:sy1, sx0:sx1].astype(np.float32), rv
 
-    best_score, best_src, best_off = None, None, None
+    best_score, best_src, best_off, best_rv = None, None, None, None
     if src_off is not None:
         # Pinned source (scale replay, or a prior edit's plan): the offset
         # is taken VERBATIM — once a patch's reference is set, NOTHING may
         # move it. It is only clamped into bounds (scale rounding can push
-        # the window a pixel past the frame). If dust has landed on it
-        # since (a new stroke painted over the sampled patch), the segment
-        # is DEFERRED and re-run after the Telea pass with `sample` = the
-        # healed buffer: it clones the healed content at the very same
-        # location instead of re-searching elsewhere.
+        # the window a pixel past the frame). Same pixels-actually-read rule
+        # as the search (so a plan picked beside a neighboring speck replays
+        # identically at every scale): a clean hole projection samples raw
+        # pixels, with the ring's clean subset driving the tone. Only when
+        # dust has landed on the FILL pixels themselves (a new stroke
+        # painted over the sampled patch) is the segment DEFERRED and re-run
+        # after the Telea pass with `sample` = the healed buffer: it clones
+        # the healed content at the very same location instead of
+        # re-searching elsewhere.
         dy = min(max(int(src_off[0]), -wy0), h - wy1)
         dx = min(max(int(src_off[1]), -wx0), w - wx1)
         best_off = (dy, dx)
         if _box_sum(integ, wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx) == 0:
             best_src = img16[wy0 + dy:wy1 + dy,
                              wx0 + dx:wx1 + dx].astype(np.float32)
-        elif sample is not None:
-            best_src = sample[wy0 + dy:wy1 + dy,
-                              wx0 + dx:wx1 + dx].astype(np.float32)
         else:
-            g0, d0 = forced_flags if forced_flags is not None else (True,
-                                                                    False)
-            return best_off, g0, d0, "defer"
+            sm = mask_pad[wy0 + dy:wy1 + dy, wx0 + dx:wx1 + dx]
+            rv_pin = sm[ring] == 0
+            if not sm[hole].any() and int(rv_pin.sum()) >= _HEAL_MIN_RING_PX:
+                best_src = img16[wy0 + dy:wy1 + dy,
+                                 wx0 + dx:wx1 + dx].astype(np.float32)
+                if not rv_pin.all():
+                    best_rv = rv_pin
+            elif sample is not None:
+                best_src = sample[wy0 + dy:wy1 + dy,
+                                  wx0 + dx:wx1 + dx].astype(np.float32)
+            else:
+                g0, d0 = forced_flags if forced_flags is not None else (True,
+                                                                        False)
+                return best_off, g0, d0, "defer"
     if best_src is None:
         # Candidate source offsets: rings of directions at thickness-scaled
         # distances, NEAREST FIRST — the stroke's own surroundings are the
@@ -3509,10 +3540,12 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 ang = 2.0 * np.pi * (k + 0.35 * fi) / n_ang
                 dy = int(round(d * np.sin(ang)))
                 dx = int(round(d * np.cos(ang)))
-                src = _source_at(dy, dx)
+                src, rv = _source_at(dy, dx)
                 if src is None:
                     continue
                 diff = src[ring] - dst_ring
+                if rv is not None:
+                    diff = diff[rv]  # match on the ring's clean subset only
                 ssd = float(np.mean(diff * diff))
                 # The ring SSD never looks INSIDE the candidate window: a
                 # source whose ring matches but whose hole area holds
@@ -3526,7 +3559,7 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 score = raw * (1.0 + _HEAL_DIST_W * fi)
                 if best_score is None or score < best_score:
                     best_score, best_src, best_off = score, src, (dy, dx)
-                    best_raw = raw
+                    best_rv, best_raw = rv, raw
             if best_raw is not None and best_raw <= floor:
                 break  # the surroundings already match at the grain floor
 
@@ -3549,14 +3582,22 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
         # frequencies land on the hole's boundary values (gradients continue
         # seamlessly through the patch). Sigma is thickness-local: a
         # bbox-sized sigma turned the correction into one constant for the
-        # whole component, letting one bad segment tint it all.
+        # whole component, letting one bad segment tint it all. A partially
+        # clean source ring (window beside a neighboring speck) anchors the
+        # tone on its CLEAN subset only — the dusty positions would inject
+        # the neighbor's brightness into the correction.
+        ring_m = ring
+        if best_rv is not None and not best_rv.all():
+            ring_m = ring.copy()
+            rmy, rmx = np.nonzero(ring)
+            ring_m[rmy[~best_rv], rmx[~best_rv]] = False
         dmap = np.zeros_like(dst)
-        dmap[ring] = dst_ring - best_src[ring]
-        ind = ring.astype(np.float32)
+        dmap[ring_m] = dst[ring_m] - best_src[ring_m]
+        ind = ring_m.astype(np.float32)
         sigma = half_th + pad
         wsum = cv2.GaussianBlur(ind, (0, 0), sigma)
         dsum = cv2.GaussianBlur(dmap, (0, 0), sigma)
-        mean_diff = dmap[ring].mean(axis=0)
+        mean_diff = dmap[ring_m].mean(axis=0)
         corr = np.where(wsum[..., None] > 1e-4,
                         dsum / np.maximum(wsum, 1e-6)[..., None], mean_diff)
         heal = best_src + corr

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3492,6 +3492,32 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
         # re-searching elsewhere.
         dy = min(max(int(src_off[0]), -wy0), h - wy1)
         dx = min(max(int(src_off[1]), -wx0), w - wx1)
+        if not manual:
+            # THE RULE RETROACTS ON AUTOMATIC PINS. Stored automatic offsets
+            # that do not TOUCH their patch are pre-rule fossils: catalog
+            # plans carry them, and sticky binding propagated them into
+            # fresh, validly-keyed plans on every re-detect for as long as
+            # the old search existed — pruning by spot identity can never
+            # catch that. An automatic pin is honoured only if its sample
+            # still touches (within ±4 px for cross-scale raster rounding);
+            # otherwise it is dropped here and the segment re-picks under
+            # the rule, so the whole catalog converges as images render.
+            # USER re-picks (manual=True) keep any distance — that pick is
+            # the user's explicit choice.
+            def _shifted_hits(mask_a, ty, tx):
+                hh2, ww2 = hole.shape
+                ay0, ay1 = max(0, ty), min(hh2, hh2 + ty)
+                ax0, ax1 = max(0, tx), min(ww2, ww2 + tx)
+                if ay0 >= ay1 or ax0 >= ax1:
+                    return False
+                return bool(np.any(mask_a[ay0:ay1, ax0:ax1]
+                                   & hole[ay0 - ty:ay1 - ty,
+                                          ax0 - tx:ax1 - tx]))
+            near = cv2.dilate(hole.astype(np.uint8),
+                              np.ones((9, 9), np.uint8)).astype(bool)
+            if _shifted_hits(hole, dy, dx) or not _shifted_hits(near, dy, dx):
+                src_off = None  # fossil pin — fall through to the rule
+    if src_off is not None:
         best_off = (dy, dx)
         if _box_sum(integ, wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx) == 0:
             best_src = img16[wy0 + dy:wy1 + dy,

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3626,45 +3626,53 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
         ref = _dw(np.median(hole_px[hl <= np.median(hl)], axis=0))
         ref_h, ref_s, ref_v = _hsv1(ref)
         best_comb = None
-        # Touching distances: at dt = 2·half_th the sampled area's border
-        # meets the patch border (tangency); +1/+2 cover raster rounding.
-        # The sample-area dust check uses the RAW mask (labels) — the 1 px
-        # mask_pad dilation exists to bury antialiased speck edges and would
-        # otherwise push the sample off the border it must touch.
-        for extra in (0.0, 1.0, 2.0):
-            dt = 2.0 * half_th + extra
-            for k in range(2 * _HEAL_ANGLES):
-                ang = 2.0 * np.pi * k / (2 * _HEAL_ANGLES)
-                dy = int(round(dt * np.sin(ang)))
-                dx = int(round(dt * np.cos(ang)))
-                sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
-                if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
-                    continue
-                # Pre-existing invariant: dust is never cloned — a touching
-                # window whose SAMPLE AREA overlaps any spot is not scene.
-                # The membrane's ring subset ALSO derives from the raw mask:
-                # raw geometry scales proportionally, while mask_pad's fixed
-                # 1 px dilation shrinks relative to the export raster and
-                # gave preview and export different tone-anchor subsets (a
-                # visible drift wherever the touching source is
-                # phase-shifted on patterned content).
-                lbl_win = labels[sy0:sy1, sx0:sx1]
-                if (lbl_win[hole] > 0).any():
-                    continue
-                rv2 = lbl_win[ring] == 0
-                if not rv2.any():
-                    continue  # membrane needs ≥1 clean ring px (NaN guard)
-                src = img16[sy0:sy1, sx0:sx1].astype(np.float32)
-                area = src[hole]
-                ah, as_, av = _hsv1(_dw(np.median(area, axis=0)))
-                dh_ = abs(ah - ref_h)
-                dh_ = min(dh_, 1.0 - dh_) * 2.0 * max(as_, ref_s)
-                tex = float(area.mean(axis=1).std()) * dwk / 65535.0
-                comb = dh_ + abs(as_ - ref_s) + abs(av - ref_v) + tex
-                if best_comb is None or comb < best_comb:
-                    best_comb = comb
-                    best_src, best_off = src, (dy, dx)
-                    best_rv = None if bool(rv2.all()) else rv2
+        # THE FINITE TOUCHING SET: every translation that places a congruent
+        # copy of the patch so its border shares contact with the patch
+        # border — no angular sampling, no gaps. Translations that OVERLAP
+        # the patch form the support of the shape's autocorrelation (the
+        # Minkowski sum of the hole with its own reflection); the touching
+        # set is that support's outer 8-connected boundary. Finite and
+        # complete: every member touches by construction, and every possible
+        # touching placement is a member. The sample-area dust check uses
+        # the RAW mask (labels) — the 1 px mask_pad dilation would push the
+        # sample off the border it must touch — and the membrane's ring
+        # subset derives from the raw mask too (scale-stable, where
+        # mask_pad's fixed dilation drifted preview vs export).
+        hys, hxs = np.nonzero(hole)
+        K = hole[int(hys.min()):int(hys.max()) + 1,
+                 int(hxs.min()):int(hxs.max()) + 1].astype(np.float32)
+        kh, kw = K.shape
+        pyk, pxk = kh + 2, kw + 2
+        canvas = np.zeros((kh + 2 * pyk, kw + 2 * pxk), np.float32)
+        canvas[pyk:pyk + kh, pxk:pxk + kw] = K
+        overlap = cv2.matchTemplate(canvas, K, cv2.TM_CCORR) > 0.5
+        touching = (cv2.dilate(overlap.astype(np.uint8),
+                               np.ones((3, 3), np.uint8)).astype(bool)
+                    & ~overlap)
+        t_ys, t_xs = np.nonzero(touching)
+        for dy, dx in zip((t_ys - pyk).tolist(), (t_xs - pxk).tolist()):
+            sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
+            if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
+                continue
+            # Pre-existing invariant: dust is never cloned — a touching
+            # placement whose SAMPLE AREA overlaps any spot is not scene.
+            lbl_win = labels[sy0:sy1, sx0:sx1]
+            if (lbl_win[hole] > 0).any():
+                continue
+            rv2 = lbl_win[ring] == 0
+            if not rv2.any():
+                continue  # membrane needs ≥1 clean ring px (NaN guard)
+            src = img16[sy0:sy1, sx0:sx1].astype(np.float32)
+            area = src[hole]
+            ah, as_, av = _hsv1(_dw(np.median(area, axis=0)))
+            dh_ = abs(ah - ref_h)
+            dh_ = min(dh_, 1.0 - dh_) * 2.0 * max(as_, ref_s)
+            tex = float(area.mean(axis=1).std()) * dwk / 65535.0
+            comb = dh_ + abs(as_ - ref_s) + abs(av - ref_v) + tex
+            if best_comb is None or comb < best_comb:
+                best_comb = comb
+                best_src, best_off = src, (dy, dx)
+                best_rv = None if bool(rv2.all()) else rv2
         if best_src is None:
             # No touching candidate EXISTS: every touching direction is out
             # of frame (a patch nearly as big as the buffer) or inside other

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3727,17 +3727,23 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
         # frequencies land on the hole's boundary values (gradients continue
         # seamlessly through the patch). Sigma is thickness-local: a
         # bbox-sized sigma turned the correction into one constant for the
-        # whole component, letting one bad segment tint it all. A partially
-        # clean source ring (window beside a neighboring speck) anchors the
-        # tone on its CLEAN subset only — the dusty positions would inject
-        # the neighbor's brightness into the correction.
+        # whole component, letting one bad segment tint it all. Where the
+        # source ring is blocked by a neighboring spot (dust clusters), the
+        # blocked positions contribute the CLEAN subset's median difference
+        # instead of dropping out: dropping them left a spatially LOPSIDED
+        # anchor, and on a gradient the one-sided difference interpolated
+        # into a tone dome over the whole fill — the visible gray disc that
+        # read as "it sampled from the wrong place" even though the clone
+        # content was right.
         ring_m = ring
-        if best_rv is not None and not best_rv.all():
-            ring_m = ring.copy()
-            rmy, rmx = np.nonzero(ring)
-            ring_m[rmy[~best_rv], rmx[~best_rv]] = False
         dmap = np.zeros_like(dst)
-        dmap[ring_m] = dst[ring_m] - best_src[ring_m]
+        if best_rv is not None and not best_rv.all():
+            diffs = dst[ring] - best_src[ring]
+            med = np.median(diffs[best_rv], axis=0)
+            diffs[~best_rv] = med
+            dmap[ring] = diffs
+        else:
+            dmap[ring] = dst[ring] - best_src[ring]
         ind = ring_m.astype(np.float32)
         sigma = half_th + pad
         wsum = cv2.GaussianBlur(ind, (0, 0), sigma)

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3262,27 +3262,23 @@ _HEAL_ANGLES = 16         # candidate source directions searched around a spot
 _SRC_RING_CLEAN_MIN = 0.6  # a candidate source window beside other dust stays
                            # usable while at least this fraction of its ring
                            # positions is clean (fill pixels must ALL be clean)
-_HEAL_TONE_W = 3.0        # extra weight on the ring-MEAN mismatch (the areas'
-                          # chroma + brightness). The raw SSD weighs tone and
-                          # pattern equally per pixel, so beside a high-contrast
-                          # edge a remote FLAT patch of different color could
-                          # beat every near candidate whose ring straddles the
-                          # edge at imperfect phase ("sampled brown dirt to heal
-                          # a spot on white pavement"). Tone must dominate:
-                          # with the SSD's own mean term this makes an area
-                          # tone offset count 4x its per-pixel share, and it is
-                          # scale-stable (means survive resampling) so preview
+_HEAL_TONE_TOL_MADS = 3.0  # USABILITY gate (maintainer rule: sample the
+                           # immediate surroundings, same chroma+brightness):
+                           # a candidate is usable only when its weighted
+                           # ring-mean offset stays within this many weighted
+                           # MADs of the hole-adjacent surround. The sweep
+                           # accepts the best USABLE candidate of the NEAREST
+                           # ring that has one — distance is control flow,
+                           # not a score weight, so a far patch can never
+                           # outbid a usable adjacent one.
+_HEAL_TONE_W = 3.0        # within-ring ranking: extra weight on the ring-MEAN
+                          # mismatch (the areas' chroma + brightness), so the
+                          # tone-closest of a ring's usable candidates wins;
+                          # scale-stable (means survive resampling), preview
                           # and export rank candidates the same way.
-_HEAL_DIST_W = 0.45       # per-ring score penalty: the IMMEDIATE AREA comes
-                          # first — a far-ring candidate must be ~3x better on
-                          # raw match to beat one from the stroke's own
-                          # surroundings (0.15 was too weak to stop a flat
-                          # remote patch from outbidding the local area beside
-                          # a high-contrast edge)
-_HEAL_ACCEPT_MADS = 4.0   # accept a ring once its best raw match reaches the
-                          # grain floor (~2 sigma^2, sigma from the detrended
-                          # ring residual): farther candidates could only
-                          # swap the local pattern for a lucky remote one
+_HEAL_DIST_W = 0.45       # FALLBACK ranking only (no ring had a usable
+                          # candidate): prefer nearer among the wrong-tone
+                          # leftovers
 _HEAL_MIN_RING_PX = 8     # need at least this much clean ring to heal
 _HEAL_SEG_MIN = 32        # min heal-segment size (px) for long strokes
 _HEAL_SEG_THICKNESS = 6.0  # segment size as a multiple of hole thickness
@@ -3436,6 +3432,27 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     d_def = np.abs(ring_px - defect).mean(axis=1)
     thr = 0.5 * float(np.percentile(d_def, 95.0))
     keep = d_def >= thr
+    # The rejection is trusted only under the WHITE-DUST PRIOR, validated on
+    # the SPLIT IT PRODUCED (no ring population is trustworthy a priori — a
+    # hair's continuation can be the ring's majority, including its outer
+    # band): film dust and the bright hairs this rejection was built for
+    # read BRIGHTER than the context they leak over, so the REJECTED pixels
+    # must be brighter than the KEPT ones by a noise margin. For a faint
+    # speck or a clean-ish hole the "defect" estimate collapses onto the
+    # BACKGROUND itself; the rejection then strips the background and
+    # whatever foreign minority remains (a wall across an edge, a curb)
+    # becomes the ENTIRE matching/tone anchor — the search then hunts for
+    # wrong-toned patches far away while perfect same-tone context sits
+    # right beside the spot. That inverted split fails this check (its
+    # "rejected" side is the darker or equal one) and the full ring stays.
+    rejected_brighter = False
+    if bool(keep.any()) and not bool(keep.all()):
+        kept_med = np.median(ring_px[keep], axis=0)
+        kept_mad = float(np.median(
+            np.abs(ring_px[keep] - kept_med).mean(axis=1))) + 1e-3
+        rejected_brighter = (
+            float(np.median(ring_px[~keep], axis=0).mean())
+            > float(kept_med.mean()) + 2.0 * kept_mad)
     # Sanity cap on the rejection: discarding nearly the whole ring means
     # the "defect" was estimated as the ring's own MAJORITY — a generous
     # brush over clean content, where the top-quartile estimate collapses
@@ -3446,7 +3463,8 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     # much context (even a thick traced hair leaves ~a third of its ring
     # clean), so distrust the estimate and keep the full ring (`genuine`
     # also rides the plan as metadata).
-    genuine = int(keep.sum()) >= _HEAL_MIN_KEEP_FRAC * keep.size
+    genuine = (rejected_brighter
+               and int(keep.sum()) >= _HEAL_MIN_KEEP_FRAC * keep.size)
     if forced_flags is not None:
         genuine = bool(forced_flags[0])
     if genuine:
@@ -3482,7 +3500,7 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
             return None, None  # too little clean ring to match/tone against
         return img16[sy0:sy1, sx0:sx1].astype(np.float32), rv
 
-    best_score, best_src, best_off, best_rv = None, None, None, None
+    best_src, best_off, best_rv = None, None, None
     if src_off is not None:
         # Pinned source (scale replay, or a prior edit's plan): the offset
         # is taken VERBATIM — once a patch's reference is set, NOTHING may
@@ -3519,38 +3537,54 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 return best_off, g0, d0, "defer"
     if best_src is None:
         # Candidate source offsets: rings of directions at thickness-scaled
-        # distances, NEAREST FIRST — the stroke's own surroundings are the
-        # most likely to carry the same pattern, so the near rings are
-        # sampled at double angular density, near-ties fall to the closer
-        # patch (a mild per-ring penalty), and the sweep STOPS at the first
-        # ring whose best raw match reaches the grain floor: once a
-        # candidate matches as well as two clean patches of the same
-        # texture can, farther candidates could only trade the local
-        # pattern for a lucky remote one. The integral-image check rejects
-        # any source that touches dust/outside-crop, so offsets need only
-        # clear the local thickness — a long stroke heals from the clean
-        # strip right beside it. The window diagonal stays as a last-resort
-        # ring for compact spots.
+        # distances, NEAREST FIRST, near rings at double angular density.
+        # The pixels-actually-read check (_source_at) rejects any source
+        # that would READ dust/outside-crop, so offsets need only clear the
+        # local thickness — a long stroke heals from the clean strip right
+        # beside it. The window diagonal stays as a last-resort ring for
+        # compact spots; the acceptance rule below decides when the sweep
+        # stops.
         d_base = 2.0 * half_th + pad + 2.0
         d0 = float(np.hypot(wy1 - wy0, wx1 - wx0))
-        # Grain floor: E[SSD] between two clean patches of the same texture
-        # is ~2*sigma^2 per channel, with sigma the GRAIN — estimated from
-        # the CLEANEST QUARTILE of the 3x3-detrended ring residual. Anything
-        # less robust inflates the floor and early-accepts a bad near patch:
-        # raw ring MAD inflates on structure (stripes), and the residual's
-        # MEDIAN inflates when a high-contrast edge hugs most of the ring
-        # (edge bleed); contamination is never the cleanest quarter. An
-        # underestimated floor only costs a longer sweep, never a worse
-        # pick. (1.8: p25 of a 3-channel half-normal mean ~ 0.56 sigma.)
-        resid = np.abs((dst - cv2.blur(dst, (3, 3)))[ring]).mean(axis=1)
-        sigma = 1.8 * float(np.percentile(resid, 25.0))
-        floor = _HEAL_ACCEPT_MADS * sigma ** 2 + 1e-3
         tol = (_DLIKE_SEP_MADS * (ring_mad + 1e-3)) ** 2
-        best_raw = None
+        # THE ACCEPTANCE RULE (maintainer): the sampling point is closer the
+        # better — the IMMEDIATE surroundings, never across the frame. This
+        # holds BY CONSTRUCTION: the sweep accepts the best candidate of the
+        # FIRST (nearest) ring that contains a USABLE one, and never looks
+        # farther once it exists. A usable candidate is clean where it is
+        # read (_source_at) and matches the hole's adjacent surround in
+        # CHROMA + BRIGHTNESS (weighted ring-mean within tone_tol). Farther
+        # rings are reached only while nearer rings hold nothing usable;
+        # if NO ring does, the fallback is the overall distance-penalized
+        # best, wrong tone and all (still better than leaving the dust).
+        #
+        # Ring positions are weighted by PROXIMITY TO THE HOLE: the pixels
+        # touching the hole govern the fill's continuity, and a strong
+        # feature crossing the WINDOW's periphery — an edge a few px from
+        # the spot — must not veto a candidate whose fill-adjacent
+        # surroundings match perfectly. Demanding the whole-window
+        # surroundings match did exactly that: the perfect patch
+        # immediately beside a spot-near-an-edge could not re-phase the
+        # edge at its own periphery and scored WORSE than a remote flat
+        # patch that had no edge at all ("sampled dirt from across the
+        # frame while perfect pavement sat right next to the spot").
+        w_ring = np.exp(-0.5 * (away[ring] / (0.5 * pad)) ** 2
+                        ).astype(np.float32)
+        w_all = float(w_ring.sum()) + 1e-6
+        wmean_dst = (dst_ring * w_ring[:, None]).sum(axis=0) / w_all
+        wmad_dst = float((np.abs(dst_ring - wmean_dst).mean(axis=1)
+                          * w_ring).sum() / w_all)
+        # Tone tolerance scales with the adjacent surround's own weighted
+        # variability: tight on smooth content (sky — dirt across the frame
+        # can never qualify), naturally looser when the hole itself sits on
+        # structure (there, candidates must carry the structure anyway).
+        tone_tol = _HEAL_TONE_TOL_MADS * (wmad_dst + 1e-3)
+        fb_score, fb_src, fb_off, fb_rv = None, None, None, None
         for fi, (d, n_ang) in enumerate(
                 ((d_base, 2 * _HEAL_ANGLES), (1.5 * d_base, 2 * _HEAL_ANGLES),
                  (2.25 * d_base, _HEAL_ANGLES), (3.5 * d_base, _HEAL_ANGLES),
                  (d0, _HEAL_ANGLES))):
+            ring_best = None
             for k in range(n_ang):
                 ang = 2.0 * np.pi * (k + 0.35 * fi) / n_ang
                 dy = int(round(d * np.sin(ang)))
@@ -3559,16 +3593,16 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 if src is None:
                     continue
                 diff = src[ring] - dst_ring
+                wv = w_ring
                 if rv is not None:
                     diff = diff[rv]  # match on the ring's clean subset only
-                ssd = float(np.mean(diff * diff))
-                # Same chroma + brightness first (user rule): the per-channel
-                # ring-mean offset is the candidate AREA's tone mismatch —
-                # weigh it far above its per-pixel share so a remote flat
-                # patch of different color can never outbid the local area
-                # on pattern luck (see _HEAL_TONE_W).
-                mu = diff.mean(axis=0)
-                ssd += _HEAL_TONE_W * float(np.mean(mu * mu))
+                    wv = w_ring[rv]
+                wsum = float(wv.sum()) + 1e-6
+                ssd = float(((diff * diff).mean(axis=1) * wv).sum() / wsum)
+                # The candidate AREA's chroma + brightness offset, weighted
+                # toward the hole-adjacent pixels.
+                mu = (diff * wv[:, None]).sum(axis=0) / wsum
+                tone = float(np.abs(mu).mean())
                 # The ring SSD never looks INSIDE the candidate window: a
                 # source whose ring matches but whose hole area holds
                 # something foreign (a black border edge, an object) clones
@@ -3577,13 +3611,23 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 # penalty re-ranked near-ties by interior phase on textured
                 # content and drifted preview/export tone).
                 i_diff = np.median(src[hole], axis=0) - ring_bg
-                raw = ssd + max(0.0, float(np.mean(i_diff * i_diff)) - tol)
-                score = raw * (1.0 + _HEAL_DIST_W * fi)
-                if best_score is None or score < best_score:
-                    best_score, best_src, best_off = score, src, (dy, dx)
-                    best_rv, best_raw = rv, raw
-            if best_raw is not None and best_raw <= floor:
-                break  # the surroundings already match at the grain floor
+                raw = (ssd + _HEAL_TONE_W * float(np.mean(mu * mu))
+                       + max(0.0, float(np.mean(i_diff * i_diff)) - tol))
+                if fb_score is None or raw * (1.0 + _HEAL_DIST_W * fi) < fb_score:
+                    fb_score = raw * (1.0 + _HEAL_DIST_W * fi)
+                    fb_src, fb_off, fb_rv = src, (dy, dx), rv
+                if tone > tone_tol:
+                    continue  # wrong chroma/brightness — unusable at ANY ring
+                if ring_best is None or raw < ring_best:
+                    ring_best = raw
+                    best_src, best_off, best_rv = src, (dy, dx), rv
+            if ring_best is not None:
+                break  # nearest ring with a usable patch WINS — never farther
+        if best_src is None and fb_src is not None:
+            # No tone-matched patch on any ring (hole boxed into content
+            # unlike anything reachable) — take the least-bad match rather
+            # than leaving the dust; the membrane re-tones what it can.
+            best_src, best_off, best_rv = fb_src, fb_off, fb_rv
 
     if best_src is None:
         return None

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3259,26 +3259,11 @@ _HEAL_RING = 3            # min ring width of clean context (matching + tone)
 _HEAL_GUARD = 2           # min gap (px) between the hole and its context ring
 _HEAL_ANGLES = 16         # candidate source directions searched around a spot
                           # (the two NEAREST rings sample at double density)
-_SRC_RING_CLEAN_MIN = 0.6  # a candidate source window beside other dust stays
-                           # usable while at least this fraction of its ring
-                           # positions is clean (fill pixels must ALL be clean)
-_HEAL_TONE_TOL_MADS = 3.0  # USABILITY gate (maintainer rule: sample the
-                           # immediate surroundings, same chroma+brightness):
-                           # a candidate is usable only when its weighted
-                           # ring-mean offset stays within this many weighted
-                           # MADs of the hole-adjacent surround. The sweep
-                           # accepts the best USABLE candidate of the NEAREST
-                           # ring that has one — distance is control flow,
-                           # not a score weight, so a far patch can never
-                           # outbid a usable adjacent one.
-_HEAL_TONE_W = 3.0        # within-ring ranking: extra weight on the ring-MEAN
-                          # mismatch (the areas' chroma + brightness), so the
-                          # tone-closest of a ring's usable candidates wins;
-                          # scale-stable (means survive resampling), preview
-                          # and export rank candidates the same way.
-_HEAL_DIST_W = 0.45       # FALLBACK ranking only (no ring had a usable
-                          # candidate): prefer nearer among the wrong-tone
-                          # leftovers
+# The automatic sampling rule (maintainer, verbatim — see _heal_patch): the
+# sample area must TOUCH the patch area, and among the touching candidates
+# the lowest combined Δhue+Δsat+ΔV (vs the patch's own background) plus the
+# lowest texture wins. Total selection — no distance rings, no gates, no
+# fallback ranking. The former ring-sweep constants died with the sweep.
 _HEAL_MIN_RING_PX = 8     # need at least this much clean ring to heal
 _HEAL_SEG_MIN = 32        # min heal-segment size (px) for long strokes
 _HEAL_SEG_THICKNESS = 6.0  # segment size as a multiple of hole thickness
@@ -3334,7 +3319,8 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 half_th: float, mask_pad: np.ndarray, integ: np.ndarray,
                 filled: np.ndarray, fmap: np.ndarray, feather: float,
                 src_off=None, forced_flags=None,
-                sample=None, manual=False, auto=False):
+                sample=None, manual=False, auto=False, ws_windowed=False,
+                pref_off=None):
     """Fill one hole patch (a compact component, or one segment of a long
     stroke) by cloning the best-matching nearby clean patch.
 
@@ -3490,30 +3476,6 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     ring_bg = np.median(dst_ring, axis=0)
     ring_mad = float(np.median(np.abs(dst_ring - ring_bg).mean(axis=1)))
 
-    def _source_at(dy, dx):
-        """Candidate source window, or (None, None). Returns (pixels, rv):
-        rv is None for a fully clean window, else the boolean CLEAN subset of
-        the ring positions. The old all-or-nothing dust check rejected any
-        window touching dust ANYWHERE — in a dusty sky (specks cluster) every
-        near window was disqualified by its neighbors and the pick leapt to
-        the far rings. Only the pixels a heal actually READS must be clean:
-        the hole projection (cloned verbatim — mandatory), and the ring
-        (matching + membrane tone), which keeps its clean subset when at
-        least _SRC_RING_CLEAN_MIN of it survives."""
-        sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
-        if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
-            return None, None
-        if _box_sum(integ, sy0, sx0, sy1, sx1) == 0:
-            return img16[sy0:sy1, sx0:sx1].astype(np.float32), None
-        m = mask_pad[sy0:sy1, sx0:sx1]
-        if m[hole].any():
-            return None, None  # fill pixels would clone dust
-        rv = m[ring] == 0
-        if (float(rv.mean()) < _SRC_RING_CLEAN_MIN
-                or int(rv.sum()) < _HEAL_MIN_RING_PX):
-            return None, None  # too little clean ring to match/tone against
-        return img16[sy0:sy1, sx0:sx1].astype(np.float32), rv
-
     best_src, best_off, best_rv = None, None, None
     if src_off is not None:
         # Pinned source (scale replay, or a prior edit's plan): the offset
@@ -3535,9 +3497,41 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
             best_src = img16[wy0 + dy:wy1 + dy,
                              wx0 + dx:wx1 + dx].astype(np.float32)
         else:
-            sm = mask_pad[wy0 + dy:wy1 + dy, wx0 + dx:wx1 + dx]
-            rv_pin = sm[ring] == 0
-            if not sm[hole].any() and int(rv_pin.sum()) >= _HEAL_MIN_RING_PX:
+            # Same cleanliness criterion as the fresh pick (RAW mask for the
+            # sample area): a TOUCHING source hugs the patch border, and the
+            # 1 px mask_pad dilation flipping the verdict at another scale
+            # made replays reroute through the deferred pass — preview and
+            # export diverged on the very segments the rule pins. Scale
+            # rounding can still push a tangent offset ~1 px INTO the mask;
+            # such an offset is rescued by the nearest clean offset within a
+            # ≤4 px Chebyshev spiral (essentially the same patch) before the
+            # deferred pass is considered.
+            def _raw_clean(oy, ox):
+                if (wy0 + oy < 0 or wx0 + ox < 0
+                        or wy1 + oy > h or wx1 + ox > w):
+                    return False
+                win = labels[wy0 + oy:wy1 + oy, wx0 + ox:wx1 + ox]
+                return not (win[hole] > 0).any()
+            if not _raw_clean(dy, dx):
+                for rr in range(1, 5):
+                    hit = None
+                    for ddy in range(-rr, rr + 1):
+                        for ddx in range(-rr, rr + 1):
+                            if max(abs(ddy), abs(ddx)) != rr:
+                                continue
+                            if _raw_clean(dy + ddy, dx + ddx):
+                                hit = (dy + ddy, dx + ddx)
+                                break
+                        if hit:
+                            break
+                    if hit:
+                        dy, dx = hit
+                        best_off = (dy, dx)
+                        break
+            # Raw-mask ring subset, matching the fresh pick (scale-stable
+            # tone anchor — see the fresh branch below).
+            rv_pin = labels[wy0 + dy:wy1 + dy, wx0 + dx:wx1 + dx][ring] == 0
+            if _raw_clean(dy, dx) and bool(rv_pin.any()):
                 best_src = img16[wy0 + dy:wy1 + dy,
                                  wx0 + dx:wx1 + dx].astype(np.float32)
                 if not rv_pin.all():
@@ -3549,28 +3543,95 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 g0, d0 = forced_flags if forced_flags is not None else (True,
                                                                         False)
                 return best_off, g0, d0, "defer"
-    if best_src is None and auto:
-        # ============== AUTO SAMPLING RULE (maintainer, verbatim) ============
-        # 1. The sample area MUST TOUCH the patch area.
+    if best_src is None:
+        # ========== AUTOMATIC SAMPLING RULE (maintainer, verbatim) ==========
+        # Applies to EVERY automatically picked initial sample — AI-detected
+        # spots and painted strokes alike (only an explicit user re-pick is
+        # exempt, and it arrives as a pinned src_off above):
+        # 1. The sample area MUST TOUCH the patch area — the border of the
+        #    sample area and the border of the patch share at least one
+        #    pixel of contact (union contiguous). Not 500 px away, not
+        #    50 px away: touching.
         # 2. Among the touching candidates pick the lowest combined
         #    delta-hue + delta-saturation + delta-V (vs the patch's own
-        #    background) plus the lowest texture. This is a TOTAL selection:
-        #    the best touching candidate always wins — no distance
-        #    escalation, no "good enough" gate, no fallback.
+        #    background) plus the lowest texture. A TOTAL selection: the
+        #    best touching candidate always wins — no distance escalation,
+        #    no "good enough" gate, no fallback ranking.
         # 3. (Again) the sample area and the patch area must touch.
         # Reference = the darker half of the HOLE's own pixels (film dust is
-        # white, and the hole is SPOT_SCALE× the speck's core, so the true
-        # background is visible inside it). No ring statistic participates
-        # in the choice — a shadow band or wall crossing the ring cannot
-        # redirect the anchor (both reported failures did exactly that).
+        # white, so the darker half is the background under/around the
+        # defect). No ring statistic participates in the choice — a shadow
+        # band or wall crossing the ring cannot redirect the anchor.
+        # On a WINDOWED working-space buffer the hue/sat/value deltas are
+        # computed on de-windowed display values (container codes compress
+        # them 64×, hue degenerating first).
+        if ws_windowed:
+            dwk = 65535.0 / (WS_W - WS_B)
+
+            def _dw(v):
+                return np.clip((np.asarray(v, np.float32) - WS_B) * dwk,
+                               0.0, 65535.0)
+        else:
+            dwk = 1.0
+
+            def _dw(v):
+                return v
+        # ONE sample offset per PATCH: the rule speaks of "the patch area"
+        # as a unit — a long stroke is healed in internal segments, and
+        # letting each segment argmin independently put differently-phased
+        # clones side by side (a visible seam inside one stroke, whose
+        # raster position drifted between preview and export). The
+        # component's first segment runs the argmin; its offset is reused
+        # by the rest of the patch whenever it stays in-bounds and clean
+        # (a curled stroke folding into the offset re-runs the argmin).
+        if pref_off is not None:
+            def _pref_ok(oy, ox):
+                if (wy0 + oy < 0 or wx0 + ox < 0
+                        or wy1 + oy > h or wx1 + ox > w):
+                    return None
+                lw = labels[wy0 + oy:wy1 + oy, wx0 + ox:wx1 + ox]
+                if (lw[hole] > 0).any():
+                    return None
+                return lw[ring] == 0
+            pdy, pdx = int(pref_off[0]), int(pref_off[1])
+            rvp = _pref_ok(pdy, pdx)
+            if rvp is None:
+                # A raster-level graze (the offset has a small along-stroke
+                # component) must NUDGE the shared offset, not abandon it —
+                # an independent re-pick here puts a differently-phased
+                # clone mid-stroke (a visible seam that also drifts between
+                # preview and export). Same ≤4 px spiral as the replay
+                # rescue: essentially the same patch.
+                for rr in range(1, 5):
+                    for ddy in range(-rr, rr + 1):
+                        for ddx in range(-rr, rr + 1):
+                            if max(abs(ddy), abs(ddx)) != rr:
+                                continue
+                            rvp = _pref_ok(pdy + ddy, pdx + ddx)
+                            if rvp is not None and bool(rvp.any()):
+                                pdy, pdx = pdy + ddy, pdx + ddx
+                                break
+                            rvp = None
+                        if rvp is not None:
+                            break
+                    if rvp is not None:
+                        break
+            if rvp is not None and bool(rvp.any()):
+                best_src = img16[wy0 + pdy:wy1 + pdy,
+                                 wx0 + pdx:wx1 + pdx].astype(np.float32)
+                best_off = (pdy, pdx)
+                best_rv = None if bool(rvp.all()) else rvp
+    if best_src is None:
         hl = hole_px.mean(axis=1)
-        ref = np.median(hole_px[hl <= np.median(hl)], axis=0)
+        ref = _dw(np.median(hole_px[hl <= np.median(hl)], axis=0))
         ref_h, ref_s, ref_v = _hsv1(ref)
         best_comb = None
-        # The mask is dilated ~1 px around every spot (plus crop padding), so
-        # the touching distance steps out a few px until the sampled area
-        # clears its own spot's dilation — all three radii border the patch.
-        for extra in (2.0, 4.0, 6.0):
+        # Touching distances: at dt = 2·half_th the sampled area's border
+        # meets the patch border (tangency); +1/+2 cover raster rounding.
+        # The sample-area dust check uses the RAW mask (labels) — the 1 px
+        # mask_pad dilation exists to bury antialiased speck edges and would
+        # otherwise push the sample off the border it must touch.
+        for extra in (0.0, 1.0, 2.0):
             dt = 2.0 * half_th + extra
             for k in range(2 * _HEAL_ANGLES):
                 ang = 2.0 * np.pi * k / (2 * _HEAL_ANGLES)
@@ -3579,127 +3640,39 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 sy0, sx0, sy1, sx1 = wy0 + dy, wx0 + dx, wy1 + dy, wx1 + dx
                 if sy0 < 0 or sx0 < 0 or sy1 > h or sx1 > w:
                     continue
-                m = mask_pad[sy0:sy1, sx0:sx1]
                 # Pre-existing invariant: dust is never cloned — a touching
-                # window whose SAMPLE AREA holds another spot is not scene.
-                if m[hole].any():
+                # window whose SAMPLE AREA overlaps any spot is not scene.
+                # The membrane's ring subset ALSO derives from the raw mask:
+                # raw geometry scales proportionally, while mask_pad's fixed
+                # 1 px dilation shrinks relative to the export raster and
+                # gave preview and export different tone-anchor subsets (a
+                # visible drift wherever the touching source is
+                # phase-shifted on patterned content).
+                lbl_win = labels[sy0:sy1, sx0:sx1]
+                if (lbl_win[hole] > 0).any():
                     continue
-                rv2 = m[ring] == 0
+                rv2 = lbl_win[ring] == 0
                 if not rv2.any():
                     continue  # membrane needs ≥1 clean ring px (NaN guard)
                 src = img16[sy0:sy1, sx0:sx1].astype(np.float32)
                 area = src[hole]
-                ah, as_, av = _hsv1(np.median(area, axis=0))
+                ah, as_, av = _hsv1(_dw(np.median(area, axis=0)))
                 dh_ = abs(ah - ref_h)
                 dh_ = min(dh_, 1.0 - dh_) * 2.0 * max(as_, ref_s)
-                tex = float(area.mean(axis=1).std()) / 65535.0
+                tex = float(area.mean(axis=1).std()) * dwk / 65535.0
                 comb = dh_ + abs(as_ - ref_s) + abs(av - ref_v) + tex
                 if best_comb is None or comb < best_comb:
                     best_comb = comb
                     best_src, best_off = src, (dy, dx)
                     best_rv = None if bool(rv2.all()) else rv2
         if best_src is None:
-            # Every touching direction lies inside other dust (the spot is
-            # fully encircled). Dust pixels are never cloned (pre-existing
-            # invariant), so the segment defers and clones the HEALED
-            # content at a touching offset via the existing second pass —
-            # the answer still exists and still touches the patch.
-            dy = int(round(2.0 * half_th + 2.0))
-            dy = min(max(dy, -wy0), h - wy1)
-            return (dy, 0), False, False, "defer"
-    if best_src is None:
-        # Candidate source offsets: rings of directions at thickness-scaled
-        # distances, NEAREST FIRST, near rings at double angular density.
-        # The pixels-actually-read check (_source_at) rejects any source
-        # that would READ dust/outside-crop, so offsets need only clear the
-        # local thickness — a long stroke heals from the clean strip right
-        # beside it. The window diagonal stays as a last-resort ring for
-        # compact spots; the acceptance rule below decides when the sweep
-        # stops.
-        d_base = 2.0 * half_th + pad + 2.0
-        d0 = float(np.hypot(wy1 - wy0, wx1 - wx0))
-        tol = (_DLIKE_SEP_MADS * (ring_mad + 1e-3)) ** 2
-        # THE ACCEPTANCE RULE (maintainer): the sampling point is closer the
-        # better — the IMMEDIATE surroundings, never across the frame. This
-        # holds BY CONSTRUCTION: the sweep accepts the best candidate of the
-        # FIRST (nearest) ring that contains a USABLE one, and never looks
-        # farther once it exists. A usable candidate is clean where it is
-        # read (_source_at) and matches the hole's adjacent surround in
-        # CHROMA + BRIGHTNESS (weighted ring-mean within tone_tol). Farther
-        # rings are reached only while nearer rings hold nothing usable;
-        # if NO ring does, the fallback is the overall distance-penalized
-        # best, wrong tone and all (still better than leaving the dust).
-        #
-        # Ring positions are weighted by PROXIMITY TO THE HOLE: the pixels
-        # touching the hole govern the fill's continuity, and a strong
-        # feature crossing the WINDOW's periphery — an edge a few px from
-        # the spot — must not veto a candidate whose fill-adjacent
-        # surroundings match perfectly. Demanding the whole-window
-        # surroundings match did exactly that: the perfect patch
-        # immediately beside a spot-near-an-edge could not re-phase the
-        # edge at its own periphery and scored WORSE than a remote flat
-        # patch that had no edge at all ("sampled dirt from across the
-        # frame while perfect pavement sat right next to the spot").
-        w_ring = np.exp(-0.5 * (away[ring] / (0.5 * pad)) ** 2
-                        ).astype(np.float32)
-        w_all = float(w_ring.sum()) + 1e-6
-        wmean_dst = (dst_ring * w_ring[:, None]).sum(axis=0) / w_all
-        wmad_dst = float((np.abs(dst_ring - wmean_dst).mean(axis=1)
-                          * w_ring).sum() / w_all)
-        # Tone tolerance scales with the adjacent surround's own weighted
-        # variability: tight on smooth content (sky — dirt across the frame
-        # can never qualify), naturally looser when the hole itself sits on
-        # structure (there, candidates must carry the structure anyway).
-        tone_tol = _HEAL_TONE_TOL_MADS * (wmad_dst + 1e-3)
-        fb_score, fb_src, fb_off, fb_rv = None, None, None, None
-        for fi, (d, n_ang) in enumerate(
-                ((d_base, 2 * _HEAL_ANGLES), (1.5 * d_base, 2 * _HEAL_ANGLES),
-                 (2.25 * d_base, _HEAL_ANGLES), (3.5 * d_base, _HEAL_ANGLES),
-                 (d0, _HEAL_ANGLES))):
-            ring_best = None
-            for k in range(n_ang):
-                ang = 2.0 * np.pi * (k + 0.35 * fi) / n_ang
-                dy = int(round(d * np.sin(ang)))
-                dx = int(round(d * np.cos(ang)))
-                src, rv = _source_at(dy, dx)
-                if src is None:
-                    continue
-                diff = src[ring] - dst_ring
-                wv = w_ring
-                if rv is not None:
-                    diff = diff[rv]  # match on the ring's clean subset only
-                    wv = w_ring[rv]
-                wsum = float(wv.sum()) + 1e-6
-                ssd = float(((diff * diff).mean(axis=1) * wv).sum() / wsum)
-                # The candidate AREA's chroma + brightness offset, weighted
-                # toward the hole-adjacent pixels.
-                mu = (diff * wv[:, None]).sum(axis=0) / wsum
-                tone = float(np.abs(mu).mean())
-                # The ring SSD never looks INSIDE the candidate window: a
-                # source whose ring matches but whose hole area holds
-                # something foreign (a black border edge, an object) clones
-                # that thing into the fill. Penalize interior tone past the
-                # ring's own variability (the EXCESS only: an always-on
-                # penalty re-ranked near-ties by interior phase on textured
-                # content and drifted preview/export tone).
-                i_diff = np.median(src[hole], axis=0) - ring_bg
-                raw = (ssd + _HEAL_TONE_W * float(np.mean(mu * mu))
-                       + max(0.0, float(np.mean(i_diff * i_diff)) - tol))
-                if fb_score is None or raw * (1.0 + _HEAL_DIST_W * fi) < fb_score:
-                    fb_score = raw * (1.0 + _HEAL_DIST_W * fi)
-                    fb_src, fb_off, fb_rv = src, (dy, dx), rv
-                if tone > tone_tol:
-                    continue  # wrong chroma/brightness — unusable at ANY ring
-                if ring_best is None or raw < ring_best:
-                    ring_best = raw
-                    best_src, best_off, best_rv = src, (dy, dx), rv
-            if ring_best is not None:
-                break  # nearest ring with a usable patch WINS — never farther
-        if best_src is None and fb_src is not None:
-            # No tone-matched patch on any ring (hole boxed into content
-            # unlike anything reachable) — take the least-bad match rather
-            # than leaving the dust; the membrane re-tones what it can.
-            best_src, best_off, best_rv = fb_src, fb_off, fb_rv
+            # No touching candidate EXISTS: every touching direction is out
+            # of frame (a patch nearly as big as the buffer) or inside other
+            # dust. There is no sample to select — dust pixels are never
+            # cloned (pre-existing invariant) — so this degenerates to the
+            # boundary-diffusion fill (Telea), which grows the fill from the
+            # patch's own touching border.
+            return None
 
     if best_src is None:
         return None
@@ -3795,7 +3768,8 @@ def _nearest_plan_record(plan, cyn, cxn, tol=0.06):
 def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
                        feather: float = DUST_FEATHER_DEFAULT,
                        plan=None, collect_plan=None,
-                       prior_plan=None, crop=None) -> np.ndarray:
+                       prior_plan=None, crop=None,
+                       ws_windowed: bool = False) -> np.ndarray:
     """Heal the dust spots out of a 16-bit RGB image, non-destructively.
 
     `feather` is the edge fade width as a fraction of each hole's own
@@ -3862,7 +3836,8 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
     if long_side <= _DUST_PLAN_LONG:
         return _heal_impl(img16, spots, inpaint_radius, feather,
                           collect=collect_plan, plan=prior_plan,
-                          plan_tol=_DUST_EDIT_TOL, crop=crop)
+                          plan_tol=_DUST_EDIT_TOL, crop=crop,
+                          ws_windowed=ws_windowed)
     scale = long_side / float(_DUST_PLAN_LONG)
     if plan is None:
         # No preview plan supplied — derive one from this buffer's own
@@ -3873,16 +3848,18 @@ def apply_dust_removal(img16: np.ndarray, spots, inpaint_radius: int = 3,
         small = cv2.resize(img16, (pw, ph), interpolation=cv2.INTER_AREA)
         plan = []
         _heal_impl(small, spots, inpaint_radius, feather, collect=plan,
-                   plan_only=True, crop=crop)
+                   plan_only=True, crop=crop, ws_windowed=ws_windowed)
         print(f"Dust plan (no cached preview plan): {time.time() - t0:.3f}s")
     return _heal_impl(img16, spots, inpaint_radius, feather,
-                      plan=plan, scale_up=scale, crop=crop)
+                      plan=plan, scale_up=scale, crop=crop,
+                      ws_windowed=ws_windowed)
 
 
 def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                feather: float, plan=None, collect=None,
                scale_up: float = 1.0, plan_only: bool = False,
-               plan_tol: float = 0.06, crop=None) -> np.ndarray:
+               plan_tol: float = 0.06, crop=None,
+               ws_windowed: bool = False) -> np.ndarray:
     """apply_dust_removal's engine at ONE resolution. With `collect` (a list),
     appends a plan record per heal segment:
     (cy_norm, cx_norm, offset, genuine, dlike_on, manual) where offset is
@@ -3953,6 +3930,9 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     # Segments whose PINNED source is under newer dust: re-run after the
     # fills below so they clone the healed content at the same location.
     deferred = []
+    # One sample offset per patch (component): the first segment's argmin
+    # seeds the rest — see _heal_patch's pref_off.
+    comp_off = {}
     t_setup = time.time() - t0
     t0 = time.time()
     n_segs = 0
@@ -4017,7 +3997,11 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
                                       loc_th, mask_pad, integ, filled, fmap,
                                       feather, src_off=src_off,
                                       forced_flags=flags, manual=manual,
-                                      auto=comp_auto)
+                                      auto=comp_auto, ws_windowed=ws_windowed,
+                                      pref_off=comp_off.get(i))
+                if (res is not None and len(res) == 3 and src_off is None
+                        and res[0] is not None):
+                    comp_off.setdefault(i, res[0])
                 if res is not None and len(res) == 4:
                     # Pinned source now under new dust: fill in a SECOND
                     # pass from the healed buffer (after Telea), so the

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3476,6 +3476,27 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
     ring_bg = np.median(dst_ring, axis=0)
     ring_mad = float(np.median(np.abs(dst_ring - ring_bg).mean(axis=1)))
 
+    def _touches_patch(ty, tx):
+        """Does the sample area (hole shifted by (ty, tx)) come within the
+        rule's ±4 px of THE PATCH (labels == comp — the whole spot, not just
+        this segment's tile)? Used by both the pinned-offset validation and
+        the per-patch shared-offset (pref) path so plan time and replay
+        agree: a shared offset that stops touching where the patch boundary
+        curves away must re-pick at BOTH, or the plans drift."""
+        gy0 = max(0, min(wy0, wy0 + ty) - 5)
+        gx0 = max(0, min(wx0, wx0 + tx) - 5)
+        gy1 = min(h, max(wy1, wy1 + ty) + 5)
+        gx1 = min(w, max(wx1, wx1 + tx) + 5)
+        comp_near = cv2.dilate(
+            (labels[gy0:gy1, gx0:gx1] == comp).astype(np.uint8),
+            np.ones((9, 9), np.uint8)).astype(bool)
+        hy_, hx_ = np.nonzero(hole)
+        py_ = hy_ + (wy0 + ty - gy0)
+        px_ = hx_ + (wx0 + tx - gx0)
+        okp = ((py_ >= 0) & (py_ < gy1 - gy0)
+               & (px_ >= 0) & (px_ < gx1 - gx0))
+        return bool(comp_near[py_[okp], px_[okp]].any())
+
     best_src, best_off, best_rv = None, None, None
     if src_off is not None:
         # Pinned source (scale replay, or a prior edit's plan): the offset
@@ -3499,23 +3520,15 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
             # fresh, validly-keyed plans on every re-detect for as long as
             # the old search existed — pruning by spot identity can never
             # catch that. An automatic pin is honoured only if its sample
-            # still touches (within ±4 px for cross-scale raster rounding);
-            # otherwise it is dropped here and the segment re-picks under
-            # the rule, so the whole catalog converges as images render.
-            # USER re-picks (manual=True) keep any distance — that pick is
-            # the user's explicit choice.
-            def _shifted_hits(mask_a, ty, tx):
-                hh2, ww2 = hole.shape
-                ay0, ay1 = max(0, ty), min(hh2, hh2 + ty)
-                ax0, ax1 = max(0, tx), min(ww2, ww2 + tx)
-                if ay0 >= ay1 or ax0 >= ax1:
-                    return False
-                return bool(np.any(mask_a[ay0:ay1, ax0:ax1]
-                                   & hole[ay0 - ty:ay1 - ty,
-                                          ax0 - tx:ax1 - tx]))
-            near = cv2.dilate(hole.astype(np.uint8),
-                              np.ones((9, 9), np.uint8)).astype(bool)
-            if _shifted_hits(hole, dy, dx) or not _shifted_hits(near, dy, dx):
+            # still touches THE PATCH — the whole spot (labels == comp), not
+            # just this segment's tile: a long stroke shares ONE patch-
+            # touching offset across its segments, and a tile-local test
+            # wrongly rejected that shared offset on the stroke's far tiles.
+            # ±4 px tolerance covers cross-scale raster rounding; a sample
+            # overlapping dust routes through the existing clean/defer
+            # machinery below. USER re-picks (manual=True) keep any
+            # distance — that pick is the user's explicit choice.
+            if not _touches_patch(dy, dx):
                 src_off = None  # fossil pin — fall through to the rule
     if src_off is not None:
         best_off = (dy, dx)
@@ -3620,7 +3633,7 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                     return None
                 return lw[ring] == 0
             pdy, pdx = int(pref_off[0]), int(pref_off[1])
-            rvp = _pref_ok(pdy, pdx)
+            rvp = _pref_ok(pdy, pdx) if _touches_patch(pdy, pdx) else None
             if rvp is None:
                 # A raster-level graze (the offset has a small along-stroke
                 # component) must NUDGE the shared offset, not abandon it —
@@ -3632,6 +3645,8 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                     for ddy in range(-rr, rr + 1):
                         for ddx in range(-rr, rr + 1):
                             if max(abs(ddy), abs(ddx)) != rr:
+                                continue
+                            if not _touches_patch(pdy + ddy, pdx + ddx):
                                 continue
                             rvp = _pref_ok(pdy + ddy, pdx + ddx)
                             if rvp is not None and bool(rvp.any()):
@@ -3939,16 +3954,50 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     if not mask.any():
         return img16
 
-    n, labels, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
-    # Spot kind per component: the AUTO sampling rule (touch + HSV/texture
-    # argmin) applies only to components made purely of auto-detected spots;
-    # anything a brush touched keeps the manual machinery (hair defenses).
-    kinds = {s.get("kind") for s in spots}
-    all_auto = kinds == {"auto"}
-    brush_mask = None
-    if not all_auto and "auto" in kinds:
-        brush_mask = rasterize_dust_mask(
-            [s for s in spots if s.get("kind") != "auto"], h, w)
+    # PER-SPOT PATCHES (maintainer rule: never auto-connect two strokes —
+    # each spot samples separately). `labels` carries one id PER SPOT, with
+    # drawing order owning shared pixels, so touching/overlapping strokes
+    # keep their own segments, their own touching-sample argmin and their
+    # own per-patch offset. Only the never-clone-dust checks (mask_pad /
+    # integ / labels>0) and the feathered composite see the union. Each
+    # spot rasterizes into its own bbox-local canvas with the exact integer
+    # geometry of rasterize_dust_mask (rounded full-frame coords, integer
+    # translation), so the stamped labels match the union mask bit for bit.
+    labels = np.zeros((h, w), np.int32)
+    boxes = {}
+    for si, s in enumerate(spots, start=1):
+        r_px = max(1, int(round(float(s.get("r", 0.0)) * w)))
+        pxy = []
+        for p in (s.get("pts") or []):
+            try:
+                pxy.append((int(round(float(p[0]) * w)),
+                            int(round(float(p[1]) * h))))
+            except (TypeError, ValueError, IndexError):
+                continue
+        if not pxy:
+            continue
+        bx0 = max(0, min(p[0] for p in pxy) - r_px - 1)
+        bx1 = min(w, max(p[0] for p in pxy) + r_px + 2)
+        by0 = max(0, min(p[1] for p in pxy) - r_px - 1)
+        by1 = min(h, max(p[1] for p in pxy) + r_px + 2)
+        if bx1 <= bx0 or by1 <= by0:
+            continue
+        local = np.zeros((by1 - by0, bx1 - bx0), np.uint8)
+        prev = None
+        for (x, y) in pxy:
+            cv2.circle(local, (x - bx0, y - by0), r_px, 255, -1)
+            if prev is not None:
+                cv2.line(local, prev, (x - bx0, y - by0), 255,
+                         thickness=2 * r_px)
+            prev = (x - bx0, y - by0)
+        if not local.any():
+            continue
+        labels[by0:by1, bx0:bx1][local > 0] = si
+        lys, lxs = np.nonzero(local)
+        boxes[si] = (bx0 + int(lxs.min()), by0 + int(lys.min()),
+                     int(lxs.max()) - int(lxs.min()) + 1,
+                     int(lys.max()) - int(lys.min()) + 1)
+    n = len(spots) + 1
     # "Clean" excludes every spot plus 1 px (buries antialiased speck edges).
     mask_pad = cv2.dilate(mask, np.ones((3, 3), np.uint8))
     if crop is not None and crop[0]:
@@ -3991,15 +4040,14 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     t_setup = time.time() - t0
     t0 = time.time()
     n_segs = 0
-    for i in range(1, n):  # 0 is background
-        x0 = int(stats[i, cv2.CC_STAT_LEFT])
-        y0 = int(stats[i, cv2.CC_STAT_TOP])
-        cw = int(stats[i, cv2.CC_STAT_WIDTH])
-        ch = int(stats[i, cv2.CC_STAT_HEIGHT])
+    for i in range(1, n):  # 0 is background; one patch PER SPOT
+        if i not in boxes:
+            continue
+        x0, y0, cw, ch = boxes[i]
         comp_win = labels[y0:y0 + ch, x0:x0 + cw] == i
-        comp_auto = all_auto or (
-            brush_mask is not None
-            and not bool(brush_mask[y0:y0 + ch, x0:x0 + cw][comp_win].any()))
+        if not comp_win.any():
+            continue  # fully overwritten by later strokes (shared pixels)
+        comp_auto = spots[i - 1].get("kind") == "auto"
         # Half-thickness = the defect's local scale (1px zero border so a
         # component touching its bbox edge still measures correctly).
         hole0 = np.zeros((ch + 2, cw + 2), np.uint8)
@@ -4119,14 +4167,20 @@ def _heal_impl(img16: np.ndarray, spots, inpaint_radius: int,
     # alpha computed from its own labels is exactly the global answer.
     t0 = time.time()
     out = img16.copy()
-    for i in range(1, n):
-        bx0 = int(stats[i, cv2.CC_STAT_LEFT])
-        by0 = int(stats[i, cv2.CC_STAT_TOP])
-        bw_ = int(stats[i, cv2.CC_STAT_WIDTH])
-        bh_ = int(stats[i, cv2.CC_STAT_HEIGHT])
+    # The composite blends over the UNION's connected regions: sampling is
+    # per spot, but two overlapping strokes still cross-fade as one filled
+    # area — a per-spot alpha would ramp to zero along their shared border,
+    # cutting a seam through the middle of the union's interior.
+    nu, ulab, ustats, _ = cv2.connectedComponentsWithStats(mask,
+                                                           connectivity=8)
+    for i in range(1, nu):
+        bx0 = int(ustats[i, cv2.CC_STAT_LEFT])
+        by0 = int(ustats[i, cv2.CC_STAT_TOP])
+        bw_ = int(ustats[i, cv2.CC_STAT_WIDTH])
+        bh_ = int(ustats[i, cv2.CC_STAT_HEIGHT])
         ys = slice(max(0, by0 - 2), min(h, by0 + bh_ + 2))
         xs = slice(max(0, bx0 - 2), min(w, bx0 + bw_ + 2))
-        comp = labels[ys, xs] == i
+        comp = ulab[ys, xs] == i
         # The dome IS the whole story: no defect force-fill floor (see
         # _heal_patch's feather comment) — the slider's rolloff shows on
         # every heal, dust included.

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3262,8 +3262,23 @@ _HEAL_ANGLES = 16         # candidate source directions searched around a spot
 _SRC_RING_CLEAN_MIN = 0.6  # a candidate source window beside other dust stays
                            # usable while at least this fraction of its ring
                            # positions is clean (fill pixels must ALL be clean)
-_HEAL_DIST_W = 0.15       # per-ring score penalty: near-ties go to the CLOSER
-                          # patch — the stroke's surroundings first
+_HEAL_TONE_W = 3.0        # extra weight on the ring-MEAN mismatch (the areas'
+                          # chroma + brightness). The raw SSD weighs tone and
+                          # pattern equally per pixel, so beside a high-contrast
+                          # edge a remote FLAT patch of different color could
+                          # beat every near candidate whose ring straddles the
+                          # edge at imperfect phase ("sampled brown dirt to heal
+                          # a spot on white pavement"). Tone must dominate:
+                          # with the SSD's own mean term this makes an area
+                          # tone offset count 4x its per-pixel share, and it is
+                          # scale-stable (means survive resampling) so preview
+                          # and export rank candidates the same way.
+_HEAL_DIST_W = 0.45       # per-ring score penalty: the IMMEDIATE AREA comes
+                          # first — a far-ring candidate must be ~3x better on
+                          # raw match to beat one from the stroke's own
+                          # surroundings (0.15 was too weak to stop a flat
+                          # remote patch from outbidding the local area beside
+                          # a high-contrast edge)
 _HEAL_ACCEPT_MADS = 4.0   # accept a ring once its best raw match reaches the
                           # grain floor (~2 sigma^2, sigma from the detrended
                           # ring residual): farther candidates could only
@@ -3547,6 +3562,13 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
                 if rv is not None:
                     diff = diff[rv]  # match on the ring's clean subset only
                 ssd = float(np.mean(diff * diff))
+                # Same chroma + brightness first (user rule): the per-channel
+                # ring-mean offset is the candidate AREA's tone mismatch —
+                # weigh it far above its per-pixel share so a remote flat
+                # patch of different color can never outbid the local area
+                # on pattern luck (see _HEAL_TONE_W).
+                mu = diff.mean(axis=0)
+                ssd += _HEAL_TONE_W * float(np.mean(mu * mu))
                 # The ring SSD never looks INSIDE the candidate window: a
                 # source whose ring matches but whose hole area holds
                 # something foreign (a black border edge, an object) clones

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -3744,6 +3744,21 @@ def _heal_patch(img16: np.ndarray, img16_c: np.ndarray, labels: np.ndarray,
             dmap[ring] = diffs
         else:
             dmap[ring] = dst[ring] - best_src[ring]
+        # MEDIAN-ANCHORED tone (maintainer decision): the normalized Gaussian
+        # convolution below is a spatially-varying MEAN, and pattern
+        # mismatches between the two rings (a bokeh highlight present in
+        # only one of them) are heavy-tailed outliers that dragged the whole
+        # fill's tone — the ~4%-dark gray discs. The differences are
+        # winsorized to median ± 3 scaled-MADs per channel: the anchor's
+        # center is the ring's MEDIAN difference, the bulk still varies
+        # spatially (gradients continue through the fill), the tail cannot
+        # tint. Median/MAD resample stably, so preview == export holds.
+        diffs_all = dmap[ring]
+        med_all = np.median(diffs_all, axis=0)
+        mad_all = (np.median(np.abs(diffs_all - med_all), axis=0)
+                   * 1.4826 + 1e-3)
+        dmap[ring] = np.clip(diffs_all, med_all - 3.0 * mad_all,
+                             med_all + 3.0 * mad_all)
         ind = ring_m.astype(np.float32)
         sigma = half_th + pad
         wsum = cv2.GaussianBlur(ind, (0, 0), sigma)

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -179,11 +179,22 @@ def _get_session():
         # (e.g. onnxruntime-directml on Windows) — native-res tiled detection
         # is compute-bound on CPU (~30 s/image). Plain `onnxruntime` only has
         # CPU, so this is a no-op there; unsupported ops fall back per-node.
+        # CPU is always listed last, and if the GPU session itself fails to
+        # build (no adapter, broken driver), retry CPU-only — AI detection
+        # must degrade, never break, on machines without a usable GPU.
         preferred = ("DmlExecutionProvider", "CUDAExecutionProvider",
                      "CoreMLExecutionProvider", "CPUExecutionProvider")
         avail = set(ort.get_available_providers())
         providers = [p for p in preferred if p in avail] or ["CPUExecutionProvider"]
-        sess = ort.InferenceSession(path, providers=providers)
+        try:
+            sess = ort.InferenceSession(path, providers=providers)
+        except Exception:
+            if providers == ["CPUExecutionProvider"]:
+                raise
+            logging.warning("dust_detect: GPU provider failed to initialise "
+                            "(%s) — falling back to CPU", providers[0])
+            sess = ort.InferenceSession(path,
+                                        providers=["CPUExecutionProvider"])
         _session = sess
         _session_path = path
         return sess

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -26,7 +26,17 @@ MODEL_URL = ("https://github.com/MohaElder/openenlarge/releases/download/"
 MODEL_SHA256 = "61e4a93d4e94b4fc6212e2e9b785fa12b5cbc9654724b02aaf8b212075bb729f"
 
 # --- Detection tuning -------------------------------------------------------
-DETECT_SHORT = 512      # short side the detector runs at
+# Most real film dust sits OFF the focal plane: soft-edged, faint blobs a few
+# scan-pixels wide. At the 1080 preview they are ~1 px blips and at a 512-short
+# detection downscale they vanish entirely — the net never fires. Detection
+# therefore runs at the SOURCE buffer's native resolution (never downscaled to
+# a fixed short side), tiled through the U-Net and max-stitched, with the
+# source capped at DETECT_MAX_LONG: measured on the example dusty-sky scan,
+# recall rises up to ~3.2k long side, while full scan res quadruples the time
+# and the now-huge diffuse blobs start to fragment.
+DETECT_MAX_LONG = 3264  # cap on the detection long side (multiple of 16)
+DETECT_TILE = 768       # tile size for native-res inference
+DETECT_OVERLAP = 64     # tile overlap; max-stitch so a seam can't split a speck
 DETECT_MULTIPLE = 16    # both dims rounded to a multiple of this (U-Net req.)
 MAX_BLOB = 400          # connected-component pixel cap at ~2k px (resolution-normalized);
                         # drops large detections (film border / real image content)
@@ -156,10 +166,9 @@ def _get_session():
 
 
 def _detect_size(h: int, w: int) -> tuple:
-    """Detection resolution: short side ~DETECT_SHORT (never upscaled), both
-    dims rounded to a multiple of DETECT_MULTIPLE."""
-    short_side = max(1, min(h, w))
-    scale = min(1.0, DETECT_SHORT / short_side)
+    """Detection resolution: the input's own size capped at DETECT_MAX_LONG
+    (never upscaled), both dims rounded to a multiple of DETECT_MULTIPLE."""
+    scale = min(1.0, DETECT_MAX_LONG / float(max(1, h, w)))
     dh = max(DETECT_MULTIPLE,
              int(round(h * scale / DETECT_MULTIPLE)) * DETECT_MULTIPLE)
     dw = max(DETECT_MULTIPLE,
@@ -167,33 +176,58 @@ def _detect_size(h: int, w: int) -> tuple:
     return dh, dw
 
 
+def _tile_starts(length: int, tile: int, step: int) -> list:
+    """Start offsets covering [0, length) with `tile`-wide windows advancing
+    by `step`; the last window is pulled back flush with the end so the whole
+    extent is covered without a short remainder tile."""
+    if length <= tile:
+        return [0]
+    starts = list(range(0, length - tile, step))
+    starts.append(length - tile)
+    return starts
+
+
 def detect(positive_rgb16: np.ndarray) -> tuple:
     """Run the detector on a 16-bit RGB positive. Returns
     `(prob, luma)` — both float32 at detection resolution: the probability map
     (0..1) and the grayscale luma (0..1, used for the bright-speck gate in
     prob_to_spots). Raises if the model or onnxruntime is unavailable. Cache the
-    pair per image — a Sensitivity change re-runs only prob_to_spots, not the net."""
+    pair per image — a Sensitivity change re-runs only prob_to_spots, not the net.
+
+    The net runs at the input's NATIVE resolution (capped at DETECT_MAX_LONG),
+    TILED (DETECT_TILE, DETECT_OVERLAP overlap, max-stitched): soft off-focus
+    dust — most real film dust — survives only near scan resolution; a fixed
+    512-short downscale erased it before the net ever saw it."""
     sess = _get_session()
+    name = sess.get_inputs()[0].name
     h, w = positive_rgb16.shape[:2]
     dh, dw = _detect_size(h, w)
     small = cv2.resize(positive_rgb16, (dw, dh), interpolation=cv2.INTER_AREA)
     small_f = small.astype(np.float32) / 65535.0
     luma = (0.2126 * small_f[..., 0] + 0.7152 * small_f[..., 1]
-            + 0.0722 * small_f[..., 2])
-    inp = (luma * 2.0 - 1.0)[None, None, :, :].astype(np.float32)
-    name = sess.get_inputs()[0].name
-    out = sess.run(None, {name: inp})[0]
-    arr = np.asarray(out, dtype=np.float32).squeeze()
-    if arr.ndim > 2:
-        arr = arr.reshape(arr.shape[-2], arr.shape[-1])
-    elif arr.ndim < 2:
-        # Unexpected flat output — reshape to the detection grid (raises a clear
-        # ValueError if the size doesn't fit, rather than a cryptic IndexError).
-        arr = arr.reshape(dh, dw)
-    prob = 1.0 / (1.0 + np.exp(-arr))
-    if prob.shape != (dh, dw):
-        prob = cv2.resize(prob, (dw, dh), interpolation=cv2.INTER_LINEAR)
-    return prob.astype(np.float32), luma.astype(np.float32)
+            + 0.0722 * small_f[..., 2]).astype(np.float32)
+    prob = np.zeros((dh, dw), np.float32)
+    step = DETECT_TILE - DETECT_OVERLAP
+    for y in _tile_starts(dh, DETECT_TILE, step):
+        th = min(DETECT_TILE, dh)
+        for x in _tile_starts(dw, DETECT_TILE, step):
+            tw = min(DETECT_TILE, dw)
+            t = luma[y:y + th, x:x + tw]
+            inp = (t * 2.0 - 1.0)[None, None, :, :].astype(np.float32)
+            out = sess.run(None, {name: inp})[0]
+            arr = np.asarray(out, dtype=np.float32).squeeze()
+            if arr.ndim > 2:
+                arr = arr.reshape(arr.shape[-2], arr.shape[-1])
+            elif arr.ndim < 2:
+                # Unexpected flat output — reshape to the tile grid (raises a
+                # clear ValueError if the size doesn't fit).
+                arr = arr.reshape(th, tw)
+            p = 1.0 / (1.0 + np.exp(-arr))
+            if p.shape != (th, tw):
+                p = cv2.resize(p, (tw, th), interpolation=cv2.INTER_LINEAR)
+            win = prob[y:y + th, x:x + tw]
+            np.maximum(win, p, out=win)
+    return prob, luma
 
 
 def prob_to_spots(prob: np.ndarray, luma: np.ndarray, sensitivity: float,

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -43,10 +43,11 @@ MAX_BLOB = 400          # connected-component pixel cap at ~2k px (resolution-no
 MAX_ASPECT = 3.0        # drop elongated detections (thin LINES are usually real
                         # structure — a bike frame, the horizon — not dust)
 SPOT_PAD = 1.5          # px added to each detected spot's radius (inpaint margin)
-SPOT_SCALE = 1.35       # radius multiplier: the thresholded component is only
+SPOT_SCALE = 1.62       # radius multiplier: the thresholded component is only
                         # the bright CORE of a soft off-focus speck — its faint
                         # skirt extends beyond, and an exact area-equivalent
-                        # circle left the fringe unhealed
+                        # circle left the fringe unhealed (1.35 still clipped
+                        # the widest skirts; +20% per field feedback)
 # Auto-detection is restricted to SMOOTH regions — sky, open shadow — where
 # dust is both visible and safely distinguishable (maintainer rule). In busy
 # texture (foliage, brick, gravel) compact bright glints are indistinguishable

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -43,11 +43,12 @@ MAX_BLOB = 400          # connected-component pixel cap at ~2k px (resolution-no
 MAX_ASPECT = 3.0        # drop elongated detections (thin LINES are usually real
                         # structure — a bike frame, the horizon — not dust)
 SPOT_PAD = 1.5          # px added to each detected spot's radius (inpaint margin)
-SPOT_SCALE = 1.62       # radius multiplier: the thresholded component is only
+SPOT_SCALE = 2.9        # radius multiplier: the thresholded component is only
                         # the bright CORE of a soft off-focus speck — its faint
                         # skirt extends beyond, and an exact area-equivalent
-                        # circle left the fringe unhealed (1.35 still clipped
-                        # the widest skirts; +20% per field feedback)
+                        # circle left the fringe unhealed (raised 1.35 → 1.62
+                        # → 2.9 across three rounds of field feedback: soft
+                        # skirts are far wider than the core)
 # Auto-detection is restricted to SMOOTH regions — sky, open shadow — where
 # dust is both visible and safely distinguishable (maintainer rule). In busy
 # texture (foliage, brick, gravel) compact bright glints are indistinguishable

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -43,6 +43,21 @@ MAX_BLOB = 400          # connected-component pixel cap at ~2k px (resolution-no
 MAX_ASPECT = 3.0        # drop elongated detections (thin LINES are usually real
                         # structure — a bike frame, the horizon — not dust)
 SPOT_PAD = 1.5          # px added to each detected spot's radius (inpaint margin)
+SPOT_SCALE = 1.35       # radius multiplier: the thresholded component is only
+                        # the bright CORE of a soft off-focus speck — its faint
+                        # skirt extends beyond, and an exact area-equivalent
+                        # circle left the fringe unhealed
+# Auto-detection is restricted to SMOOTH regions — sky, open shadow — where
+# dust is both visible and safely distinguishable (maintainer rule). In busy
+# texture (foliage, brick, gravel) compact bright glints are indistinguishable
+# from dust at this scale and healing them eats real detail; those areas are
+# the manual brush's job. A component is kept only when its surround ring's
+# luma std is below SMOOTH_MAX_STD (sky measures ~0.007-0.022, deep shadow
+# ~0.01-0.03, foliage/stucco 0.04+). detect() also uses a windowed-std map to
+# SKIP whole tiles with almost no smooth content — the main speed lever.
+SMOOTH_MAX_STD = 0.025  # max surround-ring luma std for a keepable spot
+SMOOTH_WIN = 15         # window (px) of the local-texture map for tile skipping
+SMOOTH_TILE_MIN = 0.02  # run a tile only if at least this fraction is smooth
 # Film dust inverts to BRIGHT/white specks, so a real dust blob is brighter than
 # its surroundings. The gate is NOISE-RELATIVE: dust sits off the focal plane,
 # so most real specks are soft-edged and faint — a fixed absolute lift missed
@@ -159,7 +174,15 @@ def _get_session():
         if not is_model_present():
             raise FileNotFoundError("Detector model not downloaded")
         import onnxruntime as ort  # late import
-        sess = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+        # Prefer a GPU provider when the installed onnxruntime offers one
+        # (e.g. onnxruntime-directml on Windows) — native-res tiled detection
+        # is compute-bound on CPU (~30 s/image). Plain `onnxruntime` only has
+        # CPU, so this is a no-op there; unsupported ops fall back per-node.
+        preferred = ("DmlExecutionProvider", "CUDAExecutionProvider",
+                     "CoreMLExecutionProvider", "CPUExecutionProvider")
+        avail = set(ort.get_available_providers())
+        providers = [p for p in preferred if p in avail] or ["CPUExecutionProvider"]
+        sess = ort.InferenceSession(path, providers=providers)
         _session = sess
         _session_path = path
         return sess
@@ -187,7 +210,7 @@ def _tile_starts(length: int, tile: int, step: int) -> list:
     return starts
 
 
-def detect(positive_rgb16: np.ndarray) -> tuple:
+def detect(positive_rgb16: np.ndarray, keep_mask=None) -> tuple:
     """Run the detector on a 16-bit RGB positive. Returns
     `(prob, luma)` — both float32 at detection resolution: the probability map
     (0..1) and the grayscale luma (0..1, used for the bright-speck gate in
@@ -197,7 +220,13 @@ def detect(positive_rgb16: np.ndarray) -> tuple:
     The net runs at the input's NATIVE resolution (capped at DETECT_MAX_LONG),
     TILED (DETECT_TILE, DETECT_OVERLAP overlap, max-stitched): soft off-focus
     dust — most real film dust — survives only near scan resolution; a fixed
-    512-short downscale erased it before the net ever saw it."""
+    512-short downscale erased it before the net ever saw it.
+
+    Speed: tiles with almost no SMOOTH content are skipped outright (detection
+    only keeps smooth-surround spots anyway — see SMOOTH_MAX_STD), and
+    `keep_mask` (bool/uint8 at the input's resolution, e.g. the confirmed
+    crop's footprint) additionally skips tiles wholly outside it — on a film
+    strip cropped to one frame most of the strip never hits the net."""
     sess = _get_session()
     name = sess.get_inputs()[0].name
     h, w = positive_rgb16.shape[:2]
@@ -206,12 +235,26 @@ def detect(positive_rgb16: np.ndarray) -> tuple:
     small_f = small.astype(np.float32) / 65535.0
     luma = (0.2126 * small_f[..., 0] + 0.7152 * small_f[..., 1]
             + 0.0722 * small_f[..., 2]).astype(np.float32)
+    # Where could a keepable spot even live? Smooth areas (windowed-std map;
+    # a speck inflates the map only in its own small neighborhood, a tiny
+    # fraction of any tile) intersected with the caller's keep_mask.
+    m1 = cv2.boxFilter(luma, -1, (SMOOTH_WIN, SMOOTH_WIN))
+    m2 = cv2.boxFilter(luma * luma, -1, (SMOOTH_WIN, SMOOTH_WIN))
+    eligible = np.sqrt(np.maximum(m2 - m1 * m1, 0.0)) < SMOOTH_MAX_STD
+    if keep_mask is not None:
+        km = np.asarray(keep_mask)
+        if km.shape[:2] != (dh, dw):
+            km = cv2.resize(km.astype(np.uint8), (dw, dh),
+                            interpolation=cv2.INTER_NEAREST)
+        eligible &= km.astype(bool)
     prob = np.zeros((dh, dw), np.float32)
     step = DETECT_TILE - DETECT_OVERLAP
     for y in _tile_starts(dh, DETECT_TILE, step):
         th = min(DETECT_TILE, dh)
         for x in _tile_starts(dw, DETECT_TILE, step):
             tw = min(DETECT_TILE, dw)
+            if float(eligible[y:y + th, x:x + tw].mean()) < SMOOTH_TILE_MIN:
+                continue  # no smooth (or in-crop) content — nothing keepable
             t = luma[y:y + th, x:x + tw]
             inp = (t * 2.0 - 1.0)[None, None, :, :].astype(np.float32)
             out = sess.run(None, {name: inp})[0]
@@ -240,6 +283,8 @@ def prob_to_spots(prob: np.ndarray, luma: np.ndarray, sensitivity: float,
     so higher sensitivity removes more. A surviving component must be:
       - small enough (not film border / real content),
       - compact (elongated lines are structure/scratches → manual brush),
+      - on a SMOOTH surround (sky / open shadow — in busy texture a bright
+        glint is indistinguishable from dust; manual brush territory),
       - BRIGHTER than its surroundings (film dust inverts to white specks; this
         rejects normal-toned content the detector wrongly fires on — e.g. a
         face). See spec/dust-removal.md §5.3.
@@ -281,18 +326,24 @@ def prob_to_spots(prob: np.ndarray, luma: np.ndarray, sensitivity: float,
         comp_luma = float(win_luma[win_comp].mean())
         surround = win_luma[~win_comp]
         surround_luma = float(surround.mean()) if surround.size else comp_luma
+        noise = float(surround.std()) if surround.size else 0.0
+        # Smooth-surround rule: auto-detection works sky/shadow ONLY. In busy
+        # texture a compact bright glint is indistinguishable from dust and
+        # healing it eats real detail — those areas are the manual brush's job.
+        if noise > SMOOTH_MAX_STD:
+            continue  # textured surround → never auto-heal here
         # Noise-relative bar (see BRIGHT_* above): soft off-focus dust is
         # faint in absolute terms but stands many grain-sigmas above a
-        # smooth surround; busy texture keeps the full absolute margin.
-        noise = float(surround.std()) if surround.size else 0.0
+        # smooth surround.
         need = min(BRIGHT_MARGIN, max(BRIGHT_FLOOR, BRIGHT_SNR * noise))
         if comp_luma - surround_luma < need:
             continue  # not a bright speck → not film dust
         cx, cy = centroids[i]
-        # Area-EQUIVALENT radius (+ small margin), NOT the bounding-box extent:
-        # a tight circle matches the speck so the inpaint stays invisible
-        # instead of leaving a big smudge over the surrounding pixels.
-        r_px = float(np.sqrt(area / np.pi)) + SPOT_PAD
+        # Area-EQUIVALENT radius, NOT the bounding-box extent (a bbox radius
+        # over-covered and smudged) — but scaled up by SPOT_SCALE (+ pad):
+        # the thresholded component is only the bright CORE of a soft speck,
+        # and an exact-fit circle left its faint skirt unhealed.
+        r_px = float(np.sqrt(area / np.pi)) * SPOT_SCALE + SPOT_PAD
         spots.append({
             "kind": kind,
             "pts": [[float(cx) / w, float(cy) / h]],

--- a/src/core/dust_detect.py
+++ b/src/core/dust_detect.py
@@ -34,10 +34,18 @@ MAX_ASPECT = 3.0        # drop elongated detections (thin LINES are usually real
                         # structure — a bike frame, the horizon — not dust)
 SPOT_PAD = 1.5          # px added to each detected spot's radius (inpaint margin)
 # Film dust inverts to BRIGHT/white specks, so a real dust blob is brighter than
-# its surroundings. Require at least this luma lift (0..1) over the surrounding
-# ring; this rejects normal-toned content the detector wrongly fires on (a face,
-# a dark feature) — those are not bright specks.
-BRIGHT_MARGIN = 0.06
+# its surroundings. The gate is NOISE-RELATIVE: dust sits off the focal plane,
+# so most real specks are soft-edged and faint — a fixed absolute lift missed
+# nearly all of them on smooth sky while their lift stood many grain-sigmas
+# above the surround. A blob passes when its luma lift (0..1) over the
+# surrounding ring exceeds min(BRIGHT_MARGIN, max(BRIGHT_FLOOR, BRIGHT_SNR·σ)),
+# σ = the ring's own luma std: sharp dust (≥ BRIGHT_MARGIN) always passes;
+# faint dust passes where the surround is smooth; on busy texture the bar
+# stays at the full absolute margin. Normal-toned/dark content (a face, a
+# dark feature) still fails — its lift is ~0 or negative.
+BRIGHT_MARGIN = 0.06    # absolute lift that always passes (sharp dust)
+BRIGHT_FLOOR = 0.02     # minimum lift for the noise-relative pass
+BRIGHT_SNR = 3.0        # ...or the lift must beat this many surround-sigmas
 BRIGHT_RING = 3         # px ring around a blob used as the "surround" reference
 
 _session = None          # cached ort.InferenceSession
@@ -239,7 +247,12 @@ def prob_to_spots(prob: np.ndarray, luma: np.ndarray, sensitivity: float,
         comp_luma = float(win_luma[win_comp].mean())
         surround = win_luma[~win_comp]
         surround_luma = float(surround.mean()) if surround.size else comp_luma
-        if comp_luma - surround_luma < BRIGHT_MARGIN:
+        # Noise-relative bar (see BRIGHT_* above): soft off-focus dust is
+        # faint in absolute terms but stands many grain-sigmas above a
+        # smooth surround; busy texture keeps the full absolute margin.
+        noise = float(surround.std()) if surround.size else 0.0
+        need = min(BRIGHT_MARGIN, max(BRIGHT_FLOOR, BRIGHT_SNR * noise))
+        if comp_luma - surround_luma < need:
             continue  # not a bright speck → not film dust
         cx, cy = centroids[i]
         # Area-EQUIVALENT radius (+ small margin), NOT the bounding-box extent:

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -64,7 +64,9 @@ class _DetectWorker(QObject):
             if source is None:
                 self.failed.emit("No image to detect on.")
                 return
-            prob, luma = dust_detect.detect(source)
+            keep = ImagePreview.dust_detect_keep_mask_for(
+                self.img, source.shape[0], source.shape[1])
+            prob, luma = dust_detect.detect(source, keep_mask=keep)
             self.done.emit((prob, luma))
         except Exception as e:  # noqa: BLE001 — surfaced to the user
             self.failed.emit(str(e))
@@ -101,7 +103,9 @@ class _DetectAllWorker(QObject):
                 if source is None:
                     self.progress.emit(processed, total)
                     continue
-                prob, luma = dust_detect.detect(source)
+                keep = ImagePreview.dust_detect_keep_mask_for(
+                    img, source.shape[0], source.shape[1])
+                prob, luma = dust_detect.detect(source, keep_mask=keep)
                 spots = dust_detect.prob_to_spots(prob, luma, self._sensitivity)
                 self.detected.emit(img, spots)
                 processed += 1

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -51,13 +51,20 @@ class _DetectWorker(QObject):
     done = Signal(object)   # (prob, luma) numpy arrays
     failed = Signal(str)
 
-    def __init__(self, source):
+    def __init__(self, img):
         super().__init__()
-        self.source = source
+        self.img = img
 
     def run(self):
         try:
-            prob, luma = dust_detect.detect(self.source)
+            # Built here, off the GUI thread: the source is a hi-res
+            # conversion replay (decode + convert takes seconds).
+            from widgets.image_preview import ImagePreview
+            source = ImagePreview.dust_detect_source_for(self.img)
+            if source is None:
+                self.failed.emit("No image to detect on.")
+                return
+            prob, luma = dust_detect.detect(source)
             self.done.emit((prob, luma))
         except Exception as e:  # noqa: BLE001 — surfaced to the user
             self.failed.emit(str(e))
@@ -418,17 +425,19 @@ class DustRemovalPanel(QWidget):
     def _on_detect(self):
         if self._detecting or self._detecting_all or self._downloading:
             return
-        source = self.image_preview.dust_detect_source()
-        if source is None:
+        img = self._current_image()
+        if img is None or getattr(img, "resized_raw", None) is None:
             self.status_label.setText("No image to detect on.")
             return
         self._detecting = True
-        self._detect_image_ref = self._current_image()
+        self._detect_image_ref = img
         self.detect_btn.setEnabled(False)
         self.detect_btn.setText("Detecting…")
-        self.status_label.setText("Running AI detection…")
+        self.status_label.setText(
+            "Running AI detection at high resolution — this can take a "
+            "minute…")
         self._detect_thread = QThread()
-        self._detect_worker = _DetectWorker(source)
+        self._detect_worker = _DetectWorker(img)
         self._detect_worker.moveToThread(self._detect_thread)
         self._detect_thread.started.connect(self._detect_worker.run)
         self._detect_worker.done.connect(self._on_detect_done)

--- a/src/widgets/dust_panel.py
+++ b/src/widgets/dust_panel.py
@@ -438,8 +438,8 @@ class DustRemovalPanel(QWidget):
         self.detect_btn.setEnabled(False)
         self.detect_btn.setText("Detecting…")
         self.status_label.setText(
-            "Running AI detection at high resolution — this can take a "
-            "minute…")
+            "Running AI detection at high resolution — seconds on GPU, "
+            "up to a minute on CPU…")
         self._detect_thread = QThread()
         self._detect_worker = _DetectWorker(img)
         self._detect_worker.moveToThread(self._detect_thread)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -2825,10 +2825,33 @@ class ImagePreview(QWidget):
         """The working positive the AI detector should run on for `img`, or None.
         Only the MANUAL (brush) spots are healed first — the 'auto' spots are
         about to be replaced, so healing them would hide the very dust we want to
-        re-detect (making a second Detect lose the first one's coverage)."""
-        raw = getattr(img, "resized_raw", None)
-        if img is None or raw is None:
+        re-detect (making a second Detect lose the first one's coverage).
+
+        Resolution: most real film dust sits off the focal plane — soft, faint
+        blobs a few scan-pixels wide that are ~1 px blips in the 1080 preview
+        buffer and simply not there for the net to find. The source is
+        therefore a HI-RES conversion replay (render_hires_base, same snapshot
+        the zoom view uses), downscaled to dust_detect.DETECT_MAX_LONG,
+        falling back to resized_raw when no replay is possible. Runs on the
+        detect worker threads (render_hires_base is worker-safe)."""
+        if img is None or getattr(img, "resized_raw", None) is None:
             return None
+        from core import dust_detect
+        raw = None
+        try:
+            raw = img.render_hires_base(
+                max_long_side=dust_detect.DETECT_MAX_LONG)
+        except Exception:
+            raw = None   # decode/replay failed — the preview buffer still works
+        if raw is None:
+            raw = img.resized_raw
+        h, w = raw.shape[:2]
+        if max(h, w) > dust_detect.DETECT_MAX_LONG:
+            import cv2
+            s = dust_detect.DETECT_MAX_LONG / float(max(h, w))
+            raw = cv2.resize(raw, (max(1, int(round(w * s))),
+                                   max(1, int(round(h * s)))),
+                             interpolation=cv2.INTER_AREA)
         brush = [s for s in getattr(img, "dust_spots", []) if s.get("kind") == "brush"]
         rect = getattr(img, "crop_rect", None)
         crop = ((tuple(rect), float(getattr(img, "crop_angle", 0.0) or 0.0))

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -2939,8 +2939,25 @@ class ImagePreview(QWidget):
             return 0
         new_auto_spots = self._auto_spots_in_crop(img, new_auto_spots or [])
         img.push_undo_state()
+        old_auto = [s for s in img.dust_spots if s.get("kind") == "auto"]
         img.dust_spots = [s for s in img.dust_spots if s.get("kind") != "auto"]
         img.dust_spots.extend(new_auto_spots)
+        # A re-detect is a NEW initial pick for the auto set (sampling rule):
+        # cached plan records under the replaced auto spots must not rebind
+        # to the fresh ones — a re-detected speck at the same coordinates is
+        # value-identical and would inherit the old source verbatim. User
+        # re-picks (manual=True) survive; brush strokes are untouched.
+        cached = getattr(img, "_dust_plan_cache", None)
+        raw = getattr(img, "resized_raw", None)
+        if cached is not None and old_auto and raw is not None:
+            from core.ccr_processor import rasterize_dust_mask
+            h, w = raw.shape[:2]
+            gm = rasterize_dust_mask(old_auto, h, w) > 0
+            img._dust_plan_cache = (cached[0], [
+                r for r in cached[1]
+                if (len(r) >= 6 and r[5])
+                or not gm[min(h - 1, max(0, int(round(r[0] * h)))),
+                          min(w - 1, max(0, int(round(r[1] * w))))]])
         cur = (ccr_backend.get_image_by_index(self.current_idx)
                if self.current_idx is not None else None)
         if img is cur:

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -2832,10 +2832,24 @@ class ImagePreview(QWidget):
         rect = getattr(img, "crop_rect", None)
         crop = ((tuple(rect), float(getattr(img, "crop_angle", 0.0) or 0.0))
                 if rect else None)
-        return apply_dust_removal(
+        healed = apply_dust_removal(
             raw, brush,
             feather=getattr(img, "dust_feather", DUST_FEATHER_DEFAULT),
             crop=crop)
+        # A windowed working-space base is in container codes — the whole image
+        # sits in the bottom ~1.5% of the 16-bit range, so the detector would
+        # see a black frame (and the bright-speck gate's absolute margin could
+        # never be cleared). De-window + window-clamp to the display-referred
+        # positive the user actually sees, same as the WB picker / AWB do
+        # (a no-op when the feature is off / base is full-range).
+        if getattr(img, "_ws_windowed", False):
+            from core.ccr_processor import WS_B, WS_W
+            d = healed.astype(np.float32)
+            d -= np.float32(WS_B)
+            d *= np.float32(1.0 / (WS_W - WS_B))
+            np.clip(d, 0.0, 1.0, out=d)
+            healed = (d * np.float32(65535.0)).astype(np.uint16)
+        return healed
 
     def dust_detect_source(self):
         """Detection source for the current image (see dust_detect_source_for)."""

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -2881,6 +2881,20 @@ class ImagePreview(QWidget):
         return self.dust_detect_source_for(img) if img is not None else None
 
     @staticmethod
+    def dust_detect_keep_mask_for(img, h: int, w: int):
+        """Confirmed-crop footprint as a uint8 {0,1} mask at (h, w) — the
+        detection source's resolution — or None without a crop. Passed to
+        dust_detect.detect so tiles wholly outside the crop are never
+        inferred (on a film strip cropped to one frame, most of the strip
+        skips the net); _auto_spots_in_crop stays the correctness filter."""
+        rect = getattr(img, "crop_rect", None)
+        if rect is None:
+            return None
+        return _crop_keep_mask(tuple(rect),
+                               float(getattr(img, "crop_angle", 0.0) or 0.0),
+                               h, w)
+
+    @staticmethod
     def _auto_spots_in_crop(img, spots):
         """Only auto-detected spots whose center lies inside the confirmed
         crop are kept. Content outside the crop (film rebate, holder, edge

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -10,7 +10,8 @@ from PySide6.QtGui import (QPixmap, QIcon, QTransform, QPen, QColor, QAction, QP
                            QImage)
 from PySide6.QtCore import Qt, QSize, Signal, QRect, QRectF, QPointF, QThread, QTimer, QUrl
 from core.ccr_backend import ccr_backend
-from core.ccr_processor import apply_dust_removal, DUST_FEATHER_DEFAULT
+from core.ccr_processor import (apply_dust_removal, DUST_FEATHER_DEFAULT,
+                                _crop_keep_mask)
 from core import crop_aspect
 from widgets.dust_panel import DUST_BRUSH_R_MIN, DUST_BRUSH_R_MAX
 from widgets.export_dialog import ExportSettingsDialog
@@ -2856,6 +2857,34 @@ class ImagePreview(QWidget):
         img = ccr_backend.get_image_by_index(self.current_idx)
         return self.dust_detect_source_for(img) if img is not None else None
 
+    @staticmethod
+    def _auto_spots_in_crop(img, spots):
+        """Only auto-detected spots whose center lies inside the confirmed
+        crop are kept. Content outside the crop (film rebate, holder, edge
+        printing) is not scene — it is cropped away on screen and in exports,
+        and its bright markings (frame numbers, sprocket edges) read as dust
+        to the detector. Same rasterized geometry as the display crop and the
+        heal's context mask (_crop_keep_mask). No crop → whole frame kept.
+        Manual brush spots are never filtered — the user painted them."""
+        rect = getattr(img, "crop_rect", None)
+        raw = getattr(img, "resized_raw", None)
+        if not spots or rect is None or raw is None:
+            return spots
+        h, w = raw.shape[:2]
+        keep = _crop_keep_mask(tuple(rect),
+                               float(getattr(img, "crop_angle", 0.0) or 0.0),
+                               h, w)
+        if keep is None:
+            return spots
+        kept = []
+        for s in spots:
+            x, y = s["pts"][0]
+            px = min(w - 1, max(0, int(round(float(x) * w))))
+            py = min(h - 1, max(0, int(round(float(y) * h))))
+            if keep[py, px]:
+                kept.append(s)
+        return kept
+
     def apply_detected_spots(self, new_auto_spots) -> int:
         """Replace the AI-detected ('auto') spots with a fresh set; manual
         ('brush') spots are kept. Returns the new auto-spot count."""
@@ -2871,9 +2900,10 @@ class ImagePreview(QWidget):
         # the user removed or replaced (new Open) must not mutate an orphan.
         if img is None or img not in ccr_backend.images:
             return 0
+        new_auto_spots = self._auto_spots_in_crop(img, new_auto_spots or [])
         img.push_undo_state()
         img.dust_spots = [s for s in img.dust_spots if s.get("kind") != "auto"]
-        img.dust_spots.extend(new_auto_spots or [])
+        img.dust_spots.extend(new_auto_spots)
         cur = (ccr_backend.get_image_by_index(self.current_idx)
                if self.current_idx is not None else None)
         if img is cur:

--- a/tests/test_dust_crop_display.py
+++ b/tests/test_dust_crop_display.py
@@ -139,7 +139,13 @@ class TestHealSourceOverlay:
 
 
 class TestRightButtonStrokeEditing:
-    def test_right_drag_moves_stroke_and_keeps_absolute_source(self, tmp_path):
+    def test_right_drag_moves_stroke_and_repicks_touching(self, tmp_path):
+        # THE SAMPLING RULE retroacts on automatic pins: a moved stroke's
+        # AUTOMATIC source used to travel absolutely (offset compensated),
+        # which leaves it far from the stroke's new position — a non-touching
+        # automatic sample, which the rule forbids. After a move the segment
+        # re-picks a TOUCHING sample at its new location; only a USER re-pick
+        # (manual=True, see the repick test below) travels absolutely.
         ip, img = _converted_preview(tmp_path, crop_rect=None)
         ip.enter_dust_mode()
         ip._maybe_request_hires = lambda: None   # keep the test in-thread
@@ -147,7 +153,6 @@ class TestRightButtonStrokeEditing:
         img.update_thumbnail_and_preview()
         (cy, cx, off, *_), = img._dust_plan_cache[1]
         assert off is not None
-        abs_src = (cy + off[0], cx + off[1])
         ip.set_dust_source_overlay(True)
         # Right-drag the stroke 60 px right (no crop: scene == full coords).
         ip.dust_right_press(QPointF(300, 200))
@@ -155,12 +160,13 @@ class TestRightButtonStrokeEditing:
         ip.dust_right_move(QPointF(360, 200))
         ip.dust_right_release()
         assert img.dust_spots[0]["pts"][0] == pytest.approx([0.6, 0.5])
-        # The re-heal bound the translated record: the segment moved but its
-        # ABSOLUTE source position did not (the offset compensated).
+        # The moved stroke's automatic sample TOUCHES it at the new place.
         (cy2, cx2, off2, *_), = img._dust_plan_cache[1]
         assert cx2 == pytest.approx(0.6, abs=0.01)
-        assert (cy2 + off2[0], cx2 + off2[1]) == pytest.approx(abs_src,
-                                                               abs=0.01)
+        assert off2 is not None
+        h, w = img.resized_raw.shape[:2]
+        r_px = 0.03 * w
+        assert float(np.hypot(off2[0] * h, off2[1] * w)) <= 2 * r_px + 8
         # The drag is one undo step back to the pre-drag stroke.
         assert img.pop_undo_state()
         assert img.dust_spots[0]["pts"][0] == pytest.approx([0.5, 0.5])

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -662,6 +662,32 @@ class TestProbToSpots:
         assert dust_detect.prob_to_spots(prob, busy, 60) == []
 
 
+# --- Source tone locality ------------------------------------------------------
+class TestSourceMatchesLocalTone:
+    def test_edge_spot_source_stays_on_its_own_tone_side(self):
+        # The reported case: a speck right beside a high-contrast edge
+        # sampled flat DIRT from across the frame — near candidates straddle
+        # the edge at imperfect phase, so their per-pixel SSD outweighed the
+        # remote patch's wholesale tone mismatch. Area tone (chroma +
+        # brightness) now dominates the score and locality is strong: the
+        # pick must stay in the immediate area, on the spot's own tone side.
+        rng = np.random.default_rng(17)
+        img = np.zeros((300, 300, 3), np.float32)
+        img[:, :140] = [26000, 22000, 18000]        # brown dirt field
+        img[:, 140:] = [48000, 47000, 45000]        # light pavement
+        img[:, 137:143] = [61000, 61000, 61000]     # bright edge stripe
+        img += rng.normal(0, 1200, img.shape)
+        img = np.clip(img, 0, 65535).astype(np.uint16)
+        spot = {"kind": "auto", "pts": [[0.55, 0.5]], "r": 0.025}  # pavement
+        plan = []
+        apply_dust_removal(img, [spot], collect_plan=plan)
+        (cy, cx, off, *_), = plan
+        assert off is not None
+        dy, dx = off
+        assert float(np.hypot(dy * 300, dx * 300)) < 70   # immediate area
+        assert (cx + dx) * 300 > 143   # never the dirt across the edge
+
+
 # --- Source search in dust clusters ------------------------------------------
 class TestClusterSourceStaysNear:
     def test_cluster_of_specks_still_samples_nearby(self):

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -318,6 +318,9 @@ class TestApplyDustRemoval:
         # plan seeds every re-heal and matching segments reuse its offset
         # VERBATIM (no re-scoring). Proof by tampering: a shifted-but-clean
         # prior offset must drive the heal and be carried into the new plan.
+        # (The tamper stays within the rule's ±4 px touching tolerance — an
+        # AUTOMATIC pin shifted beyond touching is a fossil and re-picks,
+        # see test_fossil_automatic_pins_repick_under_the_rule.)
         rng = np.random.default_rng(17)
         img = np.clip(rng.normal(30000, 3000, (400, 400, 3)), 0,
                       65535).astype(np.uint16)
@@ -326,7 +329,7 @@ class TestApplyDustRemoval:
         apply_dust_removal(img, [spot], collect_plan=plan1)
         (cy, cx, off, g, d, *_), = plan1
         assert off is not None
-        tampered = [(cy, cx, (off[0], off[1] + 20.0 / 400.0), g, d)]
+        tampered = [(cy, cx, (off[0], off[1] + 3.0 / 400.0), g, d)]
         plan2 = []
         apply_dust_removal(img, [spot], collect_plan=plan2,
                            prior_plan=tampered)
@@ -763,6 +766,30 @@ class TestStalePlanPruning:
         # Fresh TOUCHING pick, not the resurrected 156 px fossil.
         assert float(np.hypot(off[0] * 400, off[1] * 400)) <= 2 * 12 + 8
 
+    def test_fossil_automatic_pins_repick_under_the_rule(self):
+        # Fossil offsets propagate through GENERATIONS of sticky plans (each
+        # re-detect rebound the old offset into a fresh, validly-keyed plan
+        # for as long as the pre-rule search existed) — no spot bookkeeping
+        # can identify them. The rule retroacts instead: an AUTOMATIC pin
+        # whose sample no longer touches its patch is dropped and re-picked;
+        # a USER re-pick keeps any distance (explicit choice).
+        rng = np.random.default_rng(6)
+        img16 = np.clip(rng.normal(30000, 2000, (400, 400, 3)), 0,
+                        65535).astype(np.uint16)
+        spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.03}
+        far = (120.0 / 400, 100.0 / 400)
+        plan = []
+        apply_dust_removal(img16, [spot], collect_plan=plan,
+                           prior_plan=[(0.5, 0.5, far, False, False, False)])
+        (cy, cx, off, *_), = plan
+        assert off is not None
+        assert float(np.hypot(off[0] * 400, off[1] * 400)) <= 2 * 12 + 8
+        plan2 = []
+        apply_dust_removal(img16, [spot], collect_plan=plan2,
+                           prior_plan=[(0.5, 0.5, far, False, False, True)])
+        (cy, cx, off2, *_), = plan2
+        assert off2 == far   # the user's own pick is never second-guessed
+
     def test_surviving_spots_keep_their_pinned_sources(self):
         # The stickiness the pruning must NOT break: a spot that still
         # exists keeps its planned source verbatim across a re-heal.
@@ -771,7 +798,7 @@ class TestStalePlanPruning:
                         65535).astype(np.uint16)
         holder = CCRImage.__new__(CCRImage)
         keep = {"kind": "brush", "pts": [[0.3, 0.3]], "r": 0.03}
-        pinned = (30.0 / 400, 0.0)
+        pinned = (25.0 / 400, 0.0)   # a touching offset (hole r = 12 px)
         holder._dust_plan_cache = ("k", [(0.3, 0.3, pinned,
                                           False, False, False)])
         holder._dust_plan_spots = [keep]

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -731,6 +731,60 @@ class TestAutoSamplingRule:
         assert float(np.hypot(off[0] * 200, off[1] * 200)) <= 2 * 8 + 8
 
 
+# --- Stale plan records must never seed new spots ------------------------------
+class TestStalePlanPruning:
+    def test_deleted_spots_records_never_seed_new_spots(self):
+        # THE field bug that made the touch rule look broken: catalog plans
+        # saved by OLDER code hold far offsets, the plan cache deliberately
+        # outlives spot edits (sticky sources), and a spot repainted or
+        # re-detected at a dead record's position rebound the old offset
+        # VERBATIM — the sampling rule never ran for the new spot. Records
+        # of spots that no longer exist are pruned before the cache seeds a
+        # re-heal.
+        rng = np.random.default_rng(2)
+        img16 = np.clip(rng.normal(30000, 2000, (400, 400, 3)), 0,
+                        65535).astype(np.uint16)
+        holder = CCRImage.__new__(CCRImage)
+        old_spot = {"kind": "auto", "pts": [[0.5, 0.5]], "r": 0.03}
+        holder._dust_plan_cache = (
+            "stale", [(0.5, 0.5, (120.0 / 400, 100.0 / 400),
+                       False, False, False)])       # 156 px fossil offset
+        holder._dust_plan_spots = [old_spot]
+        # The user cleared/deleted and repainted at (almost) the same place.
+        holder.dust_spots = [{"kind": "brush",
+                              "pts": [[0.501, 0.499]], "r": 0.03}]
+        holder.dust_feather = 0.25
+        holder.crop_rect = None
+        holder.crop_angle = 0.0
+        holder._apply_dust_removal(img16)
+        key, plan = holder._dust_plan_cache
+        (cy, cx, off, *_), = plan
+        assert off is not None
+        # Fresh TOUCHING pick, not the resurrected 156 px fossil.
+        assert float(np.hypot(off[0] * 400, off[1] * 400)) <= 2 * 12 + 8
+
+    def test_surviving_spots_keep_their_pinned_sources(self):
+        # The stickiness the pruning must NOT break: a spot that still
+        # exists keeps its planned source verbatim across a re-heal.
+        rng = np.random.default_rng(4)
+        img16 = np.clip(rng.normal(30000, 2000, (400, 400, 3)), 0,
+                        65535).astype(np.uint16)
+        holder = CCRImage.__new__(CCRImage)
+        keep = {"kind": "brush", "pts": [[0.3, 0.3]], "r": 0.03}
+        pinned = (30.0 / 400, 0.0)
+        holder._dust_plan_cache = ("k", [(0.3, 0.3, pinned,
+                                          False, False, False)])
+        holder._dust_plan_spots = [keep]
+        holder.dust_spots = [keep]
+        holder.dust_feather = 0.25
+        holder.crop_rect = None
+        holder.crop_angle = 0.0
+        holder._apply_dust_removal(img16)
+        key, plan = holder._dust_plan_cache
+        (cy, cx, off, *_), = plan
+        assert off == pinned
+
+
 # --- Source tone locality ------------------------------------------------------
 class TestSourceMatchesLocalTone:
     def test_edge_spot_source_stays_on_its_own_tone_side(self):

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -454,13 +454,13 @@ class TestApplyDustRemoval:
         assert abs(float(healed.mean()) - 30000) < 3000
         assert float(healed.max()) < 50000
 
-    def test_stroke_on_prior_source_merges_and_heals_clean(self):
-        # A TOUCHING source sits directly beside its patch (the sampling
-        # rule), so a stroke painted over the source area merges with the
-        # original patch into ONE connected component — the union re-heals
-        # as a single bigger patch from ITS touching border. What must hold:
-        # the new defect is never cloned into any fill, and the merged
-        # region heals to the background.
+    def test_stroke_on_prior_source_stays_separate_and_heals_clean(self):
+        # MAINTAINER RULE: two strokes are NEVER auto-connected — even when
+        # one is painted right on the other's touching source, each patch
+        # keeps its own segments and samples separately. The first stroke's
+        # pinned source now sits under the new stroke's dust, so it defers
+        # and clones the HEALED content at the same touching offset; the new
+        # stroke argmins its own touching sample. No dust is ever cloned.
         rng = np.random.default_rng(23)
         img = np.clip(rng.normal(30000, 2500, (400, 400, 3)), 0,
                       65535).astype(np.uint16)
@@ -472,7 +472,7 @@ class TestApplyDustRemoval:
         # Touching: the chosen source borders the patch.
         assert float(np.hypot(off[0] * 400, off[1] * 400)) <= 2 * 12 + 4
         # A bright defect appears at the chosen source and the user paints
-        # over it — the two patches now form one merged region.
+        # over it.
         sy, sx = cy + off[0], cx + off[1]
         img2 = img.copy()
         cv2.circle(img2, (int(sx * 400), int(sy * 400)), 5,
@@ -481,12 +481,33 @@ class TestApplyDustRemoval:
         plan2 = []
         out = apply_dust_removal(img2, [spot, b], collect_plan=plan2,
                                  prior_plan=plan1)
-        assert plan2
-        # No dust cloned anywhere in the merged fill; background restored.
+        # Two separate patches -> (at least) two records, one per stroke.
+        assert len(plan2) >= 2
+        # No dust cloned anywhere; background restored in both fills.
         m = rasterize_dust_mask([spot, b], 400, 400) > 0
         healed = out[m].astype(np.float32)
         assert float(healed.mean()) < 40000
         assert float(healed.max()) < 55000
+
+    def test_touching_strokes_sample_separately(self):
+        # MAINTAINER RULE, verbatim: "do not auto connect 2 strokes — sample
+        # separately." Two overlapping dabs must remain two patches, each
+        # with its own record and its own TOUCHING sample; the union used to
+        # merge into one component healed as a single bigger patch.
+        rng = np.random.default_rng(12)
+        img = np.clip(rng.normal(30000, 2000, (300, 300, 3)), 0,
+                      65535).astype(np.uint16)
+        a = {"kind": "brush", "pts": [[0.45, 0.5]], "r": 0.03}   # r = 9 px
+        b = {"kind": "brush", "pts": [[0.50, 0.5]], "r": 0.03}   # overlaps a
+        plan = []
+        apply_dust_removal(img, [a, b], collect_plan=plan)
+        assert len(plan) == 2                    # one record per stroke
+        for (cy, cx, off, *_), s in zip(plan, (a, b)):
+            assert off is not None
+            # Each record's segment lies on its own stroke...
+            assert abs(cx - s["pts"][0][0]) < 0.03
+            # ...and each sample touches ITS patch.
+            assert float(np.hypot(off[0] * 300, off[1] * 300)) <= 2 * 9 + 8
 
     def test_new_stroke_keeps_far_samples_stable(self):
         # Adding a dab must only re-sample segments near the edit. In the

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -564,14 +564,17 @@ class TestProbToSpots:
         assert x > 0.5 and y > 0.5  # the compact speck, not the line
 
     def test_radius_is_area_equivalent_not_extent(self):
-        # A 6x6 compact blob -> radius ~ sqrt(36/pi) ~ 3.4 px (+pad), NOT the
-        # 0.5*extent=3 of the old bounding-box sizing blown up by elongation.
+        # A 6x6 compact blob -> radius ~ sqrt(36/pi)*SPOT_SCALE (+pad), NOT
+        # the old bounding-box sizing blown up by elongation. The scale covers
+        # a soft speck's faint skirt; the area base keeps it from smudging.
         prob = np.zeros((200, 200), np.float32)
         prob[100:106, 100:106] = 0.9
         spots = dust_detect.prob_to_spots(prob, _bright_luma(prob), 60)
         assert len(spots) == 1
         r_px = spots[0]["r"] * 200
-        assert 3.0 < r_px < 7.0     # tight circle, no big smudge
+        expected = np.sqrt(36 / np.pi) * dust_detect.SPOT_SCALE + dust_detect.SPOT_PAD
+        assert abs(r_px - expected) < 0.5
+        assert r_px < 2.0 * 6.0     # still circle-sized, no big smudge
 
     def test_bright_gate_drops_dark_blob(self):
         # Film dust inverts to WHITE specks. A compact, right-sized blob that is

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -662,6 +662,55 @@ class TestProbToSpots:
         assert dust_detect.prob_to_spots(prob, busy, 60) == []
 
 
+# --- AUTO sampling rule: touch + HSV/texture argmin ---------------------------
+class TestAutoSamplingRule:
+    """Maintainer rule, verbatim: (1) the auto sample area MUST TOUCH the
+    patch area; (2) it samples the touching candidate with the lowest
+    combined delta-hue/delta-sat/delta-V vs the patch's own background plus
+    the lowest texture; (3) again — the areas must touch. Total selection:
+    always an answer, no distance escalation."""
+
+    def test_white_speck_on_light_wall_beside_shadow_band(self):
+        # THE reported case: white dust on the light wall right above a dark
+        # shadow band. The old ring machinery stripped the light context as
+        # "defect leak" and anchored on the band — sampling dark shadow from
+        # far away. The rule: sample must touch and match the LIGHT wall.
+        rng = np.random.default_rng(5)
+        H_, W_ = 220, 270
+        img = np.zeros((H_, W_, 3), np.float32)
+        img[:, :] = [52000, 51000, 49000]        # light wall
+        img[95:160, :] = [17000, 17000, 18000]   # dark shadow band
+        img[160:, :] = [46000, 45000, 43000]
+        img += rng.normal(0, 1200, img.shape)
+        img = np.clip(img, 0, 65535).astype(np.uint16)
+        cv2.line(img, (96, 122), (114, 104), (58000,) * 3, 3,
+                 lineType=cv2.LINE_AA)                   # nearby white streak
+        cv2.circle(img, (123, 88), 3, (62000,) * 3, -1,
+                   lineType=cv2.LINE_AA)                 # the white speck
+        spot = {"kind": "auto", "pts": [[123 / W_, 88 / H_]], "r": 9.0 / W_}
+        plan = []
+        out = apply_dust_removal(img, [spot], collect_plan=plan)
+        (cy, cx, off, *_), = plan
+        assert off is not None
+        dy, dx = off
+        # (1)+(3) touching: offset ~ 2·half_th + a few px of mask dilation.
+        assert float(np.hypot(dy * H_, dx * W_)) <= 2 * 9 + 8
+        # (2) the fill is LIGHT WALL, not shadow.
+        m = rasterize_dust_mask([spot], H_, W_) > 0
+        assert float(out[m].astype(np.float32).mean()) > 40000
+
+    def test_isolated_speck_samples_touching(self):
+        rng = np.random.default_rng(8)
+        img = np.clip(rng.normal(30000, 2000, (200, 200, 3)), 0,
+                      65535).astype(np.uint16)
+        spot = {"kind": "auto", "pts": [[0.5, 0.5]], "r": 0.04}  # r = 8 px
+        plan = []
+        apply_dust_removal(img, [spot], collect_plan=plan)
+        (cy, cx, off, *_), = plan
+        assert off is not None
+        assert float(np.hypot(off[0] * 200, off[1] * 200)) <= 2 * 8 + 8
+
+
 # --- Source tone locality ------------------------------------------------------
 class TestSourceMatchesLocalTone:
     def test_edge_spot_source_stays_on_its_own_tone_side(self):

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -408,8 +408,12 @@ class TestApplyDustRemoval:
 
     def test_sources_stay_inside_the_crop(self):
         # Content outside the confirmed crop (film holder, rebate, junk the
-        # user cut away) is not scene: fresh searches must never sample it,
-        # and the context ring must not anchor on it.
+        # user cut away) is not scene: the pixels a heal READS must never
+        # come from it. The source WINDOW may overlap it with its unused
+        # corners (pixels-actually-read semantics — same rule that keeps
+        # sources near inside dust clusters), but the fill projection stays
+        # in-crop and matching/tone anchor only on the ring's clean subset,
+        # so none of the junk's brightness can reach the output.
         rng = np.random.default_rng(29)
         img = np.clip(rng.normal(30000, 2500, (400, 400, 3)), 0,
                       65535).astype(np.uint16)
@@ -419,14 +423,16 @@ class TestApplyDustRemoval:
         plan = []
         out = apply_dust_removal(img, [spot], collect_plan=plan, crop=crop)
         assert plan
-        # Every sampled window lies inside the crop: source-window center +
-        # its half extent (hole r 12 + guard/ring pad 15 = 27 px) fits.
+        # Every FILL projection lies inside the crop (hole r 12 px).
         for cy, cx, off, *_ in plan:
             if off is not None:
-                assert (cx + off[1]) * 400 + 27 <= 260 + 1e-6
-        # The fill is sky, not the junk strip.
+                assert (cx + off[1]) * 400 + 12 <= 260 + 1e-6
+        # The fill is sky, not the junk strip — tone anchored on the clean
+        # ring subset, junk excluded from the membrane.
         m = rasterize_dust_mask([spot], 400, 400) > 0
-        assert float(out[m].astype(np.float32).mean()) < 40000
+        healed = out[m].astype(np.float32)
+        assert abs(float(healed.mean()) - 30000) < 3000
+        assert float(healed.max()) < 50000
 
     def test_stroke_on_prior_source_keeps_reference_samples_healed(self):
         # NO exceptions: even a stroke painted directly ON a segment's
@@ -654,6 +660,38 @@ class TestProbToSpots:
         busy = np.clip(rng.normal(0.4, 0.06, (200, 200)), 0, 1).astype(np.float32)
         busy[40:46, 40:46] = 0.95              # huge lift — still rejected
         assert dust_detect.prob_to_spots(prob, busy, 60) == []
+
+
+# --- Source search in dust clusters ------------------------------------------
+class TestClusterSourceStaysNear:
+    def test_cluster_of_specks_still_samples_nearby(self):
+        # A dusty sky: neighboring specks surround the healed one, so NO fully
+        # clean window exists on the near rings. The old all-or-nothing source
+        # check leapt to the far rings for every speck in the cluster; the
+        # pixels a heal actually READS are only the hole projection + ring, so
+        # windows whose unused corners touch a neighbor stay valid and the
+        # source stays in the immediate area.
+        rng = np.random.default_rng(3)
+        img = np.clip(rng.normal(30000, 2000, (240, 240, 3)), 0,
+                      65535).astype(np.uint16)
+        spots = [{"kind": "auto", "pts": [[0.5, 0.5]], "r": 0.03}]
+        for k in range(10):
+            a = 2 * np.pi * k / 10
+            spots.append({"kind": "auto",
+                          "pts": [[0.5 + 0.18 * np.cos(a),
+                                   0.5 + 0.18 * np.sin(a)]],
+                          "r": 0.02})
+        plan = []
+        out = apply_dust_removal(img, spots, collect_plan=plan)
+        rec = min(plan, key=lambda r: (r[0] - 0.5) ** 2 + (r[1] - 0.5) ** 2)
+        assert rec[2] is not None            # sampled, not diffusion fallback
+        dy, dx = rec[2]
+        dist = float(np.hypot(dy * 240, dx * 240))
+        assert dist < 45                     # immediate area, not a far ring
+        # And the fill still lands on the surround's tone (a partial source
+        # ring anchors the membrane on its clean subset only).
+        core = out[114:126, 114:126].astype(np.float32)
+        assert abs(float(core.mean()) - 30000) < 4000
 
 
 # --- Tiled inference grid (pure) ---------------------------------------------

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -1071,5 +1071,48 @@ class TestDetectSourceDewindow:
         assert np.array_equal(src, base)
 
 
+# --- AI detection scope: only inside the confirmed crop ----------------------
+class TestAutoSpotsCropScope:
+    """AI 'auto' spots are scene fixes: a detection whose center lies outside
+    the confirmed crop (film rebate, holder, edge printing) is dropped before
+    it is stored — that content is cropped away on screen and in exports, and
+    the rebate's bright markings read as dust to the detector."""
+
+    @staticmethod
+    def _img(crop_rect=None, crop_angle=0.0):
+        img = CCRImage.__new__(CCRImage)
+        img.resized_raw = np.zeros((100, 200, 3), np.uint16)
+        img.crop_rect = crop_rect
+        img.crop_angle = crop_angle
+        return img
+
+    @staticmethod
+    def _spot(x, y):
+        return {"kind": "auto", "pts": [[x, y]], "r": 0.01}
+
+    def test_no_crop_keeps_everything(self):
+        from widgets.image_preview import ImagePreview
+        spots = [self._spot(0.05, 0.05), self._spot(0.95, 0.95)]
+        assert ImagePreview._auto_spots_in_crop(self._img(), spots) == spots
+
+    def test_outside_crop_spots_are_dropped(self):
+        from widgets.image_preview import ImagePreview
+        img = self._img(crop_rect=(0.25, 0.25, 0.75, 0.75))
+        spots = [self._spot(0.5, 0.5),    # inside
+                 self._spot(0.05, 0.5),   # left of the crop (rebate)
+                 self._spot(0.5, 0.9)]    # below the crop
+        assert ImagePreview._auto_spots_in_crop(img, spots) == [spots[0]]
+
+    def test_rotated_crop_uses_the_rotated_footprint(self):
+        from widgets.image_preview import ImagePreview
+        # 200x100 frame, square 60x60 px crop at the center, rotated 45°:
+        # the un-rotated box corner falls OUTSIDE the rotated footprint.
+        img = self._img(crop_rect=(0.35, 0.20, 0.65, 0.80), crop_angle=45.0)
+        center = self._spot(0.5, 0.5)
+        corner = self._spot(0.36, 0.22)
+        kept = ImagePreview._auto_spots_in_crop(img, [center, corner])
+        assert kept == [center]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -604,6 +604,18 @@ class TestProbToSpots:
         busy[40:46, 40:46] += 0.03
         assert dust_detect.prob_to_spots(prob, busy, 60) == []
 
+    def test_texture_rule_rejects_even_sharp_glints(self):
+        # Auto-detection is sky/shadow ONLY (maintainer rule): in busy texture
+        # a compact bright glint is indistinguishable from dust and healing it
+        # eats real detail, so even a SHARP, high-lift blob is rejected when
+        # its surround ring is textured. Manual brush territory.
+        rng = np.random.default_rng(9)
+        prob = np.zeros((200, 200), np.float32)
+        prob[40:46, 40:46] = 0.9
+        busy = np.clip(rng.normal(0.4, 0.06, (200, 200)), 0, 1).astype(np.float32)
+        busy[40:46, 40:46] = 0.95              # huge lift — still rejected
+        assert dust_detect.prob_to_spots(prob, busy, 60) == []
+
 
 # --- Tiled inference grid (pure) ---------------------------------------------
 class TestTileStarts:

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -605,6 +605,21 @@ class TestProbToSpots:
         assert dust_detect.prob_to_spots(prob, busy, 60) == []
 
 
+# --- Tiled inference grid (pure) ---------------------------------------------
+class TestTileStarts:
+    def test_short_dim_is_one_tile(self):
+        assert dust_detect._tile_starts(512, 768, 704) == [0]
+        assert dust_detect._tile_starts(768, 768, 704) == [0]
+
+    def test_covers_to_the_end_without_remainder_tile(self):
+        starts = dust_detect._tile_starts(2000, 768, 704)
+        assert starts[0] == 0
+        assert starts[-1] == 2000 - 768        # flush with the end
+        # Full coverage: consecutive windows overlap (no gaps).
+        for a, b in zip(starts, starts[1:]):
+            assert b < a + 768
+
+
 # --- Availability / graceful degradation ------------------------------------
 class TestAvailability:
     def test_unavailable_when_onnxruntime_absent(self, monkeypatch):

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -588,6 +588,22 @@ class TestProbToSpots:
         bright[40:46, 40:46] = 0.9               # bright blob (real dust)
         assert len(dust_detect.prob_to_spots(prob, bright, 60)) == 1
 
+    def test_soft_dust_passes_on_smooth_surround_only(self):
+        # Dust sits off the focal plane, so real specks are soft and FAINT: a
+        # +0.03 lift is many grain-sigmas above smooth sky (kept) but lost in
+        # the texture of a busy surround (rejected). The bright gate is
+        # noise-relative — a fixed absolute margin missed nearly every soft
+        # speck on smooth sky (the example_raw dusty-sky case).
+        rng = np.random.default_rng(5)
+        prob = np.zeros((200, 200), np.float32)
+        prob[40:46, 40:46] = 0.9
+        smooth = np.clip(rng.normal(0.75, 0.005, (200, 200)), 0, 1).astype(np.float32)
+        smooth[40:46, 40:46] += 0.03
+        assert len(dust_detect.prob_to_spots(prob, smooth, 60)) == 1
+        busy = np.clip(rng.normal(0.75, 0.04, (200, 200)), 0, 1).astype(np.float32)
+        busy[40:46, 40:46] += 0.03
+        assert dust_detect.prob_to_spots(prob, busy, 60) == []
+
 
 # --- Availability / graceful degradation ------------------------------------
 class TestAvailability:

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -140,25 +140,37 @@ class TestApplyDustRemoval:
         out = apply_dust_removal(img, [spot])
         assert int(out[50, 50, 0]) < 45000  # moved toward the surround
 
-    def test_traced_hair_leaves_no_bright_ghost(self):
-        # THE reported artifact: tracing a bright warm hair with a brush about
-        # its own width left a yellow-green ghost of the whole stroke. The
-        # hair's edges leak past the mask; without the guard gap + robust ring
-        # rejection they poisoned the tone correction (R/G lifted, B dropped)
-        # across the entire stroke — and the bbox-diagonal source-search
-        # minimum forced long strokes into the diffusion fallback, which
-        # ghosts the same way.
+    def test_manual_stroke_samples_touching_area(self):
+        # AUTOMATIC SAMPLING RULE (maintainer): every automatically picked
+        # initial sample — painted strokes included — must TOUCH the patch.
+        # Consequence, accepted with the rule: a brush narrower than the
+        # defect it traces samples the defect's own continuation (the only
+        # thing touching it) — the brush must COVER a defect to remove it.
+        # This test pins the touch contract; the old version asserted the
+        # ring-rejection machinery healed a tight hair trace to sky, which
+        # sampled from far away and is superseded by the rule.
         sky = np.array([20000, 25000, 40000], np.float32)
         img = np.broadcast_to(sky.astype(np.uint16), (200, 200, 3)).copy()
-        # A "hair" much wider than the brush: bright/warm vs the blue sky.
         cv2.line(img, (30, 100), (170, 100), (62000, 60000, 30000), 13)
-        # Brush stroke tracing the hair core, narrower than the hair.
         spot = {"kind": "brush",
                 "pts": [[0.2, 0.5], [0.5, 0.5], [0.8, 0.5]], "r": 2.0 / 200}
-        out = apply_dust_removal(img, [spot])
+        plan = []
+        apply_dust_removal(img, [spot], collect_plan=plan)
+        assert plan
+        for cy, cx, off, *_ in plan:
+            if off is None:
+                continue
+            # Touching: segment thickness is the 2 px brush → offsets sit at
+            # ~2·half_th (+raster slack), never out on the old search rings.
+            assert float(np.hypot(off[0] * 200, off[1] * 200)) <= 12.0
+        # And a stroke that COVERS the hair heals it to sky from the
+        # touching sky on either side.
+        wide = {"kind": "brush",
+                "pts": [[0.2, 0.5], [0.5, 0.5], [0.8, 0.5]], "r": 9.0 / 200}
+        out = apply_dust_removal(img, [wide])
         core = out[99:102, 60:140].astype(np.float32).reshape(-1, 3)
         err = np.abs(core.mean(axis=0) - sky)
-        assert float(err.max()) < 5000   # fill stays sky-toned along the stroke
+        assert float(err.max()) < 6000   # covered defect heals to sky
 
     def test_feather_alpha_ramps_inward(self):
         # The fill blends over a smooth inward ramp: ~0 at the hole boundary,
@@ -363,23 +375,28 @@ class TestApplyDustRemoval:
         dist = float(np.hypot(off[0] * 400, off[1] * 400))
         assert dist <= 1.6 * 41
 
-    def test_stripes_pattern_heals_phase_aligned(self):
-        # On patterned content the match must pick a phase-aligned patch —
-        # the healed hole continues the stripes, not a misphased smear (and
-        # the early-accept must NOT trip on a misphased near candidate: the
-        # grain floor is estimated from the detrended residual, not the
-        # ring's structure).
+    def test_stripes_defect_removed_from_touching_sample(self):
+        # AUTOMATIC SAMPLING RULE: the sample must touch the patch and is
+        # chosen by hue/sat/value + texture — the rule has NO pattern-phase
+        # term, so on striped content the fill may land phase-shifted (the
+        # user's re-pick drag is the tool for pattern alignment). What must
+        # hold: the defect is gone, the fill is stripe-toned content from a
+        # TOUCHING offset, never a remote patch. (Supersedes the old
+        # phase-alignment promise of the ring-SSD search.)
         yy, xx = np.mgrid[0:200, 0:200]
         base = 30000 + 12000 * np.sin(2 * np.pi * xx / 24.0)
         img = np.stack([base] * 3, axis=-1).astype(np.uint16)
-        expected = img.copy()
         cv2.circle(img, (100, 100), 5, (62000, 62000, 62000), -1)
         spot = {"kind": "brush", "pts": [[0.5, 0.5]], "r": 0.05}
-        out = apply_dust_removal(img, [spot], feather=0.0)
-        hole = np.hypot(yy - 100, xx - 100) <= 10
-        err = np.abs(out[hole].astype(np.float32)
-                     - expected[hole].astype(np.float32))
-        assert float(err.mean()) < 1500
+        plan = []
+        out = apply_dust_removal(img, [spot], feather=0.0, collect_plan=plan)
+        (cy, cx, off, *_), = plan
+        assert off is not None
+        assert float(np.hypot(off[0] * 200, off[1] * 200)) <= 2 * 10 + 4
+        hole = np.hypot(yy - 100, xx - 100) <= 8
+        healed = out[hole].astype(np.float32)
+        assert float(healed.max()) < 50000       # the bright speck is gone
+        assert 15000 < float(healed.mean()) < 45000  # stripe-range content
 
     def test_manual_source_pick_clones_verbatim(self):
         # A USER-PICKED source (overlay ring drag, manual=True in the plan)
@@ -434,11 +451,13 @@ class TestApplyDustRemoval:
         assert abs(float(healed.mean()) - 30000) < 3000
         assert float(healed.max()) < 50000
 
-    def test_stroke_on_prior_source_keeps_reference_samples_healed(self):
-        # NO exceptions: even a stroke painted directly ON a segment's
-        # source patch must not move the reference. The segment defers to a
-        # second pass and clones the HEALED content at the very same
-        # location — same offset in the plan, no dust cloned into the fill.
+    def test_stroke_on_prior_source_merges_and_heals_clean(self):
+        # A TOUCHING source sits directly beside its patch (the sampling
+        # rule), so a stroke painted over the source area merges with the
+        # original patch into ONE connected component — the union re-heals
+        # as a single bigger patch from ITS touching border. What must hold:
+        # the new defect is never cloned into any fill, and the merged
+        # region heals to the background.
         rng = np.random.default_rng(23)
         img = np.clip(rng.normal(30000, 2500, (400, 400, 3)), 0,
                       65535).astype(np.uint16)
@@ -447,8 +466,10 @@ class TestApplyDustRemoval:
         apply_dust_removal(img, [spot], collect_plan=plan1)
         (cy, cx, off, _, _, *_), = plan1
         assert off is not None
+        # Touching: the chosen source borders the patch.
+        assert float(np.hypot(off[0] * 400, off[1] * 400)) <= 2 * 12 + 4
         # A bright defect appears at the chosen source and the user paints
-        # over it — the source patch is now under dust.
+        # over it — the two patches now form one merged region.
         sy, sx = cy + off[0], cx + off[1]
         img2 = img.copy()
         cv2.circle(img2, (int(sx * 400), int(sy * 400)), 5,
@@ -457,21 +478,20 @@ class TestApplyDustRemoval:
         plan2 = []
         out = apply_dust_removal(img2, [spot, b], collect_plan=plan2,
                                  prior_plan=plan1)
-        rec = [r for r in plan2
-               if abs(r[0] - cy) < 1e-9 and abs(r[1] - cx) < 1e-9]
-        assert rec, "first stroke's segment disappeared"
-        assert rec[0][2] == off, "reference moved"
-        # The fill sampled the HEALED source, not the new bright defect.
-        m = rasterize_dust_mask([spot], 400, 400) > 0
+        assert plan2
+        # No dust cloned anywhere in the merged fill; background restored.
+        m = rasterize_dust_mask([spot, b], 400, 400) > 0
         healed = out[m].astype(np.float32)
         assert float(healed.mean()) < 40000
         assert float(healed.max()) < 55000
 
     def test_new_stroke_keeps_far_samples_stable(self):
-        # Adding a dab must only re-sample segments near the edit. Tiles
-        # used to anchor to the component bbox and scale their windows by
-        # the component's thickness, so a dab merging at a blob's top-left
-        # shifted EVERY tile of the blob and re-sampled its far side too.
+        # Adding a dab must only re-sample segments near the edit. In the
+        # app this is the STICKY-SOURCES invariant: the panel always passes
+        # the cached plan as prior_plan, so unchanged segments rebind their
+        # offsets verbatim (the touch rule shares ONE offset per patch for
+        # fresh picks, so a no-prior re-derivation of a merged component
+        # legitimately re-seeds — priors are what pin committed strokes).
         rng = np.random.default_rng(31)
         img = np.clip(rng.normal(32000, 3000, (640, 640, 3)), 0,
                       65535).astype(np.uint16)
@@ -483,7 +503,7 @@ class TestApplyDustRemoval:
         # component bbox origin (0.38*640-19 px < the blob's old 240 px
         # edge) and its thickness, touches nothing on the far (right) side.
         added = base + [{"kind": "brush", "pts": [[0.38, 0.38]], "r": 0.03}]
-        apply_dust_removal(img, added, collect_plan=plan2)
+        apply_dust_removal(img, added, collect_plan=plan2, prior_plan=plan1)
         far1 = [r for r in plan1 if r[1] > 0.55]
         assert far1
         for rec in far1:
@@ -1145,18 +1165,20 @@ class TestResolutionConsistency:
         a8 = cv2.convertScaleAbs(healed_small, alpha=255.0 / 65535.0)
         b8 = cv2.convertScaleAbs(big_ds, alpha=255.0 / 65535.0)
         # Windows around the healed hair and the edge speck (1080x720 space).
-        # Calibrated: re-planning per resolution measures p99 = 14 / 10 and
-        # mean = 0.64 / 0.42 here; the replayed plan sits at 10 / 8. The
-        # residuals are NOT source flips (those are what the guard is for —
-        # the offsets replay verbatim): the speck's rim rides the feather
-        # dome over a high-contrast defect (a 1-px raster shift is worth
-        # more diff there), and the hair's nearest-first search now picks
-        # phase-aligned patches in the striped band whose INTEGER offsets
-        # quantize differently at export scale (sub-pixel pattern phase,
-        # bounded by ±0.5 px). The means stay far below the re-planning
-        # 0.64/0.42 and carry the structure-flip discrimination.
+        # The offsets replay VERBATIM (one shared touching offset per patch;
+        # a re-plan derives the identical plan from the identical downscale),
+        # so any residual is resampling, not source flips. Recalibrated for
+        # the touch+HSV sampling rule: on the STRIPED band the rule has no
+        # pattern-phase term, so the touching source is phase-shifted and
+        # the fill is discontinuous against its surround — resampling a
+        # discontinuous clone between scales measures p99 = 28 / mean = 1.14
+        # here (was ~10/0.33 when the old search phase-aligned; a full
+        # per-scale re-plan of THIS rule still lands in the same place, the
+        # bound guards against replay-path regressions such as reroutes to
+        # the deferred pass or tone-anchor subset drift). The smooth-scene
+        # speck window stays tight — the rule's normal habitat.
         for (y0, y1, x0, x1), p99_lim, mean_lim in (
-                ((390, 510, 490, 590), 11.0, 0.40),  # hair
+                ((390, 510, 490, 590), 32.0, 1.5),   # hair over stripes
                 ((270, 350, 390, 480), 9.0, 0.40)):  # edge speck
             d = np.abs(a8[y0:y1, x0:x1].astype(np.float32)
                        - b8[y0:y1, x0:x1].astype(np.float32))

--- a/tests/test_dust_removal.py
+++ b/tests/test_dust_removal.py
@@ -1032,5 +1032,44 @@ class TestResolutionConsistency:
         assert np.array_equal(a, b)
 
 
+# --- AI detection source: windowed working-space base ------------------------
+class TestDetectSourceDewindow:
+    """dust_detect_source_for must hand the detector a DISPLAY-referred
+    positive. A bw conversion with working-space headroom stores resized_raw
+    in windowed container codes — the whole image sits in the bottom ~1.5% of
+    the 16-bit range — so fed raw to the net it is a black frame: the detector
+    never fires and the bright-speck gate's absolute margin is unreachable
+    ("AI finds no dust" on every windowed image)."""
+
+    @staticmethod
+    def _img(base_u16, windowed):
+        img = CCRImage.__new__(CCRImage)
+        img.resized_raw = base_u16
+        img.dust_spots = []
+        img.dust_feather = DUST_FEATHER_DEFAULT
+        img.crop_rect = None
+        img.crop_angle = 0.0
+        img._ws_windowed = windowed
+        return img
+
+    def test_windowed_base_is_dewindowed_for_detection(self):
+        from core.ccr_processor import encode_window
+        from widgets.image_preview import ImagePreview
+        d = np.full((60, 80, 3), 0.4, dtype=np.float32)
+        d[20:24, 30:34] = 1.0                      # white dust speck
+        code = encode_window(d.copy())             # windowed container codes
+        assert code.max() < 3000                   # near-black fed as-is
+        src = ImagePreview.dust_detect_source_for(self._img(code, True))
+        lum = src.astype(np.float32) / 65535.0
+        assert abs(float(lum[10, 10, 0]) - 0.4) < 0.01  # display tone restored
+        assert float(lum[21, 31, 0]) > 0.98             # speck back at white
+
+    def test_full_range_base_passes_through_unchanged(self):
+        from widgets.image_preview import ImagePreview
+        base = _flat_with_speck()
+        src = ImagePreview.dust_detect_source_for(self._img(base, False))
+        assert np.array_equal(src, base)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

Auto dust detection ("Detect & Remove", single and all-images) found **zero dust on every bw-converted image**.

## Root cause

Since the working-space headroom feature, a bw conversion stores `resized_raw` as a **windowed working-space buffer**: the entire image occupies the bottom ~1.5% of the 16-bit container (`WS_B..WS_W`, ~1536 of 65535). The display path de-windows it in `apply_adjustments`, so everything *looks* normal — but `ImagePreview.dust_detect_source_for` handed the raw container codes straight to the ONNX detector:

- the net's input luma was ~0.017 (a black frame) → no probability above any threshold;
- even where it might fire, the bright-speck gate's absolute `BRIGHT_MARGIN` (0.06 luma lift) is unreachable when all contrast is squeezed by 1/64.

Reference-mode conversions (full-range base) were unaffected, which is why the breakage was total but silent on bw images only.

## Fix

`dust_detect_source_for` now de-windows + window-clamps the healed buffer to the display-referred positive before detection — the exact `(v - WS_B) / (WS_W - WS_B)` mapping the WB picker (`image_preview.py`) and AWB (`awb.py`) already use. No-op for full-range bases. No detector/threshold changes.

## Verification

- **Real scans (the user's ARW film strips, bw-converted, windowed):** detection went from **0 → 13/19/27 spots** at default sensitivity 35 on three scans; zoomed crops of each detected spot confirm genuine white dust specks and lint strings (plus two harmless hits on the rebate frame-number print outside any crop).
- **Real-life dusty archival scans** (LoC *NYC Mulberry Street*, *Migrant Mother* from Wikimedia Commons, run through the same 1080px/uint16 path): detector finds the white specks; the aspect gate correctly leaves the long scratches to the manual brush.
- New regression tests: a windowed base must come back display-referred from `dust_detect_source_for`; a full-range base passes through unchanged. `tests/test_dust_removal.py` + `tests/test_dust_crop_display.py`: **76 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
