### PR TITLE
feat(panel): Ctrl+C asks which settings to copy, like Sync to All

### DIFF
--- a/spec/copy-settings-dialog.md
+++ b/spec/copy-settings-dialog.md
@@ -1,0 +1,184 @@
+# Selective Copy/Paste of Settings
+
+Give `Ctrl/Cmd+C` the same "pick what you mean" dialog that **Sync to All**
+already has, so a copy/paste between two images can carry just the white
+balance, just the crop, just the curves — instead of the whole slider set.
+
+## Goals
+
+- `Ctrl/Cmd+C` opens a modal dialog listing the same setting groups as
+  **Sync to All** (`SYNC_GROUPS`), each with a checkbox, plus Select All /
+  Deselect All. Accepting copies **only** the checked groups.
+- `Ctrl/Cmd+V` applies only the copied groups to the current image; every
+  setting the user did not copy is left exactly as it was on the target.
+- The copy now covers the three whole-image groups Sync to All handles but the
+  old copy/paste silently ignored: **Color Profile**, **Crop**, **Curves**.
+- The group choice is remembered while the app is open (separately from the
+  Sync to All choice), so a repeated copy is two keystrokes.
+
+## Non-goals
+
+- No OS-clipboard interchange or on-disk serialisation — the clipboard stays a
+  private in-panel dict, lost on quit, as today.
+- No multi-image paste; pasting to many images is what Sync to All is for.
+- No new setting groups and no change to `SYNC_GROUPS` membership. Both
+  features stay driven by that single list, so a future group appears in both.
+- Area layers are still never *copied as layers* — see "Areas" below.
+
+## UX / interaction
+
+**Copy** (`Ctrl+C` / `Cmd+C`, unchanged shortcut):
+
+1. No image selected → unchanged behaviour: hint "No image selected to copy
+   from", no dialog.
+2. Otherwise a modal **Copy Settings** dialog opens:
+   - Prompt: *"Copy these settings:"*
+   - One checkbox per `SYNC_GROUPS` entry, in the same order and with the same
+     labels as Sync to All.
+   - `☑ Select All` / `☐ Deselect All` row, separator, then `Cancel` /
+     `Copy` (primary, default button).
+   - Checkbox state seeds from the remembered selection; all-checked the first
+     time.
+3. Cancel → nothing is copied; a previously copied set stays on the clipboard.
+4. Accept with nothing checked → hint "Nothing selected to copy." and the
+   previous clipboard is left untouched.
+5. Accept → hint `Copied N of M setting groups.` (`Copied all settings.` when
+   every group is checked).
+
+**Paste** (`Ctrl+V` / `Cmd+V`, unchanged shortcut):
+
+- Nothing copied yet → hint "No settings to paste. Copy first with Cmd+C"
+  (unchanged wording/behaviour).
+- No image selected → "No image selected to paste to" (unchanged).
+- Otherwise the copied groups are applied and the hint reads
+  `Pasted N of M setting groups.` / `Pasted all settings.`
+
+The dialog is the existing `SyncSettingsDialog` widget generalised — same
+layout, spacing and theme, only the window title, prompt and accept-button text
+differ. Users get one visual language for "choose what to apply".
+
+## Data model
+
+`SlidersPanel` state (all reset to `None` on construction):
+
+| Attribute | Meaning |
+| --- | --- |
+| `_copy_group_selection` | Remembered `{gid: bool}` for the copy dialog. Distinct from `_sync_group_selection`. |
+| `copied_selection` | The `{gid: bool}` actually used for the current clipboard entry. `None` = nothing copied. |
+| `copied_adjustment` | Dict of the copied **adjustment keys only** (a subset of `ADJUSTMENT_KEYS`), plus `curves` when the curves group was copied and the source has non-identity curves, plus `cineon_log` when the channels group was copied and the source global layer has the flag. |
+| `copied_profile` | `"color"` / `"bw"`, or `None` when the profile group was not copied. |
+| `copied_crop` | `(crop_rect, crop_angle)`, or `None` when the crop group was not copied. |
+
+`copied_adjustment` stays a plain adjustment dict, but is now **partial** —
+that is the one behavioural contract change, and `paste_adjustment_settings` is
+its only consumer.
+
+## Copy: what is read from where
+
+Mirrors the Sync to All source rules, except for the layer question:
+
+- **Adjustment-key groups + curves** are read from the *live UI* — the sliders
+  and the curve editor — i.e. the **active layer** (global, or the selected
+  area). This preserves today's copy behaviour and keeps area→area copying
+  useful.
+- **Color Profile** and **Crop** are whole-image properties with no per-area
+  meaning, so they are read from the `CCRImage` itself regardless of which
+  layer is active.
+- `cineon_log` rides the channels group exactly as in
+  `_perform_sync_to_all`, and `_attach_cineon` already restricts it to the
+  global layer.
+
+## Paste: merge semantics
+
+One undo step (`end_undo_burst()` then a single `push_undo_state()`), then:
+
+1. **Adjustment keys.** Build a *complete* dict from the target's active-layer
+   settings (missing keys filled via `_default_for`), then overwrite only the
+   copied keys. This preserves the app-wide invariant that a non-empty
+   adjustment dict carries every key — the same construction
+   `_perform_sync_to_all` uses.
+2. **Curves.** Copied → set `curves` from the clipboard, or drop the key when
+   the source had identity curves. Not copied → carry the target's own
+   `curves` across the slider-only rebuild.
+3. **`cineon_log`.** Copied (channels group) → follow the clipboard. Not
+   copied → preserve the target's existing flag. Always dropped when an area
+   layer is the paste target (the display transform is whole-image only) —
+   existing behaviour.
+4. **Color Profile.** Copied → assign `img.color_profile` and re-sync the combo
+   box (the combo is not driven by the adjustment dict).
+5. **Crop.** Copied → assign `img.crop_rect` and `img.crop_angle`. A crop
+   change also moves the region the histogram samples, so it must be followed
+   by a reprocess — which step 6 always does.
+6. Write through `set_active_settings_by_index(..., reprocess=True)`, refresh
+   the sidebar thumbnail and the preview.
+
+The sliders and curve editor are updated from the merged result, not from the
+clipboard, so keys that were not copied keep showing the target's values.
+
+### Resolved edge cases
+
+- **Nothing actually changes** (paste onto the image it was copied from). The
+  paste still runs and still pushes one undo state. Unlike Sync to All — which
+  skips unchanged images to avoid N dead undo entries across a batch — a single
+  explicit paste is cheap, and a no-op undo entry is less surprising than a
+  keystroke that appears to do nothing.
+- **Areas.** The clipboard has no notion of *which* layer it came from: copied
+  slider values paste into whatever layer is active at paste time. Area
+  geometry and the area list are never copied.
+- **`crop_rect` is `None`.** A copied "no crop" is a real value — pasting it
+  clears the target's crop rather than being treated as "nothing to copy".
+- **Crop mode open.** `ImagePreview.update_preview` reads `crop_rect` live, so
+  the refresh at the end of paste picks up a pasted crop with no extra work,
+  the same as Sync to All.
+- **Unconverted target.** Not gated, matching today's paste: the settings land
+  in the dict and take effect once the image is converted.
+- **Group removed from a future `SYNC_GROUPS`.** `copied_selection` is read
+  with `.get(gid, False)`, so a stale remembered selection can never resurrect
+  an unknown group.
+
+## Integration points
+
+| Location | Change |
+| --- | --- |
+| `SYNC_GROUPS` (`src/widgets/sliders_panel.py`) | Unchanged — now shared by both dialogs. |
+| `SyncSettingsDialog` | Generalised: `title` / `prompt` / `action_label` constructor args, defaulting to today's Sync to All strings. No call-site change. |
+| `SlidersPanel.__init__` | New `_copy_group_selection`, `copied_selection`, `copied_profile`, `copied_crop`. |
+| `copy_adjustment_settings` | Show the dialog; store the partial clipboard described above. |
+| `paste_adjustment_settings` | Group-aware merge instead of whole-dict replace. |
+| `user_guide/get_started.md` | Mention that `Ctrl/Cmd+C` now asks what to copy. |
+
+Nothing outside `sliders_panel.py` reads `copied_adjustment`, so the partial
+dict cannot leak into the render/export paths.
+
+## Test plan
+
+New `tests/test_copy_settings_dialog.py`, driving `SlidersPanel` with the
+existing offscreen-Qt fixtures and a stubbed dialog (monkeypatched `exec_` /
+`selection`) so no modal is shown:
+
+1. **Dialog reuse** — the copy dialog exposes the same group ids as
+   `SYNC_GROUPS`, in order, and `selection()` reflects the checkboxes;
+   `_set_all(False)` clears every box.
+2. **Cancelled copy keeps the old clipboard** — copy WB, cancel a second copy,
+   clipboard still holds the first entry.
+3. **Empty selection copies nothing** — clipboard untouched, hint set.
+4. **Partial copy stores only the selected keys** — copying only `wb` yields a
+   clipboard with `temperature`/`tint` and no tone keys.
+5. **Paste merges** — target with distinct tone + WB values, paste a WB-only
+   clipboard: WB takes the source values, every tone key keeps the target's.
+6. **Paste keeps target curves when curves not copied**, and replaces/removes
+   them when it is.
+7. **Profile group** — pasting a `bw` profile flips `img.color_profile` and the
+   combo row; not copying it leaves the target's profile alone.
+8. **Crop group** — pasting crop assigns `crop_rect`/`crop_angle` and triggers
+   a reprocess (target histogram matches the source's cropped histogram, as in
+   `TestSyncToAllCropHistogram`).
+9. **`cineon_log`** — preserved on the target when the channels group is not
+   copied; followed when it is; never written into an area layer's dict.
+10. **Adjustment dict completeness** — after any paste the target's active
+    settings contain every `ADJUSTMENT_KEYS` entry.
+
+Existing suites that must keep passing unchanged:
+`tests/test_sub_saturation_crop_undo.py` (`TestSyncGroups`),
+`tests/test_cineon_log.py`, `tests/test_histogram_crop.py`,
+`tests/test_curves.py`, `tests/test_color_profile.py`, `tests/test_area_editing.py`.

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -21,9 +21,9 @@ from datetime import date
 # DEFAULT_DENSITY_SLOPE (no preset). See spec/film-stock-slopes.md.
 FILM_STOCK_DEFAULT_LABEL = "Default"
 
