### PR TITLE
feat(merge): persist 3-way merged image edits across sessions

### DIFF
--- a/spec/merge-catalog-persistence.md
+++ b/spec/merge-catalog-persistence.md
@@ -1,0 +1,209 @@
+# Cross-session persistence of 3-way-merged image edits
+
+> Status: draft. This is the parked follow-up called out in
+> `spec/three-way-rgb-merge.md` ("Follow-up: key the catalog on a composite of
+> the 3 source signatures"). It makes a trichrome-merged image save and restore
+> its edits **just like a normal image**.
+
+## Summary
+
+Today a 3-way RGB-merged image is a **session-only** artifact: it is excluded
+from the per-file edit catalog on every serialization path, so its conversion,
+sliders, crop, reference frame and dust are lost when the app closes and the
+same three RAWs are re-imported (they re-merge fresh, un-edited).
+
+This change persists a merged image's edits under a **composite catalog key**
+derived from its three source RAWs (in `(R, G, B)` order) plus a **composite
+freshness signature** (each source's size + mtime). When the same three files
+are merged again and none has changed on disk, the merged image comes back with
+all its edits — identical to how a normal single-file image is restored.
+
+## Goals
+
+- A merged image's full edit state (conversion inputs + replay, adjustment
+  sliders, crop, orientation bases, reference frame, dust spots/plan, area
+  layers, colour profile, slice lineage, duplicate flag) is **saved to the
+  catalog** and **restored on the next merge of the same three frames**.
+- The catalog entry is keyed on a **composite of the three sources**, so it can
+  never collide with, or corrupt, the per-file record of any single source RAW
+  (e.g. a later *normal* open of the red exposure).
+- Staleness is validated against **all three** sources: if any source file
+  changed (size/mtime) since the edits were cataloged, the stored edits are
+  ignored and the triplet re-merges fresh (matching the single-file rule).
+- Duplicates and slices of a merged image persist and restore too (the same
+  all-or-nothing per-key restore the single-file path already uses).
+- Parity on removal: removing a merged **actual** image from the list keeps its
+  stored edits (preserved for the next save); removing a merged **duplicate**
+  drops its entry (a discarded copy must not resurrect).
+
+## Non-Goals
+
+- No change to the merge maths, the decode, or the `is_merged`/`merge_sources`
+  data model beyond what persistence needs.
+- No relink UI: "the same three images" means the same absolute paths with
+  unchanged content, exactly as the single-file catalog already defines
+  identity. Moving/renaming a source yields a fresh merge (new key).
+- The parked **density-inversion** experiment is untouched.
+- Merged-image **slice reset** already rebuilds a non-merged parent (a
+  pre-existing limitation noted in the merge spec); this change does not fix
+  that, it only keeps the preserved-catalog bookkeeping keyed consistently.
+
+## Data model
+
+### Composite key (`catalog.py`)
+
+```
+MERGE_KEY_PREFIX = "merge:"
+_merge_key(sources)         -> "merge:" + "|".join(_file_key(p) for p in sources)
+_is_merge_key(key)          -> key.startswith("merge:")
+_catalog_key_for_image(img) -> _merge_key(img.merge_sources) if img.is_merged
+                                and img.merge_sources else _file_key(img.file_path)
+```
+
+- `_file_key` already normcases + abspaths each path, so the composite is stable
+  per machine. Order is significant (R/G/B); the merge always sorts its inputs
+  by filename, so the same three files always produce the same key.
+- The `merge:` prefix guarantees a merge key is **disjoint** from every
+  single-file key (a real path never starts with `merge:`), so a merge and a
+  plain open of the red RAW live under separate records.
+
+### Composite signature
+
+```
+_merge_signature(sources) -> {"sources": [ {"size", "mtime"}, … ]}   # R,G,B order
+```
+
+`entries_for_merge(sources)` returns the stored states only when the record
+exists **and** every stored per-source signature matches the current file
+(size equal, mtime within 1.0 s — the same tolerance as `entries_for_path`).
+Any mismatch or missing/oversized list → `None` (re-merge fresh).
+
+### Serialized state (`serialize_image`)
+
+Three fields are added to every serialized image (harmless for non-merged
+images, which write `is_merged=False`, `merge_sources=None`):
+
+```
+"is_merged":      bool
+"merge_sources":  [red, green, blue] | None   # only when is_merged
+"merge_demosaic": bool                         # metadata / restore fallback
+```
+
+`merge_sources` in the record confirms identity; on restore the **live** paths
+selected in the current import are used to build the image (they equal the
+stored ones because the key matched). `merge_demosaic` is stored as a fallback,
+but restore prefers the **current global** `rgb_merge_mode` demosaic setting so
+the re-merge honours the user's current decode preference (the conversion replay
+adapts — `ref`/`bw` recompute; only `ref_params` replays fixed anchors, and the
+two demosaic modes differ only marginally in normalized percentile terms).
+
+## Processing / flow
+
+### Restore (import with merge mode ON)
+
+`ccr_backend._load_merged_triplets` loads the catalog once for the batch, then
+for each triplet calls the new
+`catalog.create_images_for_merge(sources, merge_demosaic, catalog_data)`, which
+mirrors `create_images_for_path`:
+
+- No cataloged entry → build one fresh merged `CCRImage` (a plain merge), tag
+  its `_catalog_signature` with the composite signature.
+- Cataloged entries present → restore each via `_restore_image(sources[0],
+  state, live_merge_sources=sources, live_merge_demosaic=merge_demosaic)`,
+  which now constructs a **merged** `CCRImage` (passes `is_merged`/
+  `merge_sources`/`merge_demosaic`) so every re-read re-merges then applies the
+  restored `source_ops`/conversion. All-or-nothing: any entry failure falls
+  back to a fresh merge, flagged `_catalog_restore_failed` so the next save does
+  not erase the stored record.
+
+Because `_restore_image` already replays the conversion, restores dust plans,
+crop, bases, etc., merged images inherit the entire single-file restore path for
+free; the only merge-specific work is constructing a merged image and keying by
+the composite.
+
+### Save
+
+`ccr_backend.save_catalog` → `catalog.update_for_images(self.images,
+preserved=self._catalog_preserved)`:
+
+- Grouping keys every image by `_catalog_key_for_image` (merge key for merged,
+  file key otherwise). A merged image **with no `merge_sources`** is skipped
+  (never keyed under a source file's record — the original corruption guard).
+- The signature fallback branches on the key: `_merge_signature(merge_sources)`
+  for a merge key, `_file_signature(file_path)` otherwise. Normally the
+  signature captured at load (`_catalog_signature`) is used, as for files.
+
+### Removal parity
+
+`_catalog_preserved` is now keyed by the **final catalog key**
+(`_catalog_key_for_image`) uniformly (was the raw file path). Consequently:
+
+- `remove_images_by_indices`: a removed merged **actual** image is preserved
+  under its merge key; a removed merged **duplicate** is dropped via
+  `remove_duplicate_entries` under its merge key.
+- `remove_duplicate_entries` and the preserved-merge inside `update_for_images`
+  treat their dict keys as **already-final** catalog keys (apply `_file_key`
+  only to non-merge keys / not at all).
+- `_purge_preserved_slice_round` is looked up by `_catalog_key_for_image(template)`
+  so it stays consistent for both kinds.
+
+## Integration points
+
+| Where | Change |
+|---|---|
+| `catalog.py` | `MERGE_KEY_PREFIX`, `_merge_key`, `_is_merge_key`, `_catalog_key_for_image`, `_merge_signature`; `entries_for_merge`; `create_images_for_merge`. |
+| `catalog.serialize_image` | add `is_merged`/`merge_sources`/`merge_demosaic`. |
+| `catalog._restore_image` | accept `live_merge_sources`/`live_merge_demosaic`; construct a merged `CCRImage` when the state is merged. |
+| `catalog.update_for_images` | group by `_catalog_key_for_image`; skip an unkeyable merge; merge-aware signature fallback; preserved keys used as-is. |
+| `catalog.remove_duplicate_entries` | keys are final catalog keys (`_file_key` only for non-merge keys). |
+| `ccr_backend._load_merged_triplets` | load catalog once; per-triplet `create_images_for_merge` (returns a list — supports restored slices/dups); extend results; unchanged sort/dedup/commit. |
+| `ccr_backend.remove_images_by_indices` | remove the `is_merged: continue`; preserve/drop merged under `_catalog_key_for_image`. |
+| `ccr_backend._purge_preserved_slice_round` | key by `_catalog_key_for_image(template)`. |
+
+`CATALOG_VERSION` stays **2**: the new fields are additive and default safely on
+old records (`state.get("is_merged", False)` → normal restore), and old builds
+ignore unknown keys, so no version bump is needed.
+
+## Edge cases
+
+- **A source changed on disk** → `entries_for_merge` returns `None`; fresh merge.
+- **Only some of the three present / one missing at import** → `merge_raw_channels`
+  raises during the fresh/restore build; the loader records `last_merge_error`
+  and skips the triplet, exactly as today.
+- **Merged image never edited** → a pristine state is written (as for normal
+  images) and restores to pristine; harmless, bounded by catalog pruning.
+- **Merge key vs single-file key** → disjoint by the `merge:` prefix; a normal
+  open of the red RAW is unaffected and vice-versa.
+- **Duplicate of a merged image** → restored as a merged duplicate (carries
+  `is_merged`/`merge_sources`); removing it drops its entry under the merge key.
+- **Global demosaic toggled between sessions** → the re-merge uses the current
+  setting; stored conversion replays on top (see Data model rationale).
+
+## Test plan
+
+`tests/test_merge_catalog.py` — pure/JSON-layer unit tests (no rawpy):
+
+1. `_merge_key`/`_is_merge_key`: order-sensitive, prefix present, disjoint from a
+   single-file key; `_catalog_key_for_image` routes merged vs normal.
+2. `_merge_signature` + `entries_for_merge`: match returns the states; a changed
+   source (size/mtime) → `None`; a missing record → `None`; wrong-length stored
+   list → `None`.
+3. `serialize_image` includes the three merge fields with correct values for a
+   merged stub and safe defaults for a normal image.
+4. `update_for_images` routing: a merged stub image is stored **under the merge
+   key**, **never** under `_file_key(red)`; a mixed batch (one normal, one
+   merged) writes both keys; the stored merge state round-trips through
+   `entries_for_merge`.
+5. Removal parity via `update_for_images(preserved=…)` with a merge-keyed
+   preserved record: the preserved state survives a save where the image is not
+   loaded.
+
+The full re-merge + restore round trip (constructing a real merged `CCRImage`)
+needs an aligned RAW triplet, which the repo does not ship — the same CI
+boundary the merge feature itself documented. It is covered by launch
+verification: merge three RAWs, convert + adjust, restart, re-import the same
+three → edits restored.
+
+Existing suites `tests/test_catalog.py`, `tests/test_duplicate_remove.py`,
+`tests/test_slice.py`, `tests/test_three_way_merge.py` must stay green (the
+key-uniformity refactor of `_catalog_preserved` is internal).

--- a/spec/three-way-rgb-merge.md
+++ b/spec/three-way-rgb-merge.md
@@ -37,13 +37,12 @@ the existing Positive-mode toggle.
 
 - **No image registration / alignment.** The three frames are assumed already
   aligned (tripod, static scene). Misalignment is the user's responsibility.
-- **No cross-session catalog persistence of merged images.** A merged image is a
-  session artifact derived from 3 files; it is excluded from the per-file edit
-  catalog on every serialization path. Re-importing re-merges fresh.
-  *Consequence (intended):* edits to a merged image (reference frame, conversion,
-  crop, sliders, dust) are **not saved between sessions**. A first-merge hint
-  states this. (Follow-up: key the catalog on a composite of the 3 source
-  signatures.)
+- ~~**No cross-session catalog persistence of merged images.**~~ *(Implemented —
+  see `spec/merge-catalog-persistence.md`.)* Originally a merged image was a
+  session artifact excluded from the catalog on every serialization path. It is
+  now persisted under a **composite key of the 3 source signatures**, so edits
+  (reference frame, conversion, crop, sliders, dust) survive between sessions and
+  are restored when the same 3 frames are merged again (and none has changed).
 - **Bayer (RGGB) and monochrome sensors.** "Do not demosaic / take one channel"
   applies to a 2×2 Bayer CFA (collapse each tile → one pixel) and, even more
   naturally, to a monochrome sensor (no CFA at all — the whole grayscale frame is

--- a/src/core/catalog.py
+++ b/src/core/catalog.py
@@ -71,6 +71,44 @@ def _file_signature(file_path: str) -> dict:
     return {"size": st.st_size, "mtime": st.st_mtime}
 
 
+# --- 3-way merge (trichrome) composite keys ------------------------------
+# A merged image has no single backing file — it is synthesized from three
+# source RAWs (red, green, blue). Its edits are cataloged under a COMPOSITE key
+# derived from all three sources, validated against a COMPOSITE signature (each
+# source's size+mtime). The "merge:" prefix keeps it disjoint from every
+# single-file key (a real path never starts with it), so a merge and a plain
+# open of the red RAW never share a record. See spec/merge-catalog-persistence.md.
+MERGE_KEY_PREFIX = "merge:"
+
+
+def _is_merge_key(key: str) -> bool:
+    return isinstance(key, str) and key.startswith(MERGE_KEY_PREFIX)
+
+
+def _merge_key(sources) -> str:
+    """Composite catalog key for a merge: the ordered (R, G, B) source file keys
+    joined under the merge prefix. Order matters; the merge always sorts inputs
+    by filename, so the same three files always yield the same key."""
+    return MERGE_KEY_PREFIX + "|".join(_file_key(p) for p in sources)
+
+
+def _catalog_key_for_image(img) -> str:
+    """The catalog key this image's edits belong under: the composite merge key
+    for a trichrome-merged image (never a single source file's key, which a
+    later plain open would then read as its own edits), else the file key."""
+    if getattr(img, "is_merged", False) and getattr(img, "merge_sources", None):
+        return _merge_key(img.merge_sources)
+    return _file_key(img.file_path)
+
+
+def _merge_signature(sources) -> dict:
+    """Composite freshness signature: each source's size+mtime in (R, G, B)
+    order. A change to ANY source invalidates the cataloged edits — they were
+    computed against those exact three frames. Raises OSError if a source is
+    unreadable (callers treat that as 'no valid entry')."""
+    return {"sources": [_file_signature(p) for p in sources]}
+
+
 def _ci_to_json(ci):
     if ci is None:
         return None
@@ -149,9 +187,19 @@ def _areas_from_json(areas):
 
 def serialize_image(img) -> dict:
     """Everything needed to bring a CCRImage back to its current state."""
+    is_merged = bool(getattr(img, "is_merged", False))
     return {
         "display_name": img.display_name,
         "is_duplicate": bool(getattr(img, "is_duplicate", False)),
+        # 3-way merge (trichrome): a merged image restores by re-merging its
+        # three sources, so its identity travels with the state. Harmless for a
+        # normal image (is_merged False, merge_sources None). merge_demosaic is
+        # a restore fallback — a re-import prefers the current global setting.
+        "is_merged": is_merged,
+        "merge_sources": (list(img.merge_sources)
+                          if is_merged and getattr(img, "merge_sources", None)
+                          else None),
+        "merge_demosaic": bool(getattr(img, "merge_demosaic", True)),
         "slice_group": getattr(img, "slice_group", None),
         "slice_parent": _slice_parent_to_json(getattr(img, "slice_parent", None)),
         "source_ops": [[int(rot), list(region)] for rot, region in img.source_ops],
@@ -236,21 +284,25 @@ def update_for_images(images, path: str = None, preserved: dict = None) -> None:
     list order). Entries for files not currently loaded are kept.
 
     preserved: states of ACTUAL images removed from the list this session,
-    {file_path: {"signature": sig, "entries": {display_name: state}}} —
+    {catalog_key: {"signature": sig, "entries": {display_name: state}}} —
     removal must not lose their stored edits, so they are merged back into
-    the records alongside the loaded images."""
+    the records alongside the loaded images. Keys are FINAL catalog keys
+    (a file key or a "merge:" composite key), used as-is here."""
     catalog = load_catalog(path)
     grouped = {}
     for img in images:
-        # Merged (trichrome) images are session-only — never persist their edits
-        # under a source RAW's per-file key. See spec/three-way-rgb-merge.md.
-        if getattr(img, "is_merged", False):
+        # A trichrome-merged image is keyed by the composite of its three
+        # sources, NOT by any one source RAW's file key (which a later plain
+        # open would misread as its own edits). A merged image that somehow
+        # lost its sources can't be keyed safely, so skip it rather than
+        # corrupt a file record. See spec/merge-catalog-persistence.md.
+        if getattr(img, "is_merged", False) and not getattr(img, "merge_sources", None):
             continue
-        grouped.setdefault(_file_key(img.file_path), []).append(img)
+        grouped.setdefault(_catalog_key_for_image(img), []).append(img)
     preserved_by_key = {}
-    for file_path, record in (preserved or {}).items():
+    for key, record in (preserved or {}).items():
         if record.get("entries"):
-            preserved_by_key[_file_key(file_path)] = record
+            preserved_by_key[key] = record
     now = time.time()
     for fkey, imgs in grouped.items():
         states = [serialize_image(im) for im in imgs]
@@ -273,7 +325,9 @@ def update_for_images(images, path: str = None, preserved: dict = None) -> None:
                           if getattr(im, "_catalog_signature", None)), None)
         if signature is None:
             try:
