### PR TITLE
feat(merge): replace trichrome originals with a lossless linear TIFF

### DIFF
--- a/spec/merge-linear-tiff-replace.md
+++ b/spec/merge-linear-tiff-replace.md
@@ -1,0 +1,239 @@
+# Replace trichrome originals with a linear TIFF
+
+> Status: draft.
+
+## Summary
+
+An opt-in workflow for **3-way RGB merge (trichrome)** capture: after a merge
+import succeeds, **bake each merged image to a full-resolution 16-bit linear
+TIFF**, **permanently delete** its three source RAWs, and **reload the list from
+the generated TIFFs**. This flattens a trichrome shoot (3 RAWs per frame) into
+one archival file per frame, so future sessions load a single normal linear-TIFF
+negative instead of re-merging three RAWs.
+
+The linear TIFF is the exact `merge_raw_channels` output — each frame's own
+channel, black-subtracted, white-level-scaled, stacked — written losslessly
+(deflate), untagged, camera-native linear RGB. It is **not** a Bayer RAW, but for
+a merged image the merge output *is* the final full-resolution pixel data, so no
+information about the merged result is lost. The only thing not preserved is the
+ability to re-merge differently later (e.g. change the demosaic mode), because
+that needs the original mosaics — the current merge/demosaic choice is baked in.
+
+Reuses the existing linear-TIFF writer (`_export_merged_linear`,
+spec/trichrome-linear-tiff-export.md).
+
+## Goals
+
+- A persistent checkbox in the **Trichrome capture** group of Settings → Color
+  Management: **"Replace originals with linear TIFF on import"**.
+- While the checkbox and 3-way merge are both on, after a **successful** merge
+  import (Open Files or Open Folder), FreeCCR:
+  1. **confirms** once (count of TIFFs to create + RAWs to delete; states it is
+     permanent and cannot be undone);
+  2. writes one full-resolution linear TIFF per merged image, next to its red
+     source, `<mergedDisplayNameStem>.tiff`;
+  3. **verifies** each TIFF exists and reads back as a valid uint16 `(H, W, 3)`
+     image **before** touching any original;
+  4. **permanently deletes** the three source RAWs of every image whose TIFF was
+     written and verified;
+  5. **reloads** the list from the generated TIFFs as normal images (merge
+     bypassed for this reload), and reports how many were replaced + any
+     failures.
+- Non-destructive on failure: a source RAW is deleted **only** after its
+  replacement exists and verifies; a per-image write/verify failure leaves that
+  image's originals intact.
+- Cancellable: cancelling the bake deletes **nothing** and removes any TIFFs
+  already written (leaves the session exactly as it was — merged, all RAWs
+  present).
+
+## Non-Goals
+
+- Not for non-merged images (trichrome only).
+- No Recycle Bin / trash: deletion is a permanent `os.remove` (user choice), so
+  it is gated by an explicit confirmation and readback verification.
+- No re-merge after baking (originals are gone); the demosaic mode is baked in.
+- No new export format or change to the existing linear-TIFF export path.
+- No framing at import time: a freshly imported merged image has no slice/crop,
+  so the baked TIFF is the full canonical merge. (`_export_merged_linear` applies
+  `source_ops`/crop, which are identity here.)
+
+## UX / Interaction
+
+### The checkbox (`settings_dialog.py`)
+
+In the **Trichrome capture** group, after the "Merge detail" row, add
+`self._cb_rgb_replace` — *"Replace originals with linear TIFF on import"* — with
+muted help:
+
+> After a successful 3-way merge import, each merged frame is written as a
+> full-resolution 16-bit linear TIFF next to its red source, then the three
+> original RAWs are **permanently deleted** and the list reloads from the TIFFs.
+> You'll confirm before anything is deleted. The merge/demosaic choice is baked
+> in and cannot be changed afterwards. Requires 3-way merge to be on.
+
+- Staged like the other trichrome toggles: seeded in `_init_toggles` from
+  `ccr_backend.rgb_merge_replace`; applied on Done in `_apply_pending` via
+  `self._mw.on_rgb_merge_replace_toggled(checked)` when it differs.
+
+### Trigger (`main_window.py`)
+
+- Persistent flag `ccr_backend.rgb_merge_replace` (QSettings
+  `import/rgb_merge_replace`), restored at startup next to `rgb_merge_mode`.
+- After a load finishes, `_cleanup_loader` (GUI thread, after thumbnails +
+  merge-error surfacing) calls `_maybe_replace_merged_with_tiff()`:
+  - Runs only when `rgb_merge_mode and rgb_merge_replace`, there is **no**
+    `last_merge_error`, at least one loaded image `is_merged`, and no replace is
+    already in progress (re-entrancy guard).
+  - Shows a modal confirm (`Yes`/`No`, default `No`) naming the counts. `No` →
+    keep the merged session untouched.
+  - `Yes` → start `MergeReplaceWorker` in a `QThread` with a `QProgressDialog`
+    ("Writing linear TIFFs…", cancellable).
+- On the worker's `finished(result)`:
+  - Close the progress dialog; clear the in-progress guard.
+  - If `result["cancelled"]` → toast "Replace cancelled — originals kept.",
+    reload nothing (session stays merged).
+  - Else reload from `result["tiff_paths"]` via `_launch_file_loader(tiffs,
+    force_no_merge=True)`, and toast/warn a summary ("Replaced M frames with
+    linear TIFFs; deleted N originals" + any failures list).
+- The reload runs through the normal loader worker (thumbnails, progress). Its
+  images are ordinary TIFFs (`is_merged=False`), so the reload's own
+  `_cleanup_loader` never re-triggers the bake.
+
+### Force-no-merge reload
+
+`load_images_from_files(..., force_no_merge=True)` skips the merge branch so the
+generated TIFFs load as normal negatives even though `rgb_merge_mode` is still
+on (TIFFs aren't RAW; the merge validator would otherwise reject them). The
+global merge toggle is **not** changed — the user's preference is preserved.
+
+### Reopening a baked TIFF in merge mode (marker)
+
+So the user never has to toggle 3-way merge off just to reopen a baked frame,
+the generated TIFF is stamped with a marker in its **Software** tag
+(`ccr_merge.FREECCR_MERGE_TIFF_MARKER`, written by `_export_merged_linear(...,
+mark=True)`). `ccr_merge.is_freeccr_merge_tiff(path)` reads only the TIFF header
+to detect it.
+
+When 3-way merge is on, `load_images_from_files` (and `open_files`'
+pre-validation) partition the selection:
+
+- **marked TIFFs** → loaded as **normal images** (never merge inputs);
+- **everything else** → the usual merge path (validate multiple-of-3 + RAW,
+  group into triplets).
+
+If every selected file is a marked TIFF, the whole import falls through to the
+normal load (no merge, no "needs a multiple of 3" error). A mixed import (marked
+TIFFs + RAW triplets) merges the RAWs and loads the marked TIFFs alongside them
+(`_load_merged_triplets(..., passthrough_paths=…)`). The `force_no_merge` reload
+path above still exists for the replace flow's own reload; the marker makes a
+*manual* reopen work too. Only files FreeCCR baked carry the marker — an
+arbitrary third-party TIFF in merge mode is still rejected as a non-RAW input.
+
+## Data Model
+
+- `ccr_backend.rgb_merge_replace: bool = False` (in `_init`, next to
+  `rgb_merge_mode`/`rgb_merge_demosaic`).
+- No catalog impact: replaced merged images simply leave the list on reload;
+  their composite-key catalog entries (if any) become stale (sources deleted)
+  and are ignored/pruned. The new TIFFs are normal cataloged files.
+
+## Processing
+
+### Backend `bake_merged_to_linear_tiff(images=None, cancel_flag=None, progress_cb=None)`
+
+Returns `{"tiff_paths": [...], "deleted": [...], "failures": [(name, reason)],
+"cancelled": bool}`.
+
+1. `imgs` = the `is_merged` images (with `merge_sources`) from `images`
+   (default `self.images`).
+2. For each, in order (emitting `progress_cb(done, total, name)`):
+   - `out = _linear_tiff_output_path(im)` — `<stem>.tiff` next to the red
+     source, conflict-suffixed (`_2`, `_3`, …) if the name is taken.
+   - `_export_merged_linear(im, out)` — full-res re-merge + framing (identity at
+     import) → lossless untagged linear TIFF.
+   - `_verify_linear_tiff(out, im)` — the file exists, is non-empty, and its
+     TIFF series reads back as `uint16`, `ndim == 3`, 3 channels, H/W > 0.
+     Raises otherwise.
+   - Success → record `(im, out)`; failure → record `(name, reason)` and add the
+     image's sources to a `bad_sources` set (never delete those).
+   - `cancel_flag()` before an image → set `cancelled`, stop.
+3. **Cancelled** → delete every TIFF already written (no orphans), delete **no**
+   source, return `cancelled=True`, `tiff_paths=[]`.
+4. Else → for each successfully baked image, mark its sources for deletion,
+   **excluding** any source also referenced by a failed image (shared-source
+   safety); delete each unique source with `os.remove` (per-file failures become
+   `failures` entries but never abort the rest). Return the tiff paths (for
+   reload), the deleted sources, and any failures.
+
+Helpers:
+- `_linear_tiff_output_path(im)` — dir of `merge_sources[0]`, stem of
+  `display_name` (falls back to the red basename), `.tiff`, conflict-suffixed.
+- `_verify_linear_tiff(out, im)` — the readback guard above (uses
+  `safe_unicode_path` + `tifffile.TiffFile`).
+
+### Worker (`main_window.py`)
+
+`MergeReplaceWorker(QObject)`: `progress(int, int, str)`, `finished(object)`;
+`run()` calls `ccr_backend.bake_merged_to_linear_tiff(self.images, cancel_flag,
+progress_cb)` and emits the result; `cancel()` sets the flag.
+
+## Integration Points
+
+| Where | Change |
+|---|---|
+| `ccr_backend.py` `_init` | `rgb_merge_replace = False`. |
+| `ccr_backend.py` `load_images_from_files` | new `force_no_merge=False`; merge branch guarded by `and not force_no_merge`; partitions marked TIFFs out of the merge set. |
+| `ccr_backend.py` `_load_merged_triplets` | new `passthrough_paths` — marked TIFFs loaded as normal images alongside merged triplets. |
+| `ccr_backend.py` `_export_merged_linear` | new `mark=False`; when True, stamps the Software-tag marker; the bake passes `mark=True`. |
+| `ccr_merge.py` | `FREECCR_MERGE_TIFF_MARKER`; `is_freeccr_merge_tiff(path)`. |
+| `main_window.py` `open_files` | merge pre-validation excludes marked TIFFs. |
+| `ccr_backend.py` | `bake_merged_to_linear_tiff`, `_linear_tiff_output_path`, `_verify_linear_tiff`. |
+| `settings_dialog.py` | `_cb_rgb_replace` checkbox + help; seed in `_init_toggles`; apply in `_apply_pending`. |
+| `main_window.py` `__init__` | restore `import/rgb_merge_replace` → backend. |
+| `main_window.py` | `on_rgb_merge_replace_toggled`; `ImageLoaderWorker(force_no_merge=…)`; `_launch_file_loader` helper (shared by `open_files` + reload); `MergeReplaceWorker`; `_maybe_replace_merged_with_tiff`, `_start_merge_replace`, `_on_replace_progress`, `_on_replace_finished`. |
+| `main_window.py` `_cleanup_loader` | call `_maybe_replace_merged_with_tiff()` after the merge-error check. |
+
+## Edge Cases
+
+- **User declines the confirm** → nothing happens; session stays merged.
+- **A source RAW missing at bake** → `merge_raw_channels` raises → that image
+  fails, its (present) sources are **not** deleted, others proceed.
+- **TIFF write returns False / truncated** → `_export_merged_linear` raises or
+  `_verify_linear_tiff` rejects → failure, sources kept.
+- **Cancel mid-bake** → no deletions, written TIFFs removed, session unchanged.
+- **Output name already exists** → conflict-suffixed; never overwrites.
+- **Duplicate/slice of a merged image present** (not at fresh import, but
+  defensive) → images sharing a source: a source is deleted only if every image
+  referencing it succeeded.
+- **`force_no_merge` reload** → TIFFs load as normal negatives; merge toggle
+  unchanged; reloaded images are not merged, so no re-trigger.
+- **Replace on but merge off** → no trigger (guard requires `rgb_merge_mode`).
+- **Partial failures** → the summary lists them; successfully replaced frames
+  are reloaded, failed frames' RAWs remain on disk (re-import to retry).
+
+## Test Plan
+
+`tests/test_merge_replace.py` (offscreen Qt, `merge_raw_channels` monkeypatched —
+no real triplet in the repo; stub merged images with real temp source files):
+
+1. **Bake + delete**: two stub merged images → two valid uint16 `(H, W, 3)`
+   TIFFs on disk; all six source files deleted; no failures; `cancelled` False.
+2. **Write failure preserves sources**: make the merge raise for one image → it
+   is a failure, its three sources survive; the other image bakes and its
+   sources are deleted.
+3. **Verify catches corruption**: monkeypatch `safe_tifffile_imwrite` to create
+   an empty/invalid file → `_verify_linear_tiff` raises → failure, sources kept.
+4. **Cancel aborts deletion**: `cancel_flag` → `cancelled` True, no deletions,
+   no leftover TIFFs, all sources present.
+5. **Conflict-safe naming**: a pre-existing `<stem>.tiff` → the bake writes
+   `<stem>_2.tiff` and does not overwrite the existing file.
+6. **force_no_merge load**: with `rgb_merge_mode` on, `load_images_from_files
+   ([tiff], force_no_merge=True)` loads the TIFF as one non-merged image.
+7. **Marker + reopen**: a baked TIFF is detected by `is_freeccr_merge_tiff`
+   (a plain TIFF / RAW ext / missing file is not); with `rgb_merge_mode` on and
+   NO force flag, `load_images_from_files([marked_tiff])` loads it as one normal
+   image with no `last_merge_error` (no toggling needed).
+
+Manual / launch verification (needs a real triplet): enable both toggles, Open
+three RAWs, confirm → a linear TIFF appears, the RAWs are gone, the list shows
+the TIFF; reopen it later as a normal negative.

--- a/spec/trichrome-linear-tiff-export.md
+++ b/spec/trichrome-linear-tiff-export.md
@@ -141,8 +141,10 @@ def _export_merged_linear(self, image_obj, output_path: str) -> None:
 `apply_crop_to_image` is a no-op for `crop_rect is None`, so the uncropped,
 unsliced export remains byte-identical to round 2.
 
-- `compression="deflate"` is lossless (bit-exact values), matching the normal
-  TIFF export; no `iccprofile` argument → untagged.
+- `compression="deflate", predictor=True` is lossless (bit-exact values); the
+  horizontal predictor (TIFF Predictor 2) decorrelates adjacent pixels so deflate
+  compresses 16-bit continuous-tone data ~1.3–2× (plain deflate barely shrinks
+  it). Universally readable (libtiff/OpenCV/tifffile). No `iccprofile` → untagged.
 - The 3 rawpy decodes per image are the documented cost of any merged-image
   re-read (spec/three-way-rgb-merge.md, Performance note); the parallel export
   pool amortises across images exactly as it does for normal exports.

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -48,6 +48,12 @@ class CCRBackend:
         # import (CCRImage.merge_demosaic); toggling affects the NEXT import.
         # Persisted by MainWindow. See spec/trichrome-demosaic-mode.md.
         self.rgb_merge_demosaic: bool = True
+        # Opt-in: after a successful merge import, bake each merged image to a
+        # full-resolution linear TIFF, PERMANENTLY delete its three source RAWs,
+        # and reload the list from the TIFFs (flatten a trichrome shoot to one
+        # archival file per frame). Global, persisted by MainWindow; the delete
+        # is always gated by a UI confirmation. See spec/merge-linear-tiff-replace.md.
+        self.rgb_merge_replace: bool = False
         # Last merge-import rejection (bad count / non-RAW / non-Bayer / decode
         # failure), set by the loader and surfaced by the UI after load, then
         # cleared. Reset at the top of every load so it never goes stale.
@@ -118,9 +124,14 @@ class CCRBackend:
         # abandoned loader thread clobbering a newer load.
         self._load_generation = 0
 
-    def load_images_from_files(self, file_paths: List[str], cancel_flag=None) -> int:
+    def load_images_from_files(self, file_paths: List[str], cancel_flag=None,
+                               force_no_merge: bool = False) -> int:
         """Load files (with catalog restore). Returns the number of FILES
-        that produced at least one image (a sliced file yields several)."""
+        that produced at least one image (a sliced file yields several).
+
+        force_no_merge bypasses the 3-way merge branch even when rgb_merge_mode
+        is on — used to reload the linear TIFFs produced by the merge-replace
+        flow (they are normal negatives, not RAW). See spec/merge-linear-tiff-replace.md."""
         self._load_generation += 1
         gen = self._load_generation
         self.images.clear()
@@ -144,8 +155,23 @@ class CCRBackend:
 
         # 3-way RGB merge: handle the whole batch on a dedicated path (sort,
         # validate multiple-of-3 + RAW, group into triplets, merge each).
-        if self.rgb_merge_mode:
-            return self._load_merged_triplets(file_paths, cancel_flag, gen)
+        # force_no_merge skips this so a merge-replace reload loads its TIFFs.
+        if self.rgb_merge_mode and not force_no_merge:
+            from core import ccr_merge
+            # Files we previously baked carry a marker so they re-open as normal
+            # images even in merge mode (no need to toggle merge off). See
+            # spec/merge-linear-tiff-replace.md.
+            passthrough = [p for p in file_paths
+                           if ccr_merge.is_freeccr_merge_tiff(p)]
+            if passthrough:
+                marked = set(passthrough)
+                to_merge = [p for p in file_paths if p not in marked]
+                if to_merge:   # mixed: merge the RAWs, load the baked TIFFs too
+                    return self._load_merged_triplets(
+                        to_merge, cancel_flag, gen, passthrough_paths=passthrough)
+                # every file is a baked merge TIFF → fall through to a normal load
+            else:
+                return self._load_merged_triplets(file_paths, cancel_flag, gen)
 
         # Read the catalog ONCE for the whole batch — per-file reads would
         # re-parse the entire JSON N times across the loader threads.
@@ -231,13 +257,18 @@ class CCRBackend:
         self.file_paths = [img.file_path for img in results]
         return True
 
-    def _load_merged_triplets(self, file_paths: List[str], cancel_flag=None, gen=None) -> int:
+    def _load_merged_triplets(self, file_paths: List[str], cancel_flag=None, gen=None,
+                              passthrough_paths=None) -> int:
         """3-way RGB merge load: sort by filename, validate (multiple of 3, all
         RAW), group into (red, green, blue) triplets, and merge each into one
         CCRImage (in parallel). Returns the number of merged images produced. A
         validation failure records last_merge_error and loads nothing; a per-
         triplet decode failure (e.g. non-Bayer sensor) is recorded and skipped.
-        See spec/three-way-rgb-merge.md."""
+        See spec/three-way-rgb-merge.md.
+
+        passthrough_paths are FreeCCR-baked merge TIFFs (marked) selected in the
+        same import: they are NOT merge inputs but are loaded as normal images
+        alongside the freshly merged triplets. See spec/merge-linear-tiff-replace.md."""
         from core import ccr_merge
 
         ordered = ccr_merge.sort_for_merge(file_paths)
@@ -251,9 +282,10 @@ class CCRBackend:
             return 0
 
         triplets = ccr_merge.group_into_triplets(ordered)
-        # Progress bar in merged units: total = number of triplets (not 3N files).
+        # Progress bar in merged units: triplet count + any passthrough TIFFs.
         if current:
-            self.file_paths = [t[0] for t in triplets]
+            self.file_paths = ([t[0] for t in triplets]
+                               + list(passthrough_paths or []))
 
         # Read the catalog ONCE for the batch so a re-merge of the same three
         # frames restores its saved edits. See spec/merge-catalog-persistence.md.
@@ -304,6 +336,22 @@ class CCRBackend:
                     imgs = future.result()
                     if imgs:
                         results.extend(imgs)
+
+        # Marked FreeCCR merge TIFFs selected alongside the RAWs: load them as
+        # normal images (with catalog restore) so a mixed import opens them
+        # without toggling merge mode off. See spec/merge-linear-tiff-replace.md.
+        if passthrough_paths:
+            from core.catalog import create_images_for_path
+            for p in passthrough_paths:
+                if cancel_flag and cancel_flag():
+                    break
+                try:
+                    imgs = create_images_for_path(p, catalog_data=catalog_data)
+                    for order, im in enumerate(imgs):
+                        im._catalog_order = order
+                    results.extend(imgs)
+                except Exception as e:
+                    print(f"Failed to load merge TIFF {os.path.basename(p)}: {e}")
 
         # User cancelled mid-load: suppress any decode error a worker recorded
         # for the aborted import (the pool above has joined, so every write has
@@ -1264,14 +1312,19 @@ class CCRBackend:
             except Exception as e:
                 print(f"Failed to convert image at index {idx}: {e}")
 
-    def _export_merged_linear(self, image_obj, output_path: str) -> None:
+    def _export_merged_linear(self, image_obj, output_path: str,
+                              mark: bool = False) -> None:
         """Write the raw trichrome combination as an untagged 16-bit linear
         TIFF: what merge_raw_channels produced at full canonical resolution,
         plus FRAMING only — the slice chain and the user crop (which is
         defined in the sliced frame's space, so source_ops must accompany
         it). NO orientation/conversion/adjustments/colour management; an
         axis-aligned crop is a bit-exact sub-array, an angled crop (or a
-        slice rotation) interpolates. See spec/trichrome-linear-tiff-export.md."""
+        slice rotation) interpolates. See spec/trichrome-linear-tiff-export.md.
+
+        mark=True stamps the FreeCCR merge marker into the Software tag (used by
+        the replace-originals bake) so the file re-opens as a normal image even
+        with 3-way merge mode on. See spec/merge-linear-tiff-replace.md."""
         from core import ccr_merge
         from core.ccr_processor import apply_crop_to_image, safe_tifffile_imwrite
         merged, _full = ccr_merge.merge_raw_channels(
@@ -1282,10 +1335,121 @@ class CCRBackend:
         merged = apply_crop_to_image(merged, getattr(image_obj, "crop_rect", None),
                                      getattr(image_obj, "crop_angle", 0.0) or 0.0)
         out = os.path.splitext(output_path)[0] + ".tiff"
+        extra = {"software": ccr_merge.FREECCR_MERGE_TIFF_MARKER} if mark else {}
+        # predictor=True (horizontal differencing, TIFF Predictor 2) decorrelates
+        # adjacent pixels before deflate — still fully lossless and universally
+        # readable (libtiff/OpenCV/tifffile), but ~1.3–2x smaller on 16-bit
+        # continuous-tone data than plain deflate, which barely compresses it.
         if not safe_tifffile_imwrite(out, merged, photometric="rgb",
-                                     compression="deflate"):
+                                     compression="deflate", predictor=True, **extra):
             raise IOError(f"Failed to save image to {out}")
         print(f"Linear merge saved to {out}")
+
+    def _linear_tiff_output_path(self, image_obj) -> str:
+        """Where a merged image's replacement linear TIFF is written: next to its
+        red source, named after the merged display name, with a numeric suffix if
+        that name is already taken (never overwrites an existing file)."""
+        red = image_obj.merge_sources[0]
+        folder = os.path.dirname(red)
+        stem = os.path.splitext(image_obj.display_name
+                                or os.path.basename(red))[0]
+        out = os.path.join(folder, stem + ".tiff")
+        n = 2
+        while os.path.exists(out):
+            out = os.path.join(folder, f"{stem}_{n}.tiff")
+            n += 1
+        return out
+
+    def _verify_linear_tiff(self, out: str, image_obj) -> None:
+        """Confirm a just-written linear TIFF is a real, non-empty uint16 RGB
+        image BEFORE its source RAWs (the only copy) are deleted. Raises on any
+        mismatch. See spec/merge-linear-tiff-replace.md."""
+        import numpy as np
+        import tifffile
+        from core.ccr_processor import safe_unicode_path
+        if not os.path.exists(out) or os.path.getsize(out) <= 0:
+            raise IOError(f"linear TIFF not written or empty: {out}")
+        with tifffile.TiffFile(safe_unicode_path(out)) as tf:
+            series = tf.series[0]
+            shape = tuple(series.shape)
+            dtype = np.dtype(series.dtype)
+        if (dtype != np.uint16 or len(shape) != 3 or shape[2] != 3
+                or shape[0] <= 0 or shape[1] <= 0):
+            raise IOError(f"linear TIFF failed verification "
+                          f"(shape={shape}, dtype={dtype}): {out}")
+
+    def bake_merged_to_linear_tiff(self, images=None, cancel_flag=None,
+                                   progress_cb=None) -> dict:
+        """Write each merged image as a full-resolution 16-bit linear TIFF next
+        to its red source, VERIFY it, then PERMANENTLY delete the source RAWs of
+        every image whose TIFF was written and verified. Destructive — the caller
+        MUST confirm first.
+
+        A source is deleted only after its replacement exists and reads back
+        valid, and only when EVERY merged image referencing it succeeded (shared-
+        source safety). Cancelling deletes nothing and removes any TIFF already
+        written, leaving the session exactly as it was.
+
+        Returns {"tiff_paths", "deleted", "failures": [(name, reason)],
+        "cancelled": bool}. See spec/merge-linear-tiff-replace.md."""
+        imgs = [im for im in (self.images if images is None else images)
+                if getattr(im, "is_merged", False)
+                and getattr(im, "merge_sources", None)]
+        total = len(imgs)
+        written = []            # (image_obj, tiff_path) — TIFF verified on disk
+        failures = []           # (name, reason)
+        bad_sources = set()     # sources of failed images — never delete these
+        cancelled = False
+        for i, im in enumerate(imgs):
+            if cancel_flag and cancel_flag():
+                cancelled = True
+                break
+            name = im.display_name or os.path.basename(im.file_path)
+            if progress_cb:
+                progress_cb(i, total, name)
+            try:
+                out = self._linear_tiff_output_path(im)
+                self._export_merged_linear(im, out, mark=True)
+                out = os.path.splitext(out)[0] + ".tiff"   # writer normalises ext
+                self._verify_linear_tiff(out, im)
+            except Exception as e:
+                print(f"Linear TIFF replace failed for {name}: {e}")
+                failures.append((name, str(e)))
+                bad_sources.update(os.path.normpath(s) for s in im.merge_sources)
+                continue
+            written.append((im, out))
+        if progress_cb:
+            progress_cb(total, total, "")
+
+        if cancelled:
+            # Abort cleanly: no source is ever deleted, and the TIFFs written so
+            # far are removed so the folder is left untouched.
+            for _im, out in written:
+                try:
+                    os.remove(out)
+                except OSError:
+                    pass
+            return {"tiff_paths": [], "deleted": [], "failures": failures,
+                    "cancelled": True}
+
+        # Delete the sources of successfully baked images, skipping any source
+        # also referenced by a FAILED image (never orphan a frame's only copy).
+        to_delete = []
+        for im, _out in written:
+            for s in im.merge_sources:
+                sp = os.path.normpath(s)
+                if sp not in bad_sources:
+                    to_delete.append(sp)
+        deleted = []
+        for sp in dict.fromkeys(to_delete):    # unique, order-preserving
+            try:
+                if os.path.exists(sp):
+                    os.remove(sp)
+                    deleted.append(sp)
+            except OSError as e:
+                failures.append((os.path.basename(sp), f"could not delete: {e}"))
+        return {"tiff_paths": [out for _im, out in written], "deleted": deleted,
+                "failures": failures, "cancelled": False}
 
     def export_image_by_index(self, idx: int, output_path: str, jpg_output: bool = False,
                               jpg_quality: int = 95, max_long_side: int = None,

--- a/src/core/ccr_merge.py
+++ b/src/core/ccr_merge.py
@@ -46,6 +46,30 @@ RAW_EXTENSIONS = frozenset({
 # Number of source frames per merged image (red, green, blue).
 MERGE_GROUP_SIZE = 3
 
+# Marker stamped into the Software tag of a FreeCCR-generated 3-way-merge linear
+# TIFF (see ccr_backend.bake_merged_to_linear_tiff). It lets such a file be
+# re-opened while 3-way merge mode is ON without toggling the mode off: the
+# loader recognises a marked TIFF and loads it as a normal image instead of
+# treating it as a (RAW) merge input. See spec/merge-linear-tiff-replace.md.
+FREECCR_MERGE_TIFF_MARKER = "FreeCCR:3-way-RGB-merge-linear-v1"
+
+
+def is_freeccr_merge_tiff(path) -> bool:
+    """True when `path` is a TIFF FreeCCR wrote as a baked 3-way-merge result
+    (carries FREECCR_MERGE_TIFF_MARKER in its Software tag). Reads only the TIFF
+    header; a non-TIFF, unreadable, or unmarked file returns False."""
+    if os.path.splitext(str(path))[1].lower() not in (".tif", ".tiff"):
+        return False
+    try:
+        import tifffile
+        from core.ccr_processor import safe_unicode_path
+        with tifffile.TiffFile(safe_unicode_path(str(path))) as tf:
+            tag = tf.pages[0].tags.get("Software")
+            value = tag.value if tag is not None else ""
+        return isinstance(value, str) and FREECCR_MERGE_TIFF_MARKER in value
+    except Exception:
+        return False
+
 
 def is_raw_path(path: str) -> bool:
     """True when the file extension is a RAW format this module can merge."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QApplication, QMainWindow, QHBoxLayout, QWidget, QFileDialog, QMessageBox, QDialog, QVBoxLayout, QTextEdit, QPushButton, QLabel
+from PySide6.QtWidgets import QApplication, QMainWindow, QHBoxLayout, QWidget, QFileDialog, QMessageBox, QDialog, QVBoxLayout, QTextEdit, QPushButton, QLabel, QProgressDialog
 from PySide6.QtGui import QIcon, QShortcut, QKeySequence
 from PySide6.QtCore import (Qt, QEvent, QThread, Signal, QObject, QSettings,
                             QTimer, QMetaObject, Q_ARG)
@@ -88,10 +88,14 @@ class UpdateAvailableDialog(QDialog):
 
 class ImageLoaderWorker(QObject):
     finished = Signal()
-    def __init__(self, folder=None, files=None):
+    def __init__(self, folder=None, files=None, force_no_merge=False):
         super().__init__()
         self.folder = folder
         self.files = files
+        # Load the files as normal images even when 3-way merge is on (used to
+        # reload the linear TIFFs a merge-replace produced). See
+        # spec/merge-linear-tiff-replace.md.
+        self.force_no_merge = force_no_merge
         self._cancelled = False
 
     def cancel(self):
@@ -101,8 +105,34 @@ class ImageLoaderWorker(QObject):
         if self.folder:
             ccr_backend.load_images_from_folder(self.folder, cancel_flag=lambda: self._cancelled)
         elif self.files:
-            ccr_backend.load_images_from_files(self.files, cancel_flag=lambda: self._cancelled)
+            ccr_backend.load_images_from_files(
+                self.files, cancel_flag=lambda: self._cancelled,
+                force_no_merge=self.force_no_merge)
         self.finished.emit()
+
+
+class MergeReplaceWorker(QObject):
+    """Runs the destructive bake-and-delete for the merge-replace flow off the
+    GUI thread: writes each merged image's linear TIFF, verifies it, then deletes
+    the source RAWs. Emits progress and the result dict. See
+    spec/merge-linear-tiff-replace.md."""
+    progress = Signal(int, int, str)   # done, total, current name
+    finished = Signal(object)          # result dict from bake_merged_to_linear_tiff
+
+    def __init__(self, images):
+        super().__init__()
+        self.images = images
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
+
+    def run(self):
+        result = ccr_backend.bake_merged_to_linear_tiff(
+            images=self.images,
+            cancel_flag=lambda: self._cancelled,
+            progress_cb=lambda d, t, n: self.progress.emit(d, t, n))
+        self.finished.emit(result)
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -192,6 +222,15 @@ class MainWindow(QMainWindow):
         # res). Captured per image at import. See spec/trichrome-demosaic-mode.md.
         ccr_backend.rgb_merge_demosaic = self._settings.value(
             "import/rgb_merge_demosaic", True, type=bool)
+        # Restore the "replace originals with linear TIFF" opt-in. When on with
+        # merge mode, a successful merge import offers (with confirmation) to bake
+        # each frame to a linear TIFF and delete the source RAWs. See
+        # spec/merge-linear-tiff-replace.md.
+        ccr_backend.rgb_merge_replace = self._settings.value(
+            "import/rgb_merge_replace", False, type=bool)
+        # Guards re-entrancy of the merge-replace flow (its reload also finishes
+        # through _cleanup_loader).
+        self._merge_replacing = False
         # Restore the two-point B/W Density-inversion default (ON — density keeps
         # real highlight headroom in the working space; linear has ~0.15 stops).
         # New two-point conversions bake this; see spec/density-bwpoint-toggle.md.
@@ -717,6 +756,24 @@ class MainWindow(QMainWindow):
              "Trichrome merge detail: single photosite (half resolution).")
             + " Applies to the next import.", duration=5000)
 