-# Setting groups offered by the "Sync to All" dialog. The adjustment-key
-# groups partition SlidersPanel.ADJUSTMENT_KEYS exactly; "crop" syncs the
-# image's crop box (rect + angle) instead of adjustment keys.
+# Setting groups offered by the "Sync to All" and "Copy Settings" dialogs. The
+# adjustment-key groups partition SlidersPanel.ADJUSTMENT_KEYS exactly; "crop"
+# syncs the image's crop box (rect + angle) instead of adjustment keys.
 SYNC_GROUPS = [
     ("profile", "Color Profile (Color / B&W)", ()),
     ("wb", "White Balance / Tint", ("temperature", "tint")),
@@ -49,15 +49,21 @@ SYNC_GROUPS = [
 
 
 class SyncSettingsDialog(QDialog):
-    """Pick which setting groups 'Sync to All' copies to every image."""
+    """Pick which setting groups an apply-to-many action covers.
 
-    def __init__(self, parent=None, selection=None):
+    Used by both 'Sync to All' (its defaults) and Ctrl/Cmd+C's 'Copy
+    Settings' — same layout and group list, only the wording differs, so the
+    two share one visual language for "choose what to apply"."""
+
+    def __init__(self, parent=None, selection=None, title="Sync to All",
+                 prompt="Sync these settings to all images:",
+                 action_label="Sync"):
         super().__init__(parent)
-        self.setWindowTitle("Sync to All")
+        self.setWindowTitle(title)
         self.setMinimumWidth(theme.DIALOG_W_SM)
         layout = QVBoxLayout(self)
         theme.apply_panel_spacing(layout)
-        layout.addWidget(QLabel("Sync these settings to all images:"))
+        layout.addWidget(QLabel(prompt))
 
         self._checkboxes = {}
         for gid, label, _keys in SYNC_GROUPS:
@@ -84,7 +90,7 @@ class SyncSettingsDialog(QDialog):
         layout.addWidget(theme.section_separator())
 
         button_row = theme.apply_button_row(QHBoxLayout())
-        sync_btn = QPushButton("Sync")
+        sync_btn = QPushButton(action_label)
         cancel_btn = QPushButton("Cancel")
         theme.style_button(sync_btn, "primary", default=True)
         theme.style_button(cancel_btn, "secondary")
@@ -296,7 +302,15 @@ class SlidersPanel(QWidget):
         self._layers_sig = None  # cheap signature to avoid needless rebuilds
         self.adjustment_keys = list(self.ADJUSTMENT_KEYS)
         self._sync_group_selection = None  # remembered while the app is open
-        self.copied_adjustment = None  # Store copied adjustment settings
+        self._copy_group_selection = None  # Ctrl+C's own remembered choice
+        # Ctrl+C clipboard — a PARTIAL adjustment dict (only the copied
+        # groups' keys) plus the whole-image groups that live outside it.
+        # paste_adjustment_settings is the only consumer. See
+        # spec/copy-settings-dialog.md.
+        self.copied_adjustment = None
+        self.copied_selection = None   # {gid: bool} used for this clipboard
+        self.copied_profile = None     # "color"/"bw" when the profile group was copied
+        self.copied_crop = None        # (crop_rect, crop_angle) when crop was copied
         self._hint_timer = QTimer(self)  # Timer for temporary hints
         self._hint_timer.setSingleShot(True)
         
@@ -1852,62 +1866,145 @@ class SlidersPanel(QWidget):
         ccr_backend.save_catalog()
         self.set_temporary_hint("B/W Point conversion complete!", duration=3000)
 
+    @staticmethod
+    def _group_count_phrase(verb: str, selection: dict) -> str:
+        """'Copied all settings.' / 'Pasted 2 of 8 setting groups.' — the
+        group LABELS are too long to list, so report the count."""
+        n = sum(1 for gid, _l, _k in SYNC_GROUPS if selection.get(gid))
+        total = len(SYNC_GROUPS)
+        if n == total:
+            return f"{verb} all settings."
+        return f"{verb} {n} of {total} setting group{'' if n == 1 else 's'}."
+
     def copy_adjustment_settings(self):
         """
-        Copy the current adjustment settings to clipboard.
+        Copy the current image's settings to the in-panel clipboard. A dialog
+        picks which setting groups to copy (the same groups Sync to All
+        offers); the choice is remembered while the app is open.
         """
-        if self.current_idx is not None:
-            # Get the current adjustment settings from sliders
-            self.copied_adjustment = {key: slider.value() for key, slider in zip(self.adjustment_keys, self.sliders)}
-            self._attach_curves(self.copied_adjustment)
-            self._attach_cineon(self.copied_adjustment)
-            print(f"Copied adjustment settings: {self.copied_adjustment}")
-            self.set_temporary_hint("Adjustments Copied!", duration=4000)
-        else:
+        if self.current_idx is None:
             print("No image selected to copy adjustment settings from.")
             self.set_temporary_hint("No image selected to copy from", duration=4000)
+            return
+
+        dialog = SyncSettingsDialog(
+            self, self._copy_group_selection, title="Copy Settings",
+            prompt="Copy these settings:", action_label="Copy")
+        if dialog.exec_() != QDialog.Accepted:
+            return  # cancelled — leave any previously copied settings alone
+        selection = dialog.selection()
+        self._copy_group_selection = selection
+        if not any(selection.values()):
+            self.set_temporary_hint("Nothing selected to copy.", duration=3000)
+            return
+
+        keys = [k for gid, _label, group_keys in SYNC_GROUPS
+                if selection.get(gid) for k in group_keys]
+        # Adjustment keys and curves come from the LIVE UI, i.e. the active
+        # layer (global or area) — that keeps area→area copying useful. The
+        # whole-image groups below have no per-area meaning, so they're read
+        # off the image itself.
+        live = {key: slider.value()
+                for key, slider in zip(self.adjustment_keys, self.sliders)}
+        self._attach_curves(live)
+        self._attach_cineon(live)
+        self.copied_adjustment = {k: live[k] for k in keys if k in live}
+        if selection.get("curves") and live.get("curves"):
+            self.copied_adjustment["curves"] = copy.deepcopy(live["curves"])
+
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        self.copied_profile = (getattr(img, "color_profile", "color")
+                               if selection.get("profile") and img is not None else None)
+        self.copied_crop = ((img.crop_rect, getattr(img, "crop_angle", 0.0))
+                            if selection.get("crop") and img is not None else None)
+        self.copied_selection = selection
+        print(f"Copied groups {sorted(g for g, on in selection.items() if on)}: "
+              f"{self.copied_adjustment}")
+        self.set_temporary_hint(
+            self._group_count_phrase("Copied", selection), duration=4000)
 
     def paste_adjustment_settings(self):
         """
-        Paste the copied adjustment settings to the current image.
+        Apply the copied setting groups to the current image, leaving every
+        setting that was NOT copied untouched.
         """
-        if self.current_idx is not None and self.copied_adjustment is not None:
-            print(f"Pasting adjustment settings: {self.copied_adjustment}")
-            self.end_undo_burst()
-            img = ccr_backend.get_image_by_index(self.current_idx)
-            if img is not None:
-                img.push_undo_state()
-
-            # Apply the copied settings to the current sliders
-            for i, key in enumerate(self.adjustment_keys):
-                if key in self.copied_adjustment and i < len(self.sliders):
-                    self.sliders[i].blockSignals(True)
-                    self.sliders[i].setValue(self.copied_adjustment[key])
-                    self.sliders[i].blockSignals(False)
-                    self.slider_value_labels[i].setText(str(self.copied_adjustment[key]))
-            # Mirror the pasted tone curves into the editor (set_curves does not
-            # emit, so it won't re-trigger a save).
-            self.curve_editor.set_curves(self.copied_adjustment.get("curves"))
-
-            # Save the adjustment to the ACTIVE layer and update preview. Copy
-            # the dict so the clipboard isn't aliased by the image's settings.
-            pasted = copy.deepcopy(self.copied_adjustment)
-            img = ccr_backend.get_image_by_index(self.current_idx)
-            if img is not None and img.active_area_id is not None:
-                # The Cineon display conversion is whole-image only — never
-                # paste it into an area layer's dict.
-                pasted.pop("cineon_log", None)
-            ccr_backend.set_active_settings_by_index(
-                self.current_idx, pasted, reprocess=True)
-            self.parent().parent().image_preview.update_preview(self.current_idx)
-            self.set_temporary_hint("Adjustments Pasted!", duration=2000)
-            
-        elif self.copied_adjustment is None:
-            print("No adjustment settings to paste. Copy settings first with Cmd+C (or Ctrl+C).")
-            self.set_temporary_hint("No adjustments to paste. Copy first with Cmd+C", duration=3000)
-        else:
+        if self.copied_selection is None:
+            print("No settings to paste. Copy settings first with Cmd+C (or Ctrl+C).")
+            self.set_temporary_hint("No settings to paste. Copy first with Cmd+C", duration=3000)
+            return
+        if self.current_idx is None:
             print("No image selected to paste adjustment settings to.")
             self.set_temporary_hint("No image selected to paste to", duration=2000)
+            return
+
+        selection = self.copied_selection
+        print(f"Pasting groups {sorted(g for g, on in selection.items() if on)}: "
+              f"{self.copied_adjustment}")
+        self.end_undo_burst()
+        img = ccr_backend.get_image_by_index(self.current_idx)
+        if img is not None:
+            img.push_undo_state()
+
+        # Build a COMPLETE dict from the TARGET's active layer (missing keys
+        # filled with their defaults) and overwrite only the copied keys, so
+        # un-copied settings survive and the app-wide "a non-empty adjustment
+        # dict carries every key" invariant holds. Same shape as
+        # _perform_sync_to_all's merge.
+        target = self._read_active_settings(self.current_idx)
+        merged = {k: target.get(k, self._default_for(k)) for k in self.adjustment_keys}
+        for k, v in self.copied_adjustment.items():
+            if k in merged:
+                merged[k] = v
+        # Curves and the Cineon flag live outside adjustment_keys: follow the
+        # clipboard when their group was copied, else carry the target's own
+        # value across the slider-only rebuild.
+        if selection.get("curves"):
+            src_curves = self.copied_adjustment.get("curves")
+            if src_curves:
+                merged["curves"] = copy.deepcopy(src_curves)
+        elif target.get("curves") is not None:
+            merged["curves"] = target["curves"]
+        if selection.get("channels"):
+            if self.copied_adjustment.get("cineon_log"):
+                merged["cineon_log"] = True
+        elif target.get("cineon_log"):
+            merged["cineon_log"] = True
+        if img is not None and img.active_area_id is not None:
+            # The Cineon display conversion is whole-image only — never
+            # paste it into an area layer's dict.
+            merged.pop("cineon_log", None)
+
+        # Mirror the result into the UI (from the MERGE, not the clipboard, so
+        # un-copied sliders keep showing the target's values).
+        for i, key in enumerate(self.adjustment_keys):
+            if i < len(self.sliders):
+                self.sliders[i].blockSignals(True)
+                self.sliders[i].setValue(merged[key])
+                self.sliders[i].blockSignals(False)
+                self.slider_value_labels[i].setText(str(merged[key]))
+        # set_curves does not emit, so it won't re-trigger a save.
+        self.curve_editor.set_curves(merged.get("curves"))
+
+        if img is not None:
+            if selection.get("profile") and self.copied_profile is not None:
+                img.color_profile = self.copied_profile
+                self._sync_color_profile_combo(self.current_idx)
+            if selection.get("crop") and self.copied_crop is not None:
+                # A copied "no crop" is a real value — pasting it clears the
+                # target's crop. The reprocess below refreshes the crop-aware
+                # histogram.
+                img.crop_rect, img.crop_angle = self.copied_crop
+
+        ccr_backend.set_active_settings_by_index(
+            self.current_idx, merged, reprocess=True)
+        mw = self.parent().parent()
+        try:
+            mw.thumbnail_list.update_thumbnail(self.current_idx)
+        except AttributeError:
+            pass
+        mw.image_preview.update_preview(self.current_idx)
+        self.set_temporary_hint(
+            self._group_count_phrase("Pasted", selection), duration=2000)
 
     # --- Dynamic Hint Management Methods ---
     def set_hint(self, message, temporary=False, duration=3000):

--- a/tests/test_copy_settings_dialog.py
+++ b/tests/test_copy_settings_dialog.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Tests for the selective Ctrl/Cmd+C copy — the dialog that asks which
+setting groups to copy, and the group-aware merge Ctrl/Cmd+V performs.
+See spec/copy-settings-dialog.md."""
+
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import cv2  # noqa: E402
+from PySide6.QtWidgets import (QApplication, QDialog, QWidget,  # noqa: E402
+                               QVBoxLayout)
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+from widgets.sliders_panel import (SlidersPanel, SyncSettingsDialog,  # noqa: E402
+                                   SYNC_GROUPS)
+
+
+# --- harness -----------------------------------------------------------------
+
+def _ccr_image(tmp_path, name="scan.png"):
+    """A CCRImage from a tiny uniform on-disk scan so __init__ succeeds."""
+    path = str(tmp_path / name)
+    base = np.full((40, 60, 3), 20000, np.uint16)
+    cv2.imwrite(path, cv2.cvtColor(base, cv2.COLOR_RGB2BGR))
+    return CCRImage(path)
+
+
+def _half_image(h=40, w=60):
+    """Left half red, right half blue — the halves' histograms differ, so a
+    crop must change the computed histogram."""
+    a = np.zeros((h, w, 3), np.uint16)
+    a[:, : w // 2] = (60000, 0, 0)
+    a[:, w // 2:] = (0, 0, 60000)
+    return a
+
+
+def _hist_bytes(img):
+    return img.histogram_data.tobytes()
+
+
+class _ImagePreviewStub:
+    def __init__(self):
+        self.updated = []
+
+    def update_preview(self, idx):
+        self.updated.append(idx)
+
+
+class _Host(QWidget):
+    """parent().parent() target carrying image_preview (as MainWindow does)."""
+    def __init__(self):
+        super().__init__()
+        self.image_preview = _ImagePreviewStub()
+        self.mid = QWidget(self)
+
+
+_HOSTS = []
+
+
+def _panel():
+    host = _Host()
+    _HOSTS.append(host)               # keep alive for the test's lifetime
+    mid_layout = QVBoxLayout(host.mid)
+    panel = SlidersPanel(host.mid)
+    mid_layout.addWidget(panel)
+    return panel
+
+
+def _stub_dialog(monkeypatch, selection, accepted=True):
+    """Replace the modal group picker with a canned answer. `selection` is a
+    partial {gid: bool}; unlisted groups count as unchecked."""
+    full = {gid: bool(selection.get(gid)) for gid, _l, _k in SYNC_GROUPS}
+
+    def _exec(self):
+        return QDialog.Accepted if accepted else QDialog.Rejected
+
+    monkeypatch.setattr(SyncSettingsDialog, "exec_", _exec, raising=False)
+    monkeypatch.setattr(SyncSettingsDialog, "selection", lambda self: dict(full))
+    return full
+
+
+def _set(panel, key, value):
+    """Set one slider by adjustment key, as a user drag would."""
+    panel.sliders[panel.adjustment_keys.index(key)].setValue(value)
+
+
+def _val(img, key):
+    return img.adjustment_settings.get(key)
+
+
+def _copy(panel, monkeypatch, selection, accepted=True):
+    _stub_dialog(monkeypatch, selection, accepted)
+    panel.copy_adjustment_settings()
+
+
+# --- the dialog itself --------------------------------------------------------
+
+class TestDialog:
+    def test_copy_dialog_offers_the_sync_groups(self):
+        dlg = SyncSettingsDialog(None, None, title="Copy Settings",
+                                 prompt="Copy these settings:",
+                                 action_label="Copy")
+        assert dlg.windowTitle() == "Copy Settings"
+        assert list(dlg._checkboxes) == [gid for gid, _l, _k in SYNC_GROUPS]
+        assert all(dlg.selection().values())          # all checked by default
+
+    def test_select_all_and_deselect_all(self):
+        dlg = SyncSettingsDialog(None, None)
+        dlg._set_all(False)
+        assert not any(dlg.selection().values())
+        dlg._set_all(True)
+        assert all(dlg.selection().values())
+
+    def test_seeds_from_remembered_selection(self):
+        dlg = SyncSettingsDialog(None, {"wb": True, "tone": False})
+        sel = dlg.selection()
+        assert sel["wb"] is True and sel["tone"] is False
+        assert sel["crop"] is True                    # unlisted → checked
+
+    def test_sync_defaults_unchanged(self):
+        """Sync to All's call site passes no wording — its strings are the
+        constructor defaults."""
+        dlg = SyncSettingsDialog(None, None)
+        assert dlg.windowTitle() == "Sync to All"
+
+
+# --- copy ---------------------------------------------------------------------
+
+class TestCopy:
+    def test_copies_only_selected_groups(self, tmp_path, monkeypatch):
+        img = _ccr_image(tmp_path)
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+        panel = _panel()
+        panel.current_idx = 0
+        _set(panel, "temperature", 40)
+        _set(panel, "contrast", 25)
+
+        _copy(panel, monkeypatch, {"wb": True})
+
+        assert panel.copied_adjustment == {"temperature": 40, "tint": 0}
+        assert "contrast" not in panel.copied_adjustment
+        assert panel.copied_profile is None and panel.copied_crop is None
+
+    def test_cancel_keeps_previous_clipboard(self, tmp_path, monkeypatch):
+        img = _ccr_image(tmp_path)
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+        panel = _panel()
+        panel.current_idx = 0
+        _set(panel, "temperature", 40)
+        _copy(panel, monkeypatch, {"wb": True})
+        first = dict(panel.copied_adjustment)
+
+        _set(panel, "temperature", -40)
+        _copy(panel, monkeypatch, {"tone": True}, accepted=False)
+
+        assert panel.copied_adjustment == first
+        assert panel.copied_selection["wb"] is True
+
+    def test_empty_selection_copies_nothing(self, tmp_path, monkeypatch):
+        img = _ccr_image(tmp_path)
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+        panel = _panel()
+        panel.current_idx = 0
+
+        _copy(panel, monkeypatch, {})
+
+        assert panel.copied_selection is None
+        assert panel.copied_adjustment is None
+        assert "Nothing selected" in panel.hint_label.text()
+
+    def test_no_image_shows_hint_and_no_dialog(self, monkeypatch):
+        panel = _panel()
+        panel.current_idx = None
+
+        def _boom(self):
+            raise AssertionError("dialog must not open without an image")
+
+        monkeypatch.setattr(SyncSettingsDialog, "exec_", _boom, raising=False)
+        panel.copy_adjustment_settings()
+        assert panel.copied_selection is None
+        assert "No image selected" in panel.hint_label.text()
+
+    def test_whole_image_groups_read_from_the_image(self, tmp_path, monkeypatch):
+        img = _ccr_image(tmp_path)
+        img.color_profile = "bw"
+        img.crop_rect = (0.1, 0.2, 0.8, 0.9)
+        img.crop_angle = 3.0
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+        panel = _panel()
+        panel.current_idx = 0
+
+        _copy(panel, monkeypatch, {"profile": True, "crop": True})
+
+        assert panel.copied_profile == "bw"
+        assert panel.copied_crop == ((0.1, 0.2, 0.8, 0.9), 3.0)
+
+
+# --- paste --------------------------------------------------------------------
+
+class TestPasteMerge:
+    def _two_images(self, tmp_path):
+        src = _ccr_image(tmp_path, "src.png")
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        for i in (src, tgt):
+            i.converted = True
+            i.adjustment_settings = {}
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+        return src, tgt
+
+    def test_uncopied_groups_keep_target_values(self, tmp_path, monkeypatch):
+        src, tgt = self._two_images(tmp_path)
+        panel = _panel()
+
+        panel.current_idx = 0
+        _set(panel, "temperature", 40)
+        _set(panel, "contrast", 25)
+        _copy(panel, monkeypatch, {"wb": True})
+
+        panel.current_idx = 1
+        _set(panel, "temperature", -10)
+        _set(panel, "contrast", -30)
+        panel.paste_adjustment_settings()
+
+        assert _val(tgt, "temperature") == 40      # copied group followed
+        assert _val(tgt, "contrast") == -30        # un-copied group untouched
+
+    def test_pasted_dict_carries_every_key(self, tmp_path, monkeypatch):
+        src, tgt = self._two_images(tmp_path)
+        panel = _panel()
+        panel.current_idx = 0
+        _set(panel, "temperature", 40)
+        _copy(panel, monkeypatch, {"wb": True})
+
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        for key in SlidersPanel.ADJUSTMENT_KEYS:
+            assert key in tgt.adjustment_settings, key
+        # Defaults are honoured, not zero-filled blindly.
+        assert _val(tgt, "band_feather") == panel._default_for("band_feather")
+
+    def test_sliders_reflect_the_merge_not_the_clipboard(self, tmp_path, monkeypatch):
+        src, tgt = self._two_images(tmp_path)
+        panel = _panel()
+        panel.current_idx = 0
+        _set(panel, "temperature", 40)
+        _set(panel, "contrast", 25)
+        _copy(panel, monkeypatch, {"wb": True})
+
+        panel.current_idx = 1
+        _set(panel, "contrast", -30)
+        panel.paste_adjustment_settings()
+
+        assert panel.sliders[panel.adjustment_keys.index("temperature")].value() == 40
+        assert panel.sliders[panel.adjustment_keys.index("contrast")].value() == -30
+
+    def test_paste_pushes_one_undo_state(self, tmp_path, monkeypatch):
+        src, tgt = self._two_images(tmp_path)
+        panel = _panel()
+        panel.current_idx = 0
+        _set(panel, "temperature", 40)
+        _copy(panel, monkeypatch, {"wb": True})
+
+        panel.current_idx = 1
+        before = len(tgt.undo_stack)
+        panel.paste_adjustment_settings()
+        assert len(tgt.undo_stack) == before + 1
+
+    def test_paste_without_a_copy_is_a_no_op(self, tmp_path):
+        src, tgt = self._two_images(tmp_path)
+        panel = _panel()
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+        assert tgt.adjustment_settings == {}
+        assert "No settings to paste" in panel.hint_label.text()
+
+
+class TestPasteCurves:
+    CURVE = {"rgb": [[0.0, 0.0], [128.0, 200.0], [255.0, 255.0]]}
+    OTHER = {"rgb": [[0.0, 0.0], [128.0, 60.0], [255.0, 255.0]]}
+
+    def _panel_with(self, tmp_path):
+        src = _ccr_image(tmp_path, "src.png")
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        for i in (src, tgt):
+            i.converted = True
+            i.adjustment_settings = {}
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+        return _panel(), src, tgt
+
+    def test_curves_copied_replaces_target_curves(self, tmp_path, monkeypatch):
+        panel, src, tgt = self._panel_with(tmp_path)
+        panel.current_idx = 0
+        panel.curve_editor.set_curves(self.CURVE)
+        _copy(panel, monkeypatch, {"curves": True})
+
+        panel.current_idx = 1
+        tgt.adjustment_settings = {"curves": self.OTHER}
+        panel.paste_adjustment_settings()
+
+        assert tgt.adjustment_settings["curves"] == self.CURVE
+
+    def test_identity_source_curves_clear_the_target(self, tmp_path, monkeypatch):
+        panel, src, tgt = self._panel_with(tmp_path)
+        panel.current_idx = 0
+        panel.curve_editor.set_curves(None)           # identity
+        _copy(panel, monkeypatch, {"curves": True})
+
+        panel.current_idx = 1
+        tgt.adjustment_settings = {"curves": self.OTHER}
+        panel.paste_adjustment_settings()
+
+        assert "curves" not in tgt.adjustment_settings
+
+    def test_uncopied_curves_survive_the_rebuild(self, tmp_path, monkeypatch):
+        panel, src, tgt = self._panel_with(tmp_path)
+        panel.current_idx = 0
+        panel.curve_editor.set_curves(self.CURVE)
+        _set(panel, "temperature", 40)
+        _copy(panel, monkeypatch, {"wb": True})       # curves NOT copied
+
+        panel.current_idx = 1
+        tgt.adjustment_settings = {"curves": self.OTHER}
+        panel.paste_adjustment_settings()
+
+        assert tgt.adjustment_settings["curves"] == self.OTHER
+        assert _val(tgt, "temperature") == 40
+
+
+class TestPasteWholeImageGroups:
+    def test_profile_group_switches_the_target_and_combo(self, tmp_path, monkeypatch):
+        src = _ccr_image(tmp_path, "src.png")
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        src.color_profile = "bw"
+        tgt.color_profile = "color"
+        for i in (src, tgt):
+            i.converted = True
+            i.adjustment_settings = {}
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"profile": True})
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert tgt.color_profile == "bw"
+        assert panel.color_profile_combo.currentIndex() == \
+            SlidersPanel.COLOR_PROFILES.index("bw")
+
+    def test_profile_left_alone_when_not_copied(self, tmp_path, monkeypatch):
+        src = _ccr_image(tmp_path, "src.png")
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        src.color_profile = "bw"
+        tgt.color_profile = "color"
+        for i in (src, tgt):
+            i.converted = True
+            i.adjustment_settings = {}
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"wb": True})
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert tgt.color_profile == "color"
+
+    def test_crop_group_reprocesses_the_target_histogram(self, tmp_path, monkeypatch):
+        """Pasting a crop must regenerate the crop-aware histogram, not just
+        copy the value (mirrors TestSyncToAllCropHistogram)."""
+        full = _half_image()
+
+        src = _ccr_image(tmp_path, "src.png")
+        src.converted = True
+        src.adjustment_settings = {}
+        src.resized_raw = full.copy()
+        src.crop_rect = (0.5, 0.0, 1.0, 1.0)
+        src.update_thumbnail_and_preview()
+        src_cropped = _hist_bytes(src)
+
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        tgt.converted = True
+        tgt.adjustment_settings = {}
+        tgt.resized_raw = full.copy()
+        tgt.crop_rect = None
+        tgt.update_thumbnail_and_preview()
+        assert _hist_bytes(tgt) != src_cropped        # precondition
+
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"crop": True})
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert tgt.crop_rect == (0.5, 0.0, 1.0, 1.0)
+        assert _hist_bytes(tgt) == src_cropped
+
+    def test_copied_no_crop_clears_the_target_crop(self, tmp_path, monkeypatch):
+        src = _ccr_image(tmp_path, "src.png")
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        for i in (src, tgt):
+            i.converted = True
+            i.adjustment_settings = {}
+        src.crop_rect = None
+        src.crop_angle = 0.0
+        tgt.crop_rect = (0.1, 0.1, 0.9, 0.9)
+        tgt.crop_angle = 5.0
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"crop": True})
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert tgt.crop_rect is None and tgt.crop_angle == 0.0
+
+    def test_crop_left_alone_when_not_copied(self, tmp_path, monkeypatch):
+        src = _ccr_image(tmp_path, "src.png")
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        for i in (src, tgt):
+            i.converted = True
+            i.adjustment_settings = {}
+        src.crop_rect = (0.5, 0.0, 1.0, 1.0)
+        tgt.crop_rect = (0.1, 0.1, 0.9, 0.9)
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+
+        panel = _panel()
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"wb": True})
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert tgt.crop_rect == (0.1, 0.1, 0.9, 0.9)
+
+
+class TestPasteCineonFlag:
+    """cineon_log rides the channels group and is whole-image only."""
+
+    def _pair(self, tmp_path):
+        src = _ccr_image(tmp_path, "src.png")
+        tgt = _ccr_image(tmp_path, "tgt.png")
+        for i in (src, tgt):
+            i.converted = True
+            i.adjustment_settings = {}
+        ccr_backend.images = [src, tgt]
+        ccr_backend.file_paths = [src.file_path, tgt.file_path]
+        return src, tgt
+
+    def test_channels_group_carries_the_flag(self, tmp_path, monkeypatch):
+        src, tgt = self._pair(tmp_path)
+        src.adjustment_settings = {"cineon_log": True}
+        panel = _panel()
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"channels": True})
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert tgt.adjustment_settings.get("cineon_log") is True
+
+    def test_target_flag_survives_an_unrelated_paste(self, tmp_path, monkeypatch):
+        src, tgt = self._pair(tmp_path)
+        panel = _panel()
+        panel.current_idx = 0
+        _set(panel, "temperature", 40)
+        _copy(panel, monkeypatch, {"wb": True})
+
+        panel.current_idx = 1
+        tgt.adjustment_settings = {"cineon_log": True}
+        panel.paste_adjustment_settings()
+
+        assert tgt.adjustment_settings.get("cineon_log") is True
+
+    def test_channels_paste_clears_an_unset_flag(self, tmp_path, monkeypatch):
+        src, tgt = self._pair(tmp_path)
+        panel = _panel()
+        panel.current_idx = 0                 # source has no flag
+        _copy(panel, monkeypatch, {"channels": True})
+
+        panel.current_idx = 1
+        tgt.adjustment_settings = {"cineon_log": True}
+        panel.paste_adjustment_settings()
+
+        assert "cineon_log" not in tgt.adjustment_settings
+
+    def test_never_written_into_an_area_layer(self, tmp_path, monkeypatch):
+        src, tgt = self._pair(tmp_path)
+        src.adjustment_settings = {"cineon_log": True}
+        panel = _panel()
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"channels": True})
+
+        panel.current_idx = 1
+        tgt.area_layers = [{"id": "a1", "kind": "circle", "enabled": True,
+                            "feather": 0.2, "angle": 0,
+                            "geometry": {"cx": 0.5, "cy": 0.5, "rx": 0.3, "ry": 0.3},
+                            "settings": {}}]
+        tgt.active_area_id = "a1"
+        panel.paste_adjustment_settings()
+
+        assert "cineon_log" not in tgt.get_area("a1")["settings"]
+        assert tgt.adjustment_settings.get("cineon_log") is not True

--- a/user_guide/get_started.md
+++ b/user_guide/get_started.md
@@ -35,7 +35,7 @@ Use the adjustment sliders on the right panel:
 - **White/Black Point**: Set highlight and shadow clipping points
 - **Contrast**: Increase or decrease contrast
 - **Saturation**: Adjust color intensity
-You can use the "Sync to All" button to apply adjustments to all images, or use `Ctrl/Command+C` and `Ctrl/Command+V` to copy and paste adjustments to another image
+You can use the "Sync to All" button to apply adjustments to all images, or use `Ctrl/Command+C` and `Ctrl/Command+V` to copy and paste settings to another image. Both ask which setting groups you mean — white balance, tone, saturation, crop, curves and so on — so you can copy just the crop, or just the white balance, and leave everything else on the target image untouched.
 
 ### Step 7: Export Your Images
 -  (Optional) Select Checkbox **Export Jpg** to export JPEG for web use


### PR DESCRIPTION
`Ctrl/Cmd+C` now opens the same "pick what you mean" dialog **Sync to All** has, so a copy/paste between two images can carry just the white balance, just the crop, or just the curves — instead of the whole slider set.

### Before / after

| | Before | After |
| --- | --- | --- |
| `Ctrl+C` | silently grabbed every slider | dialog: one checkbox per setting group |
| `Ctrl+V` | replaced the target's whole dict | merges — un-copied settings keep the target's values |
| Crop / Color Profile / Curves | not copied at all | copyable, like in Sync to All |

The dialog is the existing `SyncSettingsDialog` widget with the wording parameterised, driven by the same `SYNC_GROUPS` list — so both features stay in step and a future group shows up in both automatically.

| Copy Settings | Sync to All (unchanged) |
| --- | --- |
| Title "Copy Settings", prompt "Copy these settings:", accept button "Copy" | Title "Sync to All", prompt "Sync these settings to all images:", accept button "Sync" |

### Paste semantics

Paste rebuilds a **complete** adjustment dict from the *target's* active layer (missing keys filled with their defaults) and overwrites only the copied keys — the same merge construction `_perform_sync_to_all` uses, so the app-wide "a non-empty adjustment dict carries every key" invariant holds.

- **Curves** — copied → replace (or clear, when the source is identity); not copied → the target's own curves survive the slider-only rebuild.
- **`cineon_log`** — still rides the channels group, still never written into an area layer's dict.
- **Color Profile** — assigns `color_profile` and re-syncs the combo (it isn't driven by the adjustment dict).
- **Crop** — assigns `crop_rect`/`crop_angle`; the reprocess that follows refreshes the crop-aware histogram. A copied "no crop" is a real value and clears the target's crop.

Cancelling the dialog leaves any previously copied settings on the clipboard; an empty selection copies nothing. The copy dialog remembers its own group choice for the session, separate from Sync's.

### Notes

- The clipboard (`copied_adjustment`) is now a **partial** dict. `paste_adjustment_settings` is its only consumer, so the partial dict can't leak into the render/export paths.
- Slider/curve UI after a paste is populated from the **merge**, not the clipboard, so un-copied controls keep showing the target's values.

### Testing

- `tests/test_copy_settings_dialog.py` — 26 new cases: dialog wiring and Select All/Deselect All, cancel/empty-selection, partial copy, merge preservation, dict completeness, curves (replace / clear / survive), profile and crop groups (including the crop-histogram reprocess and the "no crop" case), and the four `cineon_log` paths. **26 passed.**
- Regression: `test_histogram_crop.py`, `test_sub_saturation_crop_undo.py`, `test_cineon_log.py` (38 passed) and `test_curves.py`, `test_color_profile.py`, `test_area_editing.py` (57 passed).
- Both dialogs captured offscreen via the `qt-testing` skill and inspected — identical layout, only the wording differs.

Spec: `spec/copy-settings-dialog.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
