### PR TITLE
fix(loader): tell the user why a file could not be loaded

### DIFF
--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -58,6 +58,12 @@ class CCRBackend:
         # failure), set by the loader and surfaced by the UI after load, then
         # cleared. Reset at the top of every load so it never goes stale.
         self.last_merge_error: Optional[str] = None
+        # Files dropped by the last load, as [(path, reason)] — set by the
+        # loader and surfaced by the UI after load, then cleared. Without this a
+        # file that cannot be decoded (e.g. a Nikon HE NEF, which no
+        # open-source decoder reads) just vanished from the import with only a
+        # stdout print, invisible in a built exe. Reset at the top of every load.
+        self.last_load_errors: List[tuple] = []
         # Two-point B/W conversion mode: True recovers optical density (log
         # space), False uses the legacy linear transmittance stretch. The choice
         # is baked per image into conversion_inputs["density"]; this holds the
@@ -149,6 +155,7 @@ class CCRBackend:
         # Per-load merge error: reset up front so a prior load's message can't
         # carry over and be shown after this (possibly successful) one.
         self.last_merge_error = None
+        self.last_load_errors = []
         # Preserved removal states belong to the previous batch (the open
         # flows save the catalog before loading a new one)
         self._catalog_preserved = {}
@@ -176,6 +183,7 @@ class CCRBackend:
         # Read the catalog ONCE for the whole batch — per-file reads would
         # re-parse the entire JSON N times across the loader threads.
         from core.catalog import create_images_for_path, load_catalog
+        from core import load_errors
         try:
             catalog_data = load_catalog()
         except Exception:
@@ -195,6 +203,12 @@ class CCRBackend:
                 return path, imgs
             except Exception as e:
                 print(f"Failed to load {os.path.basename(path)}: {e}")
+                # Recorded so the UI can say WHY the file is missing from the
+                # import. list.append is atomic, so the worker threads can
+                # record without a lock; order is arbitrary and irrelevant
+                # (the summary groups by reason).
+                failures.append(
+                    (path, load_errors.describe_load_failure(path, e)))
                 return path, None
         
         # Use parallel loading with ThreadPoolExecutor
@@ -204,6 +218,11 @@ class CCRBackend:
         # Collect into a local list (both branches) and publish once at the
         # end — the backend lists must never hold a half-loaded batch.
         results = []
+        # Same for the per-file failures: publishing them only alongside a
+        # successful commit means a cancelled or superseded load reports
+        # nothing, and a stale thread can never pop a dialog over the batch
+        # that replaced it.
+        failures = []
         if max_workers == 1:
             # Sequential fallback
             for path in file_paths:
@@ -234,6 +253,7 @@ class CCRBackend:
         # clobber the newer batch.
         if not self._commit_load(gen, results, cancel_flag):
             return 0
+        self.last_load_errors = failures
         return loaded_file_count
 
     def _commit_load(self, gen, results, cancel_flag=None) -> bool:
@@ -340,8 +360,10 @@ class CCRBackend:
         # Marked FreeCCR merge TIFFs selected alongside the RAWs: load them as
         # normal images (with catalog restore) so a mixed import opens them
         # without toggling merge mode off. See spec/merge-linear-tiff-replace.md.
+        failures = []
         if passthrough_paths:
             from core.catalog import create_images_for_path
+            from core import load_errors
             for p in passthrough_paths:
                 if cancel_flag and cancel_flag():
                     break
@@ -352,6 +374,8 @@ class CCRBackend:
                     results.extend(imgs)
                 except Exception as e:
                     print(f"Failed to load merge TIFF {os.path.basename(p)}: {e}")
+                    failures.append(
+                        (p, load_errors.describe_load_failure(p, e)))
 
         # User cancelled mid-load: suppress any decode error a worker recorded
         # for the aborted import (the pool above has joined, so every write has
@@ -366,6 +390,7 @@ class CCRBackend:
         self._dedupe_display_names(results)
         if not self._commit_load(gen, results, cancel_flag):
             return 0
