### PR TITLE
feat(panel): copy/sync the 90-degree rotation and mirror flags

### DIFF
--- a/spec/orientation-sync-group.md
+++ b/spec/orientation-sync-group.md
@@ -1,0 +1,185 @@
+# Orientation as a Copy/Sync Setting Group
+
+Add **Orientation** — the coarse 90° rotation and the horizontal/vertical
+mirror flags — to the group list both "apply to many" popups offer, so a roll
+scanned upside-down or emulsion-side-up can be righted once and pushed onto the
+other frames instead of clicking `[` / `]` on every one.
+
+## Goals
+
+- A new `SYNC_GROUPS` entry, `orientation`, covering `rotation_angle`,
+  `horizontal_mirrored` and `vertical_mirrored`.
+- It appears — same layout, same wording rules — in **both** dialogs that are
+  driven by `SYNC_GROUPS`: **Sync to All** and `Ctrl/Cmd+C`'s **Copy Settings**.
+  Checking it makes **Sync to All** push the source frame's orientation onto
+  every image, and makes `Ctrl/Cmd+V` apply it to the frame(s) the user pastes
+  onto.
+- Orientation participates in undo exactly like crop: one snapshot per changed
+  image, restored by `Ctrl+Z`.
+- A frame whose orientation is *not* being synced/pasted keeps its own,
+  untouched — same per-group isolation the other entries have.
+
+## Non-goals
+
+- **`fine_rotation_angle` is not included.** The micro-rotation is measured per
+  frame from *that frame's* own film edge (`auto_fine_angle`), so copying one
+  frame's value onto another mis-straightens it. It also folds into
+  `crop_angle` (`folded_crop_angle`), which the existing **Crop** group already
+  carries — the straighten a user sets in the Crop panel therefore still
+  travels, under Crop.
+- No new UI surface: no toolbar button, no thumbnail context-menu entry. The
+  two existing popups are the whole delivery.
+- No re-processing. Rotation and mirroring are display-level transforms applied
+  at paint time (`ImagePreview.apply_transformations`,
+  `ThumbnailList.apply_frontend_transformations`) and at export
+  (`ccr_processor`). They do not touch `resized_raw`, the histogram, or any
+  conversion input, so syncing them must **not** trigger
+  `update_thumbnail_and_preview()`.
+
+## UX / interaction
+
+The group is inserted **directly after `crop`**, keeping the two geometry
+entries adjacent:
+
+```
+Color Profile (Color / B&W)
+White Balance / Tint
+Tone (gain, brightness, contrast, ...)
+Saturation
+Crop
+Orientation (rotate 90° / mirror)      ← new
+Channel Levels
+Subtractive Saturations (per color)
+Curves
+```
+
+Everything else about the dialogs is unchanged: checked by default on first
+open, remembered per-dialog while the app is open, Select All / Deselect All,
+and the `Copied N of M setting groups.` hint — whose `M` simply becomes 9.
+
+Because a remembered selection is read with `.get(gid, True)` in the dialog and
+`.get(gid)` at apply time, an in-flight session that predates the group is not
+a concern (the selections are session-only), and a *stale* clipboard selection
+that lacks `orientation` reads as unchecked.
+
+## Data model
+
+Nothing new is persisted. `rotation_angle` / `horizontal_mirrored` /
+`vertical_mirrored` already live on `CCRImage`, are already captured by
+`capture_undo_state` / `pop_undo_state`, and are already serialised by
+`core/catalog.py`. This feature only adds new *writers*.
+
+New `SlidersPanel` state, alongside `copied_profile` / `copied_crop`:
+
+| Attribute | Meaning |
+| --- | --- |
+| `copied_orientation` | `(rotation_angle, horizontal_mirrored, vertical_mirrored)`, or `None` when the orientation group was not copied. |
+
+Orientation is a whole-image property with no per-area meaning, so — like
+Color Profile and Crop — it is read off the `CCRImage`, never off the live UI,
+regardless of which layer is active.
+
+## Behaviour
+
+### Sync to All (`_perform_sync_to_all`)
+
+1. Read `src_orientation = (rot, hflip, vflip)` from the source image.
+2. Per target: `orientation_changes = sync_orientation and target triple !=
+   src_orientation`. Fold it into the existing "nothing to change → skip"
+   guard so an all-identical batch still pushes no dead undo entries.
+3. After `push_undo_state()`, assign the three attributes.
+4. **Do not** add `orientation_changes` to the condition that calls
+   `update_thumbnail_and_preview()` — see Non-goals. The trailing
+   `update_all_thumbnails()` re-runs `apply_frontend_transformations`, and
+   `update_preview()` re-reads the orientation for the canvas.
+5. Zoom needs no reset: the currently displayed image *is* the sync source, so
+   its own orientation cannot change here.
+
+### Copy (`copy_adjustment_settings`)
+
+`copied_orientation = (img.rotation_angle, img.horizontal_mirrored,
+img.vertical_mirrored)` when the group is checked, else `None` — mirroring how
+`copied_crop` is built (`getattr` defaults keep a stub image safe).
+
+### Paste (`paste_adjustment_settings`)
+
+Inside the existing `if img is not None:` block, alongside profile and crop:
+assign the three attributes from `copied_orientation`.
+
+Unlike Sync to All, the paste target **is** the displayed image, so a changed
+orientation moves the displayed content under a zoomed viewport. Reset the zoom
+first — the same reason `rotate_left`/`rotate_right` and `undo_last_action`
+call `_reset_zoom()`. Guard it with `hasattr`, since tests drive the panel with
+a stub preview.
+
+The refresh at the tail of paste (`update_thumbnail(idx)` +
+`update_preview(idx)`) already picks the new orientation up; no extra call.
+
+## Integration points
+
+| Location | Change |
+| --- | --- |
+| `SYNC_GROUPS` (`src/widgets/sliders_panel.py:27`) | New `("orientation", "Orientation (rotate 90° / mirror)", ())` entry after `crop`. |
+| `SlidersPanel.__init__` (`:313`) | New `copied_orientation = None`, next to `copied_crop`. |
+| `_perform_sync_to_all` (`:1437`) | Read the source triple; per-target change detection, undo, assignment. |
+| `copy_adjustment_settings` (`:1886`) | Populate `copied_orientation`. |
+| `paste_adjustment_settings` (`:1933`) | Apply `copied_orientation`; reset zoom when it lands. |
+| `tests/test_sub_saturation_crop_undo.py::TestSyncGroups::test_expected_group_ids` | Expected id list gains `"orientation"`. |
+| `user_guide/get_started.md:38` | Add orientation to the enumerated copyable groups. |
+
+The `°` in the label is safe on the macOS ASCII-stdout path
+(`memory: macos-ascii-stdout-crash`): group **labels** are only ever rendered
+into `QCheckBox` text, while the one `print` in `_perform_sync_to_all` logs
+group **ids**. The same dialog already carries `☑`/`☐` in its button text.
+
+Deliberately unchanged: `_tether_template` / `_apply_tether_template` already
+carry orientation to a new capture, `core/catalog.py` already persists it, and
+`SlidersPanel.ADJUSTMENT_KEYS` gains nothing (the group has an empty key tuple,
+like `crop`, `profile` and `curves`), so
+`TestSyncGroups::test_groups_partition_adjustment_keys` keeps passing as-is.
+
+## Resolved edge cases
+
+- **Default orientation is a real value.** Pasting/syncing a frame that is
+  upright and unmirrored *straightens* targets that were rotated, exactly as a
+  copied `crop_rect is None` clears a target's crop.
+- **Crop + orientation together.** `crop_rect` is stored in un-rotated,
+  un-mirrored image coordinates, so the two groups are independent and can be
+  synced in either combination without interacting.
+- **Reference frame.** Also stored in un-rotated full-image coordinates —
+  unaffected.
+- **Crop mode open during a paste.** `update_preview` → `apply_transformations`
+  rebuilds the crop overlay from the new base transform, the same path a manual
+  rotate takes while cropping.
+- **Unconverted target.** Not gated. Orientation is display-level and applies
+  whether or not the frame has been converted.
+
+## Test plan
+
+New `tests/test_orientation_sync_group.py`, reusing the offscreen-Qt harness
+and stubbed-dialog pattern of `tests/test_copy_settings_dialog.py`:
+
+1. **Group registration** — `orientation` is present in `SYNC_GROUPS`, sits
+   immediately after `crop`, and carries an empty key tuple (so it cannot
+   perturb the ADJUSTMENT_KEYS partition).
+2. **Copy stores the triple** — copying with only `orientation` checked leaves
+   `copied_orientation == (90, True, False)` and an empty `copied_adjustment`.
+3. **Copy without the group** — `copied_orientation is None`.
+4. **Paste applies it** — a target at `(0, False, False)` becomes the copied
+   triple, and one undo state is pushed.
+5. **Paste without the group leaves the target's orientation alone** — copy WB
+   only, paste onto a rotated frame: rotation/mirrors unchanged.
+6. **Paste restores the default orientation** — copying an upright source onto
+   a rotated target un-rotates it.
+7. **Sync to All** — orientation lands on every image; images that already
+   matched push no undo state.
+8. **Sync isolation** — syncing orientation only does not disturb targets'
+   adjustment values, crop, or profile.
+9. **No reprocess** — syncing orientation alone leaves each target's
+   `histogram_data` byte-identical (guards the "display-level only" contract).
+10. **`fine_rotation_angle` is never copied or synced** — a source with a
+    non-zero fine rotation leaves targets' fine rotation untouched.
+
+Existing suites that must keep passing unchanged:
+`tests/test_copy_settings_dialog.py`, `tests/test_sub_saturation_crop_undo.py`
+(`TestSyncGroups` after its id-list update), `tests/test_cineon_log.py`.

