### PR TITLE
fix(awb): estimate from midtones only, and show the result immediately

### DIFF
--- a/spec/auto-white-balance.md
+++ b/spec/auto-white-balance.md
@@ -108,7 +108,8 @@ correct it.
   - tint: `t = tanh(slider·0.02)·0.26·balance` → `G·(1−t)`, `R·(1+0.3t)`, `B·(1+0.3t)`
 - The result is applied by `sliders_panel.on_wb_sampled(temp, tint)`
   (`sliders_panel.py:1527`): blockSignals slider set + label update +
-  `on_slider_changed()` (stores into `adjustment_settings`, reprocesses, hint).
+  `on_slider_changed()` (stores into `adjustment_settings`, reprocesses, hint) +
+  `_settle_preview()` (renders and shows the result now — see §4.4).
 - `compute_neutral_temp_tint` is **scale-invariant** (it only uses channel
   ratios), so any positive-scaled RGB triple works as input.
 - Auto Gain (`spec/auto-gain.md`) established: backend flag + QSettings key +
@@ -133,13 +134,37 @@ d = base.astype(float32)
 d = (d - WS_B) * _WS_INV_WIDTH        if ws_windowed else d / 65535.0
 ```
 
-**Valid-pixel mask** (applied per pixel, all three channels must pass):
+**Valid-pixel mask — midtones only.** An uncropped film scan *always* contains
+pure black and pure white that is not scene content: the holder masks the film
+to pure black in the scan (→ clipped white once inverted) and the clear film
+base / sprocket holes are the scan's maximum (→ crushed black once inverted).
+Neither carries a usable cast, both are large, and they are noisy rather than
+exactly 1.0/0.0 — so a wide gate lets them through and they hijack the
+estimator (measured on a synthetic uncropped frame: `white_patch` returned a
+perfectly neutral 1.000/1.000, i.e. it balanced on the holder; `shades_of_gray`
+lost a third of the cast). AWB therefore reads the **midtones plus a slice of
+the shadows and highlights**, via two independent rejections:
 
 ```
-valid = all_channels(d >= AWB_LO) & all_channels(d <= AWB_HI)
-AWB_LO = 0.02      # noise floor / sub-black & holder rejection
-AWB_HI = 0.98      # near-clip & headroom rejection
+lum   = 0.299·R + 0.587·G + 0.114·B          # Rec.601, as compute_auto_gain_offset
+valid = all_channels(d >= AWB_LO) & all_channels(d <= AWB_HI)   # 1. ratios are real
+        & (lum >= AWB_TONE_LO) & (lum <= AWB_TONE_HI)           # 2. tonal region
+
+AWB_LO      = 0.06   # per-channel floor: clear-film black / crushed channel
+AWB_HI      = 0.94   # per-channel ceiling: holder white / blown channel
+AWB_TONE_LO = 0.15   # luminance band: midtones + a slice of the shadows...
+AWB_TONE_HI = 0.85   # ...and a slice of the highlights
 ```
+
+The per-channel gate guarantees no channel is crushed or blown, so the pixel's
+ratios mean something; the luminance band picks the tonal region the WB decision
+is made from. `AWB_LO < AWB_TONE_LO < AWB_TONE_HI < AWB_HI`, so the band is the
+binding limit on neutral content and the gate additionally catches single blown
+channels in saturated colors.
+
+This applies to **every** algorithm, `white_patch` included: it takes the
+brightest *retained* pixel, i.e. the brightest real scene highlight rather than
+the film surround.
 
 If `valid.sum() < MIN_CONTENT_FRACTION · N` (reuse 0.005), the estimate is
 `None` → the button shows a hint ("AWB: not enough usable image content") and the
@@ -170,6 +195,9 @@ Notes:
   gradient magnitude `sqrt(gx²+gy²)` (numpy `np.gradient`), then the Minkowski
   p=6 mean over pixels whose source pixel is valid. Uses `cv2.GaussianBlur` if
   available (cv2 is already a dependency), else a small numpy separable blur.
+  The mask is **eroded** by a 5×5 kernel first: the blur+gradient stencil reaches
+  ~2 px, so a sample merely *next to* a rejected pixel still carries that pixel's
+  edge — and the holder border is the strongest edge in an uncropped scan.
 - Degenerate guard: if any channel estimate ≤ `AWB_EPS` (1e-6), return `None`.
 
 ### 4.3 New module `src/core/awb.py`
@@ -219,6 +247,15 @@ pattern as `ccr_image.py`) to read the selected algorithm.
   ```
   Everything downstream (undo burst, slider set, store, reprocess, hint) is the
   existing `on_wb_sampled` path.