+        self.last_load_errors = failures
         return len(results)
 
     @staticmethod

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -148,6 +148,11 @@ class CCRImage:
         self.slice_parent: Optional[Dict[str, Any]] = slice_parent
         self.thumbnail = thumbnail
         self.resized_raw = resized_raw
+        # Underlying exception from the last failed decode, kept because
+        # read_image reports failure as None and would otherwise throw the
+        # cause away. The load path chains it onto the ValueError it raises so
+        # the loader can explain WHY a file was dropped (see core/load_errors).
+        self.last_read_error: Optional[BaseException] = None
         # Camera profile (ICC/DCP/none) this image's decode was graded under;
         # stamped on every working decode so the thumbnail can flag a mismatch
         # when the active profile changes. Not persisted (a reload re-stamps).
@@ -259,7 +264,12 @@ class CCRImage:
             # Populate thumbnail and preview
             self.update_thumbnail_and_preview()
         else:
-            raise ValueError(f"Could not read image from file: {self.file_path}")
+            # Chained, not swallowed: the loader classifies the ROOT cause (a
+            # LibRaw "unsupported format" vs a missing file) to tell the user
+            # why this file was dropped from the import.
+            raise ValueError(
+                f"Could not read image from file: {self.file_path}"
+            ) from self.last_read_error
         print(f"CCRImage initialized: {self.file_path}, info: {self.info}")
 
 
@@ -696,6 +706,9 @@ class CCRImage:
                 return self._apply_input_icc(rgb, as_shot_wb)
             except Exception as e:
                 logging.exception(f"Failed to read RAW image: {file_path}")
+                # Keep the LibRaw error itself — "unsupported compression" and
+                # "damaged file" are indistinguishable once it becomes None.
+                self.last_read_error = e
                 return None
         else:
             # Handle Unicode file paths and OpenCV TIFF issues properly
@@ -779,6 +792,8 @@ class CCRImage:
             
             if img is None:
                 logging.error(f"All reading methods failed for: {file_path}")
+                self.last_read_error = RuntimeError(
+                    "no decoder (OpenCV, tifffile, PIL) could read this file")
                 return None
             # Normalize the sample format FIRST (cvtColor can't take
             # float64/int16 input, and float 0..1 data used to slip through