+    def on_rgb_merge_replace_toggled(self, checked: bool):
+        """Flip the global 'replace originals with linear TIFF' opt-in and persist
+        it. When on with 3-way merge, a successful merge import prompts to bake
+        each frame to a full-resolution linear TIFF and PERMANENTLY delete its
+        source RAWs (see _maybe_replace_merged_with_tiff). Affects only the next
+        import; nothing is deleted without confirmation.
+        See spec/merge-linear-tiff-replace.md."""
+        ccr_backend.rgb_merge_replace = bool(checked)
+        self._settings.setValue("import/rgb_merge_replace", bool(checked))
+        if checked:
+            msg = ("Replace originals: your next merge import will offer to bake "
+                   "linear TIFFs and delete the source RAWs (you'll confirm).")
+            if not ccr_backend.rgb_merge_mode:
+                msg += " Turn 3-way merge on to use it."
+        else:
+            msg = "Replace originals off — merge imports keep the source RAWs."
+        self.sliders_panel.set_temporary_hint(msg, duration=5000)
+
     # --- Two-point B/W Density inversion (global, persistent) -------------
     def on_density_bwpoint_toggled(self, checked: bool):
         """Flip the global two-point Density-inversion default, persist it, and
@@ -876,6 +933,26 @@ class MainWindow(QMainWindow):
             licenses_text = "No license files found."
         return licenses_text
 
+    def _launch_file_loader(self, files, force_no_merge=False):
+        """Start the async image loader for a file list. Shared by Open Files and
+        the merge-replace reload (force_no_merge loads the generated TIFFs as
+        normal images even while 3-way merge is on)."""
+        self._stop_loader_if_running()
+        # New batch = new roll: the combo returns to "Default"
+        # (the backend loader clears its copy too).
+        self.sliders_panel.reset_film_stock_combo()
+        self.thumbnail_list.show_loading_dialog()
+        self._loader_thread = QThread()
+        self._loader_worker = ImageLoaderWorker(files=files,
+                                                force_no_merge=force_no_merge)
+        self._loader_worker.moveToThread(self._loader_thread)
+        self._loader_thread.started.connect(self._loader_worker.run)
+        self._loader_worker.finished.connect(self._loader_thread.quit)
+        self._loader_worker.finished.connect(self._loader_worker.deleteLater)
+        self._loader_thread.finished.connect(self._cleanup_loader)
+        self._loader_worker.finished.connect(self.thumbnail_list.load_thumbnails)
+        self._loader_thread.start()
+
     def _cleanup_loader(self):
         """Called when the loader thread finishes. Nulls the references so isRunning() is never called on a deleted C++ object."""
         self._loader_thread = None
@@ -887,6 +964,112 @@ class MainWindow(QMainWindow):
         if err:
             ccr_backend.last_merge_error = None
             QMessageBox.warning(self, "3-way RGB merge", err)
+        # Offer to replace trichrome originals with linear TIFFs, if enabled.
+        self._maybe_replace_merged_with_tiff()
+
+    # --- Replace trichrome originals with linear TIFFs -------------------- #
+    def _maybe_replace_merged_with_tiff(self):
+        """After a successful merge import, if the opt-in is on, confirm and then
+        bake each merged frame to a linear TIFF, delete its source RAWs, and
+        reload from the TIFFs. No-op for a normal load, the reload itself, or
+        when the user declines. See spec/merge-linear-tiff-replace.md."""
+        if getattr(self, "_merge_replacing", False):
+            return
+        if not (getattr(ccr_backend, "rgb_merge_mode", False)
+                and getattr(ccr_backend, "rgb_merge_replace", False)):
+            return
+        if getattr(ccr_backend, "last_merge_error", None):
+            return
+        merged = [im for im in ccr_backend.images
+                  if getattr(im, "is_merged", False)
+                  and getattr(im, "merge_sources", None)]
+        if not merged:
+            return
+        n_sources = sum(len(im.merge_sources) for im in merged)
+        resp = QMessageBox.warning(
+            self, "Replace originals with linear TIFF",
+            f"Create {len(merged)} full-resolution linear TIFF file(s) and then "
+            f"PERMANENTLY DELETE the {n_sources} original RAW file(s) that were "
+            f"merged?\n\nThe TIFF keeps the full merged result (all linear data, "
+            f"lossless), but the merge/demosaic choice is baked in and the "
+            f"deletion cannot be undone.",
+            QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+        if resp != QMessageBox.Yes:
+            self.sliders_panel.set_temporary_hint(
+                "Replace originals cancelled — source RAWs kept.", duration=4000)
+            return
+        self._start_merge_replace(merged)
+
+    def _start_merge_replace(self, merged_images):
+        self._merge_replacing = True
+        self._stop_loader_if_running()
+        dlg = QProgressDialog("Writing linear TIFFs…", "Cancel", 0,
+                              len(merged_images), self)
+        dlg.setWindowTitle("Replacing originals")
+        dlg.setWindowModality(Qt.WindowModal)
+        dlg.setMinimumDuration(0)
+        dlg.setValue(0)
+        self._replace_dialog = dlg
+        self._replace_thread = QThread()
+        self._replace_worker = MergeReplaceWorker(merged_images)
+        self._replace_worker.moveToThread(self._replace_thread)
+        self._replace_thread.started.connect(self._replace_worker.run)
+        self._replace_worker.progress.connect(self._on_replace_progress)
+        self._replace_worker.finished.connect(self._on_replace_finished)
+        self._replace_worker.finished.connect(self._replace_thread.quit)
+        self._replace_worker.finished.connect(self._replace_worker.deleteLater)
+        # Null the Python refs only AFTER the thread's loop has stopped — a
+        # running QThread whose wrapper is GC'd hard-aborts (mirrors the loader).
+        self._replace_thread.finished.connect(self._cleanup_replace)
+        dlg.canceled.connect(self._replace_worker.cancel)
+        self._replace_thread.start()
+
+    def _cleanup_replace(self):
+        self._replace_thread = None
+        self._replace_worker = None
+
+    def _on_replace_progress(self, done, total, name):
+        dlg = getattr(self, "_replace_dialog", None)
+        if dlg is not None:
+            dlg.setMaximum(total)
+            dlg.setValue(done)
+            if name:
+                dlg.setLabelText(f"Writing linear TIFF {done + 1} of {total}:\n{name}")
+
+    def _on_replace_finished(self, result):
+        # Runs on worker.finished (the thread is still stopping — its refs are
+        # nulled later in _cleanup_replace on thread.finished).
+        dlg = getattr(self, "_replace_dialog", None)
+        if dlg is not None:
+            dlg.close()
+        self._replace_dialog = None
+        self._merge_replacing = False
+
+        failures = result.get("failures", [])
+        tiffs = result.get("tiff_paths", [])
+        deleted = result.get("deleted", [])
+
+        if result.get("cancelled"):
+            self.sliders_panel.set_temporary_hint(
+                "Replace cancelled — originals kept.", duration=4000)
+            return
+
+        if failures:
+            shown = "\n".join(f"• {name}: {reason}" for name, reason in failures[:8])
+            if len(failures) > 8:
+                shown += f"\n… and {len(failures) - 8} more"
+            QMessageBox.warning(
+                self, "Replace originals",
+                f"Replaced {len(tiffs)} frame(s); deleted {len(deleted)} "
+                f"original file(s).\n\nSome items were kept because they failed "
+                f"(their originals were NOT deleted):\n\n{shown}")
+
+        if tiffs:
+            # Reload from the generated TIFFs as normal negatives (merge bypassed).
+            self._launch_file_loader(tiffs, force_no_merge=True)
+            self.sliders_panel.set_temporary_hint(
+                f"Replaced {len(tiffs)} frame(s) with linear TIFFs; "
+                f"deleted {len(deleted)} original(s).", duration=5000)
 
     def _stop_loader_if_running(self):
         """Cancel and join any in-progress loader thread. A loader that
