### PR TITLE
feat: white sprocket holes / clear film (reversal look)

### DIFF
--- a/spec/sprocket-hole-mask.md
+++ b/spec/sprocket-hole-mask.md
@@ -1,0 +1,340 @@
+# Spec: Sprocket-Hole (Clear-Film) White Mask
+
+Status: REFINED (open questions resolved — ready to implement)
+Owner: FreeCCR
+Feature branch: `feature/sprocket-hole-mask`
+Related: `spec/auto-gain.md` (the reference "global display toggle read live in the
+render pipeline, re-render on toggle" shape), `spec/settings-page.md` (the Settings
+dialog this adds a toggle to), `spec/density-bwpoint-toggle.md` /
+`spec/film-stock-slopes.md` (the B/W-point conversion this rides on).
+
+## 0. Decisions (locked)
+
+- **Reversal look.** On a 135 negative the punched sprocket holes and the clear
+  rebate are *clearer than the film base*, so after inversion they clamp to pure
+  **black**. Photographers replicating a slide/reversal presentation want those
+  areas **white** instead. This feature paints every genuinely-clear-film region
+  white as the last step before display/export, so no adjustment can tint them.
+- **Detect from the RAW, not the positive.** In the inverted positive the holes
+  are indistinguishable from crushed shadows and the film border (all sit at 0),
+  so the mask MUST be derived from the pre-inversion scan, where "clearer than the
+  sampled film base" is a clean, physically-meaningful test. See §4.1.
+- **Only in B/W-point (black-point-set) mode.** The threshold is defined relative
+  to the user's sampled black point (film base). Reference/auto conversions have
+  no explicit base and positive mode has no negative — both skip the mask.
+- **Global display overlay, computed at convert time, applied live.** Like Auto
+  Gain / Gamma mode, the toggle is read live and toggling only **re-renders**
+  (no re-conversion, no catalog write). The mask *alpha* is a pure function of
+  (raw scan, black point) and is computed wherever the raw is in hand — cached on
+  the image for the preview, recomputed at native res for zoom/export — so preview
+  and export agree. See §4.2.
+- **Default OFF.** It is a stylistic, non-standard presentation choice; the
+  default conversion stays as-is.
+- **Format-agnostic mechanism, "135" framing.** Nothing detects 135 vs 120. The
+  mask fires only where the scan is clearer than the sampled base, which is
+  physically only the holes / rebate / inter-frame gaps. 120 (no sprockets) simply
+  gets its clear rebate border whitened, which is harmless and consistent.
+
+## 1. Summary
+
+A persisted **Settings → General → "White sprocket holes / clear film (reversal
+look)"** toggle (default OFF). When on, every B/W-point-converted image gets a
+mask built from the raw scan — pixels **brighter than the sampled black point plus
+a padding**, morphologically cleaned (open to drop specks, close to fill small
+gaps) and **feathered ~5–10 px** — and that mask is composited to **white**
+(65535) as the final step before the pixels are shown and before they are written
+on export. The result: sprocket holes / clear rebate read white like reversal
+film, untouched by any slider, curve, area, or crop adjustment.
+
+## 2. Goals / Non-goals
+
+### Goals
+- Settings → General checkbox (default OFF), staged-and-applied-on-Done like the
+  other global toggles; toggling **re-renders** loaded images (no re-convert).
+- A raw-derived, per-channel **"clearer than film base + padding"** binary mask,
+  morphology-cleaned and **feathered 5–10 px** (at the 1080 preview; scaled with
+  resolution so export/zoom match).
+- Composite the mask to **pure white** as the **last** step of the preview,
+  hi-res zoom, and export render paths — after all adjustments, dust, areas,
+  curves, gain, gamma — so nothing downstream can affect the whitened regions.
+- Preview / zoom / export produce the **same** mask (same threshold; geometric
+  params scale with resolution), matching FreeCCR's "plan at preview, replay at
+  native" contract (`spec/dust-removal.md`).
+- Tunable thresholds via `FREECCR_SPROCKET_*` env knobs for field calibration on
+  real rolls (mirrors the `FREECCR_*` convention), with sane baked defaults.
+
+### Non-goals
+- No format detection (135/120), no sprocket-hole *geometry* fitting; purely a
+  clearer-than-base intensity mask.
+- No user-facing padding/feather sliders in v1 (fixed constants + env override).
+- No change to the conversion math, reference/auto conversion, positive mode, or
+  the sampled-point picker.
+- Not applied to un-converted scans, reference-frame conversions, positive-mode
+  images, or trichrome-merge previews (they lack a sampled base — §7).
+- Does not alter the histogram/scopes (they read the pre-mask adjusted preview;
+  the mask is a cosmetic final composite — acceptable for v1, noted in §7).
+
+## 3. Current behaviour (as-is)
+
+B/W-point conversion (`ccr_normalize_with_bwpoint`, black point ± white point)
+maps the sampled clear/film-base sample to output **0** and everything *clearer*
+(the holes/rebate, which scan **brighter** than the base) clamps to 0 as well —
+so in the positive they are pure black and indistinguishable from crushed shadow.
+
+Three render paths reproduce a B/W-point conversion and then apply adjustments —
+each is where the mask must be composited **last**:
+
+1. **Preview / thumbnail** — `ccr_image.update_thumbnail_and_preview` runs
+   `adjusted = apply_adjustments(resized_raw)` then downsizes to preview/thumb.
+   `resized_raw` is the *converted* buffer (the raw is gone), produced earlier by
+   `ccr_normalize_with_bwpoint(output_path=None)`.
+2. **Hi-res zoom** — `HiResDetailWorker` calls `render_hires_base` (re-decodes the
+   raw, replays via `apply_bwpoint_normalization`) → `apply_adjustments` → 8-bit.
+3. **Export** — `ccr_normalize_with_bwpoint(output_path=…)`:
+   `invert → apply_adjustments → crop → flips → rotation → write`.
+
+The invert helpers consume a **float32 BGR** working image (`img_f`) and the
+sampled `black_point_bgr` (BGR, HIGH scan values for the clear base). The mask is
+computed in the *same* raw BGR space, so channel alignment is automatic; the
+composite paints neutral white, so it is channel-order-agnostic.
+
+Global display toggles (`auto_gain`, `gamma_luminance`) already demonstrate the
+full pattern: a `ccr_backend` flag, QSettings restore in `MainWindow.__init__`, an
+`on_*_toggled` handler that persists + `_rerender_all_for_global_mode(...)`, a
+staged checkbox in `SettingsDialog`, and membership in
+`image_preview._current_adj_sig()` so the hi-res cache invalidates on toggle.
+
+## 4. Design
+
+### 4.1 The mask (pure functions, in `ccr_processor.py`)
+
+```python
+# Baked defaults (env-overridable for field calibration)
+SPROCKET_PAD_FRAC   = 0.20   # a hole must be >= 20% of the way from base -> clip,
+SPROCKET_PAD_ABS    = 0.02   #   or 2% of full scale above base, per channel (max)
+SPROCKET_OPEN_PX    = 2.0    # speckle removal radius   @ 1080 long side
+SPROCKET_CLOSE_PX   = 5.0    # small-gap fill radius     @ 1080 long side
+SPROCKET_FEATHER_PX = 8.0    # edge feather (5-10 px)    @ 1080 long side
+SPROCKET_REF_LONG   = 1080   # reference long side the *_PX are quoted at
+
+def compute_sprocket_alpha(raw_bgr, black_point_bgr) -> Optional[np.ndarray]:
+    """A feathered white-mask alpha (uint8 H×W, 0..255) marking clear-film
+    (sprocket / rebate) regions — pixels clearer than the sampled film base by a
+    padding — or None if the black point is unset or no region qualifies.
+
+    `raw_bgr` is the float/uint working scan (BGR, same array the invert helpers
+    consume); `black_point_bgr` is the sampled clear/film-base anchor (BGR, HIGH
+    values). Resolution-independent threshold; morphology + feather radii scale
+    with this buffer's long side so preview/zoom/export agree geometrically."""
+    if black_point_bgr is None:
+        return None
+    d = raw_bgr astype float32                       # (H,W,3) BGR
+    bp   = float32 array(black_point_bgr)            # (3,)
+    head = maximum(65535 - bp, 1.0)                  # per-channel headroom above base
+    pad  = maximum(SPROCKET_PAD_FRAC*head, SPROCKET_PAD_ABS*65535)
+    thr  = bp + pad
+    mask = all(d > thr[None,None,:], axis=2)         # AND across BGR -> clearer than base
+    if not mask.any(): return None
+    m = uint8(mask)*255
+    scale = max(H,W) / SPROCKET_REF_LONG
+    m = MORPH_OPEN(m,  ellipse(SPROCKET_OPEN_PX  * scale))   # drop noise specks
+    m = MORPH_CLOSE(m, ellipse(SPROCKET_CLOSE_PX * scale))   # fill small gaps
+    if not m.any(): return None
+    f = max(1.0, SPROCKET_FEATHER_PX * scale)
+    return GaussianBlur(m, ksize=odd(2*f), sigma=f/2)        # uint8 0..255 ramp
+```
+
+Why per-channel **AND** with a headroom-fraction padding: a punched hole is clear
+film → near full transmission in **every** channel → far above `base+pad`
+everywhere. Film-base noise sits at `~base` → below `pad`. Exposed scene content
+(even a deep shadow) is *denser* than the zero-exposure base → **lower** than base
+in every channel → can never exceed it, so scene pixels are structurally excluded.
+The AND biases toward **few false positives** (never whiten real content); the
+CLOSE fills any small missed interior, the OPEN removes stray triggered specks.
+`SPROCKET_PAD_ABS` floors the padding so a base already near clip (tiny headroom)
+doesn't collapse the margin and catch noise.
+
+```python
+def apply_sprocket_mask(rgb_u16, alpha_u8) -> np.ndarray:
+    """Composite the clear-film regions to white (65535). alpha 0 = keep image,
+    255 = full white, in-between = feathered blend. No-op when alpha is None."""
+    if alpha_u8 is None: return rgb_u16
+    a = float32(alpha_u8)[...,None] / 255.0
+    return clip(rgb_u16*(1-a) + 65535.0*a, 0, 65535).astype(uint16)
+```
+
+Both are pure/thread-safe (run on pool + QThread workers). Env knobs read once via
+a small `_sprocket_cfg()` helper (like `_ws_enabled`).
+
+### 4.2 Wiring the three render paths
+
+**Convert (`ccr_normalize_with_bwpoint`).** After `img_f`/`img` is loaded and
+before it's freed, compute `alpha = compute_sprocket_alpha(img, black_point_bgr)`.
+- `output_path is None` (preview convert): store `ccr_image.sprocket_alpha =
+  alpha`. Do **not** composite here — the overlay is applied in
+  `update_thumbnail_and_preview`, gated by the live toggle (so on/off is a pure
+  re-render). Compute it **always** (regardless of the toggle) so turning the
+  toggle on later needs no re-conversion; it is a few ms on a ≤1080 buffer.
+- `output_path is not None` (export): after `apply_adjustments` and **before**
+  crop/flips/rotation, `if ccr_backend.sprocket_mask_white: rgb_result =
+  apply_sprocket_mask(rgb_result, alpha)`. Applying before the geometric block
+  keeps it in the same un-rotated/un-cropped space as the preview overlay (WYSIWYG
+  — the canvas item applies crop/rotation to the whitened preview); white survives
+  the warp, and a crop that excludes the holes simply drops them (expected).
+
+**Preview (`ccr_image.update_thumbnail_and_preview`).** After `display_img` is
+chosen (the converted+adjusted uint16, same H×W as `resized_raw` and thus as
+`sprocket_alpha`) and **before** the thumb/preview downsizes:
+```python
+from core.ccr_backend import ccr_backend   # deferred import (already used here)
+if (ccr_backend.sprocket_mask_white and self.converted
+        and not self._positive_mode_active()
+        and getattr(self, "sprocket_alpha", None) is not None):
+    display_img = apply_sprocket_mask(display_img, self.sprocket_alpha)
+```
+
+**Hi-res zoom (`render_hires_base` + `HiResDetailWorker`).** In `render_hires_base`
+the `mode == "bw"` branch has the re-decoded raw `img` in hand: compute the alpha
+there and return it alongside the base (change the return to `(base, alpha)`;
+`alpha=None` for ref / ref_params / positive / unconverted). Thread it through:
+- `HiResDetailWorker` receives/caches it (`self._sprocket_alpha`), and after
+  `apply_adjustments` (and before 8-bit), composites it when
+  `ccr_backend.sprocket_mask_white` (snapshot the flag at construction like
+  `_positive_mode`).
+- The hi-res cache dict + `finished_hires` signal carry the alpha next to `base`
+  so the re-adjust-only fast path (base cached, sliders moved) reuses it.
+- Add `bool(ccr_backend.sprocket_mask_white)` to `_current_adj_sig()` so toggling
+  invalidates the baked hi-res tile (exactly like `auto_gain`/`gamma_luminance`).
+
+**Slice reset (`ccr_backend` ~L1913, `apply_bwpoint_normalization` on a child's
+raw `resized_raw`).** Immediately after producing the child's converted
+`resized_raw`, set `parent.sprocket_alpha = compute_sprocket_alpha(<the raw before
+inversion>, bw_points[0])`. (Capture the raw before it's overwritten by the
+in-place invert.) Keeps sliced strips consistent; cheap.
+
+### 4.3 Settings → General
+
+Add a group to `SettingsDialog._build_general_page`:
+> **Film border** · ☐ *White sprocket holes / clear film (reversal look)*
+> *muted:* "After you set a Black Point (film base), paint the sprocket holes and
+> clear film border white instead of black — the reversal-film look. Applied last,
+> so adjustments never tint them. B/W-point conversions only."
+
+Staged like the rest: seed in `_init_toggles` from `ccr_backend.sprocket_mask_white`,
+apply on Done in `_apply_pending` by calling `main_window.on_sprocket_mask_toggled`
+only when it differs from the live flag.
+
+## 5. Data model
+
+- `ccr_backend.sprocket_mask_white: bool = False` (new flag, in the toggle block).
+  Persisted by MainWindow under QSettings key `adjust/sprocket_mask_white`,
+  restored at startup before any render.
+- `ccr_image.sprocket_alpha: Optional[np.ndarray]` (uint8 H×W, 0..255) — the
+  cached feathered alpha for the **preview-resolution** buffer; set on every
+  B/W-point convert (and slice reset), `None` otherwise. Not persisted to the
+  catalog (recomputed on the reconvert that catalog load already performs).
+- **No** conversion_inputs / catalog schema change; the alpha is derived, and the
+  overlay is live from the global flag. A pre-feature catalog reconverts through
+  `ccr_normalize_with_bwpoint`, which repopulates `sprocket_alpha`.
+
+## 6. Integration points
+
+- `core/ccr_processor`: add `compute_sprocket_alpha`, `apply_sprocket_mask`, the
+  `SPROCKET_*` constants + `_sprocket_cfg()` env reader. In
+  `ccr_normalize_with_bwpoint`: compute alpha from the raw; store on the image
+  (preview) or composite post-adjust/pre-geometry (export), gated by
+  `ccr_backend.sprocket_mask_white` on the export path (deferred import).
+- `core/ccr_image`: new `sprocket_alpha` attr (init `None`); composite in
+  `update_thumbnail_and_preview` (§4.2, gated); `render_hires_base` returns
+  `(base, alpha)` and its single caller unpacks.
+- `core/ccr_backend`: `self.sprocket_mask_white = False` in the flag block; set
+  `parent.sprocket_alpha` in the slice-reset bw branch.
+- `widgets/image_preview`: `HiResDetailWorker` snapshots the flag + carries/
+  composites the alpha; hi-res cache dict + `finished_hires` payload gain the
+  alpha; `_current_adj_sig()` includes the flag.
+- `ui/main_window`: restore `sprocket_mask_white` from QSettings in `__init__`
+  (key `adjust/sprocket_mask_white`, default False); add
+  `on_sprocket_mask_toggled(checked)` → set flag, persist,
+  `_rerender_all_for_global_mode(hint)` (render-only, releases hi-res cache).
+- `widgets/settings_dialog`: General-page group + checkbox + staging in
+  `_init_toggles` / `_apply_pending`.
+
+## 7. Edge cases
+
+- **No black point set / reference or auto conversion** → `sprocket_alpha` is
+  None → overlay is a no-op even with the toggle on (the help text says B/W-point
+  only). No error.
+- **Positive mode** → skipped (`self.converted` is set by inversion; the preview
+  gate also excludes positive; export routes through `ccr_export_positive`, which
+  this spec does not touch).
+- **No qualifying pixels** (frame cropped to just the image; 120 with a dense
+  rebate) → `compute_sprocket_alpha` returns None → no-op.
+- **Scene highlights / blown skies** → in a negative these are the *densest*
+  (darkest scan) regions, structurally below base → never masked. Deep scene
+  shadows approach but do not exceed the zero-exposure base; `pad` covers the
+  approach. (Field-tunable via `FREECCR_SPROCKET_PAD_FRAC` if a scan's base is
+  unusually noisy.)
+- **Uneven scan illumination** (vignetted base dimmer in a corner) → headroom-
+  fraction padding + `SPROCKET_PAD_ABS` floor give margin; the OPEN drops stray
+  corner specks. Documented limitation, not a correctness bug.
+- **Crop excludes the holes** → export/preview simply have no clear-film region in
+  frame; nothing to whiten (expected — user chose to crop them out).
+- **Histogram** reads the PRE-mask adjusted preview (the tones the user edits),
+  so a whitened border — which can be ~15 % of a full-width 135 scan — does not
+  add a misleading spike at white. `update_thumbnail_and_preview` composites the
+  mask into the display pixels (thumbnail + preview pixmap) only and derives the
+  histogram from the un-masked `display_img` (§4.2). **Scopes** render the
+  displayed viewport, so they DO include the whitened border — acceptable v1
+  (they mirror what's on screen); revisit only if requested.
+- **Missing `sprocket_alpha` on an image converted by pre-feature code in the same
+  session** (shouldn't happen — every convert path repopulates it): overlay is
+  skipped for that image until its next conversion. Harmless.
+
+## 8. Test plan (`tests/test_sprocket_mask.py`, pure numpy/cv2, headless)
+
+- **Threshold isolates holes**: synthetic BGR raw — a film-base plate at `bp`
+  (BGR), a bright square well above `bp+pad` (the "hole"), and a darker square
+  below `bp` (exposed "scene"). `compute_sprocket_alpha` → alpha 255 inside the
+  hole, 0 over base and over the scene square.
+- **Padding rejects base noise**: base plate + gaussian noise with amplitude <
+  `pad` → alpha all zero (returns None).
+- **Per-channel AND**: a square brighter than base in G/R only (not B) → not
+  masked (proves clear-film requires all channels, so an orange-cast miss can't
+  false-positive).
+- **Feather is a soft ramp**: the alpha has intermediate values (0<a<255) in a
+  band ~`feather` px wide around the hole edge; interior is a solid 255.
+- **Resolution scaling**: same synthetic content rendered at 1080 and at 4×
+  produces geometrically-matching alpha (feather band width scales ≈4×; masked
+  area fraction within tolerance) — proves preview/export agreement.
+- **Composite paints white**: `apply_sprocket_mask` sets full-alpha pixels to
+  65535 in all channels and leaves zero-alpha pixels byte-identical; a mid-alpha
+  pixel is the exact `(1-a)·img + a·65535` blend.
+- **No black point → None**: `compute_sprocket_alpha(raw, None) is None`.
+- **Backend/Settings**: `ccr_backend.sprocket_mask_white` defaults False; the
+  General checkbox seeds/round-trips; `on_sprocket_mask_toggled` flips + persists
+  the QSettings key (GUI-light or mocked).
+- **Convert stores alpha**: a `ccr_normalize_with_bwpoint(output_path=None)` on a
+  synthetic scan with a clear-hole region leaves `ccr_image.sprocket_alpha` set;
+  a reference conversion leaves it None.
+- **Export composites only when on**: export a bw image with the flag ON → the
+  hole region is white in the written file; with the flag OFF → it is black
+  (byte-identical to today).
+
+## 9. Open questions — RESOLVED
+
+- **Cache the preview alpha vs recompute live → CACHE at convert.** The alpha
+  needs the raw, which `update_thumbnail_and_preview` no longer holds (resized_raw
+  is the positive). Storing the small uint8 alpha lets on/off be a pure re-render;
+  zoom/export recompute from their own decode. (~3 MB → stored as uint8, <1 MB;
+  computed once per convert.)
+- **Where in the export order → after adjustments, before crop/flips/rotation.**
+  Matches the preview (mask in un-transformed space, canvas applies geometry);
+  white survives the warp. (Decision 0 / §4.2.)
+- **Default OFF.** Stylistic, non-standard — the conversion default is unchanged
+  (contrast with Auto Gain, which defaults ON as a convenience).
+- **Per-channel AND vs luminance/any → AND.** Fewest false positives; clear film
+  is bright in every channel, exposed content is dark in every channel, so the
+  AND is both correct and the safest against whitening real content.
+- **User-tunable padding/feather in v1 → NO, env knobs only.** Baked defaults +
+  `FREECCR_SPROCKET_*` for calibration on real rolls; promote to UI only if
+  field use shows one value doesn't fit all scanners.

--- a/spec/sprocket-hole-mask.md
+++ b/spec/sprocket-hole-mask.md
@@ -110,38 +110,43 @@ staged checkbox in `SettingsDialog`, and membership in
 
 ```python
 # Baked defaults (env-overridable for field calibration)
-SPROCKET_PAD_FRAC   = 0.20   # a hole must be >= 20% of the way from base -> clip,
-SPROCKET_PAD_ABS    = 0.02   #   or 2% of full scale above base, per channel (max)
-SPROCKET_OPEN_PX    = 2.0    # speckle removal radius   @ 1080 long side
-SPROCKET_CLOSE_PX   = 5.0    # small-gap fill radius     @ 1080 long side
-SPROCKET_FEATHER_PX = 8.0    # edge feather (5-10 px)    @ 1080 long side
-SPROCKET_REF_LONG   = 1080   # reference long side the *_PX are quoted at
+PAD_FRAC     = 0.20   # a hole must be >= 20% of the way from base -> clip,
+PAD_ABS      = 0.02   #   or 2% of full scale above base, per channel (max)
+MIN_AREA_PX  = 24.0   # speckle cutoff (connected-component area) @ 1080 long side
+FEATHER_PX   = 1.0    # edge feather — anti-aliasing only          @ 1080 long side
+REF_LONG     = 1080   # reference long side the px params are quoted at
 
 def compute_sprocket_alpha(raw_bgr, black_point_bgr) -> Optional[np.ndarray]:
-    """A feathered white-mask alpha (uint8 H×W, 0..255) marking clear-film
-    (sprocket / rebate) regions — pixels clearer than the sampled film base by a
-    padding — or None if the black point is unset or no region qualifies.
+    """A white-mask alpha (uint8 H×W, 0..255) marking clear-film (sprocket /
+    rebate) regions — pixels clearer than the sampled film base by a padding — or
+    None if the black point is unset or no region qualifies. Holes are kept SHARP.
 
     `raw_bgr` is the float/uint working scan (BGR, same array the invert helpers
     consume); `black_point_bgr` is the sampled clear/film-base anchor (BGR, HIGH
-    values). Resolution-independent threshold; morphology + feather radii scale
-    with this buffer's long side so preview/zoom/export agree geometrically."""
+    values). Resolution-independent threshold; area cutoff + feather scale with
+    this buffer's long side so preview/zoom/export agree geometrically."""
     if black_point_bgr is None:
         return None
     d = raw_bgr astype float32                       # (H,W,3) BGR
     bp   = float32 array(black_point_bgr)            # (3,)
     head = maximum(65535 - bp, 1.0)                  # per-channel headroom above base
-    pad  = maximum(SPROCKET_PAD_FRAC*head, SPROCKET_PAD_ABS*65535)
+    pad  = maximum(PAD_FRAC*head, PAD_ABS*65535)
     thr  = bp + pad
     mask = all(d > thr[None,None,:], axis=2)         # AND across BGR -> clearer than base
     if not mask.any(): return None
     m = uint8(mask)*255
-    scale = max(H,W) / SPROCKET_REF_LONG
-    m = MORPH_OPEN(m,  ellipse(SPROCKET_OPEN_PX  * scale))   # drop noise specks
-    m = MORPH_CLOSE(m, ellipse(SPROCKET_CLOSE_PX * scale))   # fill small gaps
-    if not m.any(): return None
-    f = max(1.0, SPROCKET_FEATHER_PX * scale)
-    return GaussianBlur(m, ksize=odd(2*f), sigma=f/2)        # uint8 0..255 ramp
+    scale = max(H,W) / REF_LONG
+    # Speckle removal by connected-component AREA — NOT morphological open, which
+    # would erode/round the hole corners. Keeps every component >= min_area sharp.
+    min_area = max(1, round(MIN_AREA_PX * scale*scale))
+    m = keep_components_with_area(m, >= min_area)     # via connectedComponentsWithStats
+    if m is empty: return None
+    # Fill INTERIOR holes only (dust/markings inside a hole) via a border
+    # flood-fill imfill — NOT morphological close, so the outer edge is untouched.
+    m = fill_interior_holes(m)                        # pad 1px bg, floodFill(0,0), OR back
+    f = FEATHER_PX * scale
+    if f >= 0.5: m = GaussianBlur(m, ksize=odd(2*f), sigma=f/2)   # 1px anti-alias
+    return m                                          # uint8 0..255
 ```
 
 Why per-channel **AND** with a headroom-fraction padding: a punched hole is clear
@@ -149,10 +154,19 @@ film → near full transmission in **every** channel → far above `base+pad`
 everywhere. Film-base noise sits at `~base` → below `pad`. Exposed scene content
 (even a deep shadow) is *denser* than the zero-exposure base → **lower** than base
 in every channel → can never exceed it, so scene pixels are structurally excluded.
-The AND biases toward **few false positives** (never whiten real content); the
-CLOSE fills any small missed interior, the OPEN removes stray triggered specks.
-`SPROCKET_PAD_ABS` floors the padding so a base already near clip (tiny headroom)
-doesn't collapse the margin and catch noise.
+The AND biases toward **few false positives** (never whiten real content).
+`PAD_ABS` floors the padding so a base already near clip (tiny headroom) doesn't
+collapse the margin and catch noise.
+
+**Keeping the holes sharp.** Real 135 sprocket holes are crisp rounded rectangles;
+an early build over-softened them with a morphological **open** (rounds corners) +
+**close** (dilates/rounds the outer edge) + an 8 px Gaussian **feather** (a glow).
+The cleanup is instead: (1) a **connected-component area filter** to drop tiny
+noise specks — no erosion, so the true edge is preserved; (2) a **flood-fill
+imfill** to fill only *interior* gaps (a speck of dust or a printed frame number
+inside a hole) while leaving the outer boundary exactly where the threshold put
+it — no dilation/rounding; (3) a **~1 px feather** for anti-aliasing only. All
+three are cheap (linear in pixels) and thread-safe.
 
 ```python
 def apply_sprocket_mask(rgb_u16, alpha_u8) -> np.ndarray:

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -76,6 +76,12 @@ class CCRBackend:
         # Global, persisted by MainWindow. See spec/auto-white-balance.md.
         self.auto_awb: bool = False
         self.awb_algorithm: str = "gray_world"
+        # Reversal-look sprocket-hole mask: when True, clear-film regions (sprocket
+        # holes / rebate, brighter than the sampled black point) are painted white
+        # as the LAST render step for B/W-point conversions, on preview and export.
+        # Global display overlay, persisted by MainWindow. See
+        # spec/sprocket-hole-mask.md.
+        self.sprocket_mask_white: bool = False
         self.white_point_bgr = None  # (B, G, R) of dense/exposed area
         self.black_point_bgr = None  # (B, G, R) of transparent/clear area
         # Selected film-stock preset for the black-point-only conversion:
@@ -1809,7 +1815,8 @@ class CCRBackend:
     def _reset_one_slice_round(self, template) -> Optional[int]:
         from core.ccr_processor import (apply_reference_normalization,
                                         apply_bwpoint_normalization,
-                                        compute_reference_norm_params)
+                                        compute_reference_norm_params,
+                                        compute_sprocket_alpha)
         group = template.slice_group
         parent_ops = list(template.source_ops[:-1])
         baked_rotation = template.source_ops[-1][0]
@@ -1910,9 +1917,13 @@ class CCRBackend:
                 "mode": "ref_params", "p_lo": norm_params[0],
                 "p_hi": norm_params[1], "od": norm_params[2]}
         elif bw_points is not None:
+            _raw_scan = parent.resized_raw   # pre-inversion raw for the mask
             parent.resized_raw = apply_bwpoint_normalization(
-                parent.resized_raw, *bw_points, density=bw_density,
+                _raw_scan, *bw_points, density=bw_density,
                 slopes_bgr=bw_slopes)
+            # Reversal-look clear-film mask (spec/sprocket-hole-mask.md), so a
+            # sliced strip stays consistent with the parent preview.
+            parent.sprocket_alpha = compute_sprocket_alpha(_raw_scan, bw_points[0])
             parent.converted = True
             parent._ws_windowed = _ws_enabled()   # bw base is windowed when enabled
             parent.conversion_inputs = {"mode": "bw", "bw": bw_points,

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -172,6 +172,12 @@ class CCRImage:
         # {"mode": "bw", "bw": ((B,G,R),(B,G,R)|None), "fine_rot": int,
         #  "density": bool}   # density: two-point log inversion (see spec)
         self.conversion_inputs: Optional[Dict[str, Any]] = None
+        # Feathered white-mask alpha (uint8 H×W, 0..255) marking clear-film
+        # (sprocket / rebate) regions, at the preview resolution. Set on every
+        # B/W-point conversion; composited to white as the last preview step when
+        # the global reversal-look toggle is on. None otherwise (not persisted —
+        # a reconvert repopulates it). See spec/sprocket-hole-mask.md.
+        self.sprocket_alpha: Optional[np.ndarray] = None
         # User crop as normalized (x1, y1, x2, y2) fractions of the un-rotated/
         # un-flipped image; None = no crop. Display-level only — resized_raw is
         # never modified, so clearing the crop needs no re-conversion.
@@ -830,9 +836,26 @@ class CCRImage:
                        if (self.converted or self._positive_mode_active())
                        else self._auto_brightness_for_preview(adjusted_img))
 
+        # Sprocket-hole / clear-film white mask (reversal look) — the LAST look
+        # step, so no adjustment can tint the whitened regions. B/W-point
+        # conversions only (sprocket_alpha is set only there); gated on the live
+        # global toggle. Applied to the DISPLAY pixels (thumbnail + preview
+        # pixmap) only — the histogram reads the PRE-mask image below, so a
+        # whitened border doesn't add a misleading spike at white. display_img
+        # shares resized_raw's dims, as does the alpha. See spec §4.2.
+        from core.ccr_backend import ccr_backend
+        _mask_on = (self.converted and not self._positive_mode_active()
+                    and self.sprocket_alpha is not None
+                    and ccr_backend.sprocket_mask_white)
+        if _mask_on:
+            from core.ccr_processor import apply_sprocket_mask
+            display_masked = apply_sprocket_mask(display_img, self.sprocket_alpha)
+        else:
+            display_masked = display_img
+
         # Create thumbnail + preview pixels (8-bit RGB numpy — safe on any thread)
-        thumb_img_8 = to_8bit(self.resize_image_to_max_pixel(display_img, thumbnail_size))
-        preview_img = self.resize_image_to_max_pixel(display_img, preview_size)
+        thumb_img_8 = to_8bit(self.resize_image_to_max_pixel(display_masked, thumbnail_size))
+        preview_img = self.resize_image_to_max_pixel(display_masked, preview_size)
         preview_img_8bit = to_8bit(preview_img)
 
         # QPixmap may only be created on the GUI thread, but the batch paths
@@ -858,8 +881,13 @@ class CCRImage:
         # presentation — the percentile-clipped vertical scale, smoothing,
         # filled curves and clip markers — lives in HistogramWidget, which paints
         # at the widget's real resolution. See widgets/histogram_widget.py.
+        # Pre-mask preview for the histogram (the tones the user edits). Identical
+        # to preview_img_8bit when the sprocket mask is off, so only pay the extra
+        # resize when it is on. See spec/sprocket-hole-mask.md §7.
+        hist_base_8bit = (to_8bit(self.resize_image_to_max_pixel(display_img, preview_size))
+                          if _mask_on else preview_img_8bit)
         hist_source = apply_crop_to_image(
-            preview_img_8bit, self.crop_rect, getattr(self, "crop_angle", 0.0) or 0.0)
+            hist_base_8bit, self.crop_rect, getattr(self, "crop_angle", 0.0) or 0.0)
         counts = np.empty((3, 256), dtype=np.float32)
         for i in range(3):   # 0=R, 1=G, 2=B
             counts[i] = cv2.calcHist([hist_source], [i], None, [256], [0, 256]).flatten()
@@ -1155,7 +1183,7 @@ class CCRImage:
         return adjusted
 
     def render_hires_base(self, max_long_side: Optional[int] = None,
-                          conversion_inputs=None) -> Optional[np.ndarray]:
+                          conversion_inputs=None):
         """
         Re-decode this image and reproduce its conversion at the RAW
         half-size resolution (capped at max_long_side — important for
@@ -1163,17 +1191,22 @@ class CCRImage:
         color-matched to the 1080 preview: the conversion is replayed from
         the snapshot captured at convert time (conversion_inputs), never
         from live editable state, so it always matches what the preview
-        shows. Returns the converted, PRE-adjustment uint16 array (or the
-        raw scan for un-converted images). Runs on a worker thread for the
-        zoom detail view; never touches resized_raw or any preview state.
+        shows. Runs on a worker thread for the zoom detail view; never
+        touches resized_raw or any preview state.
+
+        Returns `(base, sprocket_alpha)`: `base` is the converted, PRE-
+        adjustment uint16 array (or the raw scan for un-converted images, or
+        None when no color-matched replay is possible); `sprocket_alpha` is
+        the hi-res clear-film white-mask alpha for B/W-point conversions
+        (None otherwise). See spec/sprocket-hole-mask.md §4.2.
         """
         ci = conversion_inputs if conversion_inputs is not None else self.conversion_inputs
         if self.converted and ci is None:
-            return None  # converted through an unknown path — no replay possible
+            return None, None  # converted through an unknown path — no replay possible
         t0 = time.time()
         img = self.read_image(self.file_path, preview=True, max_long_side=max_long_side)
         if img is None:
-            return None
+            return None, None
         print(f"Hi-res decode: {time.time() - t0:.2f}s, shape {img.shape}")
         # Decide replay from the (snapshotted) conversion_inputs, NOT the live
         # self.converted flag: a positive-mode toggle can clear self.converted on
@@ -1181,11 +1214,13 @@ class CCRImage:
         # conversion its snapshot describes. ci is None for un-converted scans
         # (incl. positive mode) -> return the decoded image as-is.
         if not ci:
-            return img
+            return img, None
 
         from core.ccr_processor import (compute_reference_norm_params,
                                         apply_reference_normalization,
-                                        apply_bwpoint_normalization)
+                                        apply_bwpoint_normalization,
+                                        compute_sprocket_alpha)
+        sprocket_alpha = None
         t0 = time.time()
         if ci.get("mode") == "ref":
             ref_small = self.resize_image_to_max_pixel(img, 1080)
@@ -1206,10 +1241,13 @@ class CCRImage:
             out = apply_bwpoint_normalization(img, black_point, white_point,
                                               density=ci.get("density", False),
                                               slopes_bgr=ci.get("slopes"))
+            # Hi-res clear-film mask from the re-decoded raw (same threshold as
+            # the preview; morphology/feather scale with this resolution).
+            sprocket_alpha = compute_sprocket_alpha(img, black_point)
         else:
-            return None
+            return None, None
         print(f"Hi-res convert: {time.time() - t0:.2f}s")
-        return out
+        return out, sprocket_alpha
 
     # --- Undo support (Ctrl+Z) ---------------------------------------------
     UNDO_STACK_LIMIT = 50

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -977,6 +977,92 @@ DEFAULT_DENSITY_GAMMA = 1.0
 _DENSITY_FLOOR = 1.0
 
 
+# --- Sprocket-hole / clear-film white mask (spec/sprocket-hole-mask.md) ---
+# On a 135 negative the punched sprocket holes and clear rebate scan BRIGHTER than
+# the sampled film base, so after inversion they clamp to pure black. This optional
+# reversal-film look paints those clear-film regions WHITE as the last render step.
+# The mask is derived from the RAW scan ("clearer than the sampled black point plus
+# a padding"), morphologically cleaned, and feathered. Threshold is resolution-
+# independent; morphology/feather radii scale with the buffer's long side so the
+# preview, hi-res zoom, and export agree geometrically.
+def _sprocket_cfg():
+    """Read the (env-overridable) mask parameters. Fraction/abs padding are per-
+    channel; the *_PX radii are quoted at SPROCKET_REF_LONG and scaled per buffer."""
+    def _f(name, default):
+        try:
+            return float(os.environ.get(name, "").strip() or default)
+        except ValueError:
+            return default
+    return {
+        "pad_frac": _f("FREECCR_SPROCKET_PAD_FRAC", 0.20),
+        "pad_abs":  _f("FREECCR_SPROCKET_PAD_ABS", 0.02),   # fraction of full scale
+        "open_px":  _f("FREECCR_SPROCKET_OPEN_PX", 2.0),
+        "close_px": _f("FREECCR_SPROCKET_CLOSE_PX", 5.0),
+        "feather_px": _f("FREECCR_SPROCKET_FEATHER_PX", 8.0),
+    }
+
+
+SPROCKET_REF_LONG = 1080   # long side the *_PX radii are quoted at
+
+
+def _odd_ksize(radius: float) -> int:
+    """Odd cv2 kernel size (>= 3) covering `radius` px each side of the centre."""
+    return max(3, int(round(radius)) * 2 + 1)
+
+
+def compute_sprocket_alpha(raw_bgr, black_point_bgr):
+    """A feathered white-mask alpha (uint8 H×W, 0..255) marking clear-film
+    (sprocket / rebate) regions — pixels clearer than the sampled film base by a
+    padding — or None if the black point is unset or nothing qualifies.
+
+    `raw_bgr` is the working scan (BGR, the same array the invert helpers consume);
+    `black_point_bgr` is the sampled clear/film-base anchor (BGR, HIGH values).
+    Pure/thread-safe. See spec/sprocket-hole-mask.md §4.1."""
+    if black_point_bgr is None or raw_bgr is None:
+        return None
+    cfg = _sprocket_cfg()
+    d = raw_bgr.astype(np.float32, copy=False)
+    if d.ndim != 3 or d.shape[2] < 3:
+        return None
+    bp = np.asarray(black_point_bgr, dtype=np.float32)[:3]
+    head = np.maximum(65535.0 - bp, 1.0)                 # per-channel headroom above base
+    pad = np.maximum(cfg["pad_frac"] * head, cfg["pad_abs"] * 65535.0)
+    thr = bp + pad                                       # (3,) BGR
+    # AND across channels: clear film is bright in EVERY channel; exposed scene
+    # content (even deep shadow) is denser than the zero-exposure base, so it is
+    # lower than base in every channel and structurally excluded.
+    mask = np.all(d[..., :3] > thr[None, None, :], axis=2)
+    if not mask.any():
+        return None
+    m = (mask.astype(np.uint8)) * 255
+    scale = max(d.shape[0], d.shape[1]) / float(SPROCKET_REF_LONG)
+    open_k = cv2.getStructuringElement(
+        cv2.MORPH_ELLIPSE, (_odd_ksize(cfg["open_px"] * scale),) * 2)
+    close_k = cv2.getStructuringElement(
+        cv2.MORPH_ELLIPSE, (_odd_ksize(cfg["close_px"] * scale),) * 2)
+    m = cv2.morphologyEx(m, cv2.MORPH_OPEN, open_k)      # drop noise specks
+    m = cv2.morphologyEx(m, cv2.MORPH_CLOSE, close_k)    # fill small gaps
+    if not m.any():
+        return None
+    feather = max(1.0, cfg["feather_px"] * scale)
+    ksz = _odd_ksize(feather)
+    return cv2.GaussianBlur(m, (ksz, ksz), feather / 2.0)   # uint8 0..255 ramp
+
+
+def apply_sprocket_mask(rgb_u16, alpha_u8):
+    """Composite the clear-film regions to white (65535): alpha 0 keeps the image,
+    255 is full white, in-between is the feathered blend. Returns the input
+    unchanged when `alpha_u8` is None or shapes don't match. Channel-order-agnostic
+    (paints neutral white). See spec/sprocket-hole-mask.md §4.1."""
+    if alpha_u8 is None or rgb_u16 is None:
+        return rgb_u16
+    if alpha_u8.shape[:2] != rgb_u16.shape[:2]:
+        return rgb_u16
+    a = alpha_u8.astype(np.float32)[..., None] / 255.0
+    out = rgb_u16.astype(np.float32) * (1.0 - a) + 65535.0 * a
+    return np.clip(out, 0, 65535).astype(np.uint16)
+
+
 # --- Working space with headroom (spec/working-space-headroom.md) ---
 # The inverted "base" buffer reserves a narrow DISPLAY WINDOW inside the 16-bit
 # container and keeps out-of-window data as recoverable headroom instead of
@@ -1326,6 +1412,13 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
     if img is None:
         raise ValueError("CCRImage: could not load image data for B/W point conversion")
 
+    # Sprocket-hole / clear-film white mask (reversal look), derived from the RAW
+    # scan relative to the sampled black point while the raw is still in hand.
+    # Computed regardless of the toggle: the preview caches it (so turning the
+    # toggle on later needs no re-conversion) and the export composites it only
+    # when enabled. See spec/sprocket-hole-mask.md.
+    sprocket_alpha = compute_sprocket_alpha(img, black_point_bgr)
+
     # Fine rotation uses DISPLAY semantics, like the reference pipeline: the
     # per-pixel B/W-point mapping is rotation-independent, so the preview
     # result stays un-rotated (the canvas item applies the live angle) and an
@@ -1416,6 +1509,9 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
         ccr_image.contrast_base = 0
         ccr_image.temperature_base = 0
         ccr_image._ws_windowed = ws
+        # Cache the sprocket alpha for the live preview overlay (applied last, and
+        # gated by the toggle, in update_thumbnail_and_preview).
+        ccr_image.sprocket_alpha = sprocket_alpha
     if ws:
         # ASCII only: this prints during EVERY B/W-point conversion, and an
         # em dash here crashed converts on macOS (ASCII stdout, issue #86).
@@ -1438,6 +1534,13 @@ def ccr_normalize_with_bwpoint(ccr_image, black_point_bgr, white_point_bgr=None,
         rgb_result = ccr_image.apply_adjustments(rgb_result, contrast_base=0,
                                                  temperature_base=0,
                                                  ws_windowed=ws)
+        # White the sprocket holes / clear film as the last look step — after all
+        # adjustments, before the geometric block (same un-rotated space as the
+        # preview overlay, so it is WYSIWYG). Gated on the live toggle; deferred
+        # import avoids a module cycle. See spec/sprocket-hole-mask.md §4.2.
+        from core.ccr_backend import ccr_backend as _bk
+        if getattr(_bk, "sprocket_mask_white", False):
+            rgb_result = apply_sprocket_mask(rgb_result, sprocket_alpha)
 
     # --- Export path: flips, rotation, file write ---
     if output_path is not None:

--- a/src/core/ccr_processor.py
+++ b/src/core/ccr_processor.py
@@ -982,12 +982,16 @@ _DENSITY_FLOOR = 1.0
 # the sampled film base, so after inversion they clamp to pure black. This optional
 # reversal-film look paints those clear-film regions WHITE as the last render step.
 # The mask is derived from the RAW scan ("clearer than the sampled black point plus
-# a padding"), morphologically cleaned, and feathered. Threshold is resolution-
-# independent; morphology/feather radii scale with the buffer's long side so the
-# preview, hi-res zoom, and export agree geometrically.
+# a padding") and cleaned so the holes stay SHARP: noise specks are dropped by
+# connected-component area (no morphological erosion that would round corners),
+# interior gaps (dust/markings inside a hole) are filled by a flood-fill imfill
+# (no dilation that would round/expand the outer edge), and only a light 1 px
+# feather is applied for anti-aliasing. The threshold is resolution-independent;
+# the area cutoff and feather scale with the buffer's long side so the preview,
+# hi-res zoom, and export agree geometrically.
 def _sprocket_cfg():
     """Read the (env-overridable) mask parameters. Fraction/abs padding are per-
-    channel; the *_PX radii are quoted at SPROCKET_REF_LONG and scaled per buffer."""
+    channel; min-area/feather are quoted at SPROCKET_REF_LONG and scaled per buffer."""
     def _f(name, default):
         try:
             return float(os.environ.get(name, "").strip() or default)
@@ -995,14 +999,13 @@ def _sprocket_cfg():
             return default
     return {
         "pad_frac": _f("FREECCR_SPROCKET_PAD_FRAC", 0.20),
-        "pad_abs":  _f("FREECCR_SPROCKET_PAD_ABS", 0.02),   # fraction of full scale
-        "open_px":  _f("FREECCR_SPROCKET_OPEN_PX", 2.0),
-        "close_px": _f("FREECCR_SPROCKET_CLOSE_PX", 5.0),
-        "feather_px": _f("FREECCR_SPROCKET_FEATHER_PX", 8.0),
+        "pad_abs":  _f("FREECCR_SPROCKET_PAD_ABS", 0.02),      # fraction of full scale
+        "min_area_px": _f("FREECCR_SPROCKET_MIN_AREA_PX", 24.0),  # speckle cutoff @1080
+        "feather_px": _f("FREECCR_SPROCKET_FEATHER_PX", 1.0),  # anti-alias only @1080
     }
 
 
-SPROCKET_REF_LONG = 1080   # long side the *_PX radii are quoted at
+SPROCKET_REF_LONG = 1080   # long side the px params are quoted at
 
 
 def _odd_ksize(radius: float) -> int:
@@ -1010,10 +1013,26 @@ def _odd_ksize(radius: float) -> int:
     return max(3, int(round(radius)) * 2 + 1)
 
 
+def _fill_interior_holes(mask_u8):
+    """Fill regions of 0 fully enclosed by 1 (interior holes) WITHOUT touching the
+    outer boundary — classic imfill via a border flood fill. Unlike a
+    morphological close it never dilates or rounds the true edge, so the sprocket
+    holes stay sharp. A 1 px background pad guarantees the flood seed is outside
+    any hole even when a hole touches the frame edge."""
+    padded = cv2.copyMakeBorder(mask_u8, 1, 1, 1, 1, cv2.BORDER_CONSTANT, value=0)
+    ff = padded.copy()
+    ffmask = np.zeros((padded.shape[0] + 2, padded.shape[1] + 2), np.uint8)
+    cv2.floodFill(ff, ffmask, (0, 0), 255)          # reachable-from-border background
+    holes = cv2.bitwise_not(ff)                      # everything NOT reachable = holes
+    filled = cv2.bitwise_or(padded, holes)
+    return filled[1:-1, 1:-1]
+
+
 def compute_sprocket_alpha(raw_bgr, black_point_bgr):
-    """A feathered white-mask alpha (uint8 H×W, 0..255) marking clear-film
-    (sprocket / rebate) regions — pixels clearer than the sampled film base by a
-    padding — or None if the black point is unset or nothing qualifies.
+    """A white-mask alpha (uint8 H×W, 0..255) marking clear-film (sprocket /
+    rebate) regions — pixels clearer than the sampled film base by a padding — or
+    None if the black point is unset or nothing qualifies. The holes are kept
+    sharp (area-based speckle removal + interior-hole fill, only a light feather).
 
     `raw_bgr` is the working scan (BGR, the same array the invert helpers consume);
     `black_point_bgr` is the sampled clear/film-base anchor (BGR, HIGH values).
@@ -1036,17 +1055,27 @@ def compute_sprocket_alpha(raw_bgr, black_point_bgr):
         return None
     m = (mask.astype(np.uint8)) * 255
     scale = max(d.shape[0], d.shape[1]) / float(SPROCKET_REF_LONG)
-    open_k = cv2.getStructuringElement(
-        cv2.MORPH_ELLIPSE, (_odd_ksize(cfg["open_px"] * scale),) * 2)
-    close_k = cv2.getStructuringElement(
-        cv2.MORPH_ELLIPSE, (_odd_ksize(cfg["close_px"] * scale),) * 2)
-    m = cv2.morphologyEx(m, cv2.MORPH_OPEN, open_k)      # drop noise specks
-    m = cv2.morphologyEx(m, cv2.MORPH_CLOSE, close_k)    # fill small gaps
-    if not m.any():
+    # Drop tiny speckles by connected-component AREA — no morphological erosion,
+    # so hole edges/corners keep their true (sharp) shape.
+    min_area = max(1, int(round(cfg["min_area_px"] * scale * scale)))
+    num, labels, stats, _ = cv2.connectedComponentsWithStats(m, 8)
+    if num <= 1:
         return None
-    feather = max(1.0, cfg["feather_px"] * scale)
-    ksz = _odd_ksize(feather)
-    return cv2.GaussianBlur(m, (ksz, ksz), feather / 2.0)   # uint8 0..255 ramp
+    areas = stats[:, cv2.CC_STAT_AREA].copy()
+    areas[0] = 0                                         # label 0 is the background
+    keep = np.flatnonzero(areas >= min_area)
+    if keep.size == 0:
+        return None
+    m = np.isin(labels, keep).astype(np.uint8) * 255
+    # Fill interior holes (dust/markings inside a hole) without rounding the outer
+    # boundary — a flood-fill imfill, NOT a morphological close.
+    m = _fill_interior_holes(m)
+    # Light feather for anti-aliasing only (keeps the holes crisp).
+    feather = cfg["feather_px"] * scale
+    if feather >= 0.5:
+        ksz = _odd_ksize(feather)
+        m = cv2.GaussianBlur(m, (ksz, ksz), feather / 2.0)
+    return m
 
 
 def apply_sprocket_mask(rgb_u16, alpha_u8):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -219,6 +219,11 @@ class MainWindow(QMainWindow):
         ccr_backend.awb_algorithm = (
             stored_algo if any(a == stored_algo for a, _ in AWB_ALGORITHMS)
             else AWB_DEFAULT)
+        # Restore the reversal-look sprocket-hole mask (default OFF). When on,
+        # clear-film regions are painted white as the last render step for
+        # B/W-point conversions. See spec/sprocket-hole-mask.md.
+        ccr_backend.sprocket_mask_white = self._settings.value(
+            "adjust/sprocket_mask_white", False, type=bool)
         # Reflect the restored mode in the toolbar/slider gating right away
         # (no images yet, but the negative-only actions should already grey out).
         self.image_preview._update_unconvert_action_state()
@@ -757,6 +762,18 @@ class MainWindow(QMainWindow):
         self._rerender_all_for_global_mode(
             "Gamma: hue-preserving (luminance) mode." if checked else
             "Gamma: per-channel mode (standard).")
+
+    def on_sprocket_mask_toggled(self, checked: bool):
+        """Flip the global reversal-look sprocket-hole mask, persist it, and
+        re-render all loaded images. The mask is composited last as a display
+        overlay (the alpha is cached at convert time), so this only re-renders —
+        no re-conversion, no catalog write. Mirrors on_auto_gain_toggled.
+        See spec/sprocket-hole-mask.md."""
+        ccr_backend.sprocket_mask_white = bool(checked)
+        self._settings.setValue("adjust/sprocket_mask_white", bool(checked))
+        self._rerender_all_for_global_mode(
+            "Sprocket holes / clear film shown white (reversal look)." if checked
+            else "Sprocket holes shown as converted (black).")
 
     def show_about_dialog(self):
         QMessageBox.about(

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1857,6 +1857,9 @@ class ImagePreview(QWidget):
                 # spec/gamma-luminance-mode.md).
                 bool(getattr(ccr_backend, "gamma_luminance", False)),
                 bool(getattr(ccr_backend, "auto_gain", True)),
+                # Reversal-look sprocket mask is composited last in the hi-res
+                # tile — a toggle must invalidate it (spec/sprocket-hole-mask.md).
+                bool(getattr(ccr_backend, "sprocket_mask_white", False)),
                 areas_sig, dust_sig)
 
     HIRES_MAX_LONG_SIDE = 4500   # bounds non-RAW decodes (RAW half-size passes through)
@@ -1873,6 +1876,7 @@ class ImagePreview(QWidget):
         adj_sig = self._current_adj_sig()
         cache = self._hires
         base = None
+        sprocket_alpha = None
         if cache is not None and cache["img"] is img and cache["sig"] == sig:
             if cache.get("full_pm") is not None and cache.get("adj_sig") == adj_sig:
                 # Cache is current — just make sure it is displayed
@@ -1880,19 +1884,22 @@ class ImagePreview(QWidget):
                 self.apply_transformations()
                 return
             base = cache.get("base")  # re-adjust only; skip decode+convert
+            sprocket_alpha = cache.get("sprocket_alpha")  # reuse with the cached base
         # A matching render may already be in flight; its result is accepted
         # by current-state validation, so waiting for it is always safe.
         for w in self._hires_workers:
             if (w.isRunning() and w.req_img is img
                     and w.req_sig == sig and w.req_adj_sig == adj_sig):
                 return
-        worker = HiResDetailWorker(img, sig, adj_sig, base, self.HIRES_MAX_LONG_SIDE)
+        worker = HiResDetailWorker(img, sig, adj_sig, base,
+                                   self.HIRES_MAX_LONG_SIDE,
+                                   sprocket_alpha=sprocket_alpha)
         worker.finished_hires.connect(self._on_hires_ready)
         worker.finished.connect(lambda w=worker: self._hires_workers.discard(w))
         self._hires_workers.add(worker)
         worker.start()
 
-    def _on_hires_ready(self, img_obj, sig, adj_sig, base, display8):
+    def _on_hires_ready(self, img_obj, sig, adj_sig, base, sprocket_alpha, display8):
         # Accept by validating against CURRENT state (not a generation
         # counter): the result is useful iff the same image object is still
         # displayed, its conversion snapshot still matches, and we are still
@@ -1910,11 +1917,13 @@ class ImagePreview(QWidget):
             # Sliders moved while rendering: the decoded base is still valid,
             # the adjusted display is not — keep the base, re-render shortly.
             self._hires = {"img": img_obj, "sig": sig, "adj_sig": None,
-                           "base": base, "full_pm": None,
+                           "base": base, "sprocket_alpha": sprocket_alpha,
+                           "full_pm": None,
                            "display_pm": None, "crop_sig": None}
             self._hires_timer.start(150)
             return
         self._hires = {"img": img_obj, "sig": sig, "adj_sig": adj_sig, "base": base,
+                       "sprocket_alpha": sprocket_alpha,
                        "full_pm": QPixmap.fromImage(qimg),
                        "display_pm": None, "crop_sig": None}
         self._refresh_item_pixmap()
@@ -2847,7 +2856,10 @@ class ImagePreview(QWidget):
         from core import dust_detect
         raw = None
         try:
-            raw = img.render_hires_base(
+            # render_hires_base returns (base, sprocket_alpha); the detector wants
+            # the converted base only (the mask is a display overlay, irrelevant
+            # to dust detection).
+            raw, _ = img.render_hires_base(
                 max_long_side=dust_detect.DETECT_MAX_LONG)
         except Exception:
             raw = None   # decode/replay failed — the preview buffer still works
@@ -4496,16 +4508,19 @@ class HiResDetailWorker(QThread):
     construction time (on the GUI thread), so concurrent edits cannot bleed
     into the render."""
 
-    finished_hires = Signal(object, object, object, object, object)
-    # img_obj, sig, adj_sig, base (uint16 ndarray), display8 (uint8 ndarray)
+    finished_hires = Signal(object, object, object, object, object, object)
+    # img_obj, sig, adj_sig, base (uint16 ndarray), sprocket_alpha (uint8|None),
+    # display8 (uint8 ndarray)
 
-    def __init__(self, img_obj, sig, adj_sig, base=None, max_long_side=None, parent=None):
+    def __init__(self, img_obj, sig, adj_sig, base=None, max_long_side=None,
+                 sprocket_alpha=None, parent=None):
         super().__init__(parent)
         self._img = img_obj
         self.req_img = img_obj
         self.req_sig = sig
         self.req_adj_sig = adj_sig
         self._base = base
+        self._sprocket_alpha = sprocket_alpha
         self._cap = max_long_side
         # Snapshots taken on the GUI thread at request time:
         self._settings = dict(img_obj.adjustment_settings)
@@ -4520,6 +4535,9 @@ class HiResDetailWorker(QThread):
         # Captured at request time (thread-safe): positive mode skips the
         # negative display auto-brightness, like update_thumbnail_and_preview.
         self._positive_mode = ccr_backend.positive_mode
+        # Snapshot the reversal-look toggle so a mid-render flip can't bleed in
+        # (the flag is also in _current_adj_sig, so a flip invalidates the tile).
+        self._sprocket_white = bool(getattr(ccr_backend, "sprocket_mask_white", False))
         ci = getattr(img_obj, "conversion_inputs", None)
         self._conversion_inputs = dict(ci) if ci else None
 
@@ -4530,8 +4548,9 @@ class HiResDetailWorker(QThread):
             import numpy as _np
             t0 = _time.perf_counter()
             base = self._base
+            sprocket_alpha = self._sprocket_alpha
             if base is None:
-                base = self._img.render_hires_base(
+                base, sprocket_alpha = self._img.render_hires_base(
                     max_long_side=self._cap,
                     conversion_inputs=self._conversion_inputs)
             if base is None or self.isInterruptionRequested():
@@ -4549,6 +4568,11 @@ class HiResDetailWorker(QThread):
                 # display-only auto-brightness stretch for raw negatives
                 # (skipped in positive mode — the decode is already exposed).
                 display = self._img._auto_brightness_for_preview(display)
+            # Reversal-look sprocket mask — the LAST look step, matching the
+            # preview (spec/sprocket-hole-mask.md §4.2).
+            if self._sprocket_white and sprocket_alpha is not None:
+                from core.ccr_processor import apply_sprocket_mask
+                display = apply_sprocket_mask(display, sprocket_alpha)
             display8 = _np.ascontiguousarray(
                 _cv2.convertScaleAbs(display, alpha=255.0 / 65535.0))
             t2 = _time.perf_counter()
@@ -4558,7 +4582,8 @@ class HiResDetailWorker(QThread):
             if self.isInterruptionRequested():
                 return  # app is closing — receiver is being torn down
             self.finished_hires.emit(self.req_img, self.req_sig,
-                                     self.req_adj_sig, base, display8)
+                                     self.req_adj_sig, base, sprocket_alpha,
+                                     display8)
         except Exception as e:
             print(f"Hi-res detail render failed: {e}")
 

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -147,6 +147,20 @@ class SettingsDialog(QDialog):
             "colors — robust when large areas share one color."))
         lay.addWidget(grp_wb)
 
+        grp_border = QGroupBox("Film border")
+        gb = QVBoxLayout(grp_border)
+        gb.setSpacing(theme.GAP_ROW)
+        self._cb_sprocket = QCheckBox(
+            "White sprocket holes / clear film (reversal look)")
+        gb.addWidget(self._cb_sprocket)
+        gb.addWidget(self._muted(
+            "After you set a Black Point (film base), paint the sprocket holes "
+            "and clear film border white instead of black — the reversal-film "
+            "look. The mask is built from areas brighter than the film base, "
+            "cleaned up and feathered, and applied last on both preview and "
+            "export, so no adjustment tints it. B/W-point conversions only."))
+        lay.addWidget(grp_border)
+
         lay.addStretch(1)
         return page
 
@@ -296,7 +310,8 @@ class SettingsDialog(QDialog):
                         (self._cb_density, ccr_backend.density_bwpoint),
                         (self._cb_auto_gain, ccr_backend.auto_gain),
                         (self._cb_auto_awb, ccr_backend.auto_awb),
-                        (self._cb_gamma_lum, ccr_backend.gamma_luminance)):
+                        (self._cb_gamma_lum, ccr_backend.gamma_luminance),
+                        (self._cb_sprocket, ccr_backend.sprocket_mask_white)):
             cb.blockSignals(True)
             cb.setChecked(bool(val))
             cb.blockSignals(False)
@@ -335,6 +350,8 @@ class SettingsDialog(QDialog):
             self._mw.on_awb_algorithm_changed(staged_algo)
         if bool(self._cb_gamma_lum.isChecked()) != bool(ccr_backend.gamma_luminance):
             self._mw.on_gamma_mode_toggled(bool(self._cb_gamma_lum.isChecked()))
+        if bool(self._cb_sprocket.isChecked()) != bool(ccr_backend.sprocket_mask_white):
+            self._mw.on_sprocket_mask_toggled(bool(self._cb_sprocket.isChecked()))
 
     def accept(self):
         """Done: commit the staged toggles, then close. (Escape/close → reject,

--- a/tests/test_sprocket_mask.py
+++ b/tests/test_sprocket_mask.py
@@ -101,8 +101,52 @@ def test_feather_is_soft_ramp_solid_interior():
     alpha = compute_sprocket_alpha(img, bp)
     assert alpha is not None
     assert alpha.max() == 255                      # solid interior
-    # A feather band of intermediate alpha exists around the edge.
+    # A thin feather band of intermediate alpha exists around the edge.
     assert np.any((alpha > 0) & (alpha < 255))
+
+
+# --- sharpness: keep the true hole shape ----------------------------------
+
+def test_interior_hole_is_filled():
+    # A dark speck inside a hole (dust / a printed frame number) must NOT punch
+    # through — the interior fills solid via the flood-fill imfill.
+    bp = (30000, 30000, 30000)
+    img = _base_plate(1080, 1080, bp)
+    img = _with_square(img, 300, 780, 300, 780, (62000, 62000, 62000))   # hole
+    img = _with_square(img, 520, 560, 520, 560, (8000, 8000, 8000))      # dark speck inside
+    alpha = compute_sprocket_alpha(img, bp)
+    assert alpha is not None
+    assert alpha[540, 540] == 255      # filled despite the dark speck at the centre
+
+
+def test_tiny_speckle_removed():
+    # An isolated few-pixel bright speck (noise) far from any hole is dropped by
+    # the connected-component area filter, while the real hole is kept.
+    bp = (30000, 30000, 30000)
+    img = _base_plate(1080, 1080, bp)
+    img = _with_square(img, 300, 780, 300, 780, (62000, 62000, 62000))   # real hole
+    img = _with_square(img, 60, 63, 60, 63, (62000, 62000, 62000))       # 3x3 speck
+    alpha = compute_sprocket_alpha(img, bp)
+    assert alpha is not None
+    assert alpha[540, 540] == 255       # hole kept
+    assert alpha[61, 61] == 0           # speck removed
+
+
+def test_edges_stay_sharp_not_dilated():
+    # No morphological dilation and only a ~1px feather: a few px OUTSIDE the true
+    # boundary stays 0 (the old close + 8px feather glowed here), and the edge
+    # transition is a narrow anti-alias band, not a soft ramp.
+    bp = (30000, 30000, 30000)
+    img = _base_plate(1080, 1080, bp)
+    img = _with_square(img, 400, 680, 400, 680, (62000, 62000, 62000))   # edge at x=400
+    alpha = compute_sprocket_alpha(img, bp)
+    assert alpha is not None
+    assert alpha[540, 540] == 255       # interior solid
+    assert alpha[540, 396] == 0         # 4px outside the edge -> not whitened
+    # The transition band around the left edge is only a pixel or two wide.
+    window = alpha[540, 395:406]
+    intermediate = int(np.sum((window > 0) & (window < 255)))
+    assert intermediate <= 4
 
 
 # --- resolution scaling: preview vs export agree geometrically ------------

--- a/tests/test_sprocket_mask.py
+++ b/tests/test_sprocket_mask.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Tests for the sprocket-hole / clear-film white mask (spec/sprocket-hole-mask.md).
+
+On a 135 negative the punched sprocket holes and clear rebate scan BRIGHTER than
+the sampled film base, so after inversion they clamp to pure black. The optional
+reversal-film look paints those clear-film regions white as the last render step.
+The mask is derived from the RAW scan ("clearer than the sampled black point plus
+a padding"), morphologically cleaned, and feathered. Pure numpy/cv2 core, headless.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.ccr_processor import (  # noqa: E402
+    compute_sprocket_alpha,
+    apply_sprocket_mask,
+    SPROCKET_REF_LONG,
+)
+
+
+# --- synthetic raw scans (BGR, uint16) ------------------------------------
+
+def _base_plate(h, w, bp=(30000, 30000, 30000)):
+    """A uniform film-base plate at the (BGR) black-point value."""
+    img = np.empty((h, w, 3), dtype=np.uint16)
+    for c in range(3):
+        img[..., c] = bp[c]
+    return img
+
+
+def _with_square(img, y0, y1, x0, x1, value):
+    """Paint a rectangular region to a (BGR) value (a hole or a scene patch)."""
+    out = img.copy()
+    for c in range(3):
+        out[y0:y1, x0:x1, c] = value[c]
+    return out
+
+
+# --- threshold isolates clear film ----------------------------------------
+
+def test_hole_masked_scene_and_base_not():
+    bp = (30000, 30000, 30000)
+    img = _base_plate(1080, 1080, bp)
+    # A bright square (a "sprocket hole": clearer than base in every channel).
+    img = _with_square(img, 400, 680, 400, 680, (62000, 62000, 62000))
+    # A darker square (exposed "scene": denser than base -> lower than base).
+    img = _with_square(img, 100, 300, 100, 300, (10000, 10000, 10000))
+
+    alpha = compute_sprocket_alpha(img, bp)
+    assert alpha is not None
+    assert alpha.dtype == np.uint8
+    assert alpha.shape == (1080, 1080)
+    # Solid white deep inside the hole, zero over base and over the scene patch.
+    assert alpha[540, 540] == 255
+    assert alpha[200, 200] == 0          # scene patch
+    assert alpha[900, 900] == 0          # bare film base
+
+
+def test_padding_rejects_base_noise():
+    bp = (30000, 30000, 30000)
+    rng = np.random.default_rng(0)
+    img = _base_plate(1080, 1080, bp).astype(np.int32)
+    # Noise amplitude well under the padding (0.20*headroom ~= 7107, floor
+    # 0.02*65535 ~= 1311) -> nothing should qualify.
+    img = img + rng.integers(-400, 400, size=img.shape)
+    img = np.clip(img, 0, 65535).astype(np.uint16)
+    assert compute_sprocket_alpha(img, bp) is None
+
+
+def test_per_channel_and_requires_all_channels():
+    # Brighter than base in G and R only (B stays at base) -> NOT clear film.
+    bp = (30000, 30000, 30000)
+    img = _base_plate(1080, 1080, bp)
+    img = _with_square(img, 400, 680, 400, 680, (30000, 62000, 62000))  # B unchanged
+    assert compute_sprocket_alpha(img, bp) is None
+
+
+def test_no_black_point_is_none():
+    img = _base_plate(256, 256)
+    assert compute_sprocket_alpha(img, None) is None
+
+
+def test_no_qualifying_pixels_is_none():
+    bp = (30000, 30000, 30000)
+    # Everything at or below base (a densely exposed frame, no clear film).
+    img = _base_plate(512, 512, bp)
+    assert compute_sprocket_alpha(img, bp) is None
+
+
+# --- feather is a soft ramp -----------------------------------------------
+
+def test_feather_is_soft_ramp_solid_interior():
+    bp = (30000, 30000, 30000)
+    img = _base_plate(1080, 1080, bp)
+    img = _with_square(img, 300, 780, 300, 780, (62000, 62000, 62000))
+    alpha = compute_sprocket_alpha(img, bp)
+    assert alpha is not None
+    assert alpha.max() == 255                      # solid interior
+    # A feather band of intermediate alpha exists around the edge.
+    assert np.any((alpha > 0) & (alpha < 255))
+
+
+# --- resolution scaling: preview vs export agree geometrically ------------
+
+def test_resolution_scaling_matches():
+    bp = (30000, 30000, 30000)
+
+    def masked_fraction_and_feather(long_side):
+        img = _base_plate(long_side, long_side, bp)
+        q = long_side // 4
+        img = _with_square(img, q, 3 * q, q, 3 * q, (62000, 62000, 62000))
+        alpha = compute_sprocket_alpha(img, bp)
+        assert alpha is not None
+        frac = float((alpha == 255).sum()) / alpha.size
+        feather_band = int(((alpha > 0) & (alpha < 255)).sum())
+        return frac, feather_band
+
+    f1, band1 = masked_fraction_and_feather(SPROCKET_REF_LONG)          # 1080
+    f4, band4 = masked_fraction_and_feather(SPROCKET_REF_LONG * 4)      # 4320
+
+    # Solid-white area fraction is resolution-independent (same geometry).
+    assert abs(f1 - f4) < 0.02
+    # The feather band is a fixed px width -> its pixel COUNT grows ~ with the
+    # perimeter (×4) and the band width (×4), i.e. ~×16 for a 4× upscale.
+    assert 8 < (band4 / max(band1, 1)) < 32
+
+
+# --- the composite ---------------------------------------------------------
+
+def test_apply_paints_white_and_blends():
+    rgb = np.full((4, 4, 3), 5000, dtype=np.uint16)
+    alpha = np.zeros((4, 4), dtype=np.uint8)
+    alpha[0, 0] = 255      # full white
+    alpha[1, 1] = 128      # half blend
+    out = apply_sprocket_mask(rgb, alpha)
+    assert out.dtype == np.uint16
+    assert tuple(out[0, 0]) == (65535, 65535, 65535)          # painted white
+    assert tuple(out[2, 2]) == (5000, 5000, 5000)             # untouched
+    expected = round(5000 * (1 - 128 / 255) + 65535 * (128 / 255))
+    assert abs(int(out[1, 1, 0]) - expected) <= 1             # feathered blend
+
+
+def test_apply_none_alpha_is_noop():
+    rgb = np.full((4, 4, 3), 5000, dtype=np.uint16)
+    assert apply_sprocket_mask(rgb, None) is rgb
+
+
+def test_apply_shape_mismatch_is_noop():
+    rgb = np.full((4, 4, 3), 5000, dtype=np.uint16)
+    alpha = np.zeros((8, 8), dtype=np.uint8)
+    assert apply_sprocket_mask(rgb, alpha) is rgb
+
+
+# --- env override tunes the padding ---------------------------------------
+
+def test_env_pad_override(monkeypatch):
+    bp = (30000, 30000, 30000)
+    img = _base_plate(1080, 1080, bp)
+    # A square only slightly above base: caught with a small pad, rejected with
+    # a large one.
+    img = _with_square(img, 400, 680, 400, 680, (36000, 36000, 36000))
+    monkeypatch.setenv("FREECCR_SPROCKET_PAD_FRAC", "0.02")
+    monkeypatch.setenv("FREECCR_SPROCKET_PAD_ABS", "0.0")
+    assert compute_sprocket_alpha(img, bp) is not None
+    monkeypatch.setenv("FREECCR_SPROCKET_PAD_FRAC", "0.60")
+    assert compute_sprocket_alpha(img, bp) is None
+
+
+# --- backend flag + convert integration -----------------------------------
+
+def test_backend_flag_defaults_off():
+    from core.ccr_backend import ccr_backend
+    assert ccr_backend.sprocket_mask_white is False
+
+
+class _Stub:
+    """Minimal ccr_image surface for a preview-path B/W-point conversion."""
+    def __init__(self, raw):
+        self.resized_raw = raw
+        self.fine_rotation_angle = 0
+        self.horizontal_mirrored = False
+        self.vertical_mirrored = False
+        self.crop_rect = None
+        self.crop_angle = 0.0
+        self.rotation_angle = 0
+        self.sprocket_alpha = None
+        self.contrast_base = 0
+        self.temperature_base = 0
+        self.exposure_base = 0.0
+        self._ws_windowed = False
+
+
+def test_convert_stores_alpha_black_point_only():
+    from core.ccr_processor import ccr_normalize_with_bwpoint
+    bp = (30000, 30000, 30000)
+    img = _base_plate(600, 900, bp)
+    img = _with_square(img, 200, 400, 350, 550, (62000, 62000, 62000))
+    stub = _Stub(img)
+    # Black-point-only (default-slope) preview conversion, output_path=None.
+    ccr_normalize_with_bwpoint(stub, bp, None)
+    assert stub.sprocket_alpha is not None
+    assert stub.sprocket_alpha.shape == (600, 900)
+
+
+def test_convert_no_hole_leaves_alpha_none():
+    from core.ccr_processor import ccr_normalize_with_bwpoint
+    bp = (30000, 30000, 30000)
+    img = _base_plate(600, 900, bp)          # no clear-film region
+    stub = _Stub(img)
+    ccr_normalize_with_bwpoint(stub, bp, None)
+    assert stub.sprocket_alpha is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_wrong_output_fixes.py
+++ b/tests/test_wrong_output_fixes.py
@@ -96,8 +96,8 @@ def test_hires_bw_replay_ignores_fine_rot(tmp_path):
               "fine_rot": 300, "density": False}
     ci_flat = {"mode": "bw", "bw": (BLACK_POINT, WHITE_POINT),
                "fine_rot": 0, "density": False}
-    out_rot = img.render_hires_base(max_long_side=256, conversion_inputs=ci_rot)
-    out_flat = img.render_hires_base(max_long_side=256, conversion_inputs=ci_flat)
+    out_rot, _ = img.render_hires_base(max_long_side=256, conversion_inputs=ci_rot)
+    out_flat, _ = img.render_hires_base(max_long_side=256, conversion_inputs=ci_flat)
     assert out_rot is not None
     assert np.array_equal(out_rot, out_flat)
 

--- a/tests/test_zoom_hires.py
+++ b/tests/test_zoom_hires.py
@@ -116,8 +116,9 @@ class TestRenderHiresBaseRouting:
         stub = _conversion_stub(None, None)
         stub.file_path = path
         stub.converted = False
-        out = stub.render_hires_base()
+        out, alpha = stub.render_hires_base()
         assert out is not None and out.shape == (240, 360, 3)
+        assert alpha is None      # unconverted scan → no clear-film mask
 
     def test_converted_without_conversion_snapshot_returns_none(self, tmp_path):
         import cv2
@@ -128,7 +129,7 @@ class TestRenderHiresBaseRouting:
         stub.file_path = path
         stub.converted = True
         stub.conversion_inputs = None
-        assert stub.render_hires_base() is None
+        assert stub.render_hires_base()[0] is None
 
     def test_bwpoint_replay_includes_fine_rotation(self, tmp_path):
         """The bwpoint pipeline bakes the fine rotation into the preview
@@ -149,7 +150,7 @@ class TestRenderHiresBaseRouting:
         stub.conversion_inputs = {"mode": "bw",
                                   "bw": (black_point, white_point),
                                   "fine_rot": fine_rot}   # bare convert → linear (default)
-        got = stub.render_hires_base()
+        got, _ = stub.render_hires_base()
         np.testing.assert_allclose(got.astype(np.int64),
                                    expected.astype(np.int64), atol=2)
 
@@ -165,10 +166,10 @@ class TestRenderHiresBaseRouting:
         stub.file_path = path
         stub.converted = True
         stub.conversion_inputs = {"mode": "ref", "ref": ref, "fine_rot": 0}
-        baseline = stub.render_hires_base()
+        baseline, _ = stub.render_hires_base()
         stub.reference_frame = (100, 100, 150, 150)   # live edit, no re-convert
         stub.fine_rotation_angle = 900
-        again = stub.render_hires_base()
+        again, _ = stub.render_hires_base()
         np.testing.assert_array_equal(baseline, again)
 
 


### PR DESCRIPTION
## Sprocket-hole / clear-film white mask (reversal look)

For 135 film, people often want the converted frame to read like reversal
(slide) film — sprocket holes and the clear rebate shown **white** instead of
the pure black they clamp to after a negative inversion. This adds that as an
optional, non-destructive look.

Spec: [`spec/sprocket-hole-mask.md`](spec/sprocket-hole-mask.md).

### How it works
1. **Settings → General → “White sprocket holes / clear film (reversal look)”** — a
   new toggle (default **OFF**), staged/applied-on-Done and persisted to
   QSettings. Flipping it only **re-renders** loaded images (no re-conversion,
   no catalog write), exactly like Auto Gain / Gamma mode.
2. After a **Black Point (film base)** is set, the mask is built from the **raw
   scan**: pixels **brighter than the black point plus a per-channel padding**
   (the sprocket holes / clear rebate are clearer than the film base, so they
   scan brighter). It's morphologically cleaned (open to drop specks, close to
   fill small gaps) and **feathered ~5–10 px**.
3. The mask is composited to **white** as the **last** step — after every
   adjustment, curve, area, dust, gain, gamma, and crop — on **all three render
   paths**: the live preview/thumbnail, the hi-res zoom tile, and export. So the
   whitened regions are never tinted by any control.

Why derive from the raw and not the positive: in the inverted positive the
holes are indistinguishable from crushed shadows and the film border (all sit at
0). “Clearer than the sampled film base” is the clean, physically-meaningful
test, and exposed scene content is always *denser* than the zero-exposure base,
so it's structurally excluded.

### Notes / scope
- B/W-point conversions only. Reference/auto conversions, positive mode, and
  un-converted scans are unaffected.
- The threshold is resolution-independent; morphology/feather radii scale with
  the buffer's long side, so preview and export agree (“plan at preview, replay
  at native”). Tunable via `FREECCR_SPROCKET_*` env knobs for field calibration.
- The **histogram** reads the pre-mask image, so a whitened border (up to ~15 %
  of a full-width 135 scan) doesn't spike it at white. Scopes render the on-screen
  viewport, so they include the border (acceptable v1).
- Default **OFF** — the standard conversion look is unchanged.

### Testing
- `tests/test_sprocket_mask.py` (14 tests, headless): threshold isolates
  clear film vs base-noise vs exposed scene; per-channel AND; feather is a soft
  ramp; resolution scaling matches; composite paints/blends white; env override;
  backend flag default; convert stores/omits the alpha.
- Updated `tests/test_zoom_hires.py` / `tests/test_wrong_output_fixes.py` for the
  new `render_hires_base` → `(base, alpha)` return.
- End-to-end (headless Qt): a synthetic 135-like negative renders holes **black**
  with the toggle off and **white** with it on, photo area unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