--- a/src/widgets/sliders_panel.py
+++ b/src/widgets/sliders_panel.py
@@ -23,7 +23,8 @@ FILM_STOCK_DEFAULT_LABEL = "Default"
 
 # Setting groups offered by the "Sync to All" and "Copy Settings" dialogs. The
 # adjustment-key groups partition SlidersPanel.ADJUSTMENT_KEYS exactly; "crop"
-# syncs the image's crop box (rect + angle) instead of adjustment keys.
+# syncs the image's crop box (rect + angle) and "orientation" its coarse
+# rotation/mirror flags, instead of adjustment keys.
 SYNC_GROUPS = [
     ("profile", "Color Profile (Color / B&W)", ()),
     ("wb", "White Balance / Tint", ("temperature", "tint")),
@@ -32,6 +33,12 @@ SYNC_GROUPS = [
       "shadows", "black_point", "contrast")),
     ("sat", "Saturation", ("saturation", "sub_saturation")),
     ("crop", "Crop", ()),
+    # Coarse 90-degree rotation + the mirror flags, synced like crop (whole-image
+    # properties, not adjustment keys). fine_rotation_angle is deliberately NOT
+    # part of this group — it is measured per frame from that frame's own film
+    # edge, and the straighten a user sets rides "crop" as the crop angle.
+    # See spec/orientation-sync-group.md.
+    ("orientation", "Orientation (rotate 90° / mirror)", ()),
     ("channels", "Channel Levels", (
         "ch_input_gain", "ch_master_shift", "ch_master_gain",
         "ch_r_shift", "ch_r_gain", "ch_r_blackpoint",
@@ -46,6 +53,22 @@ SYNC_GROUPS = [
     # slider), so it's synced specially in _perform_sync_to_all, like crop.
     ("curves", "Curves", ()),
 ]
+
+
+def _orientation_of(img):
+    """The "orientation" group's value for an image: coarse rotation + mirrors.
+    Returns the default triple for a missing image so callers can compare
+    without None-checks."""
+    if img is None:
+        return (0, False, False)
+    return (getattr(img, "rotation_angle", 0),
+            bool(getattr(img, "horizontal_mirrored", False)),
+            bool(getattr(img, "vertical_mirrored", False)))
+
+
+def _apply_orientation(img, orientation):
+    """Write an _orientation_of() triple back onto an image."""
+    img.rotation_angle, img.horizontal_mirrored, img.vertical_mirrored = orientation
 
 
 class SyncSettingsDialog(QDialog):
@@ -311,6 +334,9 @@ class SlidersPanel(QWidget):
         self.copied_selection = None   # {gid: bool} used for this clipboard
         self.copied_profile = None     # "color"/"bw" when the profile group was copied
         self.copied_crop = None        # (crop_rect, crop_angle) when crop was copied
+        # (rotation_angle, horizontal_mirrored, vertical_mirrored) when the
+        # orientation group was copied. See spec/orientation-sync-group.md.
+        self.copied_orientation = None
         self._hint_timer = QTimer(self)  # Timer for temporary hints
         self._hint_timer.setSingleShot(True)
         
@@ -1444,6 +1470,7 @@ class SlidersPanel(QWidget):
         sync_crop = bool(selection.get("crop"))
         sync_profile = bool(selection.get("profile"))
         sync_curves = bool(selection.get("curves"))
+        sync_orientation = bool(selection.get("orientation"))
         # Sync always copies the SOURCE image's GLOBAL (whole-image) layer, not
         # the live sliders — those may currently reflect an active area, and
         # areas are per-image (never synced). Read from the global dict.
@@ -1454,6 +1481,7 @@ class SlidersPanel(QWidget):
         crop_rect = src.crop_rect if src is not None else None
         crop_angle = getattr(src, "crop_angle", 0.0) if src is not None else 0.0
         src_profile = getattr(src, "color_profile", "color") if src is not None else "color"
+        src_orientation = _orientation_of(src)
         print(f"Syncing groups {sorted(g for g, on in selection.items() if on)} to all images")
 
         for img in ccr_backend.images:
@@ -1464,7 +1492,9 @@ class SlidersPanel(QWidget):
                                           or getattr(img, "crop_angle", 0.0) != crop_angle)
             profile_changes = sync_profile and getattr(img, "color_profile", "color") != src_profile
             curves_changes = sync_curves and img.adjustment_settings.get("curves") != src_curves
-            if not adj_changes and not crop_changes and not profile_changes and not curves_changes:
+            orient_changes = sync_orientation and _orientation_of(img) != src_orientation
+            if (not adj_changes and not crop_changes and not profile_changes
+                    and not curves_changes and not orient_changes):
                 continue  # nothing to change — and no dead undo snapshot
             img.push_undo_state()
             if adj_changes:
@@ -1498,6 +1528,10 @@ class SlidersPanel(QWidget):
                 img.crop_angle = crop_angle
             if profile_changes:
                 img.color_profile = src_profile
+            if orient_changes:
+                # Display-level only (no reprocess): the thumbnail refresh and
+                # update_preview below re-apply it from these attributes.
+                _apply_orientation(img, src_orientation)
             if adj_changes or profile_changes or curves_changes or crop_changes:
                 # Adjustments, curves, and the color profile all change pixels;
                 # a crop change moves the region the histogram is computed over
@@ -1924,6 +1958,9 @@ class SlidersPanel(QWidget):
                                if selection.get("profile") and img is not None else None)
         self.copied_crop = ((img.crop_rect, getattr(img, "crop_angle", 0.0))
                             if selection.get("crop") and img is not None else None)