--- a/src/core/load_errors.py
+++ b/src/core/load_errors.py
@@ -1,0 +1,158 @@
+"""User-facing reasons for files that failed to load.
+
+A file whose decode fails used to disappear from the import with nothing but a
+stdout print: `read_image` returns None, `CCRImage.__init__` raises, the loader
+catches it and drops the file. A built exe/app has no console, so the file
+simply never appeared and the user was given no reason.
+
+The loader now records `(path, reason)` per failed file and the UI shows one
+grouped summary after the batch. This module owns the classification and the
+message text, kept pure and Qt-free so both are unit-testable without a display.
+"""
+import os
+import textwrap
+
+# QMessageBox does not word-wrap plain text — it widens the dialog to fit the
+# longest line. The reasons are full sentences, so wrap them here.
+_WRAP = 76
+
+# Extensions read through rawpy/LibRaw — mirrors the branch list in
+# ccr_image.read_image (see ccr_image.py, the `ext in [...]` RAW test).
+RAW_EXTS = {".cr3", ".cr2", ".nef", ".arw", ".dng", ".rw2", ".orf", ".raf",
+            ".srw", ".pef", ".3fr"}
+
+# LibRaw reports an undecodable RAW differently depending on version: 0.21.x
+# opens the file, reports its size, then dies during unpack ("Data error or
+# unsupported file format" / "data corrupted at N"); 0.22+ rejects it up front
+# ("Unsupported file format or not RAW file"). Match either shape.
+_LIBRAW_UNSUPPORTED = ("unsupported file format", "data error",
+                       "data corrupted", "not raw file")
+
+# Nikon High Efficiency (HE/HE*) NEF — intoPIX TicoRAW. LibRaw decodes it only
+# in commercial builds licensed with the intoPIX SDK, so no rawpy release can
+# open these; rawspeed/darktable have the same gap. DNG Converter is the way
+# out, but only below DNG 1.7: at Camera Raw 16.0+ compatibility it writes
+# JPEG XL DNGs that LibRaw 0.21.x also cannot read.
+HE_NEF_REASON = (
+    "RAW decode failed — most likely a Nikon High Efficiency (HE/HE★) NEF. "
+    "No open-source decoder supports that compression. Convert the file with "
+    "Adobe DNG Converter (Preferences → Compatibility: Camera Raw 15.3 or "
+    "earlier) and open the DNG instead, or shoot Lossless compressed."
+)
+RAW_UNSUPPORTED_REASON = (
+    "RAW decode failed — this camera's format or compression is not supported "
+    "by the RAW decoder in this build, or the file is damaged."
+)
+MISSING_REASON = "File not found — it may have been moved or renamed."
+PERMISSION_REASON = "Permission denied — the file could not be opened."
+
+# Terse equivalents for the tethering hint strip, which shows one line inline
+# rather than a dialog and cannot carry the full explanation.
+SHORT_REASONS = {
+    HE_NEF_REASON: "Nikon HE NEF — no open-source decoder; convert to DNG",
+    RAW_UNSUPPORTED_REASON: "RAW format unsupported or file damaged",
+    MISSING_REASON: "file not found",
+    PERMISSION_REASON: "permission denied",
+}
+
+
+def _messages(error):
+    """Every message in an exception's cause/context chain, lower-cased.
+
+    The LibRaw error is not what the loader catches: read_image swallows it and
+    returns None, and CCRImage.__init__ raises a ValueError chained onto it. The
+    classification has to see through that, so walk the chain rather than
+    looking only at the outermost exception.
+    """
+    out, seen, cur = [], set(), error
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        out.append(f"{type(cur).__name__}: {cur}".lower())
+        cur = cur.__cause__ or cur.__context__
+    return out
+
+
+def _has_type(error, exc_type):
+    seen, cur = set(), error
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, exc_type):
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
+def _root_cause(error):
+    """The deepest exception in the chain — the one that actually knows what
+    went wrong. The outermost is CCRImage's "Could not read image from file",
+    which only restates the path and explains nothing."""
+    seen, cur, last = set(), error, error
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        last = cur
+        cur = cur.__cause__ or cur.__context__
+    return last
+
+
+def describe_load_failure(file_path, error, short: bool = False) -> str:
+    """One user-facing sentence explaining why `file_path` could not load.
+    `short` returns the terse form for the inline tethering hint.
+
+    Never raises: a reason is only ever cosmetic, and a load that already failed
+    must not fail again while being reported.
+    """
+    reason = _describe(file_path, error)
+    return SHORT_REASONS.get(reason, reason) if short else reason
+
+
+def _describe(file_path, error) -> str:
+    try:
+        ext = os.path.splitext(file_path or "")[1].lower()
+        # Ask the filesystem rather than trusting the exception type: rawpy
+        # reports a missing file as LibRawIOError("Input/output error"), not
+        # FileNotFoundError, so type sniffing alone misses the commonest case.
+        if _has_type(error, FileNotFoundError) or (
+                file_path and not os.path.exists(file_path)):
+            return MISSING_REASON
+        if _has_type(error, PermissionError):
+            return PERMISSION_REASON
+        text = " ".join(_messages(error))
+        if ext in RAW_EXTS and any(s in text for s in _LIBRAW_UNSUPPORTED):
+            # HE is the overwhelmingly common cause for a NEF LibRaw won't
+            # touch, but a damaged file lands here too — hence "most likely".
+            return HE_NEF_REASON if ext == ".nef" else RAW_UNSUPPORTED_REASON
+        root = _root_cause(error)
+        detail = str(root).strip()
+        if not detail:
+            detail = type(root).__name__ if root is not None else ""
+        return f"Could not be read: {detail}" if detail else "Could not be read."
+    except Exception:
+        return "Could not be read."
+
+
+def format_load_failures(failures, max_per_reason: int = 8) -> str:
+    """Build the summary dialog body from [(path, reason), ...].
+
+    Failures are grouped by reason because the realistic case is a whole roll
+    sharing one cause (36 HE NEFs from the same camera) — listing them
+    individually would bury the explanation under filenames.
+    """
+    if not failures:
+        return ""
+    groups, order = {}, []
+    for path, reason in failures:
+        if reason not in groups:
+            groups[reason] = []
+            order.append(reason)
+        groups[reason].append(os.path.basename(path))
+
+    n = len(failures)
+    parts = [f"{n} {'file' if n == 1 else 'files'} could not be loaded:"]
+    for reason in order:
+        names = groups[reason]
+        shown = names[:max_per_reason]
+        listing = "\n".join(f"    • {name}" for name in shown)
+        if len(names) > len(shown):
+            listing += f"\n    • …and {len(names) - len(shown)} more"
+        parts.append(f"\n{textwrap.fill(reason, _WRAP)}\n{listing}")
+    return "\n".join(parts)

