### PR TITLE
feat(color): field correction (flat-field) profiles for lens/light falloff

### DIFF
--- a/spec/flat-field-correction.md
+++ b/spec/flat-field-correction.md
@@ -1,0 +1,598 @@
+# Spec: Field Correction (flat-field profile for lens/light falloff)
+
+Status: REFINED v1
+Owner: FreeCCR
+Feature branch: `feature/flat-field-correction`
+
+## 1. Summary
+
+Add a **Field Correction** feature that removes the dark corners and colour
+shading a camera-scanning rig bakes into every frame — lens vignetting (natural
+cos⁴ + mechanical), sensor cover-glass/microlens colour shading, and an uneven
+light source (light table / LED panel hot-spot).
+
+The user shoots **one calibration frame**: an evenly lit, featureless neutral
+surface — ideally the bare light source they scan on, through the same lens at
+the same aperture and distance. A wizard (entry point: **Settings ▸ Color
+Management**, alongside the IT8 camera-profile wizard) decodes that frame,
+measures the falloff, and writes a **field-correction profile** (`.ffc`) into a
+per-user library. Selecting a profile makes every subsequent decode — preview,
+zoom, and export — multiply by the profile's per-channel gain map, so the frame
+is flat before negative conversion ever sees it.
+
+This is the classic **flat-field correction**: `corrected = raw × (ref / flat)`,
+done in linear light, per channel, at decode time.
+
+## 2. Goals / Non-goals
+
+### Goals
+- A **"Create Field Correction Profile…"** wizard reachable from Settings ▸
+  Color Management, mirroring the IT8 wizard's shape (guidance → analyse →
+  review → save/apply).
+- Decode the calibration shot in the **same camera-native raw-linear space** the
+  pipeline decodes scans in (reusing `read_image`'s profiling decode contract),
+  so the measured field matches the data it will correct.
+- Build a **smooth, per-channel gain map** robust to dust, noise, and hot pixels
+  on the light table.
+- **Validate the calibration shot** and tell the user when it is unusable:
+  clipped, too dark, or not actually a flat field (they photographed a scene).
+- **Report what the profile does**: max gain, per-channel corner falloff in
+  stops, and the colour-shading spread — plus a visual gain map and a corrected
+  preview of the calibration shot itself.
+- A **profile library** (`<appdata>/field_profiles/*.ffc`) with an active
+  selection, persisted across sessions, managed in the same Settings page.
+- Apply at **decode time inside `read_image`**, so preview, hi-res zoom, slices,
+  trichrome merges, and export all inherit it identically with no per-call-site
+  plumbing.
+- Reuse the existing **profile-mismatch flow**: changing the active field
+  profile does not silently re-decode; it flags affected thumbnails with ⚠ and
+  the existing *Replace with current camera profile* re-grade.
+- Unit tests for map building, normalisation, validation, save/load round-trip,
+  apply correctness, and the decode-hook integration.
+
+### Non-goals
+- **No automatic per-image profile matching** by lens/aperture/focal length. The
+  target user has one fixed copy-stand setup. EXIF is *recorded* in the profile
+  (and shown in the library) so a future auto-match is possible, but v1 selects
+  one active profile globally, like the camera profile.
+- **No distortion correction.** This is a per-pixel gain field only — geometry is
+  untouched. (The dormant `correct_lens_distortion_and_vignette` lensfun path
+  stays dead; this feature does not revive it.)
+- **No dust/scratch removal from the calibration frame's subject.** Dust on the
+  light table is *smoothed out* of the map (§5.3) rather than turned into a
+  dust-removal feature; frame dust is handled by the existing dust tools.
+- **No dark-frame / bias subtraction.** Flat-field division alone; a dark frame
+  would matter only for long-exposure sensor glow, which a copy-stand scan at
+  1/60 s does not have.
+- **No lensfun/external vignetting database.** The measurement is the user's own
+  rig, which is the point — it captures the light source, not just the lens.
+- **No new dependency.** Pure numpy + cv2 + stdlib (`json`, `base64`), both
+  already required.
+
+## 3. Background
+
+### 3.1 What the calibration frame captures
+A photograph of a uniform, evenly lit surface records the *product* of every
+multiplicative non-uniformity in the imaging chain:
+
+| Source | Behaviour |
+|---|---|
+| Natural illumination falloff | ≈cos⁴θ, radial, worse at wide angle |
+| Mechanical vignetting | radial, strongly aperture-dependent |
+| Sensor microlens / cover-glass shading | radial + **per-channel** (colour shading), sensor-specific |
+| Light source unevenness | arbitrary shape, often an off-centre hot spot |
+| Filter/adapter clipping | asymmetric corner darkening |
+
+Dividing by that measured field removes all of them at once. This is exactly why
+a *measured* flat field beats a lens-model vignetting correction for camera
+scanning: the light table is part of the optical chain, and no lens database
+knows about it.
+
+### 3.2 Why it must happen in linear light, before conversion
+Vignetting is a **multiplicative attenuation of scene radiance**. It is only a
+simple division in a linear-light space. FreeCCR's negative pipeline decodes
+RAW to linear (`gamma=(1,1)`) and inverts on that data, so correcting inside
+`read_image` — immediately after decode, before the camera profile, before the
+negative inversion — is both physically correct and the single place that covers
+every consumer.
+
+Correcting *after* inversion would be wrong twice over: the inversion is
+non-linear in the falloff (a density-space subtraction of a spatially varying
+term), and the reference-crop normalisation would already have been contaminated
+by the falloff it is supposed to be measured against.
+
+### 3.3 Why per-channel
+Colour shading (channel-dependent falloff, from the sensor stack and from the
+light source's own spectrum varying across the panel) shows as a corner colour
+cast, not just darkening. It is strongly amplified by negative inversion: a
+neutral film base that reads slightly warmer in the corners inverts to a visibly
+cyan corner. A single luminance gain map cannot fix that; three do.
+
+### 3.4 Capture guidance (surfaced in the wizard)
+- Shoot **the light source you scan on** — bare panel, no film — through the
+  **same lens at the same aperture, focal length and distance** as the scan.
+  Aperture matters most: vignetting changes by a stop or more between f/2.8 and
+  f/8.
+- **Defocus** slightly (or put a diffuser / a sheet of white acrylic on the
+  panel) so panel texture and dust don't print into the map.
+- **Fill the whole frame**; nothing dark at the edges.
+- Expose so the frame's brightest area is around **50–75 % of full scale** and
+  **nothing clips** — a clipped flat field measures the wrong falloff.
+- **Shoot RAW.** A JPEG/TIFF is accepted, but its gamma encoding and any
+  in-camera lens correction make the measurement approximate (warned in the UI).
+- Re-shoot the profile whenever the rig changes (lens, aperture, panel, height).
+
+## 4. Data model & files
+
+### 4.1 New module `src/core/flat_field.py` (pure logic, no Qt)
+
+```python
+GRID_LONG_SIDE = 128       # stored gain-grid long side (aspect-preserving)
+DEFAULT_MAX_GAIN = 4.0     # +2 stops; the build clamps to this
+FORMAT = "freeccr-field-correction"
+FORMAT_VERSION = 1
+
+class FieldProfileError(Exception): ...
+
+@dataclass
+class FieldProfile:
+    name: str
+    gain: np.ndarray            # (gh, gw, 3) float32, >= ~1.0, C-contiguous
+    aspect: float               # source frame w/h, for a mismatch hint
+    meta: dict                  # camera/lens/EXIF, source file, created, stats
+    path: Optional[str] = None  # library path once saved
+    content_id: Optional[str] = None   # short hash -> grading signature
+
+# --- capture -> profile ---
+def decode_calibration(path, sample_max=1024) -> np.ndarray      # uint16 HxWx3
+def analyze_field(arr_u16) -> FieldAnalysis                      # validation + stats
+def build_profile(arr_u16, name, *, meta=None,
+                  max_gain=DEFAULT_MAX_GAIN) -> FieldProfile
+
+# --- storage ---
+def save_profile(profile, path) -> None                          # .ffc (JSON)
+def load_profile(path) -> FieldProfile                           # raises FieldProfileError
+
+# --- apply ---
+def apply_field(arr_u16, profile, *, encoded=False) -> np.ndarray
+def gain_for_size(profile, w, h) -> np.ndarray                    # resized map cache
+
+# --- global active profile (mirrors color_management's globals) ---
+def set_active_profile(profile | None) -> None
+def get_active_profile() -> Optional[FieldProfile]
+def field_profile_active() -> bool
+def active_field_signature() -> str        # 'ff:<content_id>' | 'none'
+```
+
+`FieldAnalysis` carries what the review page shows and what blocks/warns:
+`level` (reference level, 0–1), `clipped_fraction` (per channel, max),
+`flatness_residual` (relative RMS after smoothing), `corner_stops` (3,),
+`cast_stops`, `max_gain`, and `warnings: list[str]`.
+
+### 4.2 Profile file format (`.ffc`)
+A UTF-8 JSON document — inspectable metadata, opaque payload:
+
+```json
+{
+  "format": "freeccr-field-correction",
+  "version": 1,
+  "name": "Copy stand — 55mm f/8",
+  "created": "2026-08-03T14:02:11",
+  "source": "IMG_4471.CR3",
+  "aspect": 1.5,
+  "camera": {"make": "Nikon", "model": "Z 8", "lens": "NIKKOR Z MC 105mm",
+             "focal_length": 105.0, "aperture": 8.0},
+  "stats": {"max_gain": 1.84, "corner_stops": [0.79, 0.71, 0.88],
+            "cast_stops": 0.17, "level": 0.62, "clipped_fraction": 0.0,
+            "flatness_residual": 0.008},
+  "max_gain_cap": 4.0,
+  "grid": {"w": 128, "h": 85, "channels": 3, "dtype": "float32",
+           "data": "<base64 of C-contiguous (h,w,3) little-endian float32>"}
+}
+```
+
+`GRID_LONG_SIDE=128` keeps the file ≈180 KB while over-resolving a field whose
+real bandwidth is a handful of cycles across the frame; the grid is upsampled
+bicubically at apply time (§5.5). Unknown top-level keys are ignored on load
+(forward compatibility); a `version` above `FORMAT_VERSION` is rejected with a
+clear message.
+
+### 4.3 Library storage
+`<appdata>/field_profiles/*.ffc`, created on demand, next to the existing
+`camera_profiles/` library (`ccr_backend.camera_profiles_dir()`'s sibling) so it
+survives updates. Backend surface mirrors the camera-profile library:
+`field_profiles_dir()`, `list_field_profiles()`, `set_active_field_profile(path)`,
+`delete_field_profile(path)`.
+
+### 4.4 Edits to existing files
+| File | Change |
+|---|---|
+| `src/core/ccr_image.py` | apply hook at the three decode exits (§6.1) |
+| `src/core/ccr_backend.py` | library + active selection; fold into `active_profile_signature()` |
+| `src/widgets/settings_dialog.py` | "Field correction" group on the Color Management page |
+| `src/ui/main_window.py` | wizard/select/delete handlers + startup restore |
+| `src/widgets/field_correction_dialog.py` | **new** — the wizard |
+| `src/core/flat_field.py` | **new** — all the logic |
+
+## 5. Processing / math
+
+### 5.1 Decode the calibration frame
+Reuse the profiling-decode contract (`spec/it8-camera-profile.md` §5.1/§12.5):
+
+```python
+img = CCRImage.__new__(CCRImage); img.source_ops = []
+arr = img.read_image(path, preview=True, max_long_side=1024,
+                     positive_override=False, apply_input_icc=False)
+```
+
+This yields **camera-native, raw-linear, unbalanced, absolute-sensor-value**
+RGB — the same space `read_image` hands to the correction hook, so the field is
+measured in the space it is applied in. `apply_input_icc=False` additionally
+suppresses the field correction itself (§6.1) — a calibration decode must never
+be corrected by an existing profile, or profiles would compound.
+
+A 1024-px decode is ~100× more samples than the 128-px grid needs, so noise is
+already averaged away by the downsample alone.
+
+### 5.2 Validation (`analyze_field`)
+Computed on the decoded frame, normalised to `f = arr/65535`:
+
+1. **Reference level** `level` — the robust central level (§5.3 step 4), max over
+   channels. `level < 0.05` → *"too dark to measure; the corrected corners will
+   be noisy"*. `level > 0.95` → *"over-exposed"*.
+2. **Clipping** — per channel, fraction of pixels ≥ 0.99. `> 0.001` in any
+   channel → *"highlights are clipped; the falloff can't be measured there"*.
+3. **Flatness** — downsample to a 256-px working field, blur heavily (σ ≈ 1/12 of
+   the long side), and take the relative RMS of `(field − smooth)/smooth`.
+   `> 0.05` → *"this doesn't look like an evenly lit blank surface"* (the guard
+   against profiling a photograph of an actual scene). Dust specks and panel
+   texture sit far below this threshold after the 256-px downsample; a scene's
+   edges sit far above it.
+
+Warnings are **advisory** — the wizard shows them prominently and still lets the
+user continue (their rig, their call), except that a build is refused outright
+when the reference level is below 1 % of full scale (the map would be pure
+noise amplification).
+
+### 5.3 Build the gain map (`build_profile`)
+1. **Downsample** the decoded frame to `GRID_LONG_SIDE` (aspect-preserving) with
+   `cv2.INTER_AREA` — a box average over ~8×8 source blocks, which is already a
+   strong low-pass and kills sensor noise (measured error: 2e-5).
+2. **Reject blemishes** — a 5×5 median for isolated hot/dead pixels, then a
+   **large median** whose window is `BLEMISH_WINDOW_FRAC` (0.13) of the grid's
+   long side. A median is the right robust estimator because it is *exact on
+   monotone data*: a genuine sharp shading edge (the fast corner cut of a
+   mechanical vignette) passes through untouched, while an isolated blob smaller
+   than the window is replaced by the field around it. §10.8 records the
+   alternatives that were measured and rejected.
+3. **Gaussian blur**, σ = `GRID_LONG_SIDE/128` (1 px) — just enough to
+   de-staircase the median. Deliberately minimal: blurring a curved field biases
+   it by ~σ²/2·∇²f, worst exactly at the corners, and at σ=2 a sharp
+   mechanical-vignette knee was reproduced only to 10% (vs 6% at σ=1). All
+   filtering pads by **odd (antisymmetric) reflection**, `f(−k) = 2f(0) − f(k)`,
+   which continues the field's slope past the frame edge; every OpenCV border
+   mode instead holds it flat (REPLICATE) or folds it back (REFLECT), which
+   understates a still-falling falloff and under-corrects the corners by ~1.2%.
+4. **Reference level per channel** `ref_c`: the median of the smoothed grid over
+   a **central window** covering the middle 10 % of frame area. Normalising on
+   the centre (not on each channel's max) is what keeps the profile
+   *photometrically neutral*: gain is exactly 1.0 at the centre in all three
+   channels, so the profile changes neither the frame's exposure nor its white
+   balance — it only removes **spatial variation**. A region brighter than the
+   centre (an off-centre light-table hot spot) correctly gets gain < 1.
+5. **Gain** `g = ref_c / max(smooth_c, floor)`, `floor = 1e-4` (guards a black
+   corner from producing an infinity), then **clamped to `[0.25, max_gain]`**
+   (default `max_gain = 4.0`, i.e. +2 stops). The clamp is the noise-amplification
+   guard: past +2 stops the corner is mostly read noise, and a botched
+   calibration shot (a lens cap, a partially covered panel) can't produce a map
+   that destroys images. `stats.max_gain` reports the value actually reached, and
+   the wizard says so when the clamp bites.
+6. **Stats**: `corner_stops[c] = log2(mean gain over the four corner regions)`
+   (each region = the outer 5 % × 5 % of the frame), `cast_stops =
+   max(corner_stops) − min(corner_stops)` (how much of the falloff is *colour*
+   shading rather than plain darkening).
+
+The stored grid is `float32`, C-contiguous `(gh, gw, 3)`.
+
+### 5.4 Why a grid and not a radial polynomial
+A radial model (the usual lens-profile parameterisation) assumes the falloff is
+centred and rotationally symmetric. Light-table hot spots are neither, and a
+mis-centred adapter breaks symmetry too. A 128-px grid represents any smooth
+field, costs 180 KB, and needs no fitting step that could fail to converge.
+
+### 5.5 Apply (`apply_field`)
+```
+gain = resize(profile.gain, (w, h), INTER_CUBIC)      # cached per (w,h)
+out  = clip(arr.astype(float32) * gain, 0, 65535).astype(uint16)
+```
+- **Bicubic** upsampling: the map is smooth, and bicubic's C¹-ish continuity
+  avoids the faint slope-discontinuity facets bilinear can leave when a 128-px
+  grid is stretched to 6000 px.
+- **Banded** — the multiply runs in horizontal bands of 512 rows so a
+  6000×4000 export never materialises a 288 MB float32 temporary.
+- **Cached** — the resized map is memoised on the profile keyed by `(w, h)`
+  (bounded to the last few sizes), because a batch export hits the same size for
+  every frame.
+- **Clipping**: gain ≥ 1 away from the centre means a value already at full scale
+  clips. For a negative scan the brightest area is the film base, and the
+  windowed working space (`spec/working-space-headroom.md`) plus the fact that
+  the corners being lifted are *dark* to begin with make this a non-issue in
+  practice; the wizard's "don't clip the calibration shot" guidance is the real
+  protection.
+- **`encoded=True`** (the Positive-mode RAW decode, the one decode we *know*
+  carries an sRGB TRC because we asked rawpy for it): linearise with the sRGB
+  EOTF, multiply, re-encode. A linear-light gain applied directly to
+  gamma-encoded data under-corrects by roughly the gamma exponent.
+  Non-RAW sources are left in their own space (§10.4).
+
+### 5.6 Monochrome / grayscale sources
+A monochrome RAW (and a grayscale TIFF/JPEG) is decoded to three *identical*
+channels. Applying a three-channel gain map to it would inject colour into an
+image that has none. The hook therefore passes `mono=True` for those branches
+and `apply_field` uses the **mean of the three channel gains**, keeping the
+frame neutral while still correcting the falloff. A monochrome *calibration*
+shot needs no special case — its map simply carries three equal channels.
+
+### 5.7 Aspect mismatch
+`profile.aspect` records the calibration frame's `w/h`. At apply time the map is
+resized to whatever the frame is, which is correct for any resolution of the same
+frame shape. A frame whose aspect differs by more than 2 % (a different sensor, a
+different in-camera crop) is **still corrected** but logged once, and the
+Settings library row shows the profile's camera/lens/aspect so the user can see
+the mismatch. Blocking is worse than a slightly-off correction the user asked
+for.
+
+## 6. Integration points
+
+### 6.1 Decode hook (`ccr_image.read_image`)
+The correction is applied at the **full-frame, pre-`_apply_source_ops`** point of
+every decode branch — before slicing crops the array, so the map always
+corresponds to the whole sensor frame regardless of slice/crop state:
+
+| Branch | Insertion point |
+|---|---|
+| RAW (`raw.postprocess`) | immediately after `postprocess`, before `_apply_source_ops` |
+| non-RAW (TIFF/JPEG/PNG) | after channel normalisation, before `_apply_source_ops` |
+| 3-way merge (`_read_merged`) | after `merge_raw_channels`, before `_apply_source_ops` |
+
+Gating, in one helper `_apply_field_correction(arr, *, encoded=False, mono=False)`:
+- skipped when `apply_input_icc=False` (the calibration/IT8 profiling decodes
+  must see bare, uncorrected device data — §5.1, §10.1);
+- skipped when no profile is active;
+- `encoded=True` only on the Positive-mode sRGB RAW decode (§5.5);
+- `mono=True` on the monochrome-RAW and grayscale-file branches (§5.6).
+
+Ordering relative to the RAW branch's manual white-level scaling is immaterial
+(both are linear multiplies; the uint16 clamp is reached at the same place), so
+the hook sits at the geometric point that keeps the map aligned.
+
+**Trichrome/linear-TIFF interaction**: `_export_merged_linear` writes its TIFF
+from `merge_raw_channels` directly, *not* through `read_image`, so a baked
+replacement TIFF stays **uncorrected** on disk and is corrected when reloaded
+like any other file. No double correction, no marker needed.
+
+### 6.2 Grading signature (mismatch ⚠ + Replace)
+`ccr_backend.active_profile_signature()` appends the field-correction signature:
+
+```python
+def active_profile_signature(self) -> str:
+    base = ("none" if self.positive_mode else
+            "camera_matrix" if color_management.camera_matrix_mode() else
+            color_management.active_profile_signature())
+    ff = flat_field.active_field_signature()   # 'ff:<content_id>' | 'none'
+    return base if ff == "none" else f"{base}+{ff}"
+```
+
+The camera-profile part keeps its existing meaning exactly (Positive mode still
+short-circuits it to `"none"`); the field part is composed on independently,
+because field correction **does** apply in Positive mode. The signature is
+compared as an opaque string (`thumbnail_list._profile_mismatch`), so changing or
+clearing the field profile flags exactly the images decoded under the other
+setting, and the existing **Right-click ▸ Replace with current camera profile**
+re-decodes and replays them.
+
+The mismatch tooltip/menu wording becomes "camera profile or field correction".
+
+### 6.3 Settings ▸ Color Management
+A new group box **Field correction**, below Camera profiles:
+
+```
+┌ Field correction ──────────────────────────────────────────┐
+│ Corrects dark corners and colour shading from your lens,   │
+│ sensor and light source, measured from one shot of an      │
+│ evenly lit blank surface.                                  │
+│ Active: [ None                              ▾ ]            │
+│ [ Create Field Correction Profile… ] [ Delete ]            │
+│ Copy stand — 55mm f/8 · Nikon Z 8 · 105 mm f/8 · 3:2       │
+│ Max +0.9 EV · colour spread 0.17 EV                        │
+└────────────────────────────────────────────────────────────┘
+```
+The combo lists `None` + every library profile. Selection is **immediate** (like
+camera-profile selection, not staged like the global toggles), persisted under
+`QSettings("import/field_profile_path")`, and triggers the ⚠ re-flag — never a
+silent re-decode.
+
+### 6.4 Startup restore
+`MainWindow.__init__` restores the persisted selection next to the camera-profile
+restore, before any image loads. A missing/unparseable file falls back to None
+and clears the setting.
+
+## 7. UX — the wizard (`FieldCorrectionDialog`)
+
+Three pages, Back/Next/Cancel, same chrome as `IT8ProfileDialog`.
+
+**Step 1 — Calibration shot.** Capture guidance (§3.4) + *Use current image* /
+*Browse…*. A non-RAW pick warns (gamma-encoded / possibly already corrected
+in-camera) but is allowed. Next decodes (wait cursor).
+
+**Step 2 — Review.** Three panes: the **calibration shot** (gamma-stretched),
+the **gain map** (false colour, with a `1.0× … max×` legend), and the
+**corrected shot** (the map applied to the calibration frame — visibly flat when
+the profile is good). Below them: level, max gain, per-channel corner falloff in
+EV, colour spread in EV, and any validation warnings in amber. A **Profile name**
+field, defaulted to `Field <camera/lens> <date>`.
+
+**Step 3 — Save.** The profile is always written **into the library folder**,
+named from the profile name (no path picker — a field profile is only useful
+through the library, and IT8's "save anywhere, then import it back" round-trip is
+avoidable complexity). The resolved path is shown read-only; an existing file of
+the same name asks before overwriting. Checkbox **"Use this profile now"**
+(default on). Finish writes the `.ffc`, and on *use now* activates it — which
+flags the loaded thumbnails ⚠ so the user can re-grade the frames they care
+about.
+
+## 8. Test plan
+
+Unit (`tests/test_flat_field.py`, pure numpy — no Qt):
+- **Synthetic round-trip (key test)**: build a known smooth falloff field
+  `F(x,y)` (radial + an off-centre hot spot, per-channel), synthesise a
+  calibration frame from it, build a profile, and assert the map recovers
+  `ref/F` within tolerance; then apply the profile to a *synthetic scene*
+  multiplied by the same `F` and assert the corrected result matches the
+  original scene within ~1 %.
+- **Neutrality**: the centre gain is 1.0 (all channels) and applying the profile
+  to a flat neutral frame leaves both its level and its channel ratios unchanged
+  — the profile must not become a white-balance or exposure change.
+- **Colour shading**: a field with different per-channel falloff is corrected to
+  a neutral corner; `cast_stops` reports the input spread.
+- **Robustness**: dust specks (small dark blobs) and hot pixels injected into the
+  calibration frame do not print into the map (max deviation from the clean-frame
+  map below tolerance).
+- **Clamping**: a near-black corner produces `max_gain` exactly, not an infinity
+  or a NaN; `stats.max_gain` reflects it.
+- **Validation**: a clipped frame, a black frame, and a *photograph of a scene*
+  (high-frequency content) each raise their expected warning; a good frame raises
+  none; a sub-1 % frame refuses to build.
+- **Save/load round-trip**: `save_profile` → `load_profile` reproduces the grid
+  bit-exactly (base64 float32) and all metadata; a bad JSON, a truncated base64
+  payload, a wrong `format`, and a future `version` each raise
+  `FieldProfileError` with a useful message.
+- **Apply**: resolution independence (the same normalised gain at the same
+  relative position for a 1080-px preview and a 6000-px export, ≤1 % deviation);
+  banding path equals the single-shot path exactly; `encoded=True` round-trips a
+  gamma-encoded flat frame correctly; dtype/shape/clipping preserved.
+- **Signature**: `active_profile_signature()` changes when the field profile is
+  set/cleared/swapped, and is stable when unchanged; a mismatch is detected by
+  the thumbnail predicate's comparison.
+- **Decode hook**: with a profile active, a stubbed decode returns corrected
+  data; `apply_input_icc=False` returns it **un**corrected (calibration decodes
+  must not compound); no profile ⇒ byte-identical passthrough.
+
+Manual:
+- Full wizard on a real light-table shot; corner falloff readout matches the
+  visible vignette; corrected preview is flat.
+- A converted negative before/after activation: corners lift, no colour shift in
+  the centre, histogram unchanged in the middle.
+- Export at full resolution matches the on-screen preview's corners.
+- Switching profiles flags ⚠ and *Replace* re-grades correctly.
+- A profile built from a *clipped* shot warns and (if used anyway) does not crash.
+
+## 9. Risks & mitigations
+| Risk | Mitigation |
+|---|---|
+| Calibration shot clipped → wrong falloff | Detected and warned (§5.2); guidance targets 50–75 % exposure |
+| Aperture/lens differs from the scan | Guidance + EXIF recorded and shown; aspect mismatch logged |
+| Noise amplification in deep corners | INTER_AREA + median + Gaussian smoothing; gain clamped to +2 EV |
+| Highlight clipping after correction | Corners lifted are dark; windowed working space carries headroom; documented |
+| Double correction (profile applied to its own calibration decode) | `apply_input_icc=False` suppresses the hook (§6.1) — unit-tested |
+| Baked trichrome TIFF corrected twice | Bake path bypasses `read_image`, so the TIFF is uncorrected on disk (§6.1) |
+| User profiles a photo by mistake | Flatness check (§5.2 step 3) catches scene content |
+
+## 10. Refinement (v1) — resolved decisions
+
+### 10.1 `apply_input_icc=False` is the "bare device decode" flag
+The field correction is suppressed by the **existing** `apply_input_icc=False`
+parameter rather than a new one. That parameter already means more than its name
+(it also forces the camera-native decode space, `ccr_image.py` §"icc_device_space"),
+and both of its callers — `it8_profile.decode_target` and the new
+`flat_field.decode_calibration` — are *profiling* decodes that must see bare
+device data. A separate `apply_field` parameter would have to be threaded through
+both call sites to reach the same behaviour, with a live footgun if either forgot
+it. The docstring is updated to state the parameter's real contract: **bare
+device decode — no camera profile, no field correction**.
+
+Consequence, accepted deliberately: an **IT8 target shot is not field-corrected**
+before the matrix fit. The chart is shot filling the *centre* of the frame (the
+wizard's own guidance), where falloff is smallest, and a field profile measured on
+the scanning rig would be simply wrong for a chart shot in a different setup.
+
+### 10.2 Normalise on the centre, not on the maximum
+Both keep gain ≥ 1 almost everywhere, but centre-normalisation is the one that
+makes the profile **photometrically and chromatically neutral**: gain is exactly
+1.0 at the centre in all three channels, so activating a profile changes neither
+exposure nor white balance — only spatial variation. Max-normalisation would tie
+the profile's overall gain (and, per-channel, its white balance) to wherever the
+light table happened to be brightest. It also handles an off-centre hot spot
+correctly, by darkening it (gain < 1) instead of lifting the whole frame to meet
+it. Unit-tested as the "neutrality" case in §8.
+
+### 10.3 Gain clamp at +2 EV
+`max_gain = 4.0`. Real camera-scan rigs land at +0.5…+1.5 EV in the corners;
+anything beyond +2 EV is either a badly wrong calibration shot (lens cap,
+partially covered panel, a frame that clipped to black) or a corner so dark that
+the corrected result is read noise. Clamping is the difference between "the
+profile helps a bit less than it could" and "the profile destroys the image", and
+the wizard reports when the clamp binds so a genuine super-wide-angle user knows
+why.
+
+### 10.4 Encoding: the gain is applied in the array's own space
+A multiplicative light attenuation stays multiplicative through a pure power-law
+encoding (only the exponent changes), so **measuring and applying the ratio in
+the same space is self-consistent** — a JPEG calibration shot correcting JPEG
+scans is as correct as a RAW one correcting RAW scans. The only decode where the
+space provably differs from the calibration decode is the **Positive-mode RAW**
+path (rawpy applies an sRGB TRC while `decode_calibration` pins `gamma=(1,1)`),
+and that one gets the explicit linearise/re-encode round trip (§5.5).
+
+Not attempted: guessing whether an arbitrary TIFF/JPEG is linear or gamma-encoded
+(e.g. by bit depth). FreeCCR's pipeline treats every non-RAW decode as linear
+throughout, and introducing a contradicting assumption in this one place would be
+worse than the documented limitation — **a RAW-built profile under-corrects
+gamma-encoded non-RAW scans**; the fix is to calibrate in the same format you
+scan in.
+
+### 10.5 No import, no rename, delete only
+The wizard writes straight into the library (§7 step 3). A field profile
+describes one physical rig, so cross-machine sharing — the thing Import exists
+for on camera profiles — has no real use case here; a user who copies a `.ffc`
+into the folder by hand still gets it listed. Renaming is "create it again with
+the right name", which takes seconds because the calibration shot is already on
+disk.
+
+### 10.6 Resized-map cache
+`gain_for_size` memoises the upsampled map on the profile object, keyed by
+`(w, h)`, bounded to the 4 most recent sizes (preview 1080, thumbnail, zoom tile,
+export). Decodes run on up to 8 worker threads, so two threads can race to
+compute the same entry — harmless (identical results, dict writes are atomic
+under the GIL), and cheaper than holding a lock across a resize. The cache is
+never a correctness input: it is a pure function of `(profile.gain, w, h)`, and
+selecting a different profile replaces the object entirely.
+
+### 10.7 Cost
+Preview (1080 px): resize + banded multiply ≈ 3 ms, invisible next to a ~300 ms
+RAW decode. Full export (6000×4000): ≈ 200 ms, against several seconds of decode
++ render. No caching of corrected pixels is needed, and none is added.
+
+### 10.8 Blemish rejection: what was measured
+All figures are the worst-case relative error of `gain × field` (a perfect
+profile is uniform), on synthetic fields at 768×1152.
+
+| Estimator | Clean smooth field | Off-centre hot spot | Sharp 1 EV vignette knee | Dust |
+|---|---|---|---|---|
+| 3×3 median + Gaussian σ=GRID/24 | 2.9% | — | — | ok |
+| 5×5 median + morphological CLOSE | 0.7% | 1.7% | — | fails past the kernel size |
+| Iterated clipped smoothing (reject by depth) | 0.7% | 1.7% | **29% — rewrote 54% of the grid** | best |
+| **5×5 + large median (shipped)** | **0.9%** | **1.6%** | **6%** | ≤2.5% up to a 2.6%-wide smudge |
+
+The decisive case is the sharp knee. Rejecting by *depth* rather than *size*
+looks more principled — "dust is a locally deep excursion, shading is smooth" —
+but a mechanical vignette's corner cut is also deep and also local, so that
+estimator ate it. Rejecting by *size* with a median keeps the monotone edge by
+construction. The window is then a straight trade: 0.13 of the frame rejects
+smudges up to ~2.5% of the frame width at 0.9% fidelity cost; 0.20 rejects
+5%-wide smudges but degrades the knee to 11%. Blemish rejection runs once per
+profile build (~60 ms), so its cost is irrelevant.
+
+The residual border error was likewise measured, not assumed: filtering with
+OpenCV's border modes left a **−0.94% corner** and **−1.6% edge** bias, which odd
+reflection (§5.3) reduced to −0.05% / −0.44%.

--- a/src/core/ccr_backend.py
+++ b/src/core/ccr_backend.py
@@ -118,6 +118,13 @@ class CCRBackend:
         # The library (camera_profiles/) keeps every imported/generated profile;
         # the active one is just a selection, not a copy. See spec/camera-profile-library.md.
         self.active_profile_path: Optional[str] = None
+        # Active field-correction (flat-field) profile — independent of the
+        # camera profile: it corrects the rig's vignetting / colour shading /
+        # light-source unevenness at decode time. The parsed profile lives in
+        # flat_field's module-level holder; these mirror it for the UI.
+        # See spec/flat-field-correction.md.
+        self.field_profile_path: Optional[str] = None
+        self.field_profile_name: Optional[str] = None
         # Catalog entries of ACTUAL images removed from the list this
         # session: {file_path: {"signature": sig, "entries": {name: state}}}.
         # Removal must not lose their stored edits, so saves merge these
@@ -944,16 +951,21 @@ class CCRBackend:
                 print(f"Failed to convert image at index {idx}: {e}")
 
     def active_profile_signature(self) -> str:
-        """The camera-profile signature an image decoded NOW would be graded
-        under: 'none' in Positive mode (the profile isn't applied) or when the
-        profile is disabled/unset, else 'icc:<desc>' / 'dcp:<name>'. Drives the
-        per-image thumbnail mismatch warning."""
-        from core import color_management
+        """The grading signature an image decoded NOW would carry: the camera
+        profile ('none' in Positive mode or when disabled/unset, else
+        'icc:<desc>' / 'dcp:<name>' / 'camera_matrix') composed with the active
+        field correction ('+ff:<id>'). Field correction applies in Positive mode
+        too, so it is composed on independently. Drives the per-image thumbnail
+        mismatch warning; compared only for equality."""
+        from core import color_management, flat_field
         if self.positive_mode:
-            return "none"
-        if color_management.camera_matrix_mode():
-            return "camera_matrix"          # Adobe+autoscale decode, distinct from RAW "none"
-        return color_management.active_profile_signature()
+            base = "none"
+        elif color_management.camera_matrix_mode():
+            base = "camera_matrix"          # Adobe+autoscale decode, distinct from RAW "none"
+        else:
+            base = color_management.active_profile_signature()
+        ff = flat_field.active_field_signature()
+        return base if ff == "none" else f"{base}+{ff}"
 
     @staticmethod
     def _profile_content_id(path):
@@ -1060,6 +1072,64 @@ class CCRBackend:
             name = self.input_icc_name
         self.active_profile_path = path
         return name
+
+    # --- Field-correction library (flat-field profiles) --------------------
+    def field_profiles_dir(self) -> str:
+        """Library folder for .ffc field-correction profiles, beside the camera
+        profiles under %APPDATA%/FreeCCR (survives updates/reinstalls)."""
+        from core.catalog import default_catalog_path
+        d = os.path.join(os.path.dirname(default_catalog_path()), "field_profiles")
+        os.makedirs(d, exist_ok=True)
+        return d
+
+    def list_field_profiles(self) -> list:
+        """Every profile in the library: [{name, path, summary}], by name.
+        Unreadable files are skipped rather than breaking the list."""
+        import glob
+        from core import flat_field
+        out = []
+        for p in glob.glob(os.path.join(self.field_profiles_dir(),
+                                        "*" + flat_field.EXTENSION)):
+            try:
+                prof = flat_field.load_profile(p)
+                summary = prof.summary()
+                name = prof.name
+            except Exception as e:      # never let one bad file break the list
+                print(f"Skipping unreadable field profile {p}: {e}")
+                continue
+            out.append({"name": name, "path": p, "summary": summary})
+        return sorted(out, key=lambda x: x["name"].lower())
+
+    def set_active_field_profile(self, path: Optional[str]) -> Optional[str]:
+        """Activate the field-correction profile at `path`, or None for no field
+        correction. Returns the display name, or None. Raises FieldProfileError
+        on an unreadable/invalid file."""
+        from core import flat_field
+        if not path:
+            flat_field.set_active_profile(None)
+            self.field_profile_path = None
+            self.field_profile_name = None
+            return None
+        prof = flat_field.load_profile(path)
+        flat_field.set_active_profile(prof)
+        self.field_profile_path = path
+        self.field_profile_name = prof.name
+        return prof.name
+
+    def delete_field_profile(self, path: str) -> bool:
+        """Remove a field profile from the library, deactivating it first if it
+        is the active one."""
+        from core import flat_field
+        active = flat_field.get_active_profile()
+        if active is not None and active.path and (
+                os.path.normcase(os.path.abspath(active.path))
+                == os.path.normcase(os.path.abspath(path))):
+            self.set_active_field_profile(None)
+        try:
+            os.remove(path)
+            return True
+        except OSError:
+            return False
 
     def delete_camera_profile(self, path: str) -> bool:
         """Remove a profile file from the library. Deactivates it first if active."""

--- a/src/core/ccr_image.py
+++ b/src/core/ccr_image.py
@@ -395,6 +395,31 @@ class CCRImage:
             logging.warning(f"Input ICC profile could not be applied: {e}")
             return arr
 
+    @staticmethod
+    def _apply_field_correction(arr: Optional[np.ndarray], *,
+                                encoded: bool = False,
+                                mono: bool = False) -> Optional[np.ndarray]:
+        """Multiply a freshly-decoded frame by the active field-correction gain
+        map (lens vignetting + sensor colour shading + light-source unevenness),
+        before slicing, the camera profile, and the negative conversion — the one
+        place every consumer (preview, zoom, slice, merge, export) inherits it
+        from. No-op when no field profile is active.
+
+        Called at the FULL-FRAME point of each decode branch (before
+        _apply_source_ops) so the map always lines up with the whole sensor frame
+        whatever the slice/crop state. See spec/flat-field-correction.md §6.1."""
+        if arr is None:
+            return arr
+        from core import flat_field
+        profile = flat_field.get_active_profile()
+        if profile is None:
+            return arr
+        try:
+            return flat_field.apply_field(arr, profile, encoded=encoded, mono=mono)
+        except Exception as e:
+            logging.warning(f"Field correction could not be applied: {e}")
+            return arr
+
     def _input_icc_will_apply(self) -> bool:
         """Whether read_image will burn an external camera profile into this scan
         — an input ICC **or** a DCP is active (mirrors the apply guard). Drives the
@@ -499,7 +524,8 @@ class CCRImage:
         )
 
     def _read_merged(self, preview: bool = True,
-                     max_long_side: Optional[int] = None) -> Optional[np.ndarray]:
+                     max_long_side: Optional[int] = None,
+                     apply_input_icc: bool = True) -> Optional[np.ndarray]:
         """Decode a 3-way RGB-merged image from its source RAWs. Mirrors the tail
         of read_image's RAW branch (slice ops, full-size capture, optional
         downsize) so export / zoom / slice all compose. The merge's native
@@ -513,6 +539,12 @@ class CCRImage:
         rgb, full_decode_size = ccr_merge.merge_raw_channels(
             self.merge_sources, preview=preview,
             demosaic=getattr(self, "merge_demosaic", True))
+        # Field correction on the full merged frame (camera-native linear, like
+        # the RAW branch). The linear-TIFF bake writes merge_raw_channels output
+        # directly, NOT through read_image, so a baked replacement stays
+        # uncorrected on disk and is corrected on reload — never twice.
+        if apply_input_icc:
+            rgb = self._apply_field_correction(rgb)
         # Sliced merged children read only their region of the source.
         rgb = self._apply_source_ops(rgb)
         self.original_full_size = self._ops_full_size(full_decode_size)
@@ -533,9 +565,12 @@ class CCRImage:
         without mutating global state (used by the IT8 camera-profiling decode,
         see spec/it8-camera-profile.md §6.1): positive_override=False forces the
         raw-linear negative decode regardless of the live Positive-mode toggle,
-        and apply_input_icc=False skips burning in the active input ICC profile —
-        together they yield the bare device RGB an input profile is fitted on.
-        Both default to current behaviour, so existing callers are unaffected.
+        and apply_input_icc=False is the BARE DEVICE DECODE — it forces the
+        camera-native decode space and skips BOTH the active camera profile
+        (ICC/DCP) and the active field correction, so a profiling decode measures
+        untouched device data and profiles can never compound
+        (spec/flat-field-correction.md §10.1). Both default to current behaviour,
+        so existing callers are unaffected.
         """
         # 3-way RGB merge: this image has no single backing file — it is
         # re-synthesized from its three source RAWs. Dispatch BEFORE the
@@ -543,7 +578,8 @@ class CCRImage:
         # always a camera-native negative). All re-read call sites (export,
         # zoom, slice, duplicate) flow through here, so they re-merge for free.
         if getattr(self, "is_merged", False) and self.merge_sources:
-            return self._read_merged(preview=preview, max_long_side=max_long_side)
+            return self._read_merged(preview=preview, max_long_side=max_long_side,
+                                     apply_input_icc=apply_input_icc)
 
         # Ensure file path is properly encoded for Unicode support
         file_path = os.path.normpath(file_path)
@@ -665,6 +701,14 @@ class CCRImage:
                         rgb = raw.postprocess(
                             **self._raw_color_postprocess_kwargs(
                                 positive_decode, preview, no_icc_default))
+
+                    # Field correction (flat-field) on the FULL frame, before the
+                    # slice chain crops it — a monochrome decode gets the neutral
+                    # (channel-averaged) gain so it stays colourless, and a
+                    # Positive decode is sRGB-encoded, not linear.
+                    if apply_input_icc:
+                        rgb = self._apply_field_correction(
+                            rgb, encoded=positive_decode, mono=is_monochrome)
 
                     # Sliced images read only their region of the source.
                     # Single atomic assignment of the final size (see above).
@@ -800,12 +844,20 @@ class CCRImage:
             # unconverted and render black).
             img = _to_uint16_full_range(img)
             # Convert grayscale to RGB
-            if len(img.shape) == 2:
+            is_gray = len(img.shape) == 2
+            if is_gray:
                 img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
             elif img.shape[2] == 4:
                 img = cv2.cvtColor(img, cv2.COLOR_BGRA2RGB)
             else:
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            # Field correction on the full frame, before the slice chain. The
+            # gain is applied in the file's own space (encoded=False): a
+            # multiplicative falloff stays multiplicative through a power-law
+            # encoding, so a profile measured and applied in the same space is
+            # self-consistent. See spec/flat-field-correction.md §10.4.
+            if apply_input_icc:
+                img = self._apply_field_correction(img, mono=is_gray)
             # Sliced images read only their region of the source
             img = self._apply_source_ops(img)
             # This branch always reads at full resolution regardless of `preview`

--- a/src/core/flat_field.py
+++ b/src/core/flat_field.py
@@ -1,0 +1,587 @@
+"""
+Field correction (flat-field) profiles — pure numpy/cv2, no Qt.
+
+A field-correction profile is a smooth per-channel GAIN MAP measured from one
+photograph of an evenly lit blank surface (ideally the light source the user
+scans on, through the same lens at the same aperture). Multiplying a decoded
+frame by that map removes everything multiplicative in the imaging chain at
+once: lens vignetting, sensor colour shading, and light-source unevenness.
+
+The map is measured in — and applied to — the decode that `read_image` produces,
+so measurement space == application space (see spec/flat-field-correction.md).
+Profiles are stored as `.ffc` (JSON + base64 float32 grid) in the per-user
+library and activated globally, mirroring how `color_management` holds the
+active camera profile so `ccr_image` can reach it without importing the backend.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import cv2
+import numpy as np
+
+# Stored grid long side. The measured field's real bandwidth is a few cycles
+# across the frame, so 128 samples over-resolves it while keeping the file
+# ~180 KB; it is upsampled bicubically at apply time.
+GRID_LONG_SIDE = 128
+# Working resolution for validation (§5.2) — high enough that scene content is
+# unmistakable, low enough that sensor noise is already averaged out.
+ANALYSIS_LONG_SIDE = 256
+
+# Gain clamp. +2 EV is past any real camera-scan rig; beyond it the corner is
+# mostly read noise and a botched calibration shot (lens cap, half-covered
+# panel) could otherwise produce a map that destroys every image.
+DEFAULT_MAX_GAIN = 4.0
+MIN_GAIN = 0.25
+# Smoothed-field floor (normalised units) — stops a black corner from dividing
+# by ~0 before the clamp gets a chance to bite.
+_FIELD_FLOOR = 1e-4
+
+FORMAT = "freeccr-field-correction"
+FORMAT_VERSION = 1
+EXTENSION = ".ffc"
+
+_FULL = 65535.0
+# Rows per band in the apply loop: bounds the float32 temporary to a few MB
+# even on a 6000x4000 export.
+_BAND_ROWS = 512
+
+
+class FieldProfileError(Exception):
+    """Raised when a .ffc file is missing, malformed, or from a newer format
+    version, or when a calibration frame cannot yield a usable profile. The
+    caller surfaces the message to the user."""
+
+
+# --------------------------------------------------------------------------- #
+# 1. Analysis of a calibration frame
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class FieldAnalysis:
+    """What the wizard's review page reports about a calibration frame."""
+    level: float                  # robust central level, 0..1 (max over channels)
+    clipped_fraction: float       # worst channel's fraction of pixels at the ceiling
+    flatness_residual: float      # relative RMS of (frame - smoothed frame)
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def usable(self) -> bool:
+        """Whether a profile can be built at all (warnings are advisory; this is
+        the hard floor — below 1% of full scale the map is pure noise gain)."""
+        return self.level >= 0.01
+
+
+def _to_float(arr_u16: np.ndarray) -> np.ndarray:
+    """16-bit RGB -> float32 in [0,1], always 3-channel."""
+    if arr_u16 is None:
+        raise FieldProfileError("No image data.")
+    a = np.asarray(arr_u16)
+    if a.ndim == 2:
+        a = np.stack([a, a, a], axis=2)
+    if a.ndim != 3 or a.shape[2] < 3:
+        raise FieldProfileError(
+            f"Expected an RGB image, got shape {getattr(a, 'shape', None)}.")
+    return a[..., :3].astype(np.float32) / _FULL
+
+
+def _resize_long_side(img: np.ndarray, long_side: int) -> np.ndarray:
+    """Aspect-preserving downsample with INTER_AREA (a box average — already a
+    strong low-pass, which is most of the noise/dust rejection)."""
+    h, w = img.shape[:2]
+    if max(h, w) <= long_side:
+        return img.astype(np.float32, copy=True)
+    if h >= w:
+        nh, nw = long_side, max(1, int(round(w * long_side / h)))
+    else:
+        nw, nh = long_side, max(1, int(round(h * long_side / w)))
+    return cv2.resize(img, (nw, nh), interpolation=cv2.INTER_AREA)
+
+
+def _pad_odd(a: np.ndarray, p: int) -> np.ndarray:
+    """Pad by ODD (antisymmetric) reflection: f(-k) = 2*f(0) - f(k).
+
+    Every OpenCV border mode holds the field flat (REPLICATE) or folds it back
+    on itself (REFLECT) outside the frame. Both understate a falloff that is
+    still dropping at the frame edge, so any filter biases the border *upward* —
+    which reads as less vignetting and under-corrects the corners, the exact
+    region this feature exists to measure. Odd reflection continues the local
+    slope instead (it is exact for a locally linear field), so filtering is
+    unbiased at the border. Measured: it removes a ~1.2% corner error."""
+    for axis in (0, 1):
+        n = a.shape[axis]
+        k = min(p, n - 1)
+        if k < 1:
+            continue
+        first = np.take(a, [0], axis=axis)
+        lead = 2.0 * first - np.flip(np.take(a, np.arange(1, k + 1), axis=axis),
+                                     axis=axis)
+        last = np.take(a, [-1], axis=axis)
+        trail = 2.0 * last - np.flip(np.take(a, np.arange(-k - 1, -1), axis=axis),
+                                     axis=axis)
+        if k < p:                       # tiny input: repeat the outermost value
+            lead = np.concatenate([np.repeat(np.take(lead, [0], axis=axis),
+                                             p - k, axis=axis), lead], axis=axis)
+            trail = np.concatenate([trail, np.repeat(np.take(trail, [-1], axis=axis),
+                                                     p - k, axis=axis)], axis=axis)
+        a = np.concatenate([lead, a, trail], axis=axis)
+    return np.ascontiguousarray(a, dtype=np.float32)
+
+
+def _smooth(grid: np.ndarray, sigma: float) -> np.ndarray:
+    """Gaussian blur that does not bias the frame border (see _pad_odd)."""
+    p = max(2, int(np.ceil(3.0 * float(sigma))))
+    padded = cv2.GaussianBlur(_pad_odd(grid, p), (0, 0), sigmaX=float(sigma),
+                              sigmaY=float(sigma), borderType=cv2.BORDER_REPLICATE)
+    return padded[p:p + grid.shape[0], p:p + grid.shape[1]]
+
+
+# Blemish-rejection window, as a fraction of the grid's long side. 0.13 removes
+# dust/fibres/smudges up to ~6% of the frame across; measured fidelity cost on a
+# clean field is ~0.1%. Bigger windows reject bigger smudges but a blemish that
+# large is no longer distinguishable from real shading.
+BLEMISH_WINDOW_FRAC = 0.13
+
+
+def _median_window(grid: np.ndarray, k: int) -> np.ndarray:
+    """k x k median over the grid (build-time only, so a strided view is fine).
+    Run per channel to keep the temporary small."""
+    p = k // 2
+    padded = _pad_odd(grid, p)
+    out = np.empty_like(grid, dtype=np.float32)
+    for c in range(grid.shape[2]):
+        win = np.lib.stride_tricks.sliding_window_view(padded[..., c], (k, k))
+        out[..., c] = np.median(win, axis=(-2, -1))
+    return out
+
+
+def _reject_blemishes(grid: np.ndarray) -> np.ndarray:
+    """Remove dust, fibres and hot pixels from the measured field without
+    touching the falloff underneath: a 5x5 median for isolated hot/dead pixels,
+    then a LARGE median for everything bigger.
+
+    A median is the right robust estimator here because it is exact on monotone
+    data: a genuine shading edge — the fast corner cut of a mechanical vignette —
+    passes through untouched, while an isolated blob smaller than the window is
+    replaced by the surrounding field. The alternatives were measured and
+    rejected: a Gaussian wide enough to hide a smudge flattens the corners it is
+    meant to measure, morphological closing only reaches blemishes smaller than
+    its own kernel, and iterated clipped smoothing (reject by DEPTH rather than
+    size) mistook a sharp vignette knee for a blemish and smeared it — it
+    rewrote 54% of the grid on such a field.
+
+    Baking a blemish into a profile would put a permanent BRIGHT spot in every
+    corrected scan, which is much worse than leaving one dark speck alone."""
+    g = cv2.medianBlur(_pad_odd(grid, 2), 5)[2:2 + grid.shape[0],
+                                             2:2 + grid.shape[1]]
+    k = max(3, int(round(GRID_LONG_SIDE * BLEMISH_WINDOW_FRAC)) | 1)
+    return _median_window(np.ascontiguousarray(g, dtype=np.float32), k)
+
+
+def _central_level(grid: np.ndarray) -> np.ndarray:
+    """Per-channel median over the central window (middle 10% of frame area).
+    This is the normalisation reference: gain == 1 here, in every channel, so a
+    profile changes neither exposure nor white balance — only spatial variation."""
+    h, w = grid.shape[:2]
+    # sqrt(0.10) ~= 0.316 of each dimension -> 10% of the area.
+    ch, cw = max(1, int(round(h * 0.316))), max(1, int(round(w * 0.316)))
+    y0, x0 = (h - ch) // 2, (w - cw) // 2
+    window = grid[y0:y0 + ch, x0:x0 + cw]
+    return np.median(window.reshape(-1, window.shape[2]), axis=0).astype(np.float32)
+
+
+def analyze_field(arr_u16: np.ndarray) -> FieldAnalysis:
+    """Validate a decoded calibration frame: is it bright enough, unclipped, and
+    actually a flat field rather than a photograph of a scene? Warnings are
+    advisory (the user's rig, the user's call); `usable` is the hard floor."""
+    f = _to_float(arr_u16)
+    work = _resize_long_side(f, ANALYSIS_LONG_SIDE)
+    smooth = _smooth(work, max(1.0, max(work.shape[:2]) / 12.0))
+
+    level = float(np.max(_central_level(smooth)))
+    clipped = float(np.max(np.mean(f >= 0.99, axis=(0, 1))))
+    # Relative to the global level rather than per-pixel (a per-pixel ratio
+    # explodes on a near-black frame and would report noise as structure).
+    residual = float(np.sqrt(np.mean((work - smooth) ** 2)) / max(level, 1e-6))
+
+    warnings: List[str] = []
+    if level < 0.05:
+        warnings.append(
+            "The calibration shot is very dark — the corrected corners will be "
+            "noisy. Re-shoot it brighter (around half to three-quarters of full "
+            "exposure).")
+    elif level > 0.95:
+        warnings.append(
+            "The calibration shot is over-exposed. Re-shoot it darker so no "
+            "area reaches pure white.")
+    if clipped > 0.001:
+        warnings.append(
+            f"{clipped * 100:.1f}% of pixels are clipped to white — the falloff "
+            "cannot be measured there. Re-shoot with less exposure.")
+    if residual > 0.05:
+        warnings.append(
+            "This doesn't look like an evenly lit blank surface — it has too "
+            "much detail. Shoot the bare light source (slightly defocused), not "
+            "a scene or a frame of film.")
+    return FieldAnalysis(level=level, clipped_fraction=clipped,
+                         flatness_residual=residual, warnings=warnings)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Building the profile
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class FieldProfile:
+    """A measured gain map plus the metadata that says what it was measured on."""
+    name: str
+    gain: np.ndarray                       # (gh, gw, 3) float32
+    aspect: float                          # source frame w/h
+    meta: Dict[str, Any] = field(default_factory=dict)
+    path: Optional[str] = None
+    content_id: Optional[str] = None
+    # Resized-map memo, keyed by (w, h). A pure function of (gain, w, h), so a
+    # race between decode worker threads only ever duplicates work.
+    _cache: Dict[tuple, np.ndarray] = field(default_factory=dict, repr=False,
+                                            compare=False)
+
+    @property
+    def stats(self) -> Dict[str, Any]:
+        return self.meta.get("stats", {})
+
+    def summary(self) -> str:
+        """One-line description for the Settings library row."""
+        st = self.stats
+        cs = st.get("corner_stops") or [0.0, 0.0, 0.0]
+        cam = self.meta.get("camera", {}) or {}
+        bits = [b for b in (cam.get("model") or cam.get("make"),
+                            _lens_label(cam)) if b]
+        head = " · ".join(bits)
+        tail = (f"max +{max(cs):.1f} EV · colour spread "
+                f"{st.get('cast_stops', 0.0):.2f} EV")
+        return f"{head} · {tail}" if head else tail
+
+
+def _lens_label(cam: Dict[str, Any]) -> str:
+    """'105 mm f/8' / the lens model, whichever the EXIF actually had."""
+    parts = []
+    if cam.get("lens_model"):
+        parts.append(str(cam["lens_model"]))
+    if cam.get("focal_length"):
+        parts.append(f"{float(cam['focal_length']):g} mm")
+    if cam.get("aperture"):
+        parts.append(f"f/{float(cam['aperture']):g}")
+    return " ".join(parts)
+
+
+def _corner_stops(gain: np.ndarray) -> List[float]:
+    """Per-channel mean gain over the four corner regions (outer 5% x 5%), in
+    EV — 'how many stops of falloff this profile lifts out of the corners'."""
+    h, w = gain.shape[:2]
+    ch, cw = max(2, int(round(h * 0.05))), max(2, int(round(w * 0.05)))
+    corners = np.concatenate([
+        gain[:ch, :cw].reshape(-1, 3), gain[:ch, -cw:].reshape(-1, 3),
+        gain[-ch:, :cw].reshape(-1, 3), gain[-ch:, -cw:].reshape(-1, 3)])
+    return [float(np.log2(max(v, 1e-6))) for v in corners.mean(axis=0)]
+
+
+def build_profile(arr_u16: np.ndarray, name: str, *,
+                  meta: Optional[Dict[str, Any]] = None,
+                  max_gain: float = DEFAULT_MAX_GAIN) -> FieldProfile:
+    """Measure the gain map of a decoded calibration frame.
+
+    INTER_AREA downsample -> 3x3 median (hot pixels, surviving dust specks) ->
+    Gaussian blur (the field's true bandwidth) -> divide the central reference
+    level by it. See spec/flat-field-correction.md §5.3."""
+    f = _to_float(arr_u16)
+    src_h, src_w = f.shape[:2]
+    analysis = analyze_field(arr_u16)
+    if not analysis.usable:
+        raise FieldProfileError(
+            "The calibration shot is essentially black — nothing to measure. "
+            "Shoot the lit surface itself, exposed to about half to "
+            "three-quarters of full brightness.")
+
+    # Blemish rejection does the heavy lifting; the Gaussian that follows only
+    # de-staircases the median, so it stays MINIMAL. A blur wide enough to hide
+    # dust on its own would measurably flatten the corners it is supposed to
+    # measure (blurring a curved field biases it by ~sigma^2/2 * laplacian, worst
+    # exactly at the corners): at sigma=2 a sharp mechanical-vignette knee was
+    # reproduced to 10%, at sigma=1 to 6%.
+    grid = _reject_blemishes(_resize_long_side(f, GRID_LONG_SIDE))
+    smooth = _smooth(grid, max(1.0, GRID_LONG_SIDE / 128.0))
+
+    ref = _central_level(smooth)                       # (3,) gain == 1 here
+    gain = ref[None, None, :] / np.maximum(smooth, _FIELD_FLOOR)
+    reached = float(np.max(gain))
+    gain = np.clip(gain, MIN_GAIN, float(max_gain)).astype(np.float32)
+    gain = np.ascontiguousarray(gain)
+
+    corner = _corner_stops(gain)
+    stats = {
+        "max_gain": round(float(np.max(gain)), 4),
+        "max_gain_uncapped": round(reached, 4),
+        "clamped": bool(reached > max_gain + 1e-6),
+        "corner_stops": [round(c, 4) for c in corner],
+        "cast_stops": round(float(max(corner) - min(corner)), 4),
+        "level": round(analysis.level, 4),
+        "clipped_fraction": round(analysis.clipped_fraction, 6),
+        "flatness_residual": round(analysis.flatness_residual, 6),
+    }
+    full_meta: Dict[str, Any] = dict(meta or {})
+    full_meta["stats"] = stats
+    full_meta["max_gain_cap"] = float(max_gain)
+    full_meta.setdefault("created", datetime.now().isoformat(timespec="seconds"))
+    full_meta.setdefault("warnings", analysis.warnings)
+    return FieldProfile(name=name or "Field correction", gain=gain,
+                        aspect=float(src_w) / float(max(1, src_h)),
+                        meta=full_meta)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Storage (.ffc = JSON + base64 float32 grid)
+# --------------------------------------------------------------------------- #
+
+def _profile_dict(p: FieldProfile) -> Dict[str, Any]:
+    g = np.ascontiguousarray(p.gain, dtype="<f4")
+    gh, gw = g.shape[:2]
+    doc = {
+        "format": FORMAT,
+        "version": FORMAT_VERSION,
+        "name": p.name,
+        "aspect": round(float(p.aspect), 6),
+        "grid": {"w": int(gw), "h": int(gh), "channels": 3, "dtype": "float32",
+                 "data": base64.b64encode(g.tobytes()).decode("ascii")},
+    }
+    doc.update({k: v for k, v in p.meta.items() if k not in doc})
+    return doc
+
+
+def save_profile(profile: FieldProfile, path: str) -> str:
+    """Write a .ffc. Returns the path actually written."""
+    path = os.path.normpath(path)
+    folder = os.path.dirname(os.path.abspath(path))
+    if folder:
+        os.makedirs(folder, exist_ok=True)
+    blob = json.dumps(_profile_dict(profile), indent=1, ensure_ascii=False)
+    with open(path, "wb") as f:
+        f.write(blob.encode("utf-8"))
+    profile.path = path
+    profile.content_id = _content_id(path)
+    return path
+
+
+def _content_id(path: str) -> Optional[str]:
+    """Short content hash — makes the grading signature distinguish two profiles
+    that share a name."""
+    try:
+        with open(path, "rb") as f:
+            return hashlib.md5(f.read()).hexdigest()[:12]
+    except OSError:
+        return None
+
+
+def load_profile(path: str) -> FieldProfile:
+    """Read and validate a .ffc file. Raises FieldProfileError with a message
+    meant for the user."""
+    try:
+        with open(os.path.normpath(path), "rb") as f:
+            raw = f.read()
+    except OSError as e:
+        raise FieldProfileError(f"Could not read the profile: {e}") from e
+    try:
+        doc = json.loads(raw.decode("utf-8"))
+    except Exception as e:
+        raise FieldProfileError(
+            f"This is not a valid field-correction profile: {e}") from e
+    if not isinstance(doc, dict) or doc.get("format") != FORMAT:
+        raise FieldProfileError(
+            "This file is not a FreeCCR field-correction profile.")
+    version = doc.get("version")
+    if not isinstance(version, int) or version > FORMAT_VERSION:
+        raise FieldProfileError(
+            f"This profile was written by a newer version of FreeCCR "
+            f"(format {version}). Update FreeCCR to use it.")
+
+    grid = doc.get("grid")
+    if not isinstance(grid, dict):
+        raise FieldProfileError("The profile has no gain map.")
+    try:
+        gw, gh = int(grid["w"]), int(grid["h"])
+        data = base64.b64decode(grid["data"], validate=True)
+        gain = np.frombuffer(data, dtype="<f4")
+    except Exception as e:
+        raise FieldProfileError(f"The profile's gain map is corrupt: {e}") from e
+    if gw < 2 or gh < 2 or gain.size != gw * gh * 3:
+        raise FieldProfileError("The profile's gain map is the wrong size.")
+    gain = np.ascontiguousarray(gain.reshape(gh, gw, 3).astype(np.float32))
+    if not np.all(np.isfinite(gain)) or float(np.min(gain)) <= 0.0:
+        raise FieldProfileError("The profile's gain map has invalid values.")
+
+    meta = {k: v for k, v in doc.items()
+            if k not in ("format", "version", "name", "aspect", "grid")}
+    aspect = doc.get("aspect")
+    try:
+        aspect = float(aspect)
+    except (TypeError, ValueError):
+        aspect = float(gw) / float(gh)
+    return FieldProfile(
+        name=str(doc.get("name") or os.path.splitext(os.path.basename(path))[0]),
+        gain=gain, aspect=aspect, meta=meta, path=path,
+        content_id=_content_id(path))
+
+
+# --------------------------------------------------------------------------- #
+# 4. Applying a profile
+# --------------------------------------------------------------------------- #
+
+def gain_for_size(profile: FieldProfile, w: int, h: int) -> np.ndarray:
+    """The gain map resized to (w, h), memoised per size. Bicubic: the map is
+    smooth, and bicubic avoids the faint slope-discontinuity facets bilinear can
+    leave when a 128-px grid is stretched to 6000 px."""
+    key = (int(w), int(h))
+    cached = profile._cache.get(key)
+    if cached is not None:
+        return cached
+    g = profile.gain
+    out = (g if g.shape[:2] == (h, w) else
+           cv2.resize(g, (int(w), int(h)), interpolation=cv2.INTER_CUBIC))
+    out = np.ascontiguousarray(out, dtype=np.float32)
+    if len(profile._cache) >= 4:                # preview / thumb / zoom / export
+        profile._cache.pop(next(iter(profile._cache)), None)
+    profile._cache[key] = out
+    return out
+
+
+def _srgb_to_linear(v: np.ndarray) -> np.ndarray:
+    return np.where(v <= 0.04045, v / 12.92,
+                    np.power((v + 0.055) / 1.055, 2.4))
+
+
+def _linear_to_srgb(v: np.ndarray) -> np.ndarray:
+    return np.where(v <= 0.0031308, v * 12.92,
+                    1.055 * np.power(np.maximum(v, 0.0), 1.0 / 2.4) - 0.055)
+
+
+def apply_field(arr_u16: np.ndarray, profile: Optional[FieldProfile], *,
+                encoded: bool = False, mono: bool = False) -> np.ndarray:
+    """Multiply a decoded 16-bit RGB frame by the profile's gain map.
+
+    `encoded=True` for an sRGB-gamma-encoded decode (Positive mode): linearise,
+    multiply, re-encode — a gain measured in linear light and applied straight to
+    gamma-encoded data OVER-corrects, by roughly the gamma exponent (multiplying
+    an encoded value by g scales the light it stands for by g^2.4).
+    `mono=True` for monochrome/grayscale sources: the three channel gains are
+    averaged so the frame stays neutral.
+
+    Runs in horizontal bands so a full-resolution export never materialises a
+    float32 copy of the whole frame."""
+    if profile is None or arr_u16 is None:
+        return arr_u16
+    a = np.asarray(arr_u16)
+    if a.ndim != 3 or a.shape[2] != 3:
+        return arr_u16                        # not an RGB frame — leave it alone
+    h, w = a.shape[:2]
+    gain = gain_for_size(profile, w, h)
+    if mono:
+        gain = gain.mean(axis=2, keepdims=True)
+
+    out = np.empty_like(a, dtype=np.uint16)
+    for y in range(0, h, _BAND_ROWS):
+        y1 = min(h, y + _BAND_ROWS)
+        band = a[y:y1].astype(np.float32)
+        g = gain[y:y1]
+        if encoded:
+            # Only this path needs normalised units (the sRGB transfer functions).
+            band /= _FULL
+            band = _linear_to_srgb(_srgb_to_linear(band) * g)
+            band *= _FULL
+        else:
+            # Straight multiply in the frame's own units — no /65535 round trip,
+            # which would cost a rounding step for nothing.
+            band *= g
+        np.clip(band, 0.0, _FULL, out=band)
+        out[y:y1] = band.astype(np.uint16)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# 5. Global active profile (mirrors color_management's module globals, so
+#    ccr_image can reach it without importing the backend singleton).
+# --------------------------------------------------------------------------- #
+
+_active_profile: Optional[FieldProfile] = None
+
+
+def set_active_profile(profile: Optional[FieldProfile]) -> None:
+    global _active_profile
+    _active_profile = profile
+
+
+def get_active_profile() -> Optional[FieldProfile]:
+    return _active_profile
+
+
+def field_profile_active() -> bool:
+    return _active_profile is not None
+
+
+def active_field_signature() -> str:
+    """Stable id of the field correction a decode would get now — composed into
+    the per-image grading signature so a change flags the affected thumbnails."""
+    if _active_profile is None:
+        return "none"
+    return "ff:" + (_active_profile.content_id or _active_profile.name or "?")
+
+
+# --------------------------------------------------------------------------- #
+# 6. Capture-side helpers (used by the wizard)
+# --------------------------------------------------------------------------- #
+
+def decode_calibration(path: str, sample_max: int = 1024) -> Optional[np.ndarray]:
+    """Decode a calibration shot to BARE device RGB — camera-native, raw-linear,
+    unbalanced, no camera profile and (critically) no field correction, so
+    profiles can never compound. Same decode contract as the IT8 profiling path
+    (spec/it8-camera-profile.md §5.1); `apply_input_icc=False` is what pins it.
+
+    Built on a bare CCRImage (__new__) so the heavyweight __init__ decode +
+    thumbnail work is skipped."""
+    from core.ccr_image import CCRImage
+    img = CCRImage.__new__(CCRImage)
+    img.source_ops = []
+    return img.read_image(path, preview=True, max_long_side=sample_max,
+                          positive_override=False, apply_input_icc=False)
+
+
+def source_metadata(path: str) -> Dict[str, Any]:
+    """Camera/lens EXIF for the profile's metadata block (best effort — a
+    calibration shot with no readable EXIF still makes a valid profile)."""
+    cam: Dict[str, Any] = {}
+    try:
+        from core.ccr_image import CCRImage
+        info = CCRImage.get_camera_and_lens_for_lensfun(path) or {}
+        for key in ("camera_make", "camera_model", "lens_make", "lens_model",
+                    "focal_length", "aperture"):
+            val = info.get(key)
+            if val not in (None, ""):
+                cam[key.replace("camera_", "")] = val
+    except Exception as e:                     # EXIF is a nicety, never a blocker
+        logging.debug(f"No EXIF for calibration shot {path}: {e}")
+    return {"source": os.path.basename(path), "camera": cam}
+
+
+def suggested_name(meta: Dict[str, Any]) -> str:
+    """Default profile name from what we know about the shot."""
+    cam = (meta or {}).get("camera", {}) or {}
+    lens = _lens_label(cam)
+    body = cam.get("model") or cam.get("make") or ""
+    head = " ".join(b for b in (body, lens) if b).strip()
+    return f"Field {head} {datetime.now():%Y-%m-%d}".replace("  ", " ").strip() \
+        if head else f"Field correction {datetime.now():%Y-%m-%d}"

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -307,6 +307,20 @@ class MainWindow(QMainWindow):
         self.thumbnail_list.refresh_profile_combo()
         self._refresh_profile_ui()
 
+        # Restore the active field-correction profile (independent of the camera
+        # profile; also applied to every decode). A vanished or unreadable file
+        # falls back to no correction and clears the setting.
+        saved_ff = self._settings.value("import/field_profile_path", "", type=str)
+        if saved_ff and saved_ff != "none" and os.path.exists(saved_ff):
+            try:
+                ccr_backend.set_active_field_profile(saved_ff)
+            except Exception as e:
+                print(f"Could not restore field correction {saved_ff}: {e}")
+                ccr_backend.set_active_field_profile(None)
+                self._settings.remove("import/field_profile_path")
+        elif saved_ff and saved_ff != "none":
+            self._settings.remove("import/field_profile_path")
+
         # Ctrl+Z (Cmd+Z on macOS): undo the last action on the current image;
         # repeated presses walk further back through the undo stack.
         self.undo_shortcut = QShortcut(QKeySequence.Undo, self)
@@ -686,6 +700,62 @@ class MainWindow(QMainWindow):
         else:
             self.sliders_panel.set_temporary_hint(
                 f"Camera profile saved: {base}", duration=4000)
+
+    # --- Field correction (flat-field, global + persistent) ---------------
+    def set_active_field_profile(self, path):
+        """Select the active field-correction profile (a library path), or None.
+        Persisted; re-flags thumbnail mismatches (no re-decode, exactly like a
+        camera-profile change). See spec/flat-field-correction.md §6.3."""
+        from core.flat_field import FieldProfileError
+        try:
+            name = ccr_backend.set_active_field_profile(path)
+        except (FieldProfileError, Exception) as e:
+            QMessageBox.warning(self, "Field correction",
+                                f"Could not use this profile:\n\n{e}")
+            return False
+        self._settings.setValue("import/field_profile_path", path if path else "none")
+        self._refresh_profile_mismatch()
+        self.sliders_panel.set_temporary_hint(
+            f"Field correction: {name}" if name else "Field correction: None",
+            duration=3000)
+        return True
+
+    def delete_field_profile(self, path):
+        """Remove a field-correction profile from the library (with
+        confirmation), deactivating it first if it is the active one."""
+        name = os.path.splitext(os.path.basename(path))[0]
+        if QMessageBox.question(
+                self, "Delete field correction profile",
+                f"Remove “{name}” from your field-correction library?\n"
+                "The file is deleted from FreeCCR's workspace.") != QMessageBox.Yes:
+            return
+        was_active = (path == self._settings.value(
+            "import/field_profile_path", "", type=str))
+        ccr_backend.delete_field_profile(path)
+        if was_active:
+            self._settings.remove("import/field_profile_path")
+        self._refresh_profile_mismatch()
+
+    def create_field_correction_profile(self):
+        """Open the field-correction wizard; on success the profile is already in
+        the library, so just activate it if the user asked for that."""
+        from widgets.field_correction_dialog import FieldCorrectionDialog
+        current_path = None
+        idx = self.image_preview.current_idx
+        if idx is not None:
+            img = ccr_backend.get_image_by_index(idx)
+            if img is not None:
+                current_path = img.file_path
+        dlg = FieldCorrectionDialog(self, current_path=current_path)
+        if dlg.exec() != QDialog.Accepted or not dlg.saved_path:
+            return
+        base = os.path.basename(dlg.saved_path)
+        if dlg.apply_now and self.set_active_field_profile(dlg.saved_path):
+            self.sliders_panel.set_temporary_hint(
+                f"Field correction saved and applied: {base}", duration=4000)
+        else:
+            self.sliders_panel.set_temporary_hint(
+                f"Field correction saved: {base}", duration=4000)
 
     # --- Positive mode (global, persistent) -------------------------------
     def on_positive_mode_toggled(self, checked: bool):

--- a/src/widgets/field_correction_dialog.py
+++ b/src/widgets/field_correction_dialog.py
@@ -1,0 +1,413 @@
+"""
+Create-Field-Correction-Profile wizard (PySide6).
+
+A 3-step QDialog: pick a calibration shot of an evenly lit blank surface, review
+the measured falloff (shot / gain map / corrected preview + validation warnings),
+then name and save the profile into the library. Core math lives in
+core.flat_field; this module is UI only. See spec/flat-field-correction.md §7.
+"""
+import os
+from typing import Optional
+
+import numpy as np
+
+from PySide6.QtCore import Qt, QSettings
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import (
+    QApplication, QCheckBox, QDialog, QFileDialog, QHBoxLayout, QLabel,
+    QLineEdit, QMessageBox, QPushButton, QStackedWidget, QVBoxLayout, QWidget,
+)
+
+from core import flat_field as ff
+from core.ccr_backend import ccr_backend
+from utils.unicode_path_utils import normalize_unicode_path, validate_unicode_path
+
+_RAW_EXTS = (".dng", ".arw", ".nef", ".cr2", ".cr3", ".raf", ".rw2", ".orf",
+             ".srw", ".pef", ".3fr", ".fff")
+
+
+def _gamma_stretch_qimage(arr_u16: np.ndarray, norm: Optional[float] = None):
+    """8-bit gamma-stretched view of a linear 16-bit RGB array (display only —
+    the measurement always uses the linear data). `norm` pins the exposure so two
+    panes can be compared like for like."""
+    a = arr_u16.astype(np.float32)
+    if norm is None:
+        norm = float(np.percentile(a, 99.5)) or float(a.max()) or 1.0
+    disp = np.power(np.clip(a / max(norm, 1e-6), 0.0, 1.0), 1.0 / 2.2)
+    disp8 = np.ascontiguousarray((disp * 255).astype(np.uint8))
+    h, w = disp8.shape[:2]
+    return QImage(disp8.data, w, h, 3 * w, QImage.Format_RGB888).copy(), norm
+
+
+def _gain_heatmap_qimage(gain: np.ndarray):
+    """False-colour view of the gain map: dark blue at 1.0 (no correction)
+    through to bright yellow at the map's maximum."""
+    g = gain.mean(axis=2)
+    lo, hi = 1.0, max(float(g.max()), 1.0001)
+    t = np.clip((g - lo) / (hi - lo), 0.0, 1.0)
+    # A simple perceptual-ish ramp (navy -> magenta -> orange -> pale yellow).
+    r = np.clip(1.6 * t, 0, 1)
+    gr = np.clip(1.7 * t - 0.7, 0, 1)
+    b = np.clip(0.45 + 0.9 * t - 1.6 * t * t, 0, 1)
+    rgb = np.ascontiguousarray(
+        (np.stack([r, gr, b], axis=2) * 255).astype(np.uint8))
+    h, w = rgb.shape[:2]
+    return QImage(rgb.data, w, h, 3 * w, QImage.Format_RGB888).copy(), hi
+
+
+class _Pane(QWidget):
+    """A titled image pane that scales its pixmap to fit."""
+
+    def __init__(self, title: str, parent=None):
+        super().__init__(parent)
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.setSpacing(4)
+        self._title = QLabel(title)
+        self._title.setAlignment(Qt.AlignCenter)
+        self._title.setStyleSheet("font-weight: bold;")
+        self._img = QLabel()
+        self._img.setAlignment(Qt.AlignCenter)
+        self._img.setMinimumSize(220, 160)
+        self._img.setStyleSheet("background: #1e1e1e; border: 1px solid #3a3a3a;")
+        self._caption = QLabel("")
+        self._caption.setAlignment(Qt.AlignCenter)
+        self._caption.setStyleSheet("color: #9a9a9a;")
+        lay.addWidget(self._title)
+        lay.addWidget(self._img, 1)
+        lay.addWidget(self._caption)
+        self._pix: Optional[QPixmap] = None
+
+    def set_image(self, qimg: QImage, caption: str = ""):
+        self._pix = QPixmap.fromImage(qimg)
+        self._caption.setText(caption)
+        self._rescale()
+
+    def _rescale(self):
+        if self._pix is not None and not self._pix.isNull():
+            self._img.setPixmap(self._pix.scaled(
+                self._img.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation))
+
+    def resizeEvent(self, e):
+        super().resizeEvent(e)
+        self._rescale()
+
+
+class FieldCorrectionDialog(QDialog):
+    """3-step wizard. On success `self.saved_path` holds the .ffc path and
+    `self.apply_now` whether to activate it."""
+
+    PAGE_SOURCE, PAGE_REVIEW, PAGE_SAVE = range(3)
+
+    def __init__(self, parent=None, current_path: Optional[str] = None):
+        super().__init__(parent)
+        self.setWindowTitle("Create Field Correction Profile")
+        self.setModal(True)
+        scr = self.screen() or QApplication.primaryScreen()
+        avail = scr.availableGeometry() if scr is not None else None
+        min_w, min_h, init_w, init_h = 900, 600, 1020, 680
+        if avail is not None:
+            min_w = min(min_w, avail.width() - 40)
+            min_h = min(min_h, avail.height() - 80)
+            init_w = min(init_w, avail.width() - 40)
+            init_h = min(init_h, avail.height() - 80)
+        self.setMinimumSize(min_w, min_h)
+        self.resize(max(min_w, init_w), max(min_h, init_h))
+        self._settings = QSettings("FreeCCR", "FreeCCR")
+
+        self._current_path = current_path
+        self._source_path: Optional[str] = None
+        self._decoded: Optional[np.ndarray] = None
+        self._profile: Optional[ff.FieldProfile] = None
+        self.saved_path: Optional[str] = None
+        self.apply_now = False
+
+        self.stack = QStackedWidget(self)
+        self.stack.addWidget(self._build_source_page())
+        self.stack.addWidget(self._build_review_page())
+        self.stack.addWidget(self._build_save_page())
+
+        self.back_btn = QPushButton("Back")
+        self.next_btn = QPushButton("Next")
+        self.cancel_btn = QPushButton("Cancel")
+        self.back_btn.clicked.connect(self._go_back)
+        self.next_btn.clicked.connect(self._go_next)
+        self.cancel_btn.clicked.connect(self.reject)
+
+        nav = QHBoxLayout()
+        nav.addWidget(self.cancel_btn)
+        nav.addStretch(1)
+        nav.addWidget(self.back_btn)
+        nav.addWidget(self.next_btn)
+
+        root = QVBoxLayout(self)
+        root.addWidget(self.stack, 1)
+        root.addLayout(nav)
+        self._update_nav()
+
+    # ------------------------------------------------------------------ #
+    # Page 1 — calibration shot
+    # ------------------------------------------------------------------ #
+    def _build_source_page(self):
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.addWidget(QLabel("<b>Step 1 — Calibration shot</b>"))
+        guide = QLabel(
+            "Field correction removes the dark corners and colour shading your "
+            "lens, sensor and light source put into every scan. It is measured "
+            "from a single photo of an <b>evenly lit blank surface</b>.<br><br>"
+            "<b>How to shoot it</b><ul>"
+            "<li>Photograph <b>the light source you scan on</b> — the bare "
+            "panel, no film — using the <b>same lens, aperture, focal length "
+            "and distance</b> as your scans. Aperture matters most: vignetting "
+            "changes by a stop or more between f/2.8 and f/8.</li>"
+            "<li><b>Defocus slightly</b>, or lay a diffuser over the panel, so "
+            "its texture and dust don't print into the profile.</li>"
+            "<li><b>Fill the whole frame</b> — nothing dark at the edges.</li>"
+            "<li>Expose so the brightest area is around <b>half to "
+            "three-quarters</b> of full brightness, with <b>nothing clipped</b>."
+            "</li>"
+            "<li><b>Shoot RAW.</b> Other formats work but are less exact.</li>"
+            "</ul>"
+            "Re-shoot the profile whenever the rig changes (lens, aperture, "
+            "panel or height).")
+        guide.setWordWrap(True)
+        lay.addWidget(guide)
+        row = QHBoxLayout()
+        self.use_current_btn = QPushButton("Use current image")
+        self.use_current_btn.setEnabled(bool(self._current_path))
+        self.use_current_btn.clicked.connect(self._use_current)
+        browse = QPushButton("Browse…")
+        browse.clicked.connect(self._browse_source)
+        row.addWidget(self.use_current_btn)
+        row.addWidget(browse)
+        row.addStretch(1)
+        lay.addLayout(row)
+        self.source_label = QLabel("<i>No calibration shot selected.</i>")
+        self.source_label.setWordWrap(True)
+        lay.addWidget(self.source_label)
+        lay.addStretch(1)
+        return w
+
+    def _use_current(self):
+        if self._current_path:
+            self._set_source(self._current_path)
+
+    def _browse_source(self):
+        start = self._settings.value("files/last_open_dir", "", type=str)
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select the calibration shot", start,
+            "Images (*.dng *.tif *.tiff *.arw *.nef *.cr2 *.cr3 *.raf *.png "
+            "*.jpg *.jpeg *.rw2 *.orf *.srw *.pef *.3fr *.fff);;All Files (*)")
+        if path:
+            self._set_source(path)
+
+    def _set_source(self, path):
+        self._source_path = path
+        self._decoded = None                 # force a re-decode on Next
+        self._profile = None
+        is_raw = os.path.splitext(path)[1].lower() in _RAW_EXTS
+        warn = ("" if is_raw else
+                "<br><span style='color:#cc7a00'>Note: not a RAW file. The "
+                "profile will be measured in this file's own encoding — use it "
+                "with scans in the same format for an exact match.</span>")
+        self.source_label.setText(
+            f"Selected: <b>{os.path.basename(path)}</b>{warn}")
+        self._update_nav()
+
+    def _decode_source(self) -> bool:
+        if self._decoded is not None:
+            return True
+        norm = normalize_unicode_path(self._source_path)
+        if not validate_unicode_path(norm):
+            QMessageBox.warning(self, "Unicode Path",
+                                "This file path can't be processed. Please move "
+                                "it to a simpler path.")
+            return False
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            arr = ff.decode_calibration(norm)
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.critical(self, "Decode Error",
+                                 f"Could not read the calibration shot:\n\n{e}")
+            return False
+        finally:
+            if QApplication.overrideCursor() is not None:
+                QApplication.restoreOverrideCursor()
+        if arr is None or arr.ndim != 3:
+            QMessageBox.critical(self, "Decode Error",
+                                 "Could not decode the calibration shot.")
+            return False
+        self._decoded = arr
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Page 2 — review
+    # ------------------------------------------------------------------ #
+    def _build_review_page(self):
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.addWidget(QLabel("<b>Step 2 — Review the measured falloff</b>"))
+        panes = QHBoxLayout()
+        self.pane_shot = _Pane("Calibration shot")
+        self.pane_gain = _Pane("Correction applied")
+        self.pane_fixed = _Pane("Corrected result")
+        for p in (self.pane_shot, self.pane_gain, self.pane_fixed):
+            panes.addWidget(p, 1)
+        lay.addLayout(panes, 1)
+
+        self.stats_label = QLabel("")
+        self.stats_label.setWordWrap(True)
+        lay.addWidget(self.stats_label)
+        self.warn_label = QLabel("")
+        self.warn_label.setWordWrap(True)
+        self.warn_label.setStyleSheet("color: #cc7a00;")
+        lay.addWidget(self.warn_label)
+
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Profile name:"))
+        self.name_edit = QLineEdit()
+        row.addWidget(self.name_edit, 1)
+        lay.addLayout(row)
+        return w
+
+    def _build_and_show(self) -> bool:
+        meta = ff.source_metadata(self._source_path)
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            profile = ff.build_profile(
+                self._decoded, self.name_edit.text().strip()
+                or ff.suggested_name(meta), meta=meta)
+        except ff.FieldProfileError as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.warning(self, "Calibration shot", str(e))
+            return False
+        finally:
+            if QApplication.overrideCursor() is not None:
+                QApplication.restoreOverrideCursor()
+        self._profile = profile
+
+        # Both photo panes share one exposure normalisation — the before/after
+        # is only readable if the two are displayed at the same scale — and it is
+        # taken over BOTH images so the corrected one (whose corners have been
+        # lifted to the centre's level) doesn't sit clipped against white.
+        corrected = ff.apply_field(self._decoded, profile)
+        # ...with a stop of display headroom on top: a corrected frame sits at
+        # the centre's own level, so without it the "should look even" pane is a
+        # flat white rectangle and any residual unevenness is invisible.
+        norm = 2.0 * max(float(np.percentile(self._decoded, 99.5)),
+                         float(np.percentile(corrected, 99.5)), 1.0)
+        self.pane_shot.set_image(_gamma_stretch_qimage(self._decoded, norm)[0],
+                                 "as shot — dark corners")
+        heat, hi = _gain_heatmap_qimage(profile.gain)
+        self.pane_gain.set_image(heat, f"1.0x (dark) … {hi:.2f}x (bright)")
+        self.pane_fixed.set_image(_gamma_stretch_qimage(corrected, norm)[0],
+                                  "should look even")
+
+        st = profile.stats
+        cs = st["corner_stops"]
+        self.stats_label.setText(
+            f"Corner falloff: <b>R {cs[0]:+.2f} · G {cs[1]:+.2f} · "
+            f"B {cs[2]:+.2f} EV</b> &nbsp;·&nbsp; colour spread "
+            f"<b>{st['cast_stops']:.2f} EV</b> &nbsp;·&nbsp; max gain "
+            f"<b>{st['max_gain']:.2f}x</b> &nbsp;·&nbsp; brightness "
+            f"{st['level'] * 100:.0f}% of full"
+            + ("<br><span style='color:#cc7a00'>The correction hit the "
+               f"{ff.DEFAULT_MAX_GAIN:.0f}x limit "
+               f"(needed {st['max_gain_uncapped']:.1f}x) — the darkest areas "
+               "stay a little dark on purpose, because lifting them further "
+               "would mostly amplify noise.</span>" if st["clamped"] else ""))
+        warnings = profile.meta.get("warnings") or []
+        self.warn_label.setText("⚠ " + "<br>⚠ ".join(warnings) if warnings else "")
+        self.warn_label.setVisible(bool(warnings))
+        if not self.name_edit.text().strip():
+            self.name_edit.setText(profile.name)
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Page 3 — save
+    # ------------------------------------------------------------------ #
+    def _build_save_page(self):
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.addWidget(QLabel("<b>Step 3 — Save</b>"))
+        self.save_label = QLabel(
+            "The profile is saved in FreeCCR's field-correction library, where "
+            "it survives updates. Pick it any time in Settings ▸ Color "
+            "Management.")
+        self.save_label.setWordWrap(True)
+        lay.addWidget(self.save_label)
+        self.path_label = QLabel("")
+        self.path_label.setWordWrap(True)
+        self.path_label.setStyleSheet("color: #9a9a9a;")
+        lay.addWidget(self.path_label)
+        self.apply_check = QCheckBox("Use this profile now")
+        self.apply_check.setChecked(True)
+        lay.addWidget(self.apply_check)
+        hint = QLabel(
+            "Images already loaded keep the decode they were graded with. They "
+            "are flagged ⚠ in the thumbnail list — right-click ▸ <i>Replace with "
+            "current camera profile</i> to re-grade the ones you want.")
+        hint.setWordWrap(True)
+        hint.setStyleSheet("color: #9a9a9a;")
+        lay.addWidget(hint)
+        lay.addStretch(1)
+        return w
+
+    def _target_path(self) -> str:
+        name = self.name_edit.text().strip() or "Field correction"
+        safe = "".join(c if c.isalnum() or c in " -_" else "_" for c in name)
+        return os.path.join(ccr_backend.field_profiles_dir(), safe + ff.EXTENSION)
+
+    def _do_save(self) -> bool:
+        path = self._target_path()
+        if os.path.exists(path) and QMessageBox.question(
+                self, "Replace profile?",
+                f"“{os.path.basename(path)}” already exists in your library.\n"
+                "Replace it?") != QMessageBox.Yes:
+            return False
+        self._profile.name = self.name_edit.text().strip() or self._profile.name
+        try:
+            ff.save_profile(self._profile, path)
+        except Exception as e:
+            QMessageBox.critical(self, "Save Error",
+                                 f"Could not write the profile:\n\n{e}")
+            return False
+        self.saved_path = path
+        self.apply_now = self.apply_check.isChecked()
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Navigation
+    # ------------------------------------------------------------------ #
+    def _go_back(self):
+        i = self.stack.currentIndex()
+        if i > 0:
+            self.stack.setCurrentIndex(i - 1)
+            self._update_nav()
+
+    def _go_next(self):
+        i = self.stack.currentIndex()
+        if i == self.PAGE_SOURCE:
+            if not self._source_path:
+                QMessageBox.information(self, "Calibration shot",
+                                        "Select a calibration shot.")
+                return
+            if not self._decode_source() or not self._build_and_show():
+                return
+        elif i == self.PAGE_REVIEW:
+            if self._profile is None:
+                return
+            self.path_label.setText(f"Saving to: {self._target_path()}")
+        elif i == self.PAGE_SAVE:
+            if self._do_save():
+                self.accept()
+            return
+        self.stack.setCurrentIndex(i + 1)
+        self._update_nav()
+
+    def _update_nav(self):
+        i = self.stack.currentIndex()
+        self.back_btn.setEnabled(i > 0)
+        self.next_btn.setText("Finish" if i == self.PAGE_SAVE else "Next")

--- a/src/widgets/settings_dialog.py
+++ b/src/widgets/settings_dialog.py
@@ -223,6 +223,38 @@ class SettingsDialog(QDialog):
             "it is added to the library above."))
         lay.addWidget(grp)
 
+        # --- Field correction (flat-field) ----------------------------- #
+        grp_ff = QGroupBox("Field correction")
+        gf = QVBoxLayout(grp_ff)
+        gf.setSpacing(theme.GAP_ROW)
+        gf.addWidget(self._muted(
+            "Corrects the dark corners and colour shading your lens, sensor and "
+            "light source put into every frame, measured from one shot of an "
+            "evenly lit blank surface. Applied to every decode before the "
+            "negative conversion."))
+        self._field_entries = []            # library rows, filled on refresh
+        ff_row = QHBoxLayout()
+        ff_row.setSpacing(theme.GAP_BTN)
+        ff_row.addWidget(QLabel("Active:"))
+        self._combo_field = QComboBox()
+        self._combo_field.currentIndexChanged.connect(self._field_selected)
+        ff_row.addWidget(self._combo_field, 1)
+        gf.addLayout(ff_row)
+        self._field_detail = self._muted("")
+        gf.addWidget(self._field_detail)
+        ff_btns = QHBoxLayout()
+        theme.apply_button_row(ff_btns)
+        btn_create = QPushButton("Create Field Correction Profile…")
+        btn_create.clicked.connect(self._create_field)
+        self._btn_field_delete = QPushButton("Delete")
+        theme.style_button(self._btn_field_delete, "danger")
+        self._btn_field_delete.clicked.connect(self._delete_field)
+        ff_btns.addWidget(btn_create)
+        ff_btns.addWidget(self._btn_field_delete)
+        ff_btns.addStretch(1)
+        gf.addLayout(ff_btns)
+        lay.addWidget(grp_ff)
+
         # --- Negative conversion --------------------------------------- #
         grp2 = QGroupBox("Negative conversion")
         g2 = QVBoxLayout(grp2)
@@ -311,6 +343,51 @@ class SettingsDialog(QDialog):
         self._mw.create_camera_profile_from_it8()
         self.refresh_color_management()
 
+    # --- Field correction: immediate, like the camera-profile selection ---- #
+    def _create_field(self):
+        self._mw.create_field_correction_profile()
+        self.refresh_color_management()
+
+    def _delete_field(self):
+        path = self._combo_field.currentData()
+        if not path:
+            return
+        self._mw.delete_field_profile(path)
+        self.refresh_color_management()
+
+    def _field_selected(self, _idx):
+        """User picked from the combo — apply immediately. Guarded by a flag so
+        repopulating the combo in refresh_color_management can't re-trigger it."""
+        if getattr(self, "_loading_field_combo", False):
+            return
+        self._mw.set_active_field_profile(self._combo_field.currentData())
+        self._update_field_detail()
+
+    def _update_field_detail(self):
+        path = self._combo_field.currentData()
+        entry = next((p for p in self._field_entries if p["path"] == path), None)
+        self._field_detail.setText(entry["summary"] if entry else "")
+        self._btn_field_delete.setEnabled(bool(path))
+
+    def refresh_field_correction(self):
+        """Repopulate the field-profile combo from the library and reflect the
+        active selection (without firing the selection handler)."""
+        from core import flat_field
+        active = flat_field.get_active_profile()
+        active_path = active.path if active is not None else None
+        self._field_entries = ccr_backend.list_field_profiles()
+        self._loading_field_combo = True
+        try:
+            self._combo_field.clear()
+            self._combo_field.addItem("None", None)
+            for p in self._field_entries:
+                self._combo_field.addItem(p["name"], p["path"])
+            idx = self._combo_field.findData(active_path) if active_path else 0
+            self._combo_field.setCurrentIndex(idx if idx >= 0 else 0)
+        finally:
+            self._loading_field_combo = False
+        self._update_field_detail()
+
     # --- Staged toggles: apply on Done (accept), discard on close ---------- #
     def _init_toggles(self):
         """Seed the toggle checkboxes from the live backend once, at open. They
@@ -378,6 +455,7 @@ class SettingsDialog(QDialog):
 
     def refresh_color_management(self):
         """Reflect the live active profile, the library list, and Positive mode."""
+        self.refresh_field_correction()
         icc = getattr(ccr_backend, "input_icc_name", None)
         dcp = getattr(ccr_backend, "input_dcp_name", None)
         if getattr(ccr_backend, "active_profile_path", None) == ccr_backend.CAMERA_MATRIX:

--- a/src/widgets/thumbnail_list.py
+++ b/src/widgets/thumbnail_list.py
@@ -340,8 +340,9 @@ class ThumbnailList(QWidget):
             item.setText(("⚠ " + filename) if mism else filename)
             item.setForeground(warn if mism else normal)
             item.setToolTip(
-                "Graded under a different camera profile.\nRight-click ▸ "
-                "Replace with current camera profile." if mism else "")
+                "Graded under a different camera profile or field "
+                "correction.\nRight-click ▸ Replace with current camera "
+                "profile." if mism else "")
 
     def replace_with_current_profile(self, indices):
         """Re-grade the given image(s) under the current camera profile by

--- a/tests/test_flat_field.py
+++ b/tests/test_flat_field.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""
+Tests for the field-correction (flat-field) core (src/core/flat_field.py).
+See spec/flat-field-correction.md §8. Pure numpy/cv2 — except the final
+end-to-end test, which builds a real CCRImage and so needs an (offscreen) Qt
+application for the preview QPixmap.
+"""
+import json
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core import flat_field as ff  # noqa: E402
+
+FULL = 65535.0
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic fields
+# --------------------------------------------------------------------------- #
+
+def make_field(h, w, *, strength=(0.55, 0.50, 0.45), center=(0.5, 0.5),
+               spread=0.75):
+    """A smooth per-channel falloff peaking at 1.0 at `center` — stands in for
+    lens vignetting + colour shading + an (optionally off-centre) hot spot."""
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    x = (xx + 0.5) / w - center[0]
+    y = (yy + 0.5) / h - center[1]
+    r2 = (x * x + y * y) / (spread ** 2)
+    return np.stack([np.exp(-float(s) * r2) for s in strength], axis=2)
+
+
+def calib_frame(h=768, w=1152, level=0.6, **kw):
+    """A calibration shot of an evenly lit surface seen through `make_field`."""
+    fld = make_field(h, w, **kw)
+    return np.clip(fld * level * FULL, 0, FULL).astype(np.uint16), fld
+
+
+def build(arr, **kw):
+    return ff.build_profile(arr, "test", **kw)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Building the map
+# --------------------------------------------------------------------------- #
+
+def test_recovers_the_synthetic_field():
+    """The measured map is the inverse of the field it was shot through: gain x
+    field is constant across the frame (its value is the central reference level,
+    which is what makes gain == 1 at the centre)."""
+    arr, fld = calib_frame()
+    p = build(arr)
+    gain = ff.gain_for_size(p, fld.shape[1], fld.shape[0])
+    prod = gain * fld
+    for c in range(3):
+        ch = prod[..., c]
+        # Achieved: cv ~0.0005, worst ~0.7% on the outermost row (0.01 EV).
+        assert ch.std() / ch.mean() < 0.002
+        assert np.abs(ch / ch.mean() - 1.0).max() < 0.015
+
+
+def test_correction_flattens_a_vignetted_scene():
+    """Apply to a scene shot through the same field: what comes back is the
+    scene again, uniformly scaled — that scale is the only residual."""
+    h, w = 768, 1152
+    arr, fld = calib_frame(h, w)
+    p = build(arr)
+
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    scene = 0.35 + 0.15 * np.sin(xx / 90.0) * np.cos(yy / 70.0)
+    scene = np.repeat(scene[:, :, None], 3, axis=2)
+    shot = np.clip(scene * fld * FULL, 0, FULL).astype(np.uint16)
+
+    out = ff.apply_field(shot, p).astype(np.float32) / FULL
+    ratio = out / scene
+    # Uniform across the frame (that is the whole point) to well under 1%.
+    assert ratio.std() / ratio.mean() < 0.01
+    # ...and much flatter than the uncorrected shot.
+    raw_ratio = (shot.astype(np.float32) / FULL) / scene
+    assert ratio.std() / ratio.mean() < 0.1 * (raw_ratio.std() / raw_ratio.mean())
+
+
+def test_neutral_on_an_already_flat_frame():
+    """A perfectly even calibration shot yields a unity map: activating such a
+    profile must change neither exposure nor white balance."""
+    flat = np.full((400, 600, 3), int(0.5 * FULL), dtype=np.uint16)
+    flat[..., 0] = int(0.55 * FULL)          # a global cast must be preserved
+    p = build(flat)
+    assert np.allclose(p.gain, 1.0, atol=1e-3)
+    out = ff.apply_field(flat, p)
+    assert np.abs(out.astype(int) - flat.astype(int)).max() <= 1
+
+
+def test_gain_is_unity_at_the_normalisation_reference():
+    """Gain == 1 over the central window in every channel, so the profile is
+    photometrically and chromatically neutral at the centre."""
+    arr, _ = calib_frame()
+    p = build(arr)
+    h, w = p.gain.shape[:2]
+    ch, cw = int(h * 0.316), int(w * 0.316)
+    central = p.gain[(h - ch) // 2:(h + ch) // 2, (w - cw) // 2:(w + cw) // 2]
+    assert abs(float(central.mean()) - 1.0) < 0.02
+    # Channel ratios at the centre are untouched (no white-balance shift).
+    assert float(np.ptp(central.reshape(-1, 3).mean(axis=0))) < 0.02
+
+
+def test_colour_shading_is_corrected_per_channel():
+    """Different per-channel falloff -> neutral corners, and cast_stops reports
+    the spread."""
+    arr, fld = calib_frame(strength=(0.9, 0.6, 0.3))
+    p = build(arr)
+    out = ff.apply_field(
+        np.clip(fld * 0.6 * FULL, 0, FULL).astype(np.uint16), p
+    ).astype(np.float32)
+    corner = out[:40, :40].reshape(-1, 3).mean(axis=0)
+    assert np.ptp(corner) / corner.mean() < 0.02        # corner is neutral again
+    assert p.stats["cast_stops"] > 0.3                  # ...and it wasn't before
+
+
+def test_off_centre_hot_spot_is_darkened():
+    """A region brighter than the centre correctly gets gain < 1."""
+    arr, _ = calib_frame(center=(0.25, 0.3), spread=0.6)
+    p = build(arr)
+    assert float(p.gain.min()) < 0.99
+    assert float(p.gain.max()) > 1.5
+
+
+def test_dust_and_hot_pixels_do_not_print_into_the_map():
+    """Specks, hot pixels and smudges up to ~2.5% of the frame across are
+    rejected. (Measured limit of the 13%-of-frame median window: a 2.6%-wide
+    smudge leaves <2.5% gain error, a 5%-wide one ~7%. Beyond that a dark patch
+    is no longer distinguishable from genuine light-source unevenness.)"""
+    arr, _ = calib_frame()
+    clean = build(arr).gain
+    dirty = arr.copy()
+    rng = np.random.default_rng(7)
+    for _ in range(40):                                  # dust specks
+        y, x = rng.integers(20, 700), rng.integers(20, 1100)
+        dirty[y:y + 3, x:x + 3] = (dirty[y:y + 3, x:x + 3] * 0.45).astype(np.uint16)
+    # Fibres / smudges, spaced out on purpose: two overlapping ones would form a
+    # single blemish wider than the window is meant to handle.
+    for y in (90, 420, 660):
+        for x in (120, 520, 900):
+            dirty[y:y + 30, x:x + 30] = (dirty[y:y + 30, x:x + 30] * 0.6).astype(np.uint16)
+    for _ in range(40):                                  # hot pixels
+        y, x = rng.integers(0, 768), rng.integers(0, 1152)
+        dirty[y, x] = 65535
+    got = build(dirty).gain
+    assert np.abs(got - clean).max() < 0.025
+    # ...and without rejection those blemishes would be far worse than that.
+    raw = ff._resize_long_side(dirty.astype(np.float32) / FULL, ff.GRID_LONG_SIDE)
+    naive = ff._central_level(raw)[None, None, :] / np.maximum(raw, 1e-4)
+    assert np.abs(naive - clean).max() > 0.2
+
+
+def test_a_sharp_mechanical_vignette_survives_blemish_rejection():
+    """A fast corner cut is real shading, not a blemish: the median-based
+    rejector must pass it through (an earlier depth-thresholded estimator
+    smeared it, rewriting half the grid)."""
+    h, w = 768, 1152
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    r = np.sqrt(((xx + .5) / w - .5) ** 2 + ((yy + .5) / h - .5) ** 2) / 0.5
+    fld = 1.0 - 0.5 * np.clip((r - 0.72) / 0.28, 0, 1) ** 2   # 1 EV corner cut
+    fld = np.repeat(fld[:, :, None], 3, axis=2).astype(np.float32)
+    arr = np.clip(fld * 0.6 * FULL, 0, FULL).astype(np.uint16)
+
+    p = build(arr)
+    prod = ff.gain_for_size(p, w, h) * fld
+    assert np.abs(prod[..., 0] / prod[..., 0].mean() - 1.0).max() < 0.08
+    assert p.stats["corner_stops"][0] == pytest.approx(1.0, abs=0.1)
+
+
+def test_gain_is_clamped_on_a_black_corner():
+    """A vignette that reaches ~0 must clamp, not divide by zero."""
+    arr, _ = calib_frame(strength=(9.0, 9.0, 9.0), spread=0.45)
+    p = build(arr)
+    assert np.isfinite(p.gain).all()
+    assert float(p.gain.max()) == pytest.approx(ff.DEFAULT_MAX_GAIN, abs=1e-5)
+    assert p.stats["clamped"] is True
+    assert p.stats["max_gain_uncapped"] > ff.DEFAULT_MAX_GAIN
+
+
+def test_max_gain_is_configurable():
+    arr, _ = calib_frame(strength=(9.0, 9.0, 9.0), spread=0.45)
+    p = build(arr, max_gain=2.0)
+    assert float(p.gain.max()) == pytest.approx(2.0, abs=1e-5)
+
+
+def test_corner_stops_report_the_falloff():
+    arr, fld = calib_frame(strength=(0.55, 0.55, 0.55))
+    p = build(arr)
+    true_ev = -np.log2(fld[:40, :40].mean())
+    assert p.stats["corner_stops"][0] == pytest.approx(true_ev, abs=0.1)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Validation of the calibration shot
+# --------------------------------------------------------------------------- #
+
+def test_a_good_frame_raises_no_warnings():
+    arr, _ = calib_frame()
+    rng = np.random.default_rng(1)
+    noisy = np.clip(arr.astype(np.float32)
+                    + rng.normal(0, 0.002 * FULL, arr.shape), 0, FULL).astype(np.uint16)
+    a = ff.analyze_field(noisy)
+    assert a.warnings == []
+    assert a.usable
+
+
+def test_clipped_frame_warns():
+    arr, _ = calib_frame(level=0.9)
+    arr[100:400, 100:600] = 65535
+    a = ff.analyze_field(arr)
+    assert any("clipped" in w for w in a.warnings)
+    assert a.clipped_fraction > 0.001
+
+
+def test_dark_frame_warns_and_a_black_one_refuses():
+    dark, _ = calib_frame(level=0.02)
+    a = ff.analyze_field(dark)
+    assert any("dark" in w for w in a.warnings)
+    assert a.usable                                    # advisory, still buildable
+
+    black = np.zeros((400, 600, 3), dtype=np.uint16)
+    assert not ff.analyze_field(black).usable
+    with pytest.raises(ff.FieldProfileError):
+        build(black)
+
+
+def test_a_photograph_of_a_scene_is_rejected_as_not_flat():
+    h, w = 768, 1152
+    scene = np.zeros((h, w, 3), dtype=np.uint16)
+    for i in range(0, h, 96):                          # coarse structure
+        for j in range(0, w, 96):
+            scene[i:i + 96, j:j + 96] = int(FULL * (0.15 if (i + j) % 192 else 0.75))
+    a = ff.analyze_field(scene)
+    assert any("evenly lit" in w for w in a.warnings)
+    assert a.flatness_residual > 0.05
+
+
+# --------------------------------------------------------------------------- #
+# 3. Storage
+# --------------------------------------------------------------------------- #
+
+def test_save_load_round_trip(tmp_path):
+    arr, _ = calib_frame()
+    p = build(arr, meta={"source": "cal.CR3",
+                         "camera": {"model": "Z 8", "aperture": 8.0}})
+    p.name = "Copy stand 105mm f/8"
+    path = str(tmp_path / "profile.ffc")
+    ff.save_profile(p, path)
+
+    q = ff.load_profile(path)
+    assert q.name == p.name
+    assert np.array_equal(q.gain, p.gain)              # base64 float32 is exact
+    assert q.aspect == pytest.approx(p.aspect)
+    assert q.meta["camera"]["model"] == "Z 8"
+    assert q.meta["stats"]["max_gain"] == p.stats["max_gain"]
+    assert q.content_id and len(q.content_id) == 12
+    assert q.path == path
+
+
+def test_saved_file_is_readable_json_with_metadata(tmp_path):
+    arr, _ = calib_frame()
+    path = str(tmp_path / "p.ffc")
+    ff.save_profile(build(arr), path)
+    doc = json.loads(open(path, "rb").read().decode("utf-8"))
+    assert doc["format"] == ff.FORMAT and doc["version"] == ff.FORMAT_VERSION
+    assert doc["grid"]["channels"] == 3 and doc["grid"]["dtype"] == "float32"
+    assert max(doc["grid"]["w"], doc["grid"]["h"]) == ff.GRID_LONG_SIDE
+
+
+@pytest.mark.parametrize("mangle", [
+    lambda d: {"format": "something-else", "version": 1},
+    lambda d: dict(d, version=ff.FORMAT_VERSION + 1),
+    lambda d: {k: v for k, v in d.items() if k != "grid"},
+    lambda d: dict(d, grid=dict(d["grid"], data="!!!not base64!!!")),
+    lambda d: dict(d, grid=dict(d["grid"], w=d["grid"]["w"] + 3)),
+])
+def test_bad_files_raise_field_profile_error(tmp_path, mangle):
+    arr, _ = calib_frame()
+    good = str(tmp_path / "good.ffc")
+    ff.save_profile(build(arr), good)
+    doc = json.loads(open(good, "rb").read().decode("utf-8"))
+    bad = str(tmp_path / "bad.ffc")
+    with open(bad, "wb") as f:
+        f.write(json.dumps(mangle(doc)).encode("utf-8"))
+    with pytest.raises(ff.FieldProfileError):
+        ff.load_profile(bad)
+
+
+def test_not_json_and_missing_file_raise(tmp_path):
+    junk = str(tmp_path / "junk.ffc")
+    with open(junk, "wb") as f:
+        f.write(b"\x00\x01 not json at all")
+    with pytest.raises(ff.FieldProfileError):
+        ff.load_profile(junk)
+    with pytest.raises(ff.FieldProfileError):
+        ff.load_profile(str(tmp_path / "nope.ffc"))
+
+
+# --------------------------------------------------------------------------- #
+# 4. Applying
+# --------------------------------------------------------------------------- #
+
+def test_apply_is_resolution_independent():
+    """A preview and a full-resolution export get the same correction at the
+    same relative position."""
+    import cv2
+    arr, _ = calib_frame()
+    p = build(arr)
+    small = ff.gain_for_size(p, 270, 180)
+    big = ff.gain_for_size(p, 2700, 1800)
+    big_down = cv2.resize(big, (270, 180), interpolation=cv2.INTER_AREA)
+    assert np.abs(small - big_down).max() < 0.01
+
+
+def test_banded_apply_matches_a_single_shot_multiply():
+    arr, _ = calib_frame(h=1600, w=1200)               # > _BAND_ROWS tall
+    p = build(arr)
+    img = (np.random.default_rng(3).random((1600, 1200, 3)) * 0.5 * FULL).astype(np.uint16)
+    got = ff.apply_field(img, p)
+    gain = ff.gain_for_size(p, 1200, 1600)
+    want = np.clip(img.astype(np.float32) * gain, 0, FULL).astype(np.uint16)
+    assert np.array_equal(got, want)
+
+
+def test_apply_preserves_dtype_and_shape_and_clips():
+    arr, _ = calib_frame()
+    p = build(arr)
+    img = np.full((300, 400, 3), 65000, dtype=np.uint16)
+    out = ff.apply_field(img, p)
+    assert out.dtype == np.uint16 and out.shape == img.shape
+    assert out.max() <= 65535                          # gain > 1 must not wrap
+
+
+def test_no_profile_is_a_passthrough():
+    img = np.full((32, 32, 3), 1234, dtype=np.uint16)
+    assert ff.apply_field(img, None) is img
+
+
+def test_mono_keeps_the_frame_neutral():
+    arr, _ = calib_frame(strength=(0.9, 0.6, 0.3))     # strong colour shading
+    p = build(arr)
+    gray = np.full((400, 600, 3), int(0.4 * FULL), dtype=np.uint16)
+    out = ff.apply_field(gray, p, mono=True)
+    assert np.array_equal(out[..., 0], out[..., 1])
+    assert np.array_equal(out[..., 1], out[..., 2])
+    colour = ff.apply_field(gray, p)                   # ...unlike the RGB path
+    assert not np.array_equal(colour[..., 0], colour[..., 2])
+
+
+def test_encoded_apply_corrects_in_linear_light():
+    """A gamma-encoded (Positive-mode) frame is linearised before the multiply,
+    so the correction is the same *light* ratio a linear frame would get."""
+    arr, _ = calib_frame()
+    p = build(arr)
+    lin = np.full((400, 600, 3), 0.25, dtype=np.float32)
+    enc = (ff._linear_to_srgb(lin) * FULL).astype(np.uint16)
+    out = ff.apply_field(enc, p, encoded=True).astype(np.float32) / FULL
+    got = ff._srgb_to_linear(out)
+    want = lin * ff.gain_for_size(p, 600, 400)
+    assert np.abs(got - want).max() < 2e-3
+    # Applying it as if the data were linear OVER-corrects (multiplying an
+    # encoded value by g scales the light it stands for by ~g^2.4) — that is
+    # exactly what encoded=True exists to avoid.
+    naive = ff.apply_field(enc, p).astype(np.float32) / FULL
+    assert ff.gain_for_size(p, 600, 400)[0, 0, 1] > 1.2        # a real correction
+    assert ff._srgb_to_linear(naive)[0, 0, 1] > want[0, 0, 1] * 1.1
+
+
+def test_gain_cache_is_bounded_and_correct():
+    arr, _ = calib_frame()
+    p = build(arr)
+    first = ff.gain_for_size(p, 100, 80)
+    assert ff.gain_for_size(p, 100, 80) is first        # memoised
+    for i in range(6):
+        ff.gain_for_size(p, 100 + i, 80 + i)
+    assert len(p._cache) <= 4
+
+
+# --------------------------------------------------------------------------- #
+# 5. Active-profile state and the grading signature
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture(autouse=True)
+def _clear_active_profile():
+    yield
+    ff.set_active_profile(None)
+
+
+def test_active_profile_state_and_signature(tmp_path):
+    assert ff.active_field_signature() == "none"
+    assert not ff.field_profile_active()
+
+    arr, _ = calib_frame()
+    other, _ = calib_frame(strength=(0.9, 0.8, 0.7))
+    a, b = str(tmp_path / "a.ffc"), str(tmp_path / "b.ffc")
+    ff.save_profile(build(arr), a)
+    ff.save_profile(build(other), b)
+
+    pa = ff.load_profile(a)
+    ff.set_active_profile(pa)
+    assert ff.field_profile_active()
+    sig_a = ff.active_field_signature()
+    assert sig_a.startswith("ff:")
+    assert ff.active_field_signature() == sig_a         # stable while unchanged
+
+    ff.set_active_profile(ff.load_profile(b))
+    assert ff.active_field_signature() != sig_a         # a different profile...
+    ff.set_active_profile(None)
+    assert ff.active_field_signature() == "none"        # ...and cleared
+
+
+def test_backend_signature_composes_the_field_profile(tmp_path):
+    from core.ccr_backend import ccr_backend
+    base = ccr_backend.active_profile_signature()
+    arr, _ = calib_frame()
+    path = str(tmp_path / "p.ffc")
+    ff.save_profile(build(arr), path)
+    ff.set_active_profile(ff.load_profile(path))
+    composed = ccr_backend.active_profile_signature()
+    assert composed != base
+    assert composed.startswith(base + "+ff:")
+    ff.set_active_profile(None)
+    assert ccr_backend.active_profile_signature() == base
+
+
+# --------------------------------------------------------------------------- #
+# 6. The decode hook (spec §6.1)
+# --------------------------------------------------------------------------- #
+
+def test_decode_hook_corrects_and_bare_decodes_do_not(tmp_path, monkeypatch):
+    """read_image applies the active profile; a bare-device profiling decode
+    (apply_input_icc=False) must NOT, or profiles would compound."""
+    import cv2
+    from core.ccr_image import CCRImage
+
+    arr, fld = calib_frame(h=200, w=300)
+    p = build(arr)
+    ff.set_active_profile(p)
+
+    src = np.full((200, 300, 3), 20000, dtype=np.uint16)
+    path = str(tmp_path / "scan.tif")
+    assert cv2.imwrite(path, src)
+
+    img = CCRImage.__new__(CCRImage)
+    img.source_ops = []
+    corrected = img.read_image(path)
+    bare = img.read_image(path, apply_input_icc=False)
+
+    assert not np.array_equal(corrected, bare)
+    assert np.array_equal(bare, src)
+    gain = ff.gain_for_size(p, 300, 200)
+    want = np.clip(src.astype(np.float32) * gain, 0, FULL).astype(np.uint16)
+    assert np.array_equal(corrected, want)
+
+    ff.set_active_profile(None)
+    assert np.array_equal(img.read_image(path), src)     # no profile -> untouched
+
+
+def test_a_loaded_image_is_corrected_and_stamped(tmp_path):
+    """End to end through the real CCRImage constructor: a vignetted scan comes
+    out flat, and the image records that it was graded with this profile (which
+    is what raises the thumbnail ⚠ when the profile later changes)."""
+    import cv2
+    # CCRImage.__init__ builds a preview QPixmap, which aborts the process
+    # without a QApplication. Created here (not at module scope) so the rest of
+    # this file stays Qt-free.
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    QApplication.instance() or QApplication(sys.argv[:1])
+
+    from core.ccr_image import CCRImage
+    from core.ccr_backend import ccr_backend
+
+    h, w = 400, 600
+    cal, fld = calib_frame(h, w)
+    p = build(cal)
+
+    scan = np.clip(0.4 * fld * FULL, 0, FULL).astype(np.uint16)   # vignetted scan
+    path = str(tmp_path / "scan.tif")
+    assert cv2.imwrite(path, scan[..., ::-1])                     # cv2 wants BGR
+
+    ff.set_active_profile(p)
+    img = CCRImage(path)
+    out = img.resized_raw.astype(np.float32)
+    corner = out[:20, :20].mean()
+    centre = out[h // 2 - 20:h // 2 + 20, w // 2 - 20:w // 2 + 20].mean()
+    assert abs(corner / centre - 1.0) < 0.03          # the vignette is gone...
+    raw_corner = scan[:20, :20].mean() / scan[h // 2 - 20:h // 2 + 20,
+                                              w // 2 - 20:w // 2 + 20].mean()
+    assert raw_corner < 0.75                          # ...and it was real
+    assert "+ff:" in (img.profile_signature or "")
+    assert img.profile_signature == ccr_backend.active_profile_signature()


### PR DESCRIPTION
## What

Adds **Field Correction** — a flat-field profile that removes the dark corners and colour shading your rig puts into every frame: lens vignetting (natural + mechanical), sensor colour shading, and light-source unevenness.

You shoot **one calibration frame** of an evenly lit blank surface (ideally the bare light table, through the same lens at the same aperture and distance). A wizard in **Settings ▸ Color Management** — next to the IT8 wizard — decodes it, measures the falloff, and saves a `.ffc` profile into a per-user library. The active profile multiplies every decode by its per-channel gain map, so frames are flat before the negative conversion ever sees them.

Spec: `spec/flat-field-correction.md`.

## UX

**Step 1** — capture guidance + pick the shot. **Step 2** — review: calibration shot / gain map / corrected result, with per-channel corner falloff in EV, colour spread, max gain, and warnings for a bad shot. **Step 3** — name it and use it now.

A bad calibration frame is caught and explained rather than silently baked in:

- clipped → *"21% of pixels are clipped to white — the falloff cannot be measured there"*
- too dark, over-exposed
- not actually flat → *"This doesn't look like an evenly lit blank surface — it has too much detail"*

## How it works

- **Measured in the space it is applied in.** The calibration decode is the existing bare-device path (`apply_input_icc=False`), which now also suppresses field correction — so a profiling decode always sees untouched device data and profiles can never compound.
- **Centre-normalised gain**, so gain is exactly 1.0 at the centre in all three channels: activating a profile changes neither exposure nor white balance, only spatial variation. An off-centre hot spot is correctly darkened rather than lifting the whole frame to meet it.
- **Clamped to +2 EV** — past that a corner is mostly read noise, and a lens-cap calibration shot can't produce a map that destroys images. The wizard says when the clamp binds.
- **Applied inside `read_image`** at the full-frame point of all three decode branches (RAW, non-RAW, trichrome merge), before the slice chain — so preview, zoom, slices, merges and export all inherit it with no per-call-site plumbing. Monochrome sources get the channel-averaged gain so they stay neutral; the Positive-mode sRGB decode is linearised before the multiply.
- **Grading signature**: changing the field profile does not silently re-decode. It composes into `active_profile_signature()`, so affected thumbnails get the existing ⚠ + *Replace with current camera profile* re-grade.
- **No double correction**: the trichrome linear-TIFF bake writes `merge_raw_channels` output directly, not through `read_image`, so a baked file stays uncorrected on disk and is corrected on reload.

## Two things the measurements changed

Both were found by measuring rather than assuming, and are written up in spec §10.8:

1. **Border handling.** Every OpenCV border mode holds the field flat or folds it back outside the frame, which understates a falloff that is still dropping at the edge — it under-corrected the corners by **1.2%**, i.e. exactly the region the feature exists to fix. Padding by odd (antisymmetric) reflection continues the slope instead and cut that to **0.05%**.

2. **Blemish rejection.** Rejecting dust by *depth* ("dust is a locally deep excursion, shading is smooth") reads as the principled choice — but a mechanical vignette's corner cut is also deep and also local, so that estimator ate it, rewriting **54% of the grid** on such a frame. A large median rejects by *size* instead and is exact on monotone data, so the knee passes through untouched. Measured limit: blemishes up to ~2.5% of the frame width leave <2.5% gain error.

## Tests

34 new tests in `tests/test_flat_field.py`: synthetic round-trip, neutrality (no exposure/WB shift), colour-shading correction, dust/hot-pixel robustness, sharp-vignette survival, clamping, validation, save/load round-trip + corrupt-file handling, resolution independence, banded-apply equivalence, gamma-encoded apply, signature composition, the decode hook, and an end-to-end load through the real `CCRImage` constructor.

All 943 existing tests in the surrounding areas (colour management, IT8, merge, slice, zoom, export, loader, dust, crop) still pass.

## Not included (deliberate)

Per-image auto-matching by lens/aperture (EXIF is recorded for a future version), distortion correction, dark-frame subtraction, and profile import (the wizard writes straight into the library — a profile describes one physical rig).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
