### PR TITLE
fix(ui): side panels clipped their content, and combos clipped long names

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -161,7 +161,7 @@ class MainWindow(QMainWindow):
         self.image_preview.setMinimumWidth(900)
 
         self.sliders_panel = SlidersPanel(self)
-        self.sliders_panel.setFixedWidth(300)
+        self.sliders_panel.setFixedWidth(theme.PANEL_W)
         self.sliders_panel.set_sliders_enabled(False)
         self.sliders_panel.image_preview = self.image_preview
 
@@ -170,7 +170,7 @@ class MainWindow(QMainWindow):
         # SlidersPanel's parent().parent() chain to MainWindow stays valid.
         # See spec/dust-removal.md.
         self.dust_panel = DustRemovalPanel(self, self.image_preview)
-        self.dust_panel.setFixedWidth(300)
+        self.dust_panel.setFixedWidth(theme.PANEL_W)
         self.dust_panel.setVisible(False)
         self.image_preview.set_dust_panel(self.dust_panel)
 
@@ -178,7 +178,7 @@ class MainWindow(QMainWindow):
         # pattern as dust_panel (keeps SlidersPanel's parent chain valid). See
         # spec/crop-panel.md.
         self.crop_panel = CropPanel(self, self.image_preview)
-        self.crop_panel.setFixedWidth(300)
+        self.crop_panel.setFixedWidth(theme.PANEL_W)
         self.crop_panel.setVisible(False)
         self.image_preview.set_crop_panel(self.crop_panel)
 

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -14,7 +14,7 @@ import tempfile
 
 from PySide6.QtCore import Qt, QObject, QEvent
 from PySide6.QtGui import QColor, QPalette, QIcon, QPixmap, QPainter, QPen
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import QComboBox, QWidget
 
 # --------------------------------------------------------------------------- #
 # 3.1 Surfaces (neutral grays — zero hue)
@@ -450,12 +450,57 @@ def shrinkable_combo(combo, *, min_chars=6):
     adding one long preset name (a film stock, a colour profile) is then enough
     to push a fixed-width panel's content past its edge and clip it. Sizing to a
     short contents length instead lets the combo shrink to the space the row can