-                signature = _file_signature(imgs[0].file_path)
+                signature = (_merge_signature(imgs[0].merge_sources)
+                             if _is_merge_key(fkey)
+                             else _file_signature(imgs[0].file_path))
             except OSError:
                 continue
         catalog["files"][fkey] = {
@@ -308,11 +362,13 @@ def remove_duplicate_entries(removals: dict, path: str = None) -> None:
     discarded copy does not resurrect on the next open. Entries of actual
     images are never touched here.
 
-    removals: {file_path: set of duplicate display_names removed}"""
+    removals: {catalog_key: set of duplicate display_names removed}, where the
+    key is a raw source path (normalized here) or a "merge:" composite key
+    (used as-is)."""
     catalog = load_catalog(path)
     changed = False
-    for file_path, names in removals.items():
-        fkey = _file_key(file_path)
+    for key, names in removals.items():
+        fkey = key if _is_merge_key(key) else _file_key(key)
         record = catalog["files"].get(fkey)
         if not isinstance(record, dict):
             continue
@@ -349,6 +405,29 @@ def entries_for_path(file_path: str, path: str = None, catalog_data: dict = None
     if (stored.get("size") != signature["size"]
             or abs(stored.get("mtime", 0) - signature["mtime"]) > 1.0):
         return None
+    return record.get("images") or None
+
+
+def entries_for_merge(sources, path: str = None, catalog_data: dict = None):
+    """Catalog entries for a trichrome merge of `sources` (R, G, B order), or
+    None when absent or when ANY source changed since it was cataloged (stale
+    edits must not be misapplied). The merge analogue of entries_for_path:
+    validates the composite signature source-by-source."""
+    catalog = catalog_data if catalog_data is not None else load_catalog(path)
+    record = catalog["files"].get(_merge_key(sources))
+    if not isinstance(record, dict) or not record:
+        return None
+    try:
+        current = _merge_signature(sources)["sources"]
+    except OSError:
+        return None
+    stored = (record.get("signature") or {}).get("sources") or []
+    if len(stored) != len(current):
+        return None
+    for s, c in zip(stored, current):
+        if (s.get("size") != c["size"]
+                or abs(s.get("mtime", 0) - c["mtime"]) > 1.0):
+            return None
     return record.get("images") or None
 
 
@@ -392,10 +471,69 @@ def create_images_for_path(file_path: str, path: str = None,
     return images
 
 
-def _restore_image(file_path: str, state: dict):
+def create_images_for_merge(sources, merge_demosaic: bool = True,
+                            path: str = None, catalog_data: dict = None) -> list:
+    """Create the merged CCRImage(s) for a trichrome triplet, restoring
+    cataloged state (conversion, adjustments, crop, dust, slices, duplicates)
+    when the same three frames were merged and edited before.
+
+    All-or-nothing per triplet, like create_images_for_path: any entry failure
+    falls back to a fresh merge, flagged so the next save preserves the stored
+    record. `sources` are the live (R, G, B) paths of THIS import (they equal
+    the stored ones because the composite key matched); `merge_demosaic` is the
+    current global setting the fresh/re-merge decode uses."""
+    from core.ccr_image import CCRImage
+    signature = None
+    try:
+        signature = _merge_signature(sources)
+        entries = entries_for_merge(sources, path, catalog_data)
+    except Exception as e:
+        logging.warning(f"Merge catalog lookup failed for {list(sources)}: {e}")
+        entries = None
+
+    def _plain(restore_failed=False):
+        img = CCRImage(sources[0], is_merged=True, merge_sources=list(sources),
+                       merge_demosaic=merge_demosaic)
+        img._catalog_signature = signature
+        if restore_failed:
+            img._catalog_restore_failed = True
+        return [img]
+
+    if not entries:
+        return _plain()
+    images = []
+    for state in entries:
+        try:
+            images.append(_restore_image(sources[0], state,
+                                         live_merge_sources=list(sources),
+                                         live_merge_demosaic=merge_demosaic))
+        except Exception as e:
+            logging.warning(f"Merge catalog restore failed for "
+                            f"{list(sources)}: {e}")
+            return _plain(restore_failed=True)
+    for img in images:
+        img._catalog_signature = signature
+    return images
+
+
+def _restore_image(file_path: str, state: dict, live_merge_sources=None,
+                   live_merge_demosaic=None):
     from core.ccr_image import CCRImage
     source_ops = [(int(rot), tuple(region))
                   for rot, region in (state.get("source_ops") or [])]
+    # Rebuild a trichrome-merged image when the stored state is one: every
+    # re-read (preview/zoom/export) then re-merges the three sources and applies
+    # source_ops. Prefer the live sources/demosaic (current import + current
+    # global setting) over the stored copies. See spec/merge-catalog-persistence.md.
+    is_merged = bool(state.get("is_merged", False))
+    if is_merged:
+        merge_sources = (list(live_merge_sources) if live_merge_sources
+                         else (state.get("merge_sources") or None))
+        merge_demosaic = (live_merge_demosaic if live_merge_demosaic is not None
+                          else bool(state.get("merge_demosaic", True)))
+    else:
+        merge_sources = None
+        merge_demosaic = True
     img = CCRImage(
         file_path,
         adjustment_settings=dict(state.get("adjustment_settings") or {}),
@@ -409,6 +547,9 @@ def _restore_image(file_path: str, state: dict):
         slice_parent=(dict(state["slice_parent"])
                       if state.get("slice_parent") else None),
         areas=_areas_from_json(state.get("areas")),
+        is_merged=is_merged,
+        merge_sources=merge_sources,
+        merge_demosaic=merge_demosaic,
     )
     img.is_duplicate = bool(state.get("is_duplicate", False))
     img.dust_spots = copy.deepcopy(state.get("dust_spots") or [])

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -255,21 +255,35 @@ class CCRBackend:
         if current:
             self.file_paths = [t[0] for t in triplets]
 
+        # Read the catalog ONCE for the batch so a re-merge of the same three
+        # frames restores its saved edits. See spec/merge-catalog-persistence.md.
+        from core.catalog import create_images_for_merge, load_catalog
+        try:
+            catalog_data = load_catalog()
+        except Exception:
+            catalog_data = None
+
         def load_triplet(order, triplet):
             if cancel_flag and cancel_flag():
                 return None
             red = triplet[0]
             try:
-                img = CCRImage(red, is_merged=True, merge_sources=list(triplet),
-                               merge_demosaic=self.rgb_merge_demosaic)
+                # Restores cataloged state (conversion/adjustments/crop/dust/
+                # slices) when this exact triplet was edited before; a fresh
+                # merge otherwise. Returns a LIST (>1 when the merge was sliced
+                # or duplicated last session).
+                imgs = create_images_for_merge(
+                    list(triplet), merge_demosaic=self.rgb_merge_demosaic,
+                    catalog_data=catalog_data)
             except Exception as e:
                 print(f"3-way merge failed for {os.path.basename(red)}: {e}")
                 self.last_merge_error = (
                     "3-way RGB merge could not process some frames:\n\n"
                     f"{e}")
                 return None
-            img._catalog_order = order
-            return img
+            for i, im in enumerate(imgs):
+                im._catalog_order = i   # keep slice order within a triplet
+            return imgs
 
         max_workers = min(8, os.cpu_count() or 1)
         results = []
@@ -277,9 +291,9 @@ class CCRBackend:
             for order, triplet in enumerate(triplets):
                 if cancel_flag and cancel_flag():
                     break
-                img = load_triplet(order, triplet)
-                if img is not None:
-                    results.append(img)
+                imgs = load_triplet(order, triplet)
+                if imgs:
+                    results.extend(imgs)
         else:
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = {executor.submit(load_triplet, order, triplet): order
@@ -287,9 +301,9 @@ class CCRBackend:
                 for future in concurrent.futures.as_completed(futures):
                     if cancel_flag and cancel_flag():
                         break
-                    img = future.result()
-                    if img is not None:
-                        results.append(img)
+                    imgs = future.result()
+                    if imgs:
+                        results.extend(imgs)
 
         # User cancelled mid-load: suppress any decode error a worker recorded
         # for the aborted import (the pool above has joined, so every write has
@@ -1491,22 +1505,25 @@ class CCRBackend:
         if not removed_images:
             return 0
         try:
-            from core.catalog import serialize_image, remove_duplicate_entries
+            from core.catalog import (serialize_image, remove_duplicate_entries,
+                                       _catalog_key_for_image)
             duplicate_removals = {}
             for img in removed_images:
-                # Merged (trichrome) images are session-only: never serialize
-                # their edits into a source RAW's per-file record (the red
-                # exposure's key), which would corrupt that file on a later
-                # plain open. See spec/three-way-rgb-merge.md.
-                if getattr(img, "is_merged", False):
+                # A trichrome-merged image keys by the composite of its three
+                # sources (not any one source RAW's file key — which a later
+                # plain open would misread as its own edits). A merged image
+                # that lost its sources can't be keyed safely, so leave it
+                # session-only. See spec/merge-catalog-persistence.md.
+                if getattr(img, "is_merged", False) and not getattr(img, "merge_sources", None):
                     continue
+                key = _catalog_key_for_image(img)
                 if getattr(img, "is_duplicate", False):
                     if img.display_name:
-                        duplicate_removals.setdefault(img.file_path,
-                                                      set()).add(img.display_name)
+                        duplicate_removals.setdefault(key, set()).add(
+                            img.display_name)
                 else:
                     record = self._catalog_preserved.setdefault(
-                        img.file_path,
+                        key,
                         {"signature": getattr(img, "_catalog_signature", None),
                          "entries": {}})
                     record["entries"][img.display_name] = serialize_image(img)
@@ -1941,15 +1958,18 @@ class CCRBackend:
         self.images.insert(insert_at, parent)
         # Drop preserved catalog entries for members that were earlier
         # removed (as actuals): otherwise update_for_images would merge those
-        # stale slices back in and resurrect them on the next open.
-        self._purge_preserved_slice_round(template.file_path, subtree)
+        # stale slices back in and resurrect them on the next open. Key by the
+        # final catalog key (composite for a merged template, file key else),
+        # matching how removal preserved them.
+        from core.catalog import _catalog_key_for_image
+        self._purge_preserved_slice_round(_catalog_key_for_image(template), subtree)
         print(f"Reset slice: {len(members)} slice(s) of "
               f"{os.path.basename(template.file_path)} replaced by "
               f"{parent_name or os.path.basename(template.file_path)}")
         return insert_at
 
-    def _purge_preserved_slice_round(self, file_path, groups) -> None:
-        record = self._catalog_preserved.get(file_path)
+    def _purge_preserved_slice_round(self, catalog_key, groups) -> None:
+        record = self._catalog_preserved.get(catalog_key)
         if not record:
             return
         entries = record.get("entries", {})
@@ -1958,7 +1978,7 @@ class CCRBackend:
         for name in stale:
             del entries[name]
         if not entries:
-            self._catalog_preserved.pop(file_path, None)
+            self._catalog_preserved.pop(catalog_key, None)
 
     def set_white_point(self, bgr_tuple):
         self.white_point_bgr = bgr_tuple

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -258,8 +258,8 @@ class SettingsDialog(QDialog):
             "own channel — then converted as a negative. "
             "RAW only (Bayer or monochrome); the selected count must be a "
             "multiple of 3. "
-            "Applies to the next import only; merged-image edits are not saved "
-            "between sessions."))
+            "Applies to the next import only. Your edits to a merged image are "
+            "saved and restored the next time you merge the same three frames."))
         detail_row = QHBoxLayout()
         detail_row.setSpacing(theme.GAP_BTN)
         detail_row.addWidget(QLabel("Merge detail:"))