@@ -970,27 +1153,19 @@ class MainWindow(QMainWindow):
             if valid_files:
                 # 3-way RGB merge: validate the selection up front (multiple of
                 # 3, all RAW) so the user gets immediate feedback before any load.
+                # FreeCCR-baked merge TIFFs are excluded — they re-open as normal
+                # images even in merge mode. See spec/merge-linear-tiff-replace.md.
                 if ccr_backend.rgb_merge_mode:
                     from core import ccr_merge
-                    ok, err = ccr_merge.validate_merge_inputs(
-                        ccr_merge.sort_for_merge(valid_files))
-                    if not ok:
-                        QMessageBox.warning(self, "3-way RGB merge", err)
-                        return
-                self._stop_loader_if_running()
-                # New batch = new roll: the combo returns to "Default"
-                # (the backend loader clears its copy too).
-                self.sliders_panel.reset_film_stock_combo()
-                self.thumbnail_list.show_loading_dialog()
-                self._loader_thread = QThread()
-                self._loader_worker = ImageLoaderWorker(files=valid_files)
-                self._loader_worker.moveToThread(self._loader_thread)
-                self._loader_thread.started.connect(self._loader_worker.run)
-                self._loader_worker.finished.connect(self._loader_thread.quit)
-                self._loader_worker.finished.connect(self._loader_worker.deleteLater)
-                self._loader_thread.finished.connect(self._cleanup_loader)
-                self._loader_worker.finished.connect(self.thumbnail_list.load_thumbnails)
-                self._loader_thread.start()
+                    to_merge = [p for p in valid_files
+                                if not ccr_merge.is_freeccr_merge_tiff(p)]
+                    if to_merge:
+                        ok, err = ccr_merge.validate_merge_inputs(
+                            ccr_merge.sort_for_merge(to_merge))
+                        if not ok:
+                            QMessageBox.warning(self, "3-way RGB merge", err)
+                            return
+                self._launch_file_loader(valid_files)
             elif files:  # If there were files selected but all were invalid
                 QMessageBox.critical(
                     self,

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -275,6 +275,17 @@ class SettingsDialog(QDialog):
             "resolution. Single photosite reads only the raw colour sites — "
             "no interpolation at all — at half resolution. Applies to the "
             "next import."))