-    spare and elide the text, which is what a narrow side panel needs.
+    spare, which is what a narrow side panel needs.
+
+    This governs the combo's WIDTH only. Text too long for the resulting box is
+    hard-clipped by Qt unless the combo also elides — see ElidingComboBox.
     """
     from PySide6.QtWidgets import QComboBox
     combo.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
     combo.setMinimumContentsLength(min_chars)
     return combo
+
+
+class ElidingComboBox(QComboBox):
+    """A combo whose closed-state text ends in "…" when it doesn't fit.
+
+    Qt does not elide a non-editable QComboBox: it draws the label into the
+    edit-field rect and lets the glyphs run under the arrow, so a long
+    user-supplied name (a film stock, a camera profile) reads as
+    ``Fuji Superia X-TRA 40`` with no sign that anything was cut. Nothing in the
+    UI then says the selection is longer than what's shown.
+
+    The frame and arrow are still painted by the active style, so the app's
+    global QSS applies unchanged; only the label is drawn here, elided to the
+    edit-field rect. The popup list is untouched, so the full names are always
+    one click away. Tooltips are left alone — callers set their own.
+    """
+
+    def paintEvent(self, _event):
+        from PySide6.QtWidgets import (QStyle, QStyleOptionComboBox,
+                                       QStylePainter)
+        painter = QStylePainter(self)
+        # Pick the colour group explicitly: the global QSS has no
+        # QComboBox:disabled rule, so a disabled combo's dimmed text comes from
+        # the palette's Disabled group. Drawing the label ourselves would
+        # otherwise render it at full strength and lose the disabled look.
+        group = QPalette.Active if self.isEnabled() else QPalette.Disabled
+        painter.setPen(self.palette().color(group, QPalette.Text))
+        opt = QStyleOptionComboBox()
+        self.initStyleOption(opt)
+        full = opt.currentText
+        # Blank the text so the style paints frame + arrow only; drawing the
+        # label twice would leave the un-elided version showing underneath.
+        opt.currentText = ""
+        painter.drawComplexControl(QStyle.CC_ComboBox, opt)
+        # The edit-field sub-control rect already carries the style's padding —
+        # do NOT inset it further, or short labels shift a few px right of where
+        # Qt would have drawn them and the combo stops matching its neighbours.
+        rect = self.style().subControlRect(
+            QStyle.CC_ComboBox, opt, QStyle.SC_ComboBoxEditField, self)
+        painter.drawText(
+            rect, Qt.AlignLeft | Qt.AlignVCenter,
+            self.fontMetrics().elidedText(full, Qt.ElideRight, rect.width()))
 
 
 def section_separator():

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -14,7 +14,7 @@ import tempfile
 
 from PySide6.QtCore import Qt, QObject, QEvent
 from PySide6.QtGui import QColor, QPalette, QIcon, QPixmap, QPainter, QPen
-from PySide6.QtWidgets import QComboBox, QWidget
+from PySide6.QtWidgets import QComboBox, QLabel, QWidget
 
 # --------------------------------------------------------------------------- #
 # 3.1 Surfaces (neutral grays — zero hue)
@@ -501,6 +501,62 @@ class ElidingComboBox(QComboBox):
         painter.drawText(
             rect, Qt.AlignLeft | Qt.AlignVCenter,
             self.fontMetrics().elidedText(full, Qt.ElideRight, rect.width()))
+
+
+def keep_out_of_minimum_width(widget):
+    """Stop a widget's own text from setting its panel's minimum width.
+
+    ``qSmartMinSize`` — what a layout asks each item for — skips the width
+    entirely when the horizontal policy is Ignored, and only then. Mutate the
+    policy already on the widget rather than building a fresh one: QLabel keeps
+    its height-for-width bit in there, and dropping that stops a word-wrapped
+    label from reporting the taller height its wrapped text needs.
+    """
+    from PySide6.QtWidgets import QSizePolicy
+    policy = widget.sizePolicy()
+    policy.setHorizontalPolicy(QSizePolicy.Ignored)
+    widget.setSizePolicy(policy)
+    return widget
+
+
+class ElidingLabel(QLabel):
+    """A single-line label that shortens its text rather than widening its panel.
+
+    A QLabel's minimum width is the full width of its text, so a label carrying
+    a user-supplied name inside a fixed-width panel does not merely overflow its
+    own line — it raises the minimum width of everything laid out beside it and
+    pushes the panel's content past the edge, where horizontal scrolling is off
+    and the whole panel clips. Word wrap is not a fix on its own: it lowers the
+    minimum only to the longest WORD, and "Kodak_Portra_400_pushed" is one word.
+
+    Eliding happens at PAINT time, against the width the layout actually handed
+    out — a label that is currently hidden has never been laid out, so its own
+    width() at setText time is stale or still the default. The full text stays
+    in the tooltip.
+    """
+
+    def __init__(self, text="", parent=None):
+        super().__init__(text, parent)
+        keep_out_of_minimum_width(self)
+
+    def setText(self, text):
+        # Not a virtual in Qt, so this only covers Python callers — which is all
+        # of them here. The elided form hides part of the name; the tooltip is
+        # where it stays readable.
+        super().setText(text)
+        self.setToolTip(text)
+
+    def paintEvent(self, _event):
+        painter = QPainter(self)
+        # QPainter starts on a black pen. The QSS `color:` reaches a QLabel as
+        # its palette foreground role, so read it from there — otherwise muted
+        # text paints black on the dark theme.
+        painter.setPen(self.palette().color(self.foregroundRole()))
+        rect = self.contentsRect()
+        painter.drawText(
+            rect, int(self.alignment()),
+            self.fontMetrics().elidedText(
+                self.text(), Qt.ElideRight, rect.width()))
 
 
 def section_separator():

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -85,8 +85,17 @@ GAP_SECTION = SPACE_XL    # 12 — between functional groups (usually with a sep
 CONTROL_H = 28            # sliders, combos, labels, normal & secondary buttons, tabs
 CONTROL_H_LG = 36         # weighty primary commits (Done, Export)
 GLYPH_W = 28             # square glyph buttons (✕ remove / clear) — one width
-LABEL_COL_W = 90          # right-aligned label gutter — fits the longest label ("Subtracted Sat")
+LABEL_COL_W = 100         # right-aligned label gutter — the longest label
+                          # ("Subtracted Sat") measures 89px in the macOS system
+                          # font, so 90 left it flush against the panel border and
+                          # one font step away from clipping. Keep slack here.
 VALUE_COL_W = 40          # left-aligned value gutter in a 3-column row
+PANEL_W = 340             # the right-hand side panels (sliders / dust / crop).
+                          # Widest row is WB Picker|AWB|Crop|Slice at ~293px, so
+                          # this must stay >= that + 2*GAP_PANEL, with slack for
+                          # systems whose UI font is wider than the one it was
+                          # measured on — a panel that is too narrow silently
+                          # CLIPS its content (horizontal scrolling is off).
 DIALOG_W_SM = 280         # progress / simple dialogs
 DIALOG_W_MD = 440         # forms (export, update, sync)
 
@@ -431,6 +440,22 @@ def apply_button_row(layout, *, spacing=GAP_BTN):
     layout.setContentsMargins(0, 0, 0, 0)
     layout.setSpacing(spacing)
     return layout
+
+
+def shrinkable_combo(combo, *, min_chars=6):
+    """Stop a QComboBox from dictating its panel's width.
+
+    A QComboBox's default minimumSizeHint is wide enough for its LONGEST ITEM,
+    which propagates all the way out as a hard minimum on the containing panel —
+    adding one long preset name (a film stock, a colour profile) is then enough
+    to push a fixed-width panel's content past its edge and clip it. Sizing to a
+    short contents length instead lets the combo shrink to the space the row can
+    spare and elide the text, which is what a narrow side panel needs.
+    """
+    from PySide6.QtWidgets import QComboBox
+    combo.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
+    combo.setMinimumContentsLength(min_chars)
+    return combo
 
 
 def section_separator():

--- a/src/widgets/crop_panel.py
+++ b/src/widgets/crop_panel.py
@@ -51,6 +51,7 @@ class CropPanel(QWidget):
         layout.addWidget(self._section_label("Aspect Ratio"))
         self.aspect_combo = QComboBox()
         self.aspect_combo.setFixedHeight(theme.CONTROL_H)
+        theme.shrinkable_combo(self.aspect_combo)
         for label, key, _ratio in crop_aspect.ASPECT_PRESETS:
             self.aspect_combo.addItem(label, key)
         self.aspect_combo.currentIndexChanged.connect(self._on_aspect_changed)

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -449,6 +449,9 @@ class SlidersPanel(QWidget):
         stock_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         self.film_stock_combo = QComboBox()
         self.film_stock_combo.setFixedHeight(theme.CONTROL_H)
+        # Stock names are user-supplied and can be long; without this the
+        # longest one sets the panel's minimum width and clips the panel.
+        theme.shrinkable_combo(self.film_stock_combo)
         self.save_film_stock_btn = QPushButton("＋")
         self.save_film_stock_btn.setFixedWidth(theme.GLYPH_W)
         self.save_film_stock_btn.setFixedHeight(theme.CONTROL_H)
@@ -834,6 +837,7 @@ class SlidersPanel(QWidget):
         self.color_profile_combo = QComboBox()
         self.color_profile_combo.addItems(["Color", "Black & White"])
         self.color_profile_combo.setFixedHeight(theme.CONTROL_H)
+        theme.shrinkable_combo(self.color_profile_combo)
         self.color_profile_combo.currentIndexChanged.connect(self.on_color_profile_changed)
 
         row = QHBoxLayout()

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -447,10 +447,12 @@ class SlidersPanel(QWidget):
         stock_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         stock_label.setFixedHeight(theme.CONTROL_H)
         stock_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        self.film_stock_combo = QComboBox()
+        # Stock names are user-supplied and can be long: shrinkable_combo keeps
+        # the longest one from setting the panel's minimum width, and the
+        # eliding combo ends the displayed name in "…" instead of letting it run
+        # under the arrow half-drawn.
+        self.film_stock_combo = theme.ElidingComboBox()
         self.film_stock_combo.setFixedHeight(theme.CONTROL_H)
-        # Stock names are user-supplied and can be long; without this the
-        # longest one sets the panel's minimum width and clips the panel.
         theme.shrinkable_combo(self.film_stock_combo)
         self.save_film_stock_btn = QPushButton("＋")
         self.save_film_stock_btn.setFixedWidth(theme.GLYPH_W)

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -484,8 +484,11 @@ class SlidersPanel(QWidget):
         self._settings.remove("convert/film_stock_selected")
         self._reload_film_stock_combo(select="")
 
-        # Shows which slope source the next conversion will use.
-        self.bwp_mode_label = QLabel("")
+        # Shows which slope source the next conversion will use. Eliding: this
+        # line names the selected film stock, and a user-supplied name is
+        # arbitrarily long — as a plain QLabel it would set a minimum width the
+        # whole scroll content has to honour, clipping every row in the panel.
+        self.bwp_mode_label = theme.ElidingLabel("")
         self.bwp_mode_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 11px;")
         # Starts empty (no black point yet); an empty label would still reserve a
         # line of height + spacing, leaving a gap between this and the Convert row,
@@ -760,6 +763,12 @@ class SlidersPanel(QWidget):
         # --- Hint label — fixed at bottom, outside scroll area ---
         self.hint_label = QLabel()
         self.hint_label.setWordWrap(True)
+        # Hints quote film-stock names ('Film stock "…" deleted.'), and word
+        # wrap only lowers a label's minimum width to its longest WORD — an
+        # unbroken name is one word, and one long enough would widen the panel
+        # past its fixed width. This drops the minimum to nothing; a name that
+        # cannot wrap is clipped instead of taking the panel with it.
+        theme.keep_out_of_minimum_width(self.hint_label)
         self.hint_label.setStyleSheet(f"color: {theme.TEXT_MUTED}; font-size: 12px; margin-top: 8px;")
         self.hint_label.setText("")
         layout.addWidget(self.hint_label)
@@ -1630,7 +1639,10 @@ class SlidersPanel(QWidget):
         elif wp_set:
             text = "Anchor source: white point (two-point)"
         elif stock:
-            text = f'Anchor source: film stock "{stock}" (black point only)'
+            # Stock name LAST: the label elides from the right, and the mode is
+            # the part worth keeping — a name in the middle would eat
+            # "(black point only)" and leave the line saying nothing useful.
+            text = f'Anchor source: film stock (black point only) — {stock}'
         else:
             text = "Anchor source: default slope (black point only)"
         self.bwp_mode_label.setText(text)

--- a/src/widgets/thumbnail_list.py
+++ b/src/widgets/thumbnail_list.py
@@ -113,7 +113,9 @@ class ThumbnailList(QWidget):
         # Camera-profile picker — choose which imported / IT8-generated profile
         # (kept in FreeCCR's library) is applied at decode, or None. Manage the
         # library in Settings ▸ Color Management. See spec/camera-profile-library.md.
-        self.profile_combo = QComboBox()
+        # Eliding: profile names are user-supplied filenames and routinely
+        # outrun this 216px-wide sidebar, where Qt would clip them mid-glyph.
+        self.profile_combo = theme.ElidingComboBox()
         self.profile_combo.setToolTip(
             "Camera input profile applied at decode, from your imported / "
             "IT8-generated library. 'None' applies no profile. Add and manage "

--- a/tests/test_film_stock_ui.py
+++ b/tests/test_film_stock_ui.py
@@ -71,8 +71,10 @@ def test_black_only_states_and_label(panel):
     ccr_backend.set_black_point(BASE_BGR)
     panel._update_bwp_mode_label()
     assert ccr_backend.film_stock_slopes == (0.85, 0.65, 0.56)
+    # Name last: the label elides from the right (it sits in a fixed-width
+    # panel), so the mode has to come first or a long stock name eats it.
     assert panel.bwp_mode_label.text() == \
-        'Anchor source: film stock "Portra 400" (black point only)'
+        'Anchor source: film stock (black point only) — Portra 400'
     assert not panel.save_film_stock_btn.isEnabled()
     assert panel.delete_film_stock_btn.isEnabled()
     # Back to Default: backend cleared, label reverts, delete gated off.

--- a/tests/test_panel_width.py
+++ b/tests/test_panel_width.py
@@ -135,6 +135,31 @@ def test_panel_survives_a_wider_ui_font():
         _app.setFont(base)
 
 
+def test_long_camera_profile_does_not_widen_the_sidebar(window):
+    """Camera-profile entries are user-imported ICC/DCP filenames of any
+    length. The sidebar is a fixed width, so the combo must elide rather than
+    push the layout's minimum past it."""
+    sidebar = window.thumbnail_list
+    combo = sidebar.profile_combo
+    before = sidebar.layout.minimumSize().width()
+    # blockSignals: selecting an entry fires _on_profile_combo_changed, which
+    # tries to activate the profile and raises a modal warning for a bogus
+    # path — that hangs a headless run. refresh_profile_combo() blocks the same
+    # way when it repopulates.
+    combo.blockSignals(True)
+    combo.addItem("Canon EOS R5 Adobe Standard v3 daylight  (DCP)", "x")
+    combo.setCurrentIndex(combo.count() - 1)
+    combo.blockSignals(False)
+    _app.processEvents()
+    after = sidebar.layout.minimumSize().width()
+    combo.blockSignals(True)
+    combo.removeItem(combo.count() - 1)
+    combo.blockSignals(False)
+    assert after == before <= sidebar.width(), (
+        f"a long camera-profile name widened the sidebar minimum from "
+        f"{before} to {after} (sidebar is {sidebar.width()}px)")
+
+
 def test_long_combo_entry_does_not_widen_the_panel(window):
     """A user-named film stock is arbitrarily long; the combo must elide it
     instead of pushing the panel's content past its edge."""