--- a/src/core/tether_watcher.py
+++ b/src/core/tether_watcher.py
@@ -197,7 +197,11 @@ class TetherWatchWorker(QObject):
                     self._convert(img, black, white, slopes)
                 self.captured.emit(img)
         except Exception as e:
-            self.captureError.emit(path, str(e))
+            # Terse form: the GUI shows this inline in the hint strip, so a
+            # tethered capture FreeCCR cannot decode still says why.
+            from core.load_errors import describe_load_failure
+            self.captureError.emit(
+                path, describe_load_failure(path, e, short=True))
 
     @staticmethod
     def _convert(img, black, white, slopes=None):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -964,8 +964,22 @@ class MainWindow(QMainWindow):
         if err:
             ccr_backend.last_merge_error = None
             QMessageBox.warning(self, "3-way RGB merge", err)
+        # Files the loader had to drop (undecodable RAW, missing file, …).
+        # Without this they silently never appear — a built exe has no console
+        # to show the loader's print. Read once, then clear.
+        self._report_load_failures()
         # Offer to replace trichrome originals with linear TIFFs, if enabled.
         self._maybe_replace_merged_with_tiff()
+
+    def _report_load_failures(self):
+        """One grouped warning for every file the last load could not open."""
+        failures = getattr(ccr_backend, "last_load_errors", None)
+        if not failures:
+            return
+        ccr_backend.last_load_errors = []
+        from core.load_errors import format_load_failures
+        QMessageBox.warning(self, "Some files could not be loaded",
+                            format_load_failures(failures))
 
     # --- Replace trichrome originals with linear TIFFs -------------------- #
     def _maybe_replace_merged_with_tiff(self):