+        self._cb_rgb_replace = QCheckBox(
+            "Replace originals with linear TIFF on import")
+        g3.addWidget(self._cb_rgb_replace)
+        g3.addWidget(self._muted(
+            "After a successful merge import, each merged frame is written as a "
+            "full-resolution 16-bit linear TIFF next to its red source, then the "
+            "three original RAWs are PERMANENTLY DELETED and the list reloads "
+            "from the TIFFs. You confirm before anything is deleted. The "
+            "merge/demosaic choice is baked in and can't be changed afterwards. "
+            "The generated TIFFs reopen normally even with 3-way merge left on. "
+            "Requires 3-way merge to be on."))
         lay.addWidget(grp3)
 
         lay.addStretch(1)
@@ -307,6 +318,8 @@ class SettingsDialog(QDialog):
         profile UI) so a profile import/delete can't clobber a staged toggle."""
         for cb, val in ((self._cb_positive, ccr_backend.positive_mode),
                         (self._cb_rgb_merge, ccr_backend.rgb_merge_mode),
+                        (self._cb_rgb_replace,
+                         getattr(ccr_backend, "rgb_merge_replace", False)),
                         (self._cb_density, ccr_backend.density_bwpoint),
                         (self._cb_auto_gain, ccr_backend.auto_gain),
                         (self._cb_auto_awb, ccr_backend.auto_awb),
@@ -339,6 +352,10 @@ class SettingsDialog(QDialog):
         staged_detail = bool(self._combo_merge_detail.currentData())
         if staged_detail != bool(getattr(ccr_backend, "rgb_merge_demosaic", True)):
             self._mw.on_rgb_merge_demosaic_changed(staged_detail)
+        if (bool(self._cb_rgb_replace.isChecked())
+                != bool(getattr(ccr_backend, "rgb_merge_replace", False))):
+            self._mw.on_rgb_merge_replace_toggled(
+                bool(self._cb_rgb_replace.isChecked()))
         if bool(self._cb_density.isChecked()) != bool(ccr_backend.density_bwpoint):
             self._mw.on_density_bwpoint_toggled(bool(self._cb_density.isChecked()))
         if bool(self._cb_auto_gain.isChecked()) != bool(ccr_backend.auto_gain):

--- a/tests/test_merge_replace.py
+++ b/tests/test_merge_replace.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Replace trichrome originals with a linear TIFF (spec/merge-linear-tiff-replace.md).
+
+bake_merged_to_linear_tiff writes each merged image's full-resolution linear
+TIFF, verifies it reads back valid, then PERMANENTLY deletes its source RAWs —
+never deleting a source whose replacement failed or when cancelled. No real
+trichrome triplet exists in the repo, so merge_raw_channels is monkeypatched;
+the "source RAWs" are real empty temp files so deletion is observable.
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+import tifffile  # noqa: E402
+
+from core import ccr_merge, ccr_processor  # noqa: E402
+from core.ccr_backend import ccr_backend  # noqa: E402
+
+MERGED = (np.linspace(0, 65535, 48 * 64 * 3, dtype=np.float64)
+          .reshape(48, 64, 3).astype(np.uint16))
+
+
+@pytest.fixture(autouse=True)
+def _clean_backend():
+    """CCRBackend is an enforced singleton; leave it empty + merge off for others."""
+    yield
+    ccr_backend.images = []
+    ccr_backend.file_paths = []
+    ccr_backend.rgb_merge_mode = False
+    ccr_backend.last_merge_error = None
+
+
+@pytest.fixture
+def fake_merge(monkeypatch):
+    def _fake(sources, preview=False, demosaic=False):
+        return MERGED.copy(), MERGED.shape[:2]
+    monkeypatch.setattr(ccr_merge, "merge_raw_channels", _fake)
+
+
+def _make_merged(tmp_path, prefix):
+    """A stub merged image backed by three real (empty) source files, so the
+    delete step has something to remove and assertions can see it happen."""
+    sources = []
+    for c in "RGB":
+        p = tmp_path / f"{prefix}_{c}.arw"
+        p.write_bytes(b"\x00" * 16)
+        sources.append(str(p))
+    return SimpleNamespace(
+        is_merged=True,
+        merge_sources=sources,
+        file_path=sources[0],
+        display_name=f"{prefix}_RGB.arw",
+        source_ops=[],
+        crop_rect=None,
+        crop_angle=0.0,
+        merge_demosaic=True,
+    )
+
+
+def test_bake_writes_tiffs_and_deletes_sources(tmp_path, fake_merge):
+    im1, im2 = _make_merged(tmp_path, "a"), _make_merged(tmp_path, "b")
+    res = ccr_backend.bake_merged_to_linear_tiff([im1, im2])
+
+    assert res["cancelled"] is False
+    assert res["failures"] == []
+    assert len(res["tiff_paths"]) == 2
+    for out in res["tiff_paths"]:
+        assert os.path.exists(out) and out.endswith(".tiff")
+        with tifffile.TiffFile(out) as tf:
+            arr = tf.asarray()
+        assert arr.dtype == np.uint16 and arr.shape == (48, 64, 3)
+        np.testing.assert_array_equal(arr, MERGED)
+    # every original RAW is gone
+    assert len(res["deleted"]) == 6
+    for im in (im1, im2):
+        for s in im.merge_sources:
+            assert not os.path.exists(s)
+
+
+def test_write_failure_preserves_that_images_sources(tmp_path, monkeypatch):
+    good, bad = _make_merged(tmp_path, "good"), _make_merged(tmp_path, "bad")
+
+    def _fake(sources, preview=False, demosaic=False):
+        if any("bad" in s for s in sources):
+            raise ValueError("boom")
+        return MERGED.copy(), MERGED.shape[:2]
+    monkeypatch.setattr(ccr_merge, "merge_raw_channels", _fake)
+
+    res = ccr_backend.bake_merged_to_linear_tiff([good, bad])
+
+    assert len(res["tiff_paths"]) == 1
+    assert any("bad" in name for name, _reason in res["failures"])
+    # the good frame's sources are deleted; the failed frame's are untouched
+    for s in good.merge_sources:
+        assert not os.path.exists(s)
+    for s in bad.merge_sources:
+        assert os.path.exists(s)
+
+
+def test_verify_rejects_invalid_tiff_and_keeps_sources(tmp_path, fake_merge, monkeypatch):
+    im = _make_merged(tmp_path, "c")
+
+    def _bad_write(out, image, **kwargs):
+        # A valid TIFF but the WRONG shape (2-D) — the readback verify must
+        # reject it, and the sources (only copy) must survive.
+        tifffile.imwrite(ccr_processor.safe_unicode_path(out),
+                         np.zeros((10, 10), np.uint16))
+        return True
+    monkeypatch.setattr(ccr_processor, "safe_tifffile_imwrite", _bad_write)
+
+    res = ccr_backend.bake_merged_to_linear_tiff([im])
+
+    assert res["tiff_paths"] == []
+    assert res["deleted"] == []
+    assert res["failures"] and "verification" in res["failures"][0][1]
+    for s in im.merge_sources:
+        assert os.path.exists(s)
+
+
+def test_cancel_deletes_nothing_and_removes_written_tiffs(tmp_path, fake_merge):
+    im1, im2 = _make_merged(tmp_path, "a"), _make_merged(tmp_path, "b")
+    calls = {"n": 0}
+
+    def cancel_flag():
+        calls["n"] += 1
+        return calls["n"] > 1     # let the first image write, cancel before the 2nd
+
+    res = ccr_backend.bake_merged_to_linear_tiff([im1, im2], cancel_flag=cancel_flag)
+
+    assert res["cancelled"] is True
+    assert res["tiff_paths"] == [] and res["deleted"] == []
+    for im in (im1, im2):
+        for s in im.merge_sources:
+            assert os.path.exists(s)          # nothing deleted
+    assert not list(tmp_path.glob("*.tiff"))  # the written TIFF was cleaned up
+
+
+def test_conflict_safe_naming_never_overwrites(tmp_path, fake_merge):
+    im = _make_merged(tmp_path, "a")
+    stem = os.path.splitext(im.display_name)[0]
+    existing = tmp_path / f"{stem}.tiff"
+    existing.write_bytes(b"OLD")
+
+    res = ccr_backend.bake_merged_to_linear_tiff([im])
+
+    out = res["tiff_paths"][0]
+    assert out.endswith(f"{stem}_2.tiff")
+    assert existing.read_bytes() == b"OLD"    # pre-existing file untouched
+
+
+def test_baked_tiff_is_marked_and_detected(tmp_path, fake_merge):
+    im = _make_merged(tmp_path, "a")
+    res = ccr_backend.bake_merged_to_linear_tiff([im])
+    out = res["tiff_paths"][0]
+    # the baked TIFF carries the FreeCCR merge marker; a plain TIFF does not
+    assert ccr_merge.is_freeccr_merge_tiff(out) is True
+    plain = str(tmp_path / "plain.tiff")
+    tifffile.imwrite(plain, MERGED)
+    assert ccr_merge.is_freeccr_merge_tiff(plain) is False
+    # a RAW extension / missing file is never a merge TIFF
+    assert ccr_merge.is_freeccr_merge_tiff(str(tmp_path / "x.arw")) is False
+
+
+def test_marked_tiff_opens_in_merge_mode_without_toggling(tmp_path, fake_merge):
+    im = _make_merged(tmp_path, "a")
+    out = ccr_backend.bake_merged_to_linear_tiff([im])["tiff_paths"][0]
+    # merge mode ON: a marked TIFF loads as one NORMAL image, no error, no toggle
+    ccr_backend.rgb_merge_mode = True
+    ccr_backend.last_merge_error = None
+    n = ccr_backend.load_images_from_files([out])
+    assert n == 1
+    assert len(ccr_backend.images) == 1
+    assert not getattr(ccr_backend.images[0], "is_merged", False)
+    assert not ccr_backend.last_merge_error
+
+
+def test_force_no_merge_loads_tiff_as_normal(tmp_path):
+    p = str(tmp_path / "lin.tiff")
+    tifffile.imwrite(p, MERGED)
+    ccr_backend.rgb_merge_mode = True
+    n = ccr_backend.load_images_from_files([p], force_no_merge=True)
+    assert n == 1
+    assert len(ccr_backend.images) == 1
+    assert not getattr(ccr_backend.images[0], "is_merged", False)
+
+
+def test_without_force_no_merge_a_tiff_is_rejected_in_merge_mode(tmp_path):
+    p = str(tmp_path / "lin.tiff")
+    tifffile.imwrite(p, MERGED)
+    ccr_backend.rgb_merge_mode = True
+    ccr_backend.last_merge_error = None
+    n = ccr_backend.load_images_from_files([p])   # merge on, TIFF is not RAW
+    assert n == 0
+    assert ccr_backend.last_merge_error          # a rejection was recorded
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Opt-in workflow for **3-way RGB merge (trichrome)**: after a successful merge import, bake each merged frame to a full-resolution **16-bit linear TIFF**, **permanently delete** its three source RAWs, and reload the list from the TIFFs — flattening a trichrome shoot to one archival file per frame.

The setting is **off by default** (Settings → Color Management → Trichrome capture), and the delete is always gated by a **per-import confirmation popup**.

## What's included
- **Bake + replace** (`bake_merged_to_linear_tiff`): write → verify readback → `os.remove` sources → reload.
- **Safety:** a RAW is deleted only after its TIFF is written *and* reads back as a valid uint16 H×W×3 image; per-frame failure keeps that frame's RAWs; shared sources deleted only if every referencing frame succeeded; **cancel deletes nothing** and removes any TIFF already written; conflict-safe naming.
- **Reopen without toggling merge off:** baked TIFFs carry `FREECCR_MERGE_TIFF_MARKER` in their Software tag; `is_freeccr_merge_tiff` detects it, and the loader / `open_files` pre-validation treat marked TIFFs as normal images even in merge mode (mixed imports via `passthrough_paths`). `load_images_from_files` also gains `force_no_merge` for the replace reload.
- **Lossless compression:** the linear-TIFF writer now uses `deflate + predictor` (TIFF Predictor 2). Plain deflate barely compresses 16-bit continuous-tone data; the predictor gives ~1.3–2× — still bit-exact and universally readable (verified OpenCV + tifffile). Benefits the manual linear export too.
- **Threading:** `MergeReplaceWorker` runs the bake off the GUI thread with a progress dialog; thread refs nulled on `thread.finished` (GC-a-running-QThread hazard).

## Testing
- `tests/test_merge_replace.py` (bake/delete, write-failure preserves sources, verify catches corruption, cancel aborts, conflict-safe naming, `force_no_merge` load, marker detection + reopen-in-merge-mode). All affected suites green in small groups (63 passed core set).
- Backend integration smoke (faking only the RAW decode) with real merged `CCRImage` objects: merge → bake → 3 RAWs deleted → TIFF byte-equal to the merge → reopen in merge mode via the marker as a normal image.
- Settings panel screenshot confirmed the checkbox + destructive-action help text render correctly.
- CI boundary: no aligned RAW triplet ships in-repo (same as the merge feature), so the real re-merge round trip is covered by the smoke.

Specs: `spec/merge-linear-tiff-replace.md` (+ a note in `trichrome-linear-tiff-export.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kaw7MLDhjqk9mxbqAXZGZ7
