### PR TITLE
fix(ui): onboarding hint teaches the B/W-point workflow, not the legacy reference frame

### DIFF
--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1257,12 +1257,20 @@ class ImagePreview(QWidget):
                         self.scene.addItem(self.reference_rect_item)
 
             elif not ccr_backend.positive_mode:
-                # Show hint when no reference frame exists (negative mode only —
-                # positive mode has no reference frame / conversion step).
-                self.parent().parent().sliders_panel.set_hint(
-                    "<b>Hint:</b><br>Draw a frame around the image + some film base (orange/brown). "
-                    "Avoid white backlight or black film holder areas. Right-drag to draw, right-click to clear."
-                )
+                # Negative mode with no reference frame: recommend the B/W-point
+                # workflow on unconverted images (drawing a reference frame is
+                # the legacy path). Once converted, the instruction is stale —
+                # clear it instead of re-stamping it on every refresh.
+                if getattr(ccr_backend.images[idx], "converted", False):
+                    self.parent().parent().sliders_panel.clear_hint()
+                else:
+                    self.parent().parent().sliders_panel.set_hint(
+                        "<b>Hint:</b><br>Click <b>Set Black Point</b> and draw a rect over the "
+                        "transparent/clear film base, then <b>Convert Current</b>. Optionally "
+                        "<b>Set White Point</b> on a dense/exposed area first for a two-point "
+                        "conversion. (Legacy: right-drag draws a reference frame for the "
+                        "toolbar Convert.)"
+                    )
 
 
             # Apply transformations which will handle fitting consistently


### PR DESCRIPTION
## Summary

The standing onboarding hint for an unconverted negative (`image_preview.py`) still recommended the legacy reference-frame workflow:

> Draw a frame around the image + some film base (orange/brown). Avoid white backlight or black film holder areas. Right-drag to draw, right-click to clear.

It now recommends the B/W-point workflow, mirroring the Film B/W Point section's own wording:

> Click **Set Black Point** and draw a rect over the transparent/clear film base, then **Convert Current**. Optionally **Set White Point** on a dense/exposed area first for a two-point conversion. (Legacy: right-drag draws a reference frame for the toolbar Convert.)

## Also fixed: stale hint on converted images

The branch fires whenever `reference_frame` is `None` — which stays true for images converted via B/W points. The old code re-stamped the "draw a frame" hint on **every preview refresh** of such images, overwriting temporary hints ("Auto WB applied", "Crop applied", ...) with stale instructions. Now, once the image is converted, the hint is cleared instead of re-set.

## Verification

- Offscreen script driving the real `update_preview`: unconverted negative with no reference frame → B/W-point hint shown (legacy text gone); converted image with no reference frame → hint cleared, nothing re-stamped.
- `tests/test_dust_crop_display.py`, `test_crop_hires.py`, `test_zoom_percent.py`, `test_crop_overlay.py`, `test_crop_panel.py`, `test_area_editing.py` (everything that drives the real preview widget): **112 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CWWLim8DnE9WqbqqmHV26
