### PR TITLE
feat(shortcuts): C/D/W mode hotkeys; WB picker toggles off

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -273,6 +273,17 @@ class MainWindow(QMainWindow):
         self.undo_shortcut = QShortcut(QKeySequence.Undo, self)
         self.undo_shortcut.activated.connect(self.undo_last_action)
 
+        # Mode hotkeys: C = crop, D = dust removal, W = white-balance picker.
+        # WindowShortcut context (like the rotate/undo keys) so they fire no
+        # matter which panel has focus. Each handler mirrors the corresponding
+        # toolbar/panel button and is a no-op without a current image.
+        self.crop_shortcut = QShortcut(QKeySequence("C"), self)
+        self.crop_shortcut.activated.connect(self._shortcut_toggle_crop)
+        self.dust_shortcut = QShortcut(QKeySequence("D"), self)
+        self.dust_shortcut.activated.connect(self._shortcut_toggle_dust)
+        self.wb_pick_shortcut = QShortcut(QKeySequence("W"), self)
+        self.wb_pick_shortcut.activated.connect(self._shortcut_wb_pick)
+
 
         # Non-blocking startup update check (2s network timeout, off-thread)
         self._update_worker = UpdateCheckWorker(self)
@@ -404,6 +415,39 @@ class MainWindow(QMainWindow):
         self.crop_panel.setVisible(False)
         if not self.dust_panel.isVisible():
             self.sliders_panel.setVisible(True)
+
+    # --- Mode hotkeys (C / D / W) ----------------------------------------
+    def _shortcut_toggle_crop(self):
+        """C: toggle Crop mode. Dust must be left first — the dust and crop
+        panels both cover the sliders, and only the toggle chokepoints restore
+        the panel stack correctly."""
+        if self.image_preview.current_idx is None:
+            return
+        if self.image_preview.dust_mode:
+            self.toggle_dust_removal(False)
+        self.toggle_crop_panel(not self.image_preview.crop_mode)
+
+    def _shortcut_toggle_dust(self):
+        """D: toggle Dust Removal mode. Leave crop first (commits it, like the
+        Crop panel's Done) so the panel stack swaps cleanly."""
+        if self.image_preview.current_idx is None:
+            return
+        if not self.image_preview.dust_mode and self.image_preview.crop_mode:
+            self.toggle_crop_panel(False)
+        self.toggle_dust_removal()
+
+    def _shortcut_wb_pick(self):
+        """W: toggle the white-balance eyedropper — a press arms it (next click
+        picks a neutral point), a second press disarms it. Gated exactly like
+        the WB Picker button — converted image only, never while crop/dust mode
+        owns the canvas (which already clears any armed pick)."""
+        if self.image_preview.current_idx is None:
+            return
+        if self.image_preview.dust_mode or self.image_preview.crop_mode:
+            return
+        if not self.sliders_panel.wb_picker_btn.isEnabled():
+            return
+        self.sliders_panel._on_pick_neutral_point()
 
     def _sync_dust_action(self, checked: bool):
         action = getattr(self.image_preview, "dust_action", None)

--- a/src/widgets/image_preview.py
+++ b/src/widgets/image_preview.py
@@ -1569,6 +1569,12 @@ class ImagePreview(QWidget):
         self.view.bwpoint_mode = None
         self.view.setCursor(_eyedropper_cursor() if enabled else Qt.ArrowCursor)
 
+    def is_wb_pick_active(self):
+        """Whether the WB eyedropper is currently armed (awaiting a click).
+        The click handler and every mode switch clear it, so this reads the
+        live state — the toggle in _on_pick_neutral_point relies on it."""
+        return bool(self.view.wb_pick_mode)
+
     # --- Zoom & hi-res detail --------------------------------------------
     # Wheel zooms relative to the fitted view (Lightroom-style). Once the
     # 1080px preview is displayed past its native resolution, a hi-res

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -1501,10 +1501,17 @@ class SlidersPanel(QWidget):
         self.set_temporary_hint("Synced selected settings to all images!", duration=4000)
 
     def _on_pick_neutral_point(self):
-        if hasattr(self, 'image_preview') and self.image_preview:
-            self.image_preview.set_wb_pick_mode(True)
-            self.set_temporary_hint(
-                "<b>Auto WB:</b> Click a neutral gray or white point on the image.", duration=8000)
+        if not (hasattr(self, 'image_preview') and self.image_preview):
+            return
+        # Toggle: a second press — this button or the W hotkey — disarms the
+        # eyedropper instead of re-arming it.
+        if self.image_preview.is_wb_pick_active():
+            self.image_preview.set_wb_pick_mode(False)
+            self.set_temporary_hint("WB picker cancelled.", duration=2000)
+            return
+        self.image_preview.set_wb_pick_mode(True)
+        self.set_temporary_hint(
+            "<b>Auto WB:</b> Click a neutral gray or white point on the image.", duration=8000)
 
     def _on_crop_clicked(self):
         if not (hasattr(self, 'image_preview') and self.image_preview):


### PR DESCRIPTION
﻿## Summary
Adds keyboard shortcuts for the three interactive canvas modes, and makes the WB picker toggle off on a second press.

- **`C`** — toggle Crop mode
- **`D`** — toggle Dust Removal mode
- **`W`** — toggle the White Balance eyedropper (press again to cancel)

Each hotkey mirrors its existing toolbar/panel button and is gated the same way (no-op without a current image; `W` only for a converted image and never while crop/dust owns the canvas). The `C`/`D` handlers leave the other mode first so the crop and dust panels — which both cover the sliders — swap cleanly instead of stacking.

The WB picker toggle applies to **both** the `WB Picker` button and the `W` hotkey (shared handler `_on_pick_neutral_point`), reading the live pick state via the new `ImagePreview.is_wb_pick_active()` so it re-arms correctly after a completed pick.

## Verification
- Real offscreen `MainWindow` registers `C`/`D`/`W` (distinct from `Ctrl+C`/`Ctrl+V`/`Ctrl+Z`); handler branch logic exercised across every mode combination.
- Real `ImagePreview` + `SlidersPanel`: press→arm, press→disarm (cursor resets), clean re-arm after a pick, hotkey shares the toggle.
- `test_crop_panel.py` + `test_dust_removal.py` (105) and `test_awb.py` (23) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