@@ -155,3 +180,65 @@ def test_long_combo_entry_does_not_widen_the_panel(window):
 def test_panel_combos_are_shrinkable(window, attr):
     combo = getattr(window.sliders_panel, attr)
     assert combo.sizeAdjustPolicy() == QComboBox.AdjustToMinimumContentsLengthWithIcon
+
+
+# --- eliding: the combos that carry user-supplied names ---------------------
+# Width is only half the problem. Qt does not elide a non-editable QComboBox —
+# it draws the label into the edit-field rect and lets the glyphs run under the
+# arrow, so a long film-stock or camera-profile name reads as
+# "Fuji Superia X-TRA 40" with nothing to say it was cut.
+
+LONG_NAME = "Fuji Superia X-TRA 400 — expired 2019 batch"
+SHORT_NAME = "Default"
+
+
+def _render(cls, text, *, enabled=True, width=168):
+    combo = cls()
+    combo.addItem(text)
+    combo.setEnabled(enabled)
+    combo.setFixedSize(width, theme.CONTROL_H)
+    _app.processEvents()
+    return combo.grab().toImage()
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_eliding_combo_matches_qt_exactly_for_text_that_fits(enabled):
+    """Painting the label by hand must not change anything but the eliding.
+
+    The custom paintEvent re-draws the label itself, so it can silently drift
+    from Qt on placement (an inset shifts short labels out of line with the
+    rest of the row) or on colour (losing the disabled group). Pixel equality
+    in the fits-fine case is the guard, checked in both enabled states.
+    """
+    assert (_render(QComboBox, SHORT_NAME, enabled=enabled)
+            == _render(theme.ElidingComboBox, SHORT_NAME, enabled=enabled)), (
+        "text that fits must render exactly as Qt draws it")
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_eliding_combo_shortens_text_that_does_not_fit(enabled):
+    assert (_render(QComboBox, LONG_NAME, enabled=enabled)
+            != _render(theme.ElidingComboBox, LONG_NAME, enabled=enabled)), (
+        "text too long for the box must be elided, not clipped like Qt's")
+
+
+@pytest.mark.parametrize("owner,attr", [
+    ("sliders_panel", "film_stock_combo"),      # user-named film stocks
+    ("thumbnail_list", "profile_combo"),        # user-imported ICC/DCP names
+])
+def test_user_named_combos_elide(window, owner, attr):
+    combo = getattr(getattr(window, owner), attr)
+    assert isinstance(combo, theme.ElidingComboBox), (
+        f"{owner}.{attr} holds arbitrary user text and must elide it")
+
+
+def test_eliding_combo_leaves_the_popup_list_intact(window):
+    """Elision is display-only: the dropdown must still offer full names."""
+    combo = window.sliders_panel.film_stock_combo
+    combo.blockSignals(True)
+    combo.addItem(LONG_NAME)
+    combo.blockSignals(False)
+    assert combo.itemText(combo.count() - 1) == LONG_NAME
+    combo.blockSignals(True)
+    combo.removeItem(combo.count() - 1)
+    combo.blockSignals(False)