+- **The result must appear immediately.** `on_slider_changed()` only *queues* a
+  debounced (150 ms) reprocess and paints the currently cached
+  `resized_preview` — fine for a slider drag, where the next tick redraws, but a
+  one-shot click would leave the canvas on the pre-AWB render until the user
+  touched something else. `on_wb_sampled` therefore ends with
+  `_settle_preview()`: cancel the pending reprocess, `update_thumbnail_and_preview()`,
+  *then* `update_preview()` + thumbnail refresh. `_settle_preview` is the shared
+  discrete-edit settle, factored out of `_on_curve_edit_finished`
+  (`sliders_panel.py`), and covers the WB eyedropper too — same one-shot shape.
 
 ### 4.5 The post-conversion hook
 

--- a/src/core/awb.py
+++ b/src/core/awb.py
@@ -21,12 +21,30 @@ AWB_ALGORITHMS = [
 ]
 AWB_DEFAULT = "gray_world"
 
-AWB_LO = 0.02          # noise floor: sub-black / film-holder rejection
-AWB_HI = 0.98          # near-clip / headroom rejection
+# An uncropped film scan always contains pure black AND pure white that is not
+# scene content: the holder masks the film to pure black in the scan (→ clipped
+# white once inverted) and the clear film base / sprocket holes are the scan's
+# maximum (→ crushed black once inverted). Neither carries a usable cast, and
+# both are big enough to hijack every estimator. So AWB reads the MIDTONES plus
+# a slice of the shadows and highlights, and nothing else:
+#   1. per-channel gate — no channel crushed or blown, so the ratios are real
+#   2. luminance band  — the tonal region the WB decision is actually made from
+AWB_LO = 0.06          # per-channel floor: clear-film black / crushed channel
+AWB_HI = 0.94          # per-channel ceiling: holder white / blown channel
+AWB_TONE_LO = 0.15     # luminance band: midtones + a slice of the shadows...
+AWB_TONE_HI = 0.85     # ...and a slice of the highlights
 AWB_EPS = 1e-6
 _WP_PERCENTILE = 99.0  # white_patch: robust max-RGB
 _MINK_P = 6.0          # Minkowski norm for shades_of_gray / gray_edge
 _GE_SIGMA = 1.0        # gray_edge pre-smoothing
+_GE_ERODE = 5          # gray_edge: mask shrink (px kernel) around rejected pixels
+# Rec.601 luma over RGB — the convention compute_auto_gain_offset uses.
+_LUMA = (0.299, 0.587, 0.114)
+
+
+def _luminance(flat):
+    """Luma of an (N,3) RGB float array."""
+    return (_LUMA[0] * flat[:, 0] + _LUMA[1] * flat[:, 1] + _LUMA[2] * flat[:, 2])
 
 
 def _gray_edge_estimate(d, valid_mask):
@@ -36,7 +54,13 @@ def _gray_edge_estimate(d, valid_mask):
     sm = cv2.GaussianBlur(d, (0, 0), _GE_SIGMA)
     gy, gx = np.gradient(sm, axis=(0, 1))
     mag = np.sqrt(gx * gx + gy * gy)
-    m = mag.reshape(-1, 3)[valid_mask.reshape(-1)]
+    # The blur + gradient stencil reaches a couple of pixels, so a sample that
+    # merely sits NEXT to a rejected pixel still carries that pixel's edge — the
+    # holder border is the strongest edge in an uncropped scan and would
+    # otherwise dominate the p-mean. Shrink the mask by that reach.
+    kept = cv2.erode(valid_mask.astype(np.uint8),
+                     np.ones((_GE_ERODE, _GE_ERODE), np.uint8)).astype(bool)
+    m = mag.reshape(-1, 3)[kept.reshape(-1)]
     if m.shape[0] == 0:
         return None
     return np.mean(m ** _MINK_P, axis=0) ** (1.0 / _MINK_P)