--- a/tests/test_load_errors.py
+++ b/tests/test_load_errors.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Reporting for files the loader could not open (core/load_errors.py).
+
+A file that fails to decode used to vanish from the import: read_image returns
+None, CCRImage.__init__ raises, the loader catches it and drops the file, and
+the only trace is a stdout print no built exe can show. These tests pin the
+three links in the new chain — the LibRaw cause survives to the loader, it is
+classified into a user-facing reason, and the reasons are grouped into one
+message — plus the end-to-end wiring through CCRBackend.
+"""
+import os
+import sys
+
+import cv2
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+import pytest  # noqa: E402
+
+from core.load_errors import (  # noqa: E402
+    HE_NEF_REASON, MISSING_REASON, PERMISSION_REASON, RAW_UNSUPPORTED_REASON,
+    describe_load_failure, format_load_failures)
+from core.ccr_backend import CCRBackend  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_backend():
+    """CCRBackend is an enforced singleton — leave it empty for other modules."""
+    yield
+    backend = CCRBackend()
+    backend.images = []
+    backend.file_paths = []
+    backend.last_load_errors = []
+
+
+def _wrapped(inner):
+    """The exception the loader actually sees: CCRImage.__init__'s ValueError
+    chained onto the decoder's error."""
+    try:
+        try:
+            raise inner
+        except Exception as e:
+            raise ValueError("Could not read image from file: x") from e
+    except ValueError as outer:
+        return outer
+
+
+def _touch(tmp_path, name):
+    """A file that EXISTS but cannot be decoded — the classifier checks the
+    filesystem, so an undecodable file must be told apart from a missing one."""
+    p = tmp_path / name
+    p.write_bytes(b"\x00" * 64)
+    return str(p)
+
+
+# --- classification ---------------------------------------------------------
+
+# LibRaw 0.21.x opens an HE NEF, reports its size, then dies in unpack; 0.22+
+# rejects it up front. Both must reach the same explanation.
+@pytest.mark.parametrize("message", [
+    "Data error or unsupported file format",
+    "unknown file: data corrupted at 2823171",
+    "Unsupported file format or not RAW file",
+])
+def test_undecodable_nef_reports_he(message, tmp_path):
+    err = _wrapped(RuntimeError(message))
+    assert describe_load_failure(
+        _touch(tmp_path, "DSC_6887.NEF"), err) == HE_NEF_REASON
+
+
+def test_he_reason_names_the_dng_workaround():
+    """The message is the whole point of the feature: it must tell the user
+    what to DO, including the Camera Raw compatibility trap (a DNG 1.7 / JPEG
+    XL file is equally unreadable by the bundled LibRaw)."""
+    assert "DNG Converter" in HE_NEF_REASON
+    assert "15.3" in HE_NEF_REASON
+
+
+def test_undecodable_non_nef_raw_is_generic(tmp_path):
+    """Only NEF gets the Nikon HE explanation — an unsupported CR3 must not."""
+    err = _wrapped(RuntimeError("Unsupported file format or not RAW file"))
+    assert describe_load_failure(
+        _touch(tmp_path, "IMG_0001.CR3"), err) == RAW_UNSUPPORTED_REASON
+
+
+def test_non_raw_file_never_gets_a_raw_reason(tmp_path):
+    err = _wrapped(RuntimeError("Unsupported file format or not RAW file"))
+    reason = describe_load_failure(_touch(tmp_path, "scan.jpg"), err)
+    assert reason not in (HE_NEF_REASON, RAW_UNSUPPORTED_REASON)
+
+
+def test_extension_match_is_case_insensitive(tmp_path):
+    err = _wrapped(RuntimeError("data error"))
+    assert describe_load_failure(_touch(tmp_path, "a.nef"), err) == HE_NEF_REASON
+    assert describe_load_failure(_touch(tmp_path, "b.NEF"), err) == HE_NEF_REASON
+
+
+def test_missing_file_beats_the_decoder_error(tmp_path):
+    """rawpy reports a missing RAW as LibRawIOError("Input/output error"), NOT
+    FileNotFoundError — so a deleted file used to be explained as an
+    undecodable one. The filesystem is the authority here."""
+    gone = str(tmp_path / "gone.nef")
+    assert describe_load_failure(
+        gone, _wrapped(RuntimeError("Input/output error"))) == MISSING_REASON
+    assert describe_load_failure(
+        gone, _wrapped(FileNotFoundError(2, "No such file"))) == MISSING_REASON
+
+
+def test_permission_denied(tmp_path):
+    assert describe_load_failure(
+        _touch(tmp_path, "locked.nef"),
+        _wrapped(PermissionError(13, "Denied"))) == PERMISSION_REASON
+
+
+def test_unknown_error_reports_the_root_cause(tmp_path):
+    """The outer ValueError only restates the path; the useful text is the
+    decoder's own message at the bottom of the chain."""
+    reason = describe_load_failure(_touch(tmp_path, "scan.tif"),
+                                   _wrapped(RuntimeError("weird failure")))
+    assert "weird failure" in reason
+    assert "Could not read image from file" not in reason
+
+
+def test_describe_never_raises(tmp_path):
+    """A reason is cosmetic — reporting a failed load must not fail itself."""
+    class Exploding(Exception):
+        def __str__(self):
+            raise RuntimeError("boom")
+
+    assert describe_load_failure(None, None)
+    assert describe_load_failure(_touch(tmp_path, "x.tif"), Exploding())
+
+
+def test_short_form_is_terse_for_the_tether_hint(tmp_path):
+    err = _wrapped(RuntimeError("data error"))
+    short = describe_load_failure(_touch(tmp_path, "DSC_1.NEF"), err, short=True)
+    assert short != HE_NEF_REASON
+    assert len(short) < 60
+    assert "DNG" in short
+
+
+# --- message formatting -----------------------------------------------------
+
+def test_no_failures_formats_to_empty():
+    assert format_load_failures([]) == ""
+
+
+def test_failures_group_by_reason():
+    """A whole roll usually shares one cause; the explanation must appear once,
+    not repeated under every filename."""
+    failures = [(f"/r/DSC_{i}.NEF", HE_NEF_REASON) for i in range(3)]
+    failures.append(("/r/gone.tif", MISSING_REASON))
+    body = format_load_failures(failures)
+
+    # The reason is wrapped for the dialog, so match a distinctive phrase.
+    assert body.count("High Efficiency") == 1
+    assert body.startswith("4 files could not be loaded:")
+    for i in range(3):
+        assert f"DSC_{i}.NEF" in body
+    assert "gone.tif" in body
+
+
+def test_long_group_is_capped():
+    failures = [(f"/r/DSC_{i}.NEF", HE_NEF_REASON) for i in range(40)]
+    body = format_load_failures(failures, max_per_reason=8)
+    assert "DSC_0.NEF" in body
+    assert "DSC_39.NEF" not in body
+    assert "…and 32 more" in body
+
+
+def test_singular_wording_for_one_file():
+    assert format_load_failures(
+        [("/r/x.nef", MISSING_REASON)]).startswith("1 file could not be loaded:")
+
+
+def test_message_lines_stay_narrow():
+    """QMessageBox sizes itself to the longest line — an unwrapped reason would
+    stretch the dialog across the screen."""
+    body = format_load_failures([("/r/DSC_1.NEF", HE_NEF_REASON)])
+    assert max(len(line) for line in body.splitlines()) <= 80
+    assert "High Efficiency" in body
+
+
+def test_basenames_only_no_full_paths():
+    body = format_load_failures([(os.path.join("C:", "rolls", "x.nef"),
+                                  MISSING_REASON)])
+    assert "x.nef" in body
+    assert "rolls" not in body
+
+
+# --- wiring through the real load path --------------------------------------
+
+def test_ccrimage_chains_the_decode_cause(tmp_path):
+    """CCRImage must not swallow the decoder's error — the loader classifies
+    the ROOT cause, so an unchained ValueError would flatten every failure into
+    the generic message."""
+    from core.ccr_image import CCRImage
+    missing = str(tmp_path / "nope.nef")
+    with pytest.raises(ValueError) as excinfo:
+        CCRImage(missing)
+    assert excinfo.value.__cause__ is not None
+    assert describe_load_failure(missing, excinfo.value) == MISSING_REASON
+
+
+def test_backend_records_failures_and_still_loads_the_good_files(tmp_path):
+    good = str(tmp_path / "scan.png")
+    cv2.imwrite(good, np.full((32, 48, 3), 120, dtype=np.uint8))
+    missing = str(tmp_path / "nope.nef")
+
+    backend = CCRBackend()
+    count = backend.load_images_from_files([good, missing])
+
+    assert count == 1                      # the good file still imports
+    assert len(backend.images) == 1
+    assert [p for p, _ in backend.last_load_errors] == [missing]
+    assert backend.last_load_errors[0][1] == MISSING_REASON
+
+
+def test_successful_load_clears_previous_failures(tmp_path):
+    """A stale message must never surface after a later, clean import."""
+    good = str(tmp_path / "scan.png")
+    cv2.imwrite(good, np.full((32, 48, 3), 120, dtype=np.uint8))
+
+    backend = CCRBackend()
+    backend.load_images_from_files([good, str(tmp_path / "nope.nef")])
+    assert backend.last_load_errors
+    backend.load_images_from_files([good])
+    assert backend.last_load_errors == []
+
+
+def test_cancelled_load_reports_nothing(tmp_path):
+    """No error dialog for a load the user deliberately stopped."""
+    backend = CCRBackend()
+    backend.load_images_from_files([str(tmp_path / "nope.nef")],
+                                   cancel_flag=lambda: True)
+    assert backend.last_load_errors == []