--- a/tests/test_panel_width.py
+++ b/tests/test_panel_width.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+The right-hand side panels must FIT the width they are given.
+
+Horizontal scrolling is off in these panels, so a row whose minimum width
+exceeds the panel silently clips at the right edge — the failure mode that
+produced this test (Convert All / Slice / the Color Profile dropdown were cut
+off, and the longest slider label sat flush against the border). Minimum widths
+depend on the system UI font, so these assertions are the guard rail: they fail
+on the machine whose font no longer fits rather than shipping a clipped panel.
+
+The theme's global QSS sets the control padding these widths come from, so the
+panels are measured inside a real MainWindow with the theme applied — a bare
+panel would report Qt's unstyled defaults instead. The window is never closed:
+MainWindow.closeEvent raises a modal confirm-exit dialog that would hang.
+"""
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from PySide6.QtGui import QFont, QFontMetrics  # noqa: E402
+from PySide6.QtWidgets import (QApplication, QComboBox, QLabel,  # noqa: E402
+                               QScrollArea)
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+from ui import theme  # noqa: E402
+
+theme.apply_theme(_app)
+
+from ui.main_window import MainWindow  # noqa: E402
+from widgets.sliders_panel import SlidersPanel  # noqa: E402
+
+# The longest label sitting in a LABEL_COL_W gutter.
+LONGEST_LABEL = "Subtracted Sat"
+
+# How much wider a UI font the panels must absorb (see the stress test below).
+FONT_STRESS = 1.15
+
+PANEL_NAMES = ["sliders_panel", "dust_panel", "crop_panel"]
+
+
+@pytest.fixture(scope="module")
+def window():
+    win = MainWindow()
+    win.resize(1860, 1080)
+    _app.processEvents()
+    return win
+
+
+@pytest.mark.parametrize("name", PANEL_NAMES)
+def test_panel_layout_fits_its_width(window, name):
+    """A panel layout whose minimum exceeds the panel's fixed width clips."""
+    panel = getattr(window, name)
+    assert panel.width() == theme.PANEL_W
+    need = panel.layout().minimumSize().width()
+    assert need <= theme.PANEL_W, (
+        f"{name} layout needs {need}px but the panel is {theme.PANEL_W}px wide "
+        f"— its content will be clipped")
+
+
+@pytest.mark.parametrize("name", PANEL_NAMES)
+def test_scroll_content_fits_the_viewport(window, name):
+    """Scroll content wider than its viewport is unreachable, not scrollable:
+    these areas have the horizontal scrollbar switched off."""
+    panel = getattr(window, name)
+    for area in panel.findChildren(QScrollArea):
+        content = area.widget()
+        if content is None:
+            continue
+        need = content.minimumSizeHint().width()
+        assert need <= area.viewport().width(), (
+            f"{name} scroll content needs {need}px, viewport is "
+            f"{area.viewport().width()}px")
+
+
+def test_no_sliders_row_exceeds_the_content_budget(window):
+    """Every row of the sliders panel must fit inside the panel minus its
+    content margins."""
+    budget = theme.PANEL_W - 2 * theme.GAP_PANEL
+    layout = window.sliders_panel.findChild(QScrollArea).widget().layout()
+    need, idx = max((layout.itemAt(i).minimumSize().width(), i)
+                    for i in range(layout.count()))
+    assert need <= budget, (
+        f"row {idx} needs {need}px, the content budget is {budget}px")
+
+
+def test_label_gutter_fits_the_longest_label():
+    """LABEL_COL_W is a fixed width and QLabel clips rather than elides, so the
+    longest label must fit with room to spare."""
+    text_w = QFontMetrics(QLabel().font()).horizontalAdvance(LONGEST_LABEL)
+    assert text_w <= theme.LABEL_COL_W - theme.GAP_TIGHT, (
+        f"{LONGEST_LABEL!r} measures {text_w}px in this UI font; "
+        f"LABEL_COL_W is {theme.LABEL_COL_W}px")
+
+
+def test_panel_survives_a_wider_ui_font():
+    """The headless test font is narrower than a real desktop UI font, so
+    fitting it proves little on its own — this is what makes the guard bite.
+
+    A panel sized to fit exactly one machine's font clips on the next one (how
+    the original bug shipped). Re-measure with the UI font enlarged by
+    FONT_STRESS and require everything to still fit.
+    """
+    base = _app.font()
+    stressed = QFont(base)
+    stressed.setPointSizeF(base.pointSizeF() * FONT_STRESS)
+    try:
+        _app.setFont(stressed)
+        panel = SlidersPanel(None)
+        panel.setFixedWidth(theme.PANEL_W)
+        panel.resize(theme.PANEL_W, 1200)
+        _app.processEvents()
+
+        budget = theme.PANEL_W - 2 * theme.GAP_PANEL
+        layout = panel.findChild(QScrollArea).widget().layout()
+        need, idx = max((layout.itemAt(i).minimumSize().width(), i)
+                        for i in range(layout.count()))
+        assert need <= budget, (
+            f"at {FONT_STRESS:.2f}x the UI font, row {idx} needs {need}px but "
+            f"the content budget is {budget}px — PANEL_W has no slack")
+
+        text_w = QFontMetrics(stressed).horizontalAdvance(LONGEST_LABEL)
+        assert text_w <= theme.LABEL_COL_W, (
+            f"at {FONT_STRESS:.2f}x the UI font {LONGEST_LABEL!r} measures "
+            f"{text_w}px, LABEL_COL_W is {theme.LABEL_COL_W}px")
+    finally:
+        _app.setFont(base)
+
+
+def test_long_combo_entry_does_not_widen_the_panel(window):
+    """A user-named film stock is arbitrarily long; the combo must elide it
+    instead of pushing the panel's content past its edge."""
+    panel = window.sliders_panel
+    combo = panel.film_stock_combo
+    layout = panel.findChild(QScrollArea).widget().layout()
+    before = layout.minimumSize().width()
+    combo.addItem("Kodak Portra 400 pushed two stops, 2026 batch")
+    combo.setCurrentIndex(combo.count() - 1)
+    _app.processEvents()
+    after = layout.minimumSize().width()
+    combo.removeItem(combo.count() - 1)
+    assert after == before <= theme.PANEL_W, (
+        f"a long combo entry widened the content minimum from {before} to {after}")
+
+
+@pytest.mark.parametrize("attr", ["film_stock_combo", "color_profile_combo"])
+def test_panel_combos_are_shrinkable(window, attr):
+    combo = getattr(window.sliders_panel, attr)
+    assert combo.sizeAdjustPolicy() == QComboBox.AdjustToMinimumContentsLengthWithIcon