@@ -46,6 +70,10 @@ def estimate_neutral_rgb(base_u16, ws_windowed=False, algorithm=AWB_DEFAULT):
     """Estimated neutral (cast) RGB triple of a converted base, or None when
     there is not enough usable content. The scale is arbitrary —
     compute_neutral_temp_tint only uses channel ratios. Index 0=R, 1=G, 2=B.
+    Only midtone pixels vote (AWB_LO/AWB_HI + AWB_TONE_LO/AWB_TONE_HI), so the
+    pure black and pure white an uncropped film scan always carries — clear
+    film base, sprocket holes, the holder surround — cannot reach any
+    estimator, white_patch included.
     Unknown algorithm ids fall back to gray_world (forward-compat settings)."""
     if base_u16 is None or getattr(base_u16, "size", 0) == 0:
         return None
@@ -56,7 +84,9 @@ def estimate_neutral_rgb(base_u16, ws_windowed=False, algorithm=AWB_DEFAULT):
     else:
         d *= np.float32(1.0 / 65535.0)
     flat = d.reshape(-1, 3)
-    valid = np.all((flat >= AWB_LO) & (flat <= AWB_HI), axis=1)
+    lum = _luminance(flat)
+    valid = (np.all((flat >= AWB_LO) & (flat <= AWB_HI), axis=1)
+             & (lum >= AWB_TONE_LO) & (lum <= AWB_TONE_HI))
     if valid.sum() < MIN_CONTENT_FRACTION * flat.shape[0]:
         return None
     if algorithm == "white_patch":

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -1251,16 +1251,15 @@ class SlidersPanel(QWidget):
         self._debounce_timer.stop()
         self._debounce_timer.start(150)
 
-    def _on_curve_edit_finished(self):
-        """Settle a finished curve edit (drag release, add/remove, Reset Curve).
+    def _settle_preview(self):
+        """Show the final state of a DISCRETE (one-shot) edit right away.
 
         update_preview() displays the cached resized_preview and only
         regenerates it *afterwards* (via set_current_idx), so the live
-        _on_curve_changed path leaves the final state one render behind — for a
-        discrete edit nothing redraws it, so the image looked unchanged until the
-        user clicked the canvas. Mirror on_reset_clicked: regenerate the preview
-        first, then display it, so the result is shown immediately."""
-        self.end_undo_burst()
+        on_slider_changed / _on_curve_changed path leaves the final state one
+        render behind — for a discrete edit nothing redraws it, so the image
+        looked unchanged until the user clicked the canvas. Mirror
+        on_reset_clicked: regenerate the preview first, then display it."""
         if self.current_idx is None or not (0 <= self.current_idx < len(ccr_backend.images)):
             return
         # Cancel the pending debounced reprocess — we render the final state now.
@@ -1273,6 +1272,11 @@ class SlidersPanel(QWidget):
             self.parent().parent().thumbnail_list.update_thumbnail(self.current_idx)
         except AttributeError:
             pass
+
+    def _on_curve_edit_finished(self):
+        """Settle a finished curve edit (drag release, add/remove, Reset Curve)."""
+        self.end_undo_burst()
+        self._settle_preview()
 
     def _process_pending_adjustment(self):
         """Process the pending adjustment if not already processing."""
@@ -1583,6 +1587,9 @@ class SlidersPanel(QWidget):
             self.sliders[idx].blockSignals(False)
             self.slider_value_labels[idx].setText(str(val))
         self.on_slider_changed()
+        # A WB pick/AWB click is a discrete edit: render and show it now instead
+        # of leaving the canvas one render behind until the next interaction.
+        self._settle_preview()
         self.set_temporary_hint(
             f"Auto WB applied — Temperature: {temp_value}, Tint: {tint_value}.", duration=5000)
 