+        self.copied_orientation = (_orientation_of(img)
+                                   if selection.get("orientation") and img is not None
+                                   else None)
         self.copied_selection = selection
         print(f"Copied groups {sorted(g for g, on in selection.items() if on)}: "
               f"{self.copied_adjustment}")
@@ -2001,6 +2038,16 @@ class SlidersPanel(QWidget):
                 # target's crop. The reprocess below refreshes the crop-aware
                 # histogram.
                 img.crop_rect, img.crop_angle = self.copied_crop
+            if (selection.get("orientation") and self.copied_orientation is not None
+                    and _orientation_of(img) != self.copied_orientation):
+                # Unlike Sync to All (whose source IS the displayed image), a
+                # paste re-orients what's on screen — a kept zoom would strand
+                # the viewport, exactly as for rotate_left/right and undo.
+                _apply_orientation(img, self.copied_orientation)
+                reset_zoom = getattr(self.parent().parent().image_preview,
+                                     "_reset_zoom", None)
+                if callable(reset_zoom):
+                    reset_zoom()
 
         ccr_backend.set_active_settings_by_index(
             self.current_idx, merged, reprocess=True)

--- a/tests/test_orientation_sync_group.py
+++ b/tests/test_orientation_sync_group.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Tests for the "Orientation" setting group — the coarse 90-degree rotation
+and the mirror flags carried by Sync to All and Ctrl/Cmd+C's Copy Settings.
+See spec/orientation-sync-group.md."""
+
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import cv2  # noqa: E402
+from PySide6.QtWidgets import (QApplication, QDialog, QWidget,  # noqa: E402
+                               QVBoxLayout)
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+from core.ccr_image import CCRImage  # noqa: E402
+from widgets.sliders_panel import (SlidersPanel, SyncSettingsDialog,  # noqa: E402
+                                   SYNC_GROUPS)
+
+
+# --- harness -----------------------------------------------------------------
+
+def _ccr_image(tmp_path, name="scan.png"):
+    """A CCRImage from a tiny uniform on-disk scan so __init__ succeeds."""
+    path = str(tmp_path / name)
+    base = np.full((40, 60, 3), 20000, np.uint16)
+    cv2.imwrite(path, cv2.cvtColor(base, cv2.COLOR_RGB2BGR))
+    img = CCRImage(path)
+    img.converted = True
+    img.adjustment_settings = {}
+    return img
+
+
+class _ImagePreviewStub:
+    def __init__(self):
+        self.updated = []
+
+    def update_preview(self, idx):
+        self.updated.append(idx)
+
+
+class _Host(QWidget):
+    """parent().parent() target carrying image_preview (as MainWindow does)."""
+    def __init__(self):
+        super().__init__()
+        self.image_preview = _ImagePreviewStub()
+        self.mid = QWidget(self)
+
+
+_HOSTS = []
+
+
+def _panel():
+    host = _Host()
+    _HOSTS.append(host)               # keep alive for the test's lifetime
+    mid_layout = QVBoxLayout(host.mid)
+    panel = SlidersPanel(host.mid)
+    mid_layout.addWidget(panel)
+    return panel
+
+
+def _stub_dialog(monkeypatch, selection, accepted=True):
+    """Replace the modal group picker with a canned answer. `selection` is a
+    partial {gid: bool}; unlisted groups count as unchecked."""
+    full = {gid: bool(selection.get(gid)) for gid, _l, _k in SYNC_GROUPS}
+
+    def _exec(self):
+        return QDialog.Accepted if accepted else QDialog.Rejected
+
+    monkeypatch.setattr(SyncSettingsDialog, "exec_", _exec, raising=False)
+    monkeypatch.setattr(SyncSettingsDialog, "selection", lambda self: dict(full))
+    return full
+
+
+def _copy(panel, monkeypatch, selection, accepted=True):
+    _stub_dialog(monkeypatch, selection, accepted)
+    panel.copy_adjustment_settings()
+
+
+def _set(panel, key, value):
+    panel.sliders[panel.adjustment_keys.index(key)].setValue(value)
+
+
+def _orient(img):
+    return (img.rotation_angle, img.horizontal_mirrored, img.vertical_mirrored)
+
+
+def _set_orient(img, rotation, hflip=False, vflip=False):
+    img.rotation_angle = rotation
+    img.horizontal_mirrored = hflip
+    img.vertical_mirrored = vflip
+
+
+def _two_images(tmp_path):
+    src = _ccr_image(tmp_path, "src.png")
+    tgt = _ccr_image(tmp_path, "tgt.png")
+    ccr_backend.images = [src, tgt]
+    ccr_backend.file_paths = [src.file_path, tgt.file_path]
+    return src, tgt
+
+
+# --- the group itself ---------------------------------------------------------
+
+class TestGroupRegistration:
+    def test_orientation_follows_crop(self):
+        ids = [gid for gid, _l, _k in SYNC_GROUPS]
+        assert "orientation" in ids
+        assert ids[ids.index("crop") + 1] == "orientation"
+
+    def test_carries_no_adjustment_keys(self):
+        """Whole-image group, like crop/profile/curves — so it cannot disturb
+        the SYNC_GROUPS-partitions-ADJUSTMENT_KEYS invariant."""
+        keys = dict((gid, k) for gid, _l, k in SYNC_GROUPS)["orientation"]
+        assert keys == ()
+
+    def test_offered_by_both_dialogs(self):
+        for kwargs in ({}, {"title": "Copy Settings", "action_label": "Copy"}):
+            dlg = SyncSettingsDialog(None, None, **kwargs)
+            assert "orientation" in dlg._checkboxes
+            assert dlg.selection()["orientation"] is True   # checked by default
+
+
+# --- copy ---------------------------------------------------------------------
+
+class TestCopy:
+    def test_copy_stores_the_orientation_triple(self, tmp_path, monkeypatch):
+        img = _ccr_image(tmp_path)
+        _set_orient(img, 90, hflip=True)
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+        panel = _panel()
+        panel.current_idx = 0
+
+        _copy(panel, monkeypatch, {"orientation": True})
+
+        assert panel.copied_orientation == (90, True, False)
+        assert panel.copied_adjustment == {}      # no adjustment keys ride along
+
+    def test_unselected_group_copies_nothing(self, tmp_path, monkeypatch):
+        img = _ccr_image(tmp_path)
+        _set_orient(img, 180)
+        ccr_backend.images = [img]
+        ccr_backend.file_paths = [img.file_path]
+        panel = _panel()
+        panel.current_idx = 0
+
+        _copy(panel, monkeypatch, {"wb": True})
+
+        assert panel.copied_orientation is None
+
+
+# --- paste --------------------------------------------------------------------
+
+class TestPaste:
+    def test_paste_applies_rotation_and_mirrors(self, tmp_path, monkeypatch):
+        src, tgt = _two_images(tmp_path)
+        _set_orient(src, 270, hflip=True, vflip=True)
+        panel = _panel()
+
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"orientation": True})
+
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert _orient(tgt) == (270, True, True)
+        assert len(tgt.undo_stack) == 1
+
+    def test_paste_restores_the_default_orientation(self, tmp_path, monkeypatch):
+        """An upright source is a real value: pasting it un-rotates the target,
+        the same way a copied 'no crop' clears the target's crop."""
+        src, tgt = _two_images(tmp_path)
+        _set_orient(tgt, 90, vflip=True)
+        panel = _panel()
+
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"orientation": True})
+
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert _orient(tgt) == (0, False, False)
+
+    def test_uncopied_group_leaves_target_orientation_alone(self, tmp_path, monkeypatch):
+        src, tgt = _two_images(tmp_path)
+        _set_orient(src, 180, hflip=True)
+        _set_orient(tgt, 90, vflip=True)
+        panel = _panel()
+
+        panel.current_idx = 0
+        _set(panel, "temperature", 40)
+        _copy(panel, monkeypatch, {"wb": True})
+
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert _orient(tgt) == (90, False, True)
+        assert tgt.adjustment_settings["temperature"] == 40   # the copied group did land
+
+    def test_paste_resets_the_zoom_when_the_view_re_orients(self, tmp_path, monkeypatch):
+        """The paste target IS the displayed image, so a kept zoom would strand
+        the viewport — same reason rotate_left/right and undo reset it."""
+        src, tgt = _two_images(tmp_path)
+        _set_orient(src, 90)
+        panel = _panel()
+        preview = panel.parent().parent().image_preview
+        calls = []
+        preview._reset_zoom = lambda: calls.append(True)
+
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"orientation": True})
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+        assert calls == [True]
+
+        # Pasting the same orientation onto an already-matching target is not a
+        # re-orientation — the viewport stays put.
+        panel.paste_adjustment_settings()
+        assert calls == [True]
+
+
+# --- sync to all --------------------------------------------------------------
+
+class TestSyncToAll:
+    def test_orientation_lands_on_every_image(self, tmp_path):
+        src, tgt = _two_images(tmp_path)
+        third = _ccr_image(tmp_path, "third.png")
+        ccr_backend.images.append(third)
+        ccr_backend.file_paths.append(third.file_path)
+        _set_orient(src, 90, hflip=True)
+        _set_orient(tgt, 180)
+
+        panel = _panel()
+        panel.current_idx = 0
+        panel._sync_group_selection = {"orientation": True}
+        panel._perform_sync_to_all()
+
+        assert _orient(tgt) == (90, True, False)
+        assert _orient(third) == (90, True, False)
+
+    def test_matching_images_push_no_undo_state(self, tmp_path):
+        src, tgt = _two_images(tmp_path)
+        _set_orient(src, 90)
+        _set_orient(tgt, 90)
+
+        panel = _panel()
+        panel.current_idx = 0
+        panel._sync_group_selection = {"orientation": True}
+        panel._perform_sync_to_all()
+
+        assert tgt.undo_stack == []      # no dead snapshot for an unchanged image
+
+    def test_sync_leaves_other_groups_alone(self, tmp_path):
+        src, tgt = _two_images(tmp_path)
+        _set_orient(src, 90)
+        src.color_profile = "bw"
+        src.crop_rect = (0.1, 0.1, 0.9, 0.9)
+        src.adjustment_settings = {"temperature": 40}
+        tgt.color_profile = "color"
+        tgt.crop_rect = None
+        tgt.adjustment_settings = {"temperature": -25}
+
+        panel = _panel()
+        panel.current_idx = 0
+        panel._sync_group_selection = {"orientation": True}
+        panel._perform_sync_to_all()
+
+        assert _orient(tgt) == (90, False, False)
+        assert tgt.color_profile == "color"
+        assert tgt.crop_rect is None
+        assert tgt.adjustment_settings["temperature"] == -25
+
+    def test_orientation_only_sync_does_not_reprocess(self, tmp_path):
+        """Rotation/mirroring are display-level transforms applied at paint
+        time — they must not trigger a re-render of the preview buffers."""
+        src, tgt = _two_images(tmp_path)
+        _set_orient(src, 90)
+        tgt.update_thumbnail_and_preview()
+        before = tgt.histogram_data.tobytes()
+
+        reprocessed = []
+        tgt.update_thumbnail_and_preview = lambda: reprocessed.append(True)
+
+        panel = _panel()
+        panel.current_idx = 0
+        panel._sync_group_selection = {"orientation": True}
+        panel._perform_sync_to_all()
+
+        assert reprocessed == []
+        assert tgt.histogram_data.tobytes() == before
+
+    def test_fine_rotation_is_never_synced(self, tmp_path):
+        """The micro-rotation is measured from each frame's OWN film edge;
+        copying it across frames would mis-straighten them. A user-set
+        straighten travels under the crop group, as the crop angle."""
+        src, tgt = _two_images(tmp_path)
+        _set_orient(src, 90)
+        src.fine_rotation_angle = 123
+        tgt.fine_rotation_angle = -45
+
+        panel = _panel()
+        panel.current_idx = 0
+        panel._sync_group_selection = {"orientation": True}
+        panel._perform_sync_to_all()
+
+        assert tgt.fine_rotation_angle == -45
+
+    def test_fine_rotation_is_never_copied(self, tmp_path, monkeypatch):
+        src, tgt = _two_images(tmp_path)
+        _set_orient(src, 90)
+        src.fine_rotation_angle = 123
+        tgt.fine_rotation_angle = -45
+
+        panel = _panel()
+        panel.current_idx = 0
+        _copy(panel, monkeypatch, {"orientation": True})
+        panel.current_idx = 1
+        panel.paste_adjustment_settings()
+
+        assert tgt.fine_rotation_angle == -45
+        assert tgt.rotation_angle == 90