--- a/tests/test_panel_width.py
+++ b/tests/test_panel_width.py
@@ -13,6 +13,24 @@ The theme's global QSS sets the control padding these widths come from, so the
 panels are measured inside a real MainWindow with the theme applied — a bare
 panel would report Qt's unstyled defaults instead. The window is never closed:
 MainWindow.closeEvent raises a modal confirm-exit dialog that would hang.
+
+Two kinds of test live here, and only one of them can run everywhere:
+
+* **Fit budgets** — "this row fits the panel" — are absolute pixel claims, so
+  they are only meaningful when the widths come from a real UI font. Qt no
+  longer ships fonts, and the offscreen platform on a machine with no
+  fontconfig (Windows, typically) has *none*: QFontDatabase is empty and every
+  measurement falls back to a last-resort face roughly twice as wide as a real
+  one — "Subtracted Sat" measures 168px there against 76px in Segoe UI. Held to
+  that, PANEL_W would have to exceed 500px to pass, for a font no user will
+  ever see. These tests carry @needs_ui_font and skip where there is none.
+* **Behavioural claims** — "a long name does not widen the panel", "the label
+  elides" — hold under any font, including the fallback, and are ungated. They
+  are what actually covers shrinkable_combo / ElidingLabel / ElidingComboBox,
+  so the guard keeps biting on every platform.
+
+To measure the fit budgets on Windows anyway, run this file against the real
+platform: QT_QPA_PLATFORM=windows pytest tests/test_panel_width.py
 """
 import os
 import sys
@@ -24,7 +42,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from PySide6.QtGui import QFont, QFontMetrics  # noqa: E402
+from PySide6.QtGui import QFont, QFontDatabase, QFontMetrics  # noqa: E402
 from PySide6.QtWidgets import (QApplication, QComboBox, QLabel,  # noqa: E402
                                QScrollArea)
 
@@ -46,6 +64,23 @@ FONT_STRESS = 1.15
 
 PANEL_NAMES = ["sliders_panel", "dust_panel", "crop_panel"]
 
+# An empty font database means Qt resolved every request to its last-resort
+# fallback; nothing measured against it says anything about a real desktop.
+needs_ui_font = pytest.mark.skipif(
+    not QFontDatabase.families(),
+    reason="no fonts installed on this platform (Qt ships none) — pixel budgets "
+           "would be measured against a last-resort fallback face")
+
+
+def _fitting_width(widget_font_source, text, slack):
+    """A render width the text is guaranteed to FIT in, whatever the font.
+
+    Hard-coding it assumes a font: under the fontless fallback the "short"
+    strings below measure ~450px, so a fixed 324px box elides them and the
+    fits-fine comparisons compare the wrong thing.
+    """
+    return QFontMetrics(widget_font_source.font()).horizontalAdvance(text) + slack
+
 
 @pytest.fixture(scope="module")
 def window():
@@ -55,6 +90,7 @@ def window():
     return win
 
 
+@needs_ui_font
 @pytest.mark.parametrize("name", PANEL_NAMES)
 def test_panel_layout_fits_its_width(window, name):
     """A panel layout whose minimum exceeds the panel's fixed width clips."""