--- a/tests/test_awb.py
+++ b/tests/test_awb.py
@@ -12,11 +12,13 @@ import sys
 import numpy as np
 import pytest
 
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")   # the apply-path tests
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 from core.awb import (  # noqa: E402
-    AWB_ALGORITHMS, AWB_DEFAULT, AWB_LO, AWB_HI,
+    AWB_ALGORITHMS, AWB_DEFAULT, AWB_LO, AWB_HI, AWB_TONE_LO, AWB_TONE_HI,
     estimate_neutral_rgb, compute_awb_temp_tint,
 )
 from core.ccr_processor import (  # noqa: E402
@@ -57,7 +59,7 @@ def test_white_patch_balances_on_brightest_content():
     cast = (1.1, 1.0, 0.85)
     d = np.full((100, 100, 3), 0.3, dtype=np.float32)
     d[..., 0] *= 0.9                                   # dim content: different cast
-    patch = np.array([0.85 * c for c in cast], dtype=np.float32)   # all <= 0.98
+    patch = np.array([0.75 * c for c in cast], dtype=np.float32)   # inside the band
     d[:5, :, :] = patch                                # 5% brightest rows
     est = estimate_neutral_rgb(_u16(d), ws_windowed=False, algorithm="white_patch")
     rg, bg = _ratios(est)
@@ -104,6 +106,54 @@ def test_out_of_bound_pixels_excluded():
     interior = estimate_neutral_rgb(_u16(d[4:-4]), algorithm="gray_world")
     got = estimate_neutral_rgb(_u16(dirty), algorithm="gray_world")
     assert np.allclose(interior, got, rtol=1e-4)
+
+
+def _scan_frame(rng, cast=CAST, shape=(120, 120), band=20):
+    """An UNCROPPED film scan: image content in the middle, the holder surround
+    above it (masked to pure black in the scan → clipped white once inverted)
+    and the clear film base / sprocket holes below (the scan's maximum → crushed
+    black once inverted). Both carry scanner noise, so they straddle the
+    extremes instead of sitting exactly on 1.0 / 0.0."""
+    d = _cast_scene(rng, cast=cast, shape=shape)
+    d[:band] = rng.uniform(0.95, 1.0, size=(band, shape[1], 1)).astype(np.float32)
+    d[-band:] = rng.uniform(0.0, 0.05, size=(band, shape[1], 1)).astype(np.float32)
+    return d
+
+
+@pytest.mark.parametrize("algorithm",
+                         ["gray_world", "white_patch", "shades_of_gray"])
+def test_film_surround_never_votes(algorithm):
+    """The user's case: on an uncropped scan the estimate must come from the
+    image only — the pure-white holder and pure-black film base are film, not
+    scene, and neither carries a cast. Noisy extremes (0.95-1.0 / 0.0-0.05) are
+    the real-world shape of those regions and must be rejected wholesale."""
+    d = _scan_frame(np.random.default_rng(20))
+    full = estimate_neutral_rgb(_u16(d), algorithm=algorithm)
+    content = estimate_neutral_rgb(_u16(d[20:-20]), algorithm=algorithm)
+    assert full == content
+
+
+def test_film_surround_leaves_the_cast_intact():
+    """Stated as the property that matters: the surround must not drag the
+    estimate toward neutral (its own color), for every algorithm."""
+    d = _scan_frame(np.random.default_rng(21))
+    for algorithm, _label in AWB_ALGORITHMS:
+        rg, bg = _ratios(estimate_neutral_rgb(_u16(d), algorithm=algorithm))
+        assert rg == pytest.approx(CAST[0] / CAST[1], rel=0.05), algorithm
+        assert bg == pytest.approx(CAST[2] / CAST[1], rel=0.05), algorithm
+
+
+def test_tone_band_excludes_extremes_that_pass_the_channel_gate():
+    """The luminance band is a second, independent rejection: a bright (or
+    deep) neutral surround whose channels all sit inside [AWB_LO, AWB_HI] is
+    still outside the midtone band, so it does not vote."""
+    d = _cast_scene(np.random.default_rng(22), shape=(100, 100))
+    dirty = d.copy()
+    dirty[:10] = 0.90        # lum 0.90 > AWB_TONE_HI, every channel < AWB_HI
+    dirty[-10:] = 0.10       # lum 0.10 < AWB_TONE_LO, every channel > AWB_LO
+    got = estimate_neutral_rgb(_u16(dirty), algorithm="gray_world")
+    content = estimate_neutral_rgb(_u16(d[10:-10]), algorithm="gray_world")
+    assert np.allclose(got, content, rtol=1e-4)
 
 
 def test_insufficient_content_returns_none():
@@ -262,6 +312,9 @@ def test_algorithm_registry():
     assert ids == ["gray_world", "white_patch", "shades_of_gray", "gray_edge"]
     assert AWB_DEFAULT in ids
     assert 0.0 < AWB_LO < AWB_HI < 1.0
+    # The band sits strictly inside the channel gate: midtones + a slice of the
+    # shadows and highlights, never the extremes an uncropped scan always has.
+    assert AWB_LO < AWB_TONE_LO < AWB_TONE_HI < AWB_HI
 
 
 def test_backend_defaults(backend):
@@ -269,6 +322,90 @@ def test_backend_defaults(backend):
     singleton still carries them here): auto-AWB opt-in, Gray World."""
     assert backend.auto_awb is False
     assert backend.awb_algorithm == AWB_DEFAULT
+
+
+# --- applying the result (the canvas must show it immediately) ----------------
+# update_preview() paints the CACHED resized_preview and only regenerates it
+# afterwards, so a discrete edit that merely queues the debounced reprocess
+# leaves the canvas on the pre-edit render until something else redraws it.
+# on_wb_sampled therefore has to regenerate FIRST, then display.
+
+@pytest.fixture
+def wb_panel(tmp_path):
+    """A real SlidersPanel over one converted, cast-tinted image, hosted the way
+    MainWindow hosts it (parent().parent() carries image_preview). Yields
+    (panel, image, log) where log records render/show in the order they happen."""
+    import cv2
+    from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout
+    QApplication.instance() or QApplication(sys.argv[:1])
+    from core.ccr_backend import ccr_backend
+    from core.ccr_image import CCRImage
+    from widgets.sliders_panel import SlidersPanel
+
+    path = str(tmp_path / "scan.png")
+    cv2.imwrite(path, np.full((40, 60, 3), 20000, np.uint16))
+    img = CCRImage(path)
+    img.converted = True
+    img.adjustment_settings = {}
+    img.resized_raw = _u16(_cast_scene(np.random.default_rng(30), shape=(40, 60)))
+
+    log = []
+    render = img.update_thumbnail_and_preview
+
+    def _logged_render():
+        log.append("render")
+        return render()
+    img.update_thumbnail_and_preview = _logged_render
+
+    class _PreviewStub:
+        def update_preview(self, idx):
+            log.append("show")
+
+    class _Host(QWidget):
+        def __init__(self):
+            super().__init__()
+            self.image_preview = _PreviewStub()
+            self.mid = QWidget(self)
+
+    host = _Host()
+    QVBoxLayout(host.mid).addWidget(SlidersPanel(host.mid))
+    panel = host.mid.layout().itemAt(0).widget()
+    saved = (ccr_backend.images, ccr_backend.file_paths)
+    ccr_backend.images, ccr_backend.file_paths = [img], [img.file_path]
+    panel.current_idx = 0
+    log.clear()                      # ignore setup renders
+    yield panel, img, log
+    ccr_backend.images, ccr_backend.file_paths = saved
+
+
+def test_wb_result_is_rendered_before_it_is_shown(wb_panel):
+    """The eyedropper/AWB apply path: the new temp/tint reach the settings AND
+    the canvas is repainted from a fresh render, in that order."""
+    panel, img, log = wb_panel
+    panel.on_wb_sampled(-30, 12)
+    assert img.adjustment_settings["temperature"] == -30
+    assert img.adjustment_settings["tint"] == 12
+    assert "render" in log            # not just the stale cached preview
+    assert log[-1] == "show"          # ...and the fresh render is what's shown
+
+
+def test_wb_apply_leaves_no_pending_reprocess(wb_panel):
+    """The debounced reprocess is cancelled — the final state was rendered now,
+    so nothing is left queued to redo it."""
+    panel, _img, _log = wb_panel
+    panel.on_wb_sampled(-30, 12)
+    assert panel._pending_adjustment is None
+    assert not panel._debounce_timer.isActive()
+
+
+def test_auto_wb_button_applies_and_shows(wb_panel, backend):
+    """End-to-end: the AWB button estimates the cast, writes the sliders and
+    leaves a freshly rendered canvas."""
+    panel, img, log = wb_panel
+    backend.awb_algorithm = "gray_world"
+    panel._on_auto_wb()
+    assert img.adjustment_settings["temperature"] < 0      # warm cast → cooled
+    assert "render" in log and log[-1] == "show"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. AWB estimated from the film surround, not the image

An uncropped film scan **always** contains pure black and pure white that is not scene content — the holder masks the film to pure black in the scan (clipped white once inverted), and the clear film base / sprocket holes are the scan's maximum (crushed black once inverted). Those regions are noisy rather than exactly `1.0`/`0.0`, so the old `[0.02, 0.98]` gate let a wide margin of them through, and they hijacked the estimate.

Measured on a synthetic uncropped frame (image content with a 1.25 / 1.00 / 0.80 cast, plus a 0.95–1.0 holder band and a 0.0–0.05 film-base band):

| algorithm | R/G before | R/G after | true |
|---|---|---|---|
| `gray_world` | 1.188 | **1.250** | 1.250 |
| `white_patch` | 1.000 | **1.250** | 1.250 |
| `shades_of_gray` | 1.081 | **1.250** | 1.250 |
| `gray_edge` | 1.249 | **1.249** | 1.250 |

`white_patch` was the worst case: a perfectly neutral 1.000/1.000, i.e. it balanced on the film holder and AWB did nothing useful.

**Fix** — AWB now reads the **midtones plus a slice of the shadows and highlights**, via two independent rejections:

```
valid = all_channels(d >= 0.06) & all_channels(d <= 0.94)   # 1. ratios are real
        & (lum >= 0.15) & (lum <= 0.85)                     # 2. tonal region
```

The per-channel gate guarantees no channel is crushed or blown, so a pixel's ratios mean something; the luminance band picks the tonal region the WB decision is actually made from. This binds **every** algorithm, `white_patch` included — it now takes the brightest *retained* pixel, i.e. the brightest real scene highlight rather than the surround.

`gray_edge` additionally erodes the mask by 5 px: its blur + gradient stencil reaches ~2 px, so a sample merely *next to* a rejected pixel still carries that pixel's edge — and the holder border is the strongest edge in an uncropped scan.

## 2. Clicking AWB didn't show anything until you touched something else

`on_slider_changed()` only *queues* a debounced (150 ms) reprocess and paints the currently cached `resized_preview`. That's fine during a slider drag, where the next tick redraws — but a one-shot click had nothing to redraw it, so the canvas sat on the pre-AWB render.

This is the same bug that was already fixed for curve edits (`_on_curve_edit_finished`). That settle is now factored out as `_settle_preview()` — cancel the pending reprocess, re-render, *then* display — and `on_wb_sampled` calls it, which covers the WB eyedropper too.

## Tests

`tests/test_awb.py`, 31 passing. New coverage, all verified to fail without the corresponding fix:

- `test_film_surround_never_votes` — on an uncropped scan the estimate must equal the estimate over the image content alone, for each of `gray_world` / `white_patch` / `shades_of_gray`.
- `test_film_surround_leaves_the_cast_intact` — the property that matters, across all four algorithms: the surround must not drag the estimate toward neutral.
- `test_tone_band_excludes_extremes_that_pass_the_channel_gate` — isolates the band: a 0.90 / 0.10 neutral surround passes the per-channel gate but still must not vote.
- `test_wb_result_is_rendered_before_it_is_shown`, `test_wb_apply_leaves_no_pending_reprocess`, `test_auto_wb_button_applies_and_shows` — a real `SlidersPanel` over a converted image, logging render/display order. Without the fix the log is `['show']` with no render.

`test_white_patch_balances_on_brightest_content` had its bright patch moved from 0.85 to 0.75 — at 0.85 its luminance (0.859) is now deliberately out of band.

Also ran: `test_curves`, `test_histogram_crop`, `test_area_editing`, `test_color_bands`, `test_film_stock_ui`, `test_sub_saturation_crop_undo`, `test_copy_settings_dialog`, `test_cineon_log` — 146 passing.

`spec/auto-white-balance.md` §4.1/§4.2/§4.4 updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