--- a/tests/test_merge_catalog.py
+++ b/tests/test_merge_catalog.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Tests for cross-session persistence of 3-way-merged (trichrome) image edits:
+the composite merge key + signature, serialize routing (a merged image is
+cataloged under its three sources, never under any one source RAW's file key),
+staleness against all three sources, and _restore_image's merged construction.
+
+The full re-merge+restore round trip needs an aligned RAW triplet the repo does
+not ship (the same CI boundary the merge feature itself documents), so these
+tests exercise the catalog/JSON layer with real files + a normal CCRImage marked
+merged, plus a monkeypatched constructor for _restore_image. See
+spec/merge-catalog-persistence.md.
+"""
+
+import os
+import sys
+import time
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+import cv2  # noqa: E402
+from core import catalog  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+
+
+def _png(tmp_path, name, w=64, h=48, seed=1):
+    """A small real image file (content irrelevant — only its bytes/mtime and,
+    for the red source, a decodable image matter)."""
+    rng = np.random.default_rng(seed)
+    img = (rng.integers(2000, 60000, size=(h, w, 3))).astype(np.uint16)
+    path = str(tmp_path / name)
+    cv2.imwrite(path, cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+    return path
+
+
+def _triplet(tmp_path):
+    r = _png(tmp_path, "shot_R.png", seed=1)
+    g = _png(tmp_path, "shot_G.png", seed=2)
+    b = _png(tmp_path, "shot_B.png", seed=3)
+    return [r, g, b]
+
+
+def _merged_image(sources, demosaic=True):
+    """A real CCRImage decoded from the red source, then marked as a merge of
+    the three sources — enough for the catalog/JSON layer without rawpy."""
+    img = CCRImage(sources[0])
+    img.is_merged = True
+    img.merge_sources = list(sources)
+    img.merge_demosaic = demosaic
+    img._catalog_signature = catalog._merge_signature(sources)
+    return img
+
+
+class TestMergeKey:
+    def test_prefix_and_order_sensitive(self, tmp_path):
+        r, g, b = _triplet(tmp_path)
+        k = catalog._merge_key([r, g, b])
+        assert catalog._is_merge_key(k)
+        assert k.startswith("merge:")
+        # Order matters (R/G/B): swapping two sources is a different image.
+        assert catalog._merge_key([g, r, b]) != k
+
+    def test_disjoint_from_file_key(self, tmp_path):
+        r, g, b = _triplet(tmp_path)
+        assert not catalog._is_merge_key(catalog._file_key(r))
+        assert catalog._merge_key([r, g, b]) != catalog._file_key(r)
+
+    def test_catalog_key_for_image_routes(self, tmp_path):
+        r, g, b = _triplet(tmp_path)
+        merged = _merged_image([r, g, b])
+        assert catalog._catalog_key_for_image(merged) == catalog._merge_key([r, g, b])
+        normal = CCRImage(r)
+        assert catalog._catalog_key_for_image(normal) == catalog._file_key(r)
+
+
+class TestSerializeMergeFields:
+    def test_merged_fields(self, tmp_path):
+        r, g, b = _triplet(tmp_path)
+        merged = _merged_image([r, g, b], demosaic=False)
+        state = catalog.serialize_image(merged)
+        assert state["is_merged"] is True
+        assert state["merge_sources"] == [r, g, b]
+        assert state["merge_demosaic"] is False
+
+    def test_normal_fields_default_safe(self, tmp_path):
+        r, _, _ = _triplet(tmp_path)
+        state = catalog.serialize_image(CCRImage(r))
+        assert state["is_merged"] is False
+        assert state["merge_sources"] is None
+        assert state["merge_demosaic"] is True
+
+
+class TestUpdateRouting:
+    def test_stored_under_merge_key_not_red_file(self, tmp_path):
+        cat = str(tmp_path / "catalog.json")
+        r, g, b = _triplet(tmp_path)
+        merged = _merged_image([r, g, b])
+        merged.adjustment_settings = {"temperature": 7}
+        catalog.update_for_images([merged], path=cat)
+
+        files = catalog.load_catalog(cat)["files"]
+        assert catalog._merge_key([r, g, b]) in files
+        # The red source keeps NO per-file record — a later plain open of it is
+        # unaffected (the corruption the composite key exists to prevent).
+        assert catalog._file_key(r) not in files
+        assert catalog.entries_for_path(r, path=cat) is None
+
+    def test_entries_for_merge_round_trip(self, tmp_path):
+        cat = str(tmp_path / "catalog.json")
+        r, g, b = _triplet(tmp_path)
+        merged = _merged_image([r, g, b])
+        merged.adjustment_settings = {"contrast": 15, "saturation": -3}
+        merged.crop_rect = (0.1, 0.1, 0.9, 0.9)
+        catalog.update_for_images([merged], path=cat)
+
+        entries = catalog.entries_for_merge([r, g, b], path=cat)
+        assert entries is not None and len(entries) == 1
+        state = entries[0]
+        assert state["is_merged"] is True
+        assert state["adjustment_settings"] == {"contrast": 15, "saturation": -3}
+        assert state["crop_rect"] == [0.1, 0.1, 0.9, 0.9]
+
+    def test_mixed_batch_keys_both(self, tmp_path):
+        cat = str(tmp_path / "catalog.json")
+        r, g, b = _triplet(tmp_path)
+        a = _png(tmp_path, "plain.png", seed=9)
+        normal = CCRImage(a)
+        normal.adjustment_settings = {"tint": 4}
+        merged = _merged_image([r, g, b])
+        catalog.update_for_images([normal, merged], path=cat)
+
+        files = catalog.load_catalog(cat)["files"]
+        assert catalog._file_key(a) in files
+        assert catalog._merge_key([r, g, b]) in files
+
+
+class TestMergeStaleness:
+    def test_changed_source_invalidates(self, tmp_path):
+        cat = str(tmp_path / "catalog.json")
+        r, g, b = _triplet(tmp_path)
+        merged = _merged_image([r, g, b])
+        merged.adjustment_settings = {"temperature": 20}
+        catalog.update_for_images([merged], path=cat)
+        assert catalog.entries_for_merge([r, g, b], path=cat) is not None
+        # Rewrite the GREEN source (size + mtime change) — a different capture.
+        time.sleep(0.05)
+        _png(tmp_path, "shot_G.png", w=80, h=60, seed=99)
+        assert catalog.entries_for_merge([r, g, b], path=cat) is None
+
+    def test_unknown_triplet_is_none(self, tmp_path):
+        cat = str(tmp_path / "catalog.json")
+        r, g, b = _triplet(tmp_path)
+        assert catalog.entries_for_merge([r, g, b], path=cat) is None
+
+    def test_missing_source_is_none(self, tmp_path):
+        cat = str(tmp_path / "catalog.json")
+        r, g, b = _triplet(tmp_path)
+        catalog.update_for_images([_merged_image([r, g, b])], path=cat)
+        os.remove(b)  # a source the user deleted since editing
+        assert catalog.entries_for_merge([r, g, b], path=cat) is None
+
+
+class TestRemovalPreservation:
+    def test_preserved_merge_survives_save_when_unloaded(self, tmp_path):
+        """A merged image removed from the list (no longer loaded) keeps its
+        edits: update_for_images with a merge-keyed preserved record must write
+        it under the merge key (not mangle the key via _file_key)."""
+        cat = str(tmp_path / "catalog.json")
+        r, g, b = _triplet(tmp_path)
+        merged = _merged_image([r, g, b])
+        merged.adjustment_settings = {"exposure": 6}
+        state = catalog.serialize_image(merged)
+        preserved = {
+            catalog._merge_key([r, g, b]): {
+                "signature": catalog._merge_signature([r, g, b]),
+                "entries": {merged.display_name: state},
+            }
+        }
+        catalog.update_for_images([], path=cat, preserved=preserved)
+
+        entries = catalog.entries_for_merge([r, g, b], path=cat)
+        assert entries is not None and len(entries) == 1
+        assert entries[0]["adjustment_settings"] == {"exposure": 6}
+
+
+class TestRestoreConstruction:
+    def test_restore_image_builds_merged(self, tmp_path, monkeypatch):
+        """_restore_image threads is_merged/merge_sources/merge_demosaic into the
+        CCRImage it constructs, preferring the LIVE sources + demosaic."""
+        r, g, b = _triplet(tmp_path)
+        merged = _merged_image([r, g, b], demosaic=True)
+        state = catalog.serialize_image(merged)
+
+        recorded = {}
+
+        class _RecordingImage:
+            def __init__(self, file_path, **kwargs):
+                recorded["file_path"] = file_path
+                recorded.update(kwargs)
+                self.file_path = file_path
+                self.contrast_base = 0
+                self.temperature_base = 0
+                self.brightness_base = 0
+                self.exposure_base = 0.0
+                self.tint_balance_factor = 1.0
+                self.dust_feather = 0.25
+
+            def update_thumbnail_and_preview(self):
+                pass
+
+        monkeypatch.setattr("core.ccr_image.CCRImage", _RecordingImage)
+        out = catalog._restore_image(r, state, live_merge_sources=[r, g, b],
+                                     live_merge_demosaic=False)
+        assert isinstance(out, _RecordingImage)
+        assert recorded["is_merged"] is True
+        assert recorded["merge_sources"] == [r, g, b]
+        # Live demosaic wins over the stored value (True).
+        assert recorded["merge_demosaic"] is False
+
+    def test_restore_image_normal_state_not_merged(self, tmp_path, monkeypatch):
+        r, _, _ = _triplet(tmp_path)
+        state = catalog.serialize_image(CCRImage(r))
+
+        recorded = {}
+
+        class _RecordingImage:
+            def __init__(self, file_path, **kwargs):
+                recorded.update(kwargs)
+                self.file_path = file_path
+                self.contrast_base = 0
+                self.temperature_base = 0
+                self.brightness_base = 0
+                self.exposure_base = 0.0
+                self.tint_balance_factor = 1.0
+                self.dust_feather = 0.25
+
+            def update_thumbnail_and_preview(self):
+                pass
+
+        monkeypatch.setattr("core.ccr_image.CCRImage", _RecordingImage)
+        catalog._restore_image(r, state)
+        assert recorded["is_merged"] is False
+        assert recorded["merge_sources"] is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -504,7 +504,9 @@ class TestResetSlice:
         s2_idx = next(i for i, im in enumerate(ccr_backend.images)
                       if im.display_name == "scan_s2.png")
         ccr_backend.remove_images_by_indices([s2_idx])  # preserved
-        assert path in ccr_backend._catalog_preserved
+        # _catalog_preserved is keyed by the final catalog key (the normalized
+        # file key for a normal image; a "merge:" composite for a merged one).
+        assert catalog._file_key(path) in ccr_backend._catalog_preserved
         # Reset via a surviving sibling
         s1_idx = next(i for i, im in enumerate(ccr_backend.images)
                       if im.display_name == "scan_s1.png")


### PR DESCRIPTION
## Summary

3-way RGB-merged (trichrome) images were **session-only** — their conversion, sliders, crop, dust, slices and duplicates were excluded from the edit catalog and lost on close. This implements the follow-up parked in `spec/three-way-rgb-merge.md`: **key the catalog on a composite of the three source signatures**, so a merged image saves and restores just like a normal image.

Re-import the same three frames and every edit comes back; change *any* of the three on disk and it re-merges fresh. The `merge:` key prefix keeps merge records disjoint from a source RAW's own file key, so a merge can never corrupt a plain open of a source file.

## Changes
- **`spec/merge-catalog-persistence.md`** — new spec (spec-first workflow).
- **`src/core/catalog.py`** — `_merge_key`/`_is_merge_key`/`_merge_signature`/`_catalog_key_for_image`; merge fields in `serialize_image`; merge-aware `_restore_image`; new `entries_for_merge` + `create_images_for_merge`; key-aware `update_for_images` + `remove_duplicate_entries`.
- **`src/core/ccr_backend.py`** — merge loader restores via `create_images_for_merge`; removal preserves/drops merged images under the composite key; `_catalog_preserved` unified to the final catalog key.
- **`src/widgets/settings_dialog.py`** — drop the now-stale "edits not saved between sessions" hint.
- **`tests/test_merge_catalog.py`** (14 new) + one white-box assertion updated in `test_slice.py`.

## Testing
- New suite + affected suites green (`test_catalog`, `test_slice`, `test_duplicate_remove`, `test_three_way_merge`, `test_merge_catalog` = **102 passed**; `test_settings_dialog` green), run in small groups per the known full-run hang.
- End-to-end smoke (faking only the RAW decode) confirmed: merge → convert + slider + crop → save (stored under the composite key, red file key absent) → re-import → fully restored, pixels matching within rounding → changed source → fresh un-edited merge.
- CI boundary: no aligned RAW triplet ships in-repo, so the real re-merge round trip is covered by the smoke rather than pytest — the same boundary the original merge feature documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kaw7MLDhjqk9mxbqAXZGZ7