@@ -66,6 +102,7 @@ def test_panel_layout_fits_its_width(window, name):
         f"— its content will be clipped")
 
 
+@needs_ui_font
 @pytest.mark.parametrize("name", PANEL_NAMES)
 def test_scroll_content_fits_the_viewport(window, name):
     """Scroll content wider than its viewport is unreachable, not scrollable:
@@ -81,6 +118,7 @@ def test_scroll_content_fits_the_viewport(window, name):
             f"{area.viewport().width()}px")
 
 
+@needs_ui_font
 def test_no_sliders_row_exceeds_the_content_budget(window):
     """Every row of the sliders panel must fit inside the panel minus its
     content margins."""
@@ -92,6 +130,7 @@ def test_no_sliders_row_exceeds_the_content_budget(window):
         f"row {idx} needs {need}px, the content budget is {budget}px")
 
 
+@needs_ui_font
 def test_label_gutter_fits_the_longest_label():
     """LABEL_COL_W is a fixed width and QLabel clips rather than elides, so the
     longest label must fit with room to spare."""
@@ -101,6 +140,7 @@ def test_label_gutter_fits_the_longest_label():
         f"LABEL_COL_W is {theme.LABEL_COL_W}px")
 
 
+@needs_ui_font
 def test_panel_survives_a_wider_ui_font():
     """The headless test font is narrower than a real desktop UI font, so
     fitting it proves little on its own — this is what makes the guard bite.
@@ -155,9 +195,15 @@ def test_long_camera_profile_does_not_widen_the_sidebar(window):
     combo.blockSignals(True)
     combo.removeItem(combo.count() - 1)
     combo.blockSignals(False)
-    assert after == before <= sidebar.width(), (
+    # The behavioural claim — adding the name changed nothing — holds under any
+    # font. Only the "and it fits" tail below needs a real one.
+    assert after == before, (
         f"a long camera-profile name widened the sidebar minimum from "
-        f"{before} to {after} (sidebar is {sidebar.width()}px)")
+        f"{before} to {after}")
+    if QFontDatabase.families():
+        assert before <= sidebar.width(), (
+            f"the sidebar minimum is {before}px but the sidebar is "
+            f"{sidebar.width()}px")
 
 
 def test_long_combo_entry_does_not_widen_the_panel(window):
@@ -172,8 +218,11 @@ def test_long_combo_entry_does_not_widen_the_panel(window):
     _app.processEvents()
     after = layout.minimumSize().width()
     combo.removeItem(combo.count() - 1)