--- a/tests/test_sub_saturation_crop_undo.py
+++ b/tests/test_sub_saturation_crop_undo.py
@@ -168,7 +168,8 @@ class TestSyncGroups:
     def test_expected_group_ids(self):
         from widgets.sliders_panel import SYNC_GROUPS
         assert [gid for gid, _l, _k in SYNC_GROUPS] == [
-            "profile", "wb", "tone", "sat", "crop", "channels", "bands", "curves"]
+            "profile", "wb", "tone", "sat", "crop", "orientation",
+            "channels", "bands", "curves"]
 
 
 def _stub_image():

--- a/user_guide/get_started.md
+++ b/user_guide/get_started.md
@@ -35,7 +35,7 @@ Use the adjustment sliders on the right panel:
 - **White/Black Point**: Set highlight and shadow clipping points
 - **Contrast**: Increase or decrease contrast
 - **Saturation**: Adjust color intensity
-You can use the "Sync to All" button to apply adjustments to all images, or use `Ctrl/Command+C` and `Ctrl/Command+V` to copy and paste settings to another image. Both ask which setting groups you mean — white balance, tone, saturation, crop, curves and so on — so you can copy just the crop, or just the white balance, and leave everything else on the target image untouched.
+You can use the "Sync to All" button to apply adjustments to all images, or use `Ctrl/Command+C` and `Ctrl/Command+V` to copy and paste settings to another image. Both ask which setting groups you mean — white balance, tone, saturation, crop, orientation (90° rotation and mirroring), curves and so on — so you can copy just the crop, or just the white balance, and leave everything else on the target image untouched.
 
 ### Step 7: Export Your Images
 -  (Optional) Select Checkbox **Export Jpg** to export JPEG for web use