### PR DESCRIPTION
## Problem

A file whose decode fails disappears from the import with no explanation. `read_image` returns `None`, `CCRImage.__init__` raises, the loader catches it and drops the file — and the only trace is a `print` to stdout, which a built exe/app has no console to show.

The trigger was a **Nikon Z 8 High Efficiency (HE/HE★) NEF**. That compression is intoPIX TicoRAW, which no open-source LibRaw build decodes:

| Decoder | Result |
|---|---|
| rawpy 0.25.0 / LibRaw 0.21.3 (pinned) | opens the header, reads size, dies in unpack: `data corrupted at 2823171` |
| rawpy 0.27.0 / LibRaw 0.22.1 (latest) | `LibRawFileUnsupportedError` |

Upgrading rawpy does not help — HE decoding needs a commercially licensed intoPIX SDK, and rawspeed/darktable have the same gap. So there is nothing to fix in the decode path. The user just needs to be told, and told what to do instead.

## Change

- **`src/core/load_errors.py`** (new) — classifies a failure into a user-facing reason and groups reasons into one message. Pure and Qt-free, so both are unit-testable without a display.
- **`CCRImage`** keeps the decoder's exception (`last_read_error`) and chains it onto the `ValueError` it raises. The root cause is what tells "unsupported compression" apart from "damaged" or "moved"; an unchained raise flattens every failure into one generic message.
- **`CCRBackend`** collects `(path, reason)` into a *local* list and publishes it only alongside a successful `_commit_load`. A cancelled or superseded load therefore reports nothing, and a stale loader thread cannot pop a dialog over the batch that replaced it.
- **`MainWindow`** shows one grouped warning after the batch; **`tether_watcher`** gets the terse variant of the same reason for its inline hint strip.