-    assert after == before <= theme.PANEL_W, (
+    assert after == before, (
         f"a long combo entry widened the content minimum from {before} to {after}")
+    if QFontDatabase.families():
+        assert before <= theme.PANEL_W, (
+            f"the content minimum is {before}px, the panel is {theme.PANEL_W}px")
 
 
 @pytest.mark.parametrize("attr", ["film_stock_combo", "color_profile_combo"])
@@ -192,10 +241,17 @@ LONG_NAME = "Fuji Superia X-TRA 400 — expired 2019 batch"
 SHORT_NAME = "Default"
 
 
-def _render(cls, text, *, enabled=True, width=168):
+# Wide enough for SHORT_NAME plus the frame and drop-down arrow the style puts
+# around it, so "text that fits" is true by construction in any font.
+_COMBO_CHROME = 60
+
+
+def _render(cls, text, *, enabled=True, width=None):
     combo = cls()
     combo.addItem(text)
     combo.setEnabled(enabled)
+    if width is None:
+        width = _fitting_width(combo, SHORT_NAME, _COMBO_CHROME)
     combo.setFixedSize(width, theme.CONTROL_H)
     _app.processEvents()
     return combo.grab().toImage()
@@ -257,9 +313,12 @@ def test_selecting_a_film_stock_does_not_widen_the_panel(window):
         (ccr_backend.black_point_bgr, ccr_backend.white_point_bgr,
          ccr_backend.film_stock_name) = saved
         panel._update_bwp_mode_label()
-    assert after == before <= theme.PANEL_W, (
+    assert after == before, (
         f"naming a film stock widened the content minimum from {before} to "
-        f"{after} (panel is {theme.PANEL_W}px)")
+        f"{after}")
+    if QFontDatabase.families():
+        assert before <= theme.PANEL_W, (
+            f"the content minimum is {before}px, the panel is {theme.PANEL_W}px")
 
 
 def test_long_hint_word_does_not_widen_the_panel(window):
@@ -275,9 +334,12 @@ def test_long_hint_word_does_not_widen_the_panel(window):
         after = panel.minimumSizeHint().width()
     finally:
         panel.hint_label.setText("")
-    assert after == before <= theme.PANEL_W, (
+    assert after == before, (
         f"an unbreakable hint word widened the panel minimum from {before} to "
         f"{after}")
+    if QFontDatabase.families():
+        assert before <= theme.PANEL_W, (
+            f"the panel minimum is {before}px, the panel is {theme.PANEL_W}px")
 
 
 # The status line elides the same way the combos do, for the same reason: it
@@ -288,9 +350,11 @@ LONG_STATUS = ('Anchor source: film stock (black point only) — '
 SHORT_STATUS = "Anchor source: white point (two-point)"
 
 
-def _render_label(cls, text, *, width=324):
+def _render_label(cls, text, *, width=None):
     label = cls()
     label.setText(text)
+    if width is None:
+        width = _fitting_width(label, SHORT_STATUS, theme.GAP_TIGHT * 4)
     label.setFixedSize(width, theme.CONTROL_H)
     _app.processEvents()
     return label.grab().toImage()

--- a/tests/test_panel_width.py
+++ b/tests/test_panel_width.py
@@ -232,6 +232,92 @@ def test_user_named_combos_elide(window, owner, attr):
         f"{owner}.{attr} holds arbitrary user text and must elide it")
 
 
+def test_selecting_a_film_stock_does_not_widen_the_panel(window):
+    """The status line under the combo NAMES the selected stock.
+
+    Keeping the combo itself narrow is only half of it: a plain QLabel's
+    minimum width is its whole text, so this line was enough on its own to push
+    the scroll content ~200px past the panel and clip every row in it — the
+    combo looked innocent because it already elides.
+    """
+    panel = window.sliders_panel
+    layout = panel.findChild(QScrollArea).widget().layout()
+    before = layout.minimumSize().width()
+    saved = (ccr_backend.black_point_bgr, ccr_backend.white_point_bgr,
+             ccr_backend.film_stock_name)
+    try:
+        ccr_backend.black_point_bgr = (100.0, 100.0, 100.0)
+        ccr_backend.white_point_bgr = None
+        ccr_backend.film_stock_name = "Kodak Portra 400 pushed two stops, 2026 batch"
+        panel._update_bwp_mode_label()
+        _app.processEvents()
+        assert panel.bwp_mode_label.text(), "the status line should be showing"
+        after = layout.minimumSize().width()
+    finally:
+        (ccr_backend.black_point_bgr, ccr_backend.white_point_bgr,
+         ccr_backend.film_stock_name) = saved
+        panel._update_bwp_mode_label()
+    assert after == before <= theme.PANEL_W, (
+        f"naming a film stock widened the content minimum from {before} to "
+        f"{after} (panel is {theme.PANEL_W}px)")
+
+
+def test_long_hint_word_does_not_widen_the_panel(window):
+    """The hint label wraps, which bounds it at its longest WORD — and a film
+    stock named without spaces is a single word."""
+    panel = window.sliders_panel
+    before = panel.minimumSizeHint().width()
+    try:
+        panel.set_temporary_hint(
+            'Film stock "Kodak_Portra_400_pushed_two_stops_2026_batch" deleted.',
+            duration=60000)
+        _app.processEvents()
+        after = panel.minimumSizeHint().width()
+    finally:
+        panel.hint_label.setText("")
+    assert after == before <= theme.PANEL_W, (
+        f"an unbreakable hint word widened the panel minimum from {before} to "
+        f"{after}")
+
+
+# The status line elides the same way the combos do, for the same reason: it
+# carries a user-supplied name in a panel that cannot scroll sideways.
+
+LONG_STATUS = ('Anchor source: film stock (black point only) — '
+               'Kodak Portra 400 pushed two stops, 2026 batch')
+SHORT_STATUS = "Anchor source: white point (two-point)"
+
+
+def _render_label(cls, text, *, width=324):
+    label = cls()
+    label.setText(text)
+    label.setFixedSize(width, theme.CONTROL_H)
+    _app.processEvents()
+    return label.grab().toImage()
+
+
+def test_eliding_label_matches_qt_exactly_for_text_that_fits():
+    """Drawing the text by hand must change nothing but the eliding — placement
+    and colour both come from the label, and either can silently drift."""
+    assert (_render_label(QLabel, SHORT_STATUS)
+            == _render_label(theme.ElidingLabel, SHORT_STATUS)), (
+        "text that fits must render exactly as QLabel draws it")
+
+
+def test_eliding_label_shortens_text_that_does_not_fit():
+    assert (_render_label(QLabel, LONG_STATUS)
+            != _render_label(theme.ElidingLabel, LONG_STATUS)), (
+        "text too long for the label must be elided, not clipped")
+
+
+def test_eliding_label_keeps_the_full_text_in_its_tooltip():
+    """Elision hides part of a name the user chose — the tooltip is the only
+    place it stays readable."""
+    label = theme.ElidingLabel()
+    label.setText(LONG_STATUS)
+    assert label.toolTip() == LONG_STATUS
+
+
 def test_eliding_combo_leaves_the_popup_list_intact(window):
     """Elision is display-only: the dropdown must still offer full names."""
     combo = window.sliders_panel.film_stock_combo


### PR DESCRIPTION
Closes #120

Three related defects in the right-hand panels, all of which read as "content is cut off".

## 1. The panels were too narrow for their content

The right-hand panels are pinned to 300px, but the sliders panel's content needs **325px** in the macOS system font. The scroll area has horizontal scrolling switched off, so everything past the right edge is cut rather than scrollable: **Convert All**, **Slice**, the **Color Profile** dropdown and the slider value column all ran off the panel.

Three rows exceed the 284px content budget:

| Row | Minimum width |
|---|---|
| WB Picker / AWB / Crop / Slice | 293px |
| Film Stock (label + combo + ＋/−) | 309px |
| Set Black Point / Set White Point / ✕ | 286px |

The left edge is the same problem from the other side: `LABEL_COL_W` was 90px and *"Subtracted Sat"* measures **89px** in that font — flush against the border and one font step from truncating.

Second, independent cause: `QComboBox.minimumSizeHint()` covers its **longest item** and propagates outward as a hard minimum on the whole panel. The film-stock combo alone demanded 163px, so one long user-named stock could re-break the layout at any panel width.

### Fix

- `theme.PANEL_W = 340`, shared by the sliders, dust and crop panels (they swap in place, so they must stay equal width). Sized off the widest row with slack instead of a bare literal tuned to one machine's font metrics.
- `LABEL_COL_W` 90 → 100, so the longest label keeps a margin.
- New `theme.shrinkable_combo()` caps a combo's minimum at a short contents length; applied to the film-stock, colour-profile and crop-aspect combos.

## 2. Long combo entries were clipped mid-word

Qt does not elide a non-editable `QComboBox`. It draws the label into the edit-field rect and lets the glyphs run under the arrow, so a user-named film stock rendered as `Fuji Superia X-TRA 40` — cut mid-word with nothing to say anything was missing. Same for an imported ICC/DCP name in the 216px sidebar: `NikonZ7_ColorChecker_202`.

This is display-only truncation, **not** the width problem above. Measured under the real macOS font, no combo in the app (sliders, crop, dust, sidebar, export, IT8, settings) grows its `minimumSizeHint` with content, and the central layout's 1472px minimum keeps the side panels at full width. The text was overflowing its own control, not pushing the panel's content off the edge.

### Fix

`theme.ElidingComboBox` draws the label itself, elided to the edit-field rect, leaving frame and arrow to the active style so the global QSS still applies. The popup list is untouched, so full names stay one click away. Applied to the two combos carrying arbitrary user text: the film-stock picker and the sidebar's camera-profile picker.

Placement is the subtle part: the `SC_ComboBoxEditField` rect already carries the style's padding, so insetting it further shifted short labels a few px right of where Qt puts them, leaving these combos visibly out of line with the rest of the row.

## 3. Selecting a film stock still widened the panel

Reported after the two fixes above: picking a film stock *still* pushed the panel's content past its edge. The combo was innocent — measured under the real macOS font, the panel holds at **290px** of its 324px budget with any stock selected, so `shrinkable_combo` is doing its job. The overflow came from the status line directly beneath it, which names the stock:

```
Anchor source: film stock "Kodak Portra 400 pushed two stops, 2026 batch" (black point only)
```

A `QLabel`'s minimum width is its **entire text** — 502px here. That is not merely an overflowing line: it raises the minimum of the scroll content, which is then resized to 518px inside a 324px viewport with horizontal scrolling off, so every row in the panel shifts and clips. Hence "the picker expands the panel content" rather than "the label is too long".

### Fix

- `theme.ElidingLabel` — single-line label elided at **paint** time, against the width the layout actually handed out. A hidden label has never been laid out, so its own `width()` at `setText` time is stale or still the default; paint time is the only moment the real width is known. Full text stays in the tooltip.
- `theme.keep_out_of_minimum_width()` — sets the horizontal policy to `Ignored`, the one case `qSmartMinSize` skips the text width for. It mutates the policy already on the widget rather than building a fresh one: `QLabel` keeps its height-for-width bit in there, and dropping that stops a word-wrapped label from reporting the taller height its wrapped text needs.
- Reordered the message to `Anchor source: film stock (black point only) — <name>`. Elision runs right to left, so a long name would otherwise eat `(black point only)` and leave the line saying nothing useful. The name is still shown in full by the combo directly above.
- The same guard on the word-wrapped hint label, which quotes stock names too (`Film stock "…" deleted.`). Word wrap bounds a label only at its longest **word**, and an unbroken name is one word — it already reached 314px of the 340px panel. Not yet visible, but the same defect one character away.

## Tests

`tests/test_panel_width.py`, 25 tests:

- Panel layouts and scroll content must fit their width; no sliders row may exceed the content budget; a long combo entry must not widen the panel or the sidebar.
- The headless test font is *narrower* than a real desktop UI font, so fitting it proves little on its own — the guard that bites is `test_panel_survives_a_wider_ui_font`, which re-measures with the UI font enlarged 15%. Verified it fails on the old constants (`row 3 needs 290px, budget is 284px`).
- Elision is pinned by pixel-comparing against a plain `QComboBox` / `QLabel`: identical when the text fits (for the combo, in both enabled states), different when it doesn't. Verified these assertions fail if the custom `paintEvent` is removed.
- `test_selecting_a_long_film_stock_does_not_widen_the_panel` and `test_long_hint_word_does_not_widen_the_panel` cover §3; both were confirmed to fail on the pre-fix code even in the narrower headless font.

Suite: **1061 passed, 4 skipped** via `tests/run_tests.py`. One pre-existing unrelated failure (`test_export_naming.py::TestUniquifyInBatch::test_case_insensitive`), confirmed failing on a clean `main` and left alone.

Note for anyone running the suite in a single process: `pytest tests/` segfaults in `test_slice.py`. That reproduces on a clean `main` too — a pre-existing test-isolation issue, unrelated to this branch. `tests/run_tests.py` (file per process) is unaffected.

Verified visually on macOS at the real system font: default panel, dust panel, crop panel, the sliders panel with Curves / Subtractive Saturations / Channel Levels expanded, both combos with long names in enabled and disabled states, and the panel rendered at its real 340px width with a long film stock selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERy9JfcugxV5B1CYYbGQps