### PR DESCRIPTION
Adds an **Orientation** entry to the setting-group list that drives both apply-to-many popups — **Sync to All** and `Ctrl/Cmd+C`'s **Copy Settings**.

A roll scanned upside-down or emulsion-side-up can now be righted once and pushed onto the other frames, instead of pressing `[` / `]` on every one. Checking the box makes Sync to All push the source frame's orientation onto every image, and `Ctrl/Cmd+V` apply it to the frame being pasted onto.

The group carries `rotation_angle` (the coarse 90° steps) plus `horizontal_mirrored` / `vertical_mirrored`.

### What it deliberately leaves out

`fine_rotation_angle`. The micro-rotation is measured per frame from *that frame's* own film edge (`auto_fine_angle`), so copying one frame's value onto another mis-straightens it. A straighten the user sets in the Crop panel folds into `crop_angle` and therefore still travels — under the existing **Crop** group.

### Notes

- **No reprocess.** Rotation and mirroring are display-level transforms applied at paint time (`apply_transformations` / `apply_frontend_transformations`) and at export, so syncing them skips `update_thumbnail_and_preview()`; the thumbnail + preview refresh at the tail re-reads them.
- **Zoom.** A paste re-orients what is on screen (unlike a sync, whose source *is* the displayed image), so it resets the zoom first — the same reason `rotate_left`/`rotate_right` and undo do.
- Orientation participates in undo like crop: one snapshot per changed image, and images that already match push none.
- Nothing new is persisted — `core/catalog.py` and `capture_undo_state` already carry these three attributes; this only adds writers.

Spec: `spec/orientation-sync-group.md`.

### Tests

New `tests/test_orientation_sync_group.py` (15 tests): group registration and placement, copy/paste of the triple, un-copied groups leaving the target's orientation alone, pasting the default orientation as a real value, the zoom reset, sync isolation from other groups, no-reprocess, and `fine_rotation_angle` never travelling by either path.

Passing: `test_orientation_sync_group.py`, `test_copy_settings_dialog.py`, `test_sub_saturation_crop_undo.py`, `test_histogram_crop.py`, `test_cineon_log.py`, `test_curves.py`, `test_color_profile.py`, `test_area_editing.py` — 136 total, 0 failures.

Both dialogs were screenshot-verified offscreen; the new row sits directly under **Crop** and the `°` renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