Two details worth calling out:

- A **missing** RAW is reported as missing, not as undecodable. rawpy raises `LibRawIOError("Input/output error")` for a nonexistent file rather than `FileNotFoundError`, so the classifier asks the filesystem instead of sniffing exception types. This was caught by a failing test, not by inspection.
- Reasons are wrapped to 76 columns because `QMessageBox` does not word-wrap plain text and would otherwise stretch the dialog across the screen.

## What the user sees

```
13 files could not be loaded:

RAW decode failed — most likely a Nikon High Efficiency (HE/HE★) NEF. No
open-source decoder supports that compression. Convert the file with Adobe
DNG Converter (Preferences → Compatibility: Camera Raw 15.3 or earlier) and
open the DNG instead, or shoot Lossless compressed.
    • DSC_6887.NEF
    • …and 4 more

File not found — it may have been moved or renamed.
    • DSC_6900.NEF
```

The Camera Raw 15.3 note is not incidental: at 16.0+ compatibility the DNG Converter writes DNG 1.7 / JPEG XL files, which LibRaw 0.21.3 also cannot read — following the obvious advice without it just produces a second unreadable file.

## Testing

- `tests/test_load_errors.py` — 22 new tests: both LibRaw error shapes, NEF vs other RAW vs non-RAW, missing/permission, root-cause fallback, never-raises, short form, grouping/capping/wrapping, and end-to-end wiring through `CCRImage` and `CCRBackend` (including that a good file in the same batch still imports, and that cancelled loads stay silent).
- Verified on the real Z 8 HE NEF through the actual backend loader: the good NEF beside it still imports, the HE frame is reported with the workaround.
- Dialog rendering checked offscreen via the `qt-testing` skill.
- No regressions: `test_loader_cancel`, `test_tether_watcher`, `test_catalog`, `test_scanner_tiff`, `test_three_way_merge`, `test_merge_replace`, `test_merge_catalog`, `test_slice`, `test_positive_mode` — 169 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
