### PR TITLE
fix(macos): tag windows sRGB so previews are color-matched on wide-gamut displays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ src/utils/unicode_path_utils.py → Cross-platform Unicode filename handling
 
 **Resource resolution**: `resource_path()` in `image_preview.py` handles both dev and Nuitka-bundled contexts. Nuitka embeds `src/icons/` and `LICENSES/` directories at build time.
 
+**macOS display color management**: Qt raster windows are not color-matched — the Cocoa backing store inherits the NSWindow colorspace (default: the display's own profile), so sRGB-encoded previews render oversaturated on wide-gamut (Display P3) Macs while ICC-tagged exports display correctly. `install_macos_srgb_filter()` in `src/ui/theme.py` tags every top-level NSWindow as sRGB via a ctypes/objc shim so ColorSync matches the whole app to the display profile. Exports embed their ICC profile in `apply_export_colorspace()` (`src/core/color_management.py`) and are unaffected.
+
 **Activation system**: The license verification code in `src/activation/` is present but bypassed — `is_activated()` always returns `True` in this build. Tests in `tests/test_activation_security.py` still validate the HMAC-SHA256 signing logic.
 
 ## Build Output

--- a/src/main.py
+++ b/src/main.py
@@ -63,9 +63,11 @@ def main():
     from ui.main_window import MainWindow
 
     app = QApplication(sys.argv)
-    from ui.theme import apply_theme, apply_windows_dark_titlebar, install_dark_titlebar_filter
+    from ui.theme import (apply_theme, apply_windows_dark_titlebar,
+                          install_dark_titlebar_filter, install_macos_srgb_filter)
     apply_theme(app)  # neutral dark theme (Fusion + palette + global QSS)
     install_dark_titlebar_filter(app)  # dark title bars for dialogs / message boxes
+    install_macos_srgb_filter(app)  # color-managed previews on wide-gamut Macs
     _icon_path = os.path.join(os.path.dirname(__file__), 'icons', 'freeccr_logo.png')
     app.setWindowIcon(QIcon(_icon_path))
     print("Starting FreeCCR...")

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -558,3 +558,90 @@ def install_dark_titlebar_filter(app) -> None:
         return
     _dark_titlebar_filter = _DarkTitleBarFilter(app)
     app.installEventFilter(_dark_titlebar_filter)
+
+
+def apply_macos_srgb_colorspace(widget) -> bool:
+    """Tag a top-level window's NSWindow as sRGB on macOS.
+
+    Qt raster content is not color-managed (QTBUG-47660): the Cocoa backing
+    store inherits the NSWindow's colorspace, which defaults to the display's
+    own profile, so our sRGB-encoded preview pixels reach the screen
+    un-matched — visibly oversaturated on the wide-gamut (Display P3) panels
+    of every modern Mac, while exports (ICC-tagged sRGB/ProPhoto) display
+    correctly in ColorSync-managed viewers. Tagging the NSWindow sRGB makes
+    the WindowServer color-match the whole window (previews and UI alike) to
+    whatever profile the display uses.
+
+    Safe to call after show(): Qt observes
+    NSWindowDidChangeBackingPropertiesNotification and re-tags its backing
+    buffers on the change. No-op off macOS. Returns True if the colorspace
+    call was made.
+    """
+    if sys.platform != "darwin":
+        return False
+    try:
+        import ctypes
+        import ctypes.util
+
+        objc = ctypes.CDLL(ctypes.util.find_library("objc"))
+        objc.sel_registerName.restype = ctypes.c_void_p
+        objc.sel_registerName.argtypes = [ctypes.c_char_p]
+        objc.objc_getClass.restype = ctypes.c_void_p
+        objc.objc_getClass.argtypes = [ctypes.c_char_p]
+        # objc_msgSend is variadic — it must be cast to an exact prototype per
+        # call signature (mandatory on arm64). Everything here is id-sized.
+        send = ctypes.cast(objc.objc_msgSend, ctypes.CFUNCTYPE(
+            ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p))
+        send1 = ctypes.cast(objc.objc_msgSend, ctypes.CFUNCTYPE(
+            ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p))
+
+        def sel(name: bytes) -> ctypes.c_void_p:
+            return ctypes.c_void_p(objc.sel_registerName(name))
+
+        # On macOS winId() is the NSView* (and forces native window creation).
+        nsview = ctypes.c_void_p(int(widget.winId()))
+        nswindow = ctypes.c_void_p(send(nsview, sel(b"window")))
+        if not nswindow:
+            return False
+        srgb = ctypes.c_void_p(send(
+            ctypes.c_void_p(objc.objc_getClass(b"NSColorSpace")),
+            sel(b"sRGBColorSpace")))
+        if not srgb:
+            return False
+        send1(nswindow, sel(b"setColorSpace:"), srgb)
+        return True
+    except Exception:
+        return False
+
+
+class _MacSRGBColorSpaceFilter(QObject):
+    """App-level filter that sRGB-tags each top-level window on show.
+
+    Covers dialogs created on demand, like ``_DarkTitleBarFilter``. Re-applies
+    on every Show (no seen-set): setColorSpace is cheap and idempotent, and a
+    platform window Qt re-created in between (new winId) needs re-tagging.
+    macOS-only; inert elsewhere.
+    """
+
+    def eventFilter(self, obj, event):
+        if (event.type() == QEvent.Type.Show
+                and isinstance(obj, QWidget) and obj.isWindow()):
+            apply_macos_srgb_colorspace(obj)
+        return False
+
+
+_macos_srgb_filter = None
+
+
+def install_macos_srgb_filter(app) -> None:
+    """Install an app-wide filter so every top-level window is tagged with the
+    sRGB colorspace when shown (see ``apply_macos_srgb_colorspace``).
+
+    No-op off macOS or if already installed. Call once from the app entry
+    point, alongside ``install_dark_titlebar_filter``.
+    """
+    global _macos_srgb_filter
+    if sys.platform != "darwin" or _macos_srgb_filter is not None:
+        return
+    _macos_srgb_filter = _MacSRGBColorSpaceFilter(app)
+    app.installEventFilter(_macos_srgb_filter)

--- a/tests/test_macos_srgb_colorspace.py
+++ b/tests/test_macos_srgb_colorspace.py
@@ -1,0 +1,79 @@
+"""Tests for the macOS sRGB window-colorspace shim (src/ui/theme.py).
+
+The objc call itself can only execute on a real Mac under the cocoa platform;
+these tests cover the platform guards, the app-level filter dispatch, and
+installer idempotence. Runs headless (offscreen Qt platform).
+"""
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest  # noqa: E402
+from PySide6.QtCore import QEvent  # noqa: E402
+from PySide6.QtWidgets import QApplication, QLabel, QWidget  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from ui import theme  # noqa: E402
+
+
+@pytest.mark.skipif(sys.platform == "darwin",
+                    reason="off-macOS guard; the objc path needs cocoa, not offscreen")
+def test_apply_is_noop_off_macos():
+    assert theme.apply_macos_srgb_colorspace(QWidget()) is False
+
+
+@pytest.mark.skipif(sys.platform == "darwin",
+                    reason="off-macOS guard; the objc path needs cocoa, not offscreen")
+def test_install_is_noop_off_macos():
+    theme.install_macos_srgb_filter(_app)
+    assert theme._macos_srgb_filter is None
+
+
+def test_filter_tags_top_level_windows_only(monkeypatch):
+    calls = []
+    monkeypatch.setattr(theme, "apply_macos_srgb_colorspace",
+                        lambda w: calls.append(w) or True)
+    f = theme._MacSRGBColorSpaceFilter()
+    top = QWidget()
+    child = QLabel(top)
+    show = QEvent(QEvent.Type.Show)
+    assert f.eventFilter(top, show) is False, "filter must never consume events"
+    assert f.eventFilter(child, show) is False
+    assert f.eventFilter(top, QEvent(QEvent.Type.Paint)) is False
+    assert calls == [top], "only the shown top-level window gets tagged"
+
+
+def test_filter_reapplies_on_every_show(monkeypatch):
+    # No seen-set: a platform window Qt re-created in between needs re-tagging.
+    calls = []
+    monkeypatch.setattr(theme, "apply_macos_srgb_colorspace",
+                        lambda w: calls.append(w) or True)
+    f = theme._MacSRGBColorSpaceFilter()
+    top = QWidget()
+    f.eventFilter(top, QEvent(QEvent.Type.Show))
+    f.eventFilter(top, QEvent(QEvent.Type.Show))
+    assert calls == [top, top]
+
+
+def test_install_on_darwin_installs_once(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(theme, "_macos_srgb_filter", None)
+    try:
+        theme.install_macos_srgb_filter(_app)
+        first = theme._macos_srgb_filter
+        assert first is not None
+        theme.install_macos_srgb_filter(_app)
+        assert theme._macos_srgb_filter is first, "second install must be a no-op"
+    finally:
+        if theme._macos_srgb_filter is not None:
+            _app.removeEventFilter(theme._macos_srgb_filter)
+            theme._macos_srgb_filter = None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

A Mac user reported that exported TIFFs look **less saturated** than the in-app preview. On Windows (typical ~sRGB monitor) both look identical.

## Root cause

The export is the *correct* rendering — every export embeds an ICC profile (`apply_export_colorspace` in `src/core/color_management.py`, written via `iccprofile=` in `write_export_image`), and macOS viewers (Preview, Quick Look, Photos) are ColorSync-managed, so the file displays with true colors.

The preview is the wrong one. Qt raster content is not color-managed (QTBUG-47660): in Qt 6, `QCALayerBackingStore` inherits its colorspace from the NSWindow, and an NSWindow's colorspace defaults to the **display's own profile**. Our sRGB-encoded preview pixels therefore reach the screen un-matched — on the wide-gamut Display P3 panels of every modern Mac, sRGB values interpreted as P3 coordinates render visibly oversaturated. Hence "export less saturated than preview," for every Mac user, with stock settings.

## Fix

Tag every top-level `NSWindow` with the sRGB colorspace, so the WindowServer color-matches the whole window (preview and UI alike) to whatever profile the display uses:

- `apply_macos_srgb_colorspace(widget)` in `src/ui/theme.py` — a dependency-free ctypes/objc shim (`nsview.window.setColorSpace: NSColorSpace.sRGBColorSpace`). `objc_msgSend` is cast to exact per-signature prototypes (required on arm64). No-op off macOS, never throws.
- `install_macos_srgb_filter(app)` — app-wide Show-event filter mirroring the existing `install_dark_titlebar_filter` pattern, so on-demand dialogs are covered too. Re-applies on every Show (idempotent) in case Qt re-creates the platform window.
- Wired in `src/main.py` next to the titlebar filter.

Applying at/after show is safe on our Qt (PySide6 6.7.1): `QCALayerBackingStore` observes `NSWindowDidChangeBackingPropertiesNotification` and re-tags its IOSurface buffers when the window colorspace changes.

## Tests

`tests/test_macos_srgb_colorspace.py` (headless): platform guards no-op off macOS, filter tags top-level windows only and never consumes events, re-applies per Show, installer is idempotent. The objc call itself needs a real Mac + cocoa platform, so it's exercised by the manual verification below.

`pytest tests/test_macos_srgb_colorspace.py tests/test_theme.py -v` → 11 passed.

## Verification needed on a Mac

I developed this on Windows; someone with a Mac (ideally the reporter) should confirm:

1. Open a converted frame; export TIFF; open the TIFF in Preview.app side-by-side with the app preview → they should now match.
2. Sanity: System Settings → Displays → Color Profile → "sRGB IEC61966-2.1" should no longer change how the app preview relates to the export.
3. UI colors (dark theme) will shift very slightly less saturated on P3 Macs — expected, now correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CWWLim8DnE9WqbqqmHV26
