### PR TITLE
feat(cli): open files, folders and wildcards given on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,15 +170,20 @@ python write_version.py   # required on first run or after tagging
 python src/main.py
 ```
 
-FreeCCR can also be pointed at images from the command line — files, folders, or
-a mix. A single folder opens like **Open Folder**; anything else opens as a file
-list, with each folder expanded to the images inside it:
+FreeCCR can also be pointed at images from the command line — files, folders,
+wildcards, or a mix. A single folder opens like **Open Folder**; anything else
+opens as a file list, with each folder expanded to the images inside it:
 
 ```bash
 python src/main.py /rolls/roll-07          # open a whole folder
 python src/main.py a.nef b.nef c.nef       # open specific frames
+python src/main.py "/rolls/roll-07/*.tif"  # open everything matching
 python src/main.py --help                  # usage, then exit
 ```
+
+Wildcards (`*`, `?`, `**`) are expanded by FreeCCR itself, so they work the same
+in cmd.exe and PowerShell — which, unlike a Unix shell, hand patterns to the
+program untouched — as they do in bash or zsh.
 
 <details>
 <summary><strong>Build a standalone Windows executable + installer</strong></summary>

--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ python write_version.py   # required on first run or after tagging
 python src/main.py
 ```
 
+FreeCCR can also be pointed at images from the command line — files, folders, or
+a mix. A single folder opens like **Open Folder**; anything else opens as a file
+list, with each folder expanded to the images inside it:
+
+```bash
+python src/main.py /rolls/roll-07          # open a whole folder
+python src/main.py a.nef b.nef c.nef       # open specific frames
+python src/main.py --help                  # usage, then exit
+```
+
 <details>
 <summary><strong>Build a standalone Windows executable + installer</strong></summary>
 

--- a/spec/cli-file-args.md
+++ b/spec/cli-file-args.md
@@ -92,17 +92,27 @@ as a dialog import would, so the next dialog opens where the CLI pointed.
    `-qwindowtitle`, `-qwindowicon`, and their `--` spellings). `-opt=value`
    carries its value inline and consumes nothing. `--` ends option processing:
    everything after it is a path, even a leading-dash one.
-2. **Classify** each remaining argument: existing directory, existing file, or
+2. **Expand wildcards.** An argument containing `*`, `?` or `[` that does not
+   already name an existing path is replaced in place by its `glob` matches,
+   sorted case-insensitively (`recursive=True`, so an explicit `**` walks). A
+   pattern matching nothing is left literal for step 2 to report. Unix shells
+   do this before `argv` reaches us; cmd.exe and PowerShell do not, so doing it
+   here is what makes `freeccr *.tif` behave the same on every host. Checking
+   for an existing path first keeps a file literally named `shot[1].tif`
+   openable. Because expansion happens before the rules below, a pattern
+   behaves exactly like the paths it matched — one matching a single folder
+   takes the single-folder rule.
+3. **Classify** each remaining argument: existing directory, existing file, or
    missing.
-3. **Plan.** One argument, a directory ⇒ `folder=` that path. Otherwise expand
+4. **Plan.** One argument, a directory ⇒ `folder=` that path. Otherwise expand
    every directory (non-recursive, `SUPPORTED_EXTS`, sorted case-insensitively
    by name) and concatenate with the named files in argument order,
    de-duplicated by normalised absolute path, first occurrence winning.
-4. **Dispatch** on the GUI thread via `QTimer.singleShot(0, …)` after
+5. **Dispatch** on the GUI thread via `QTimer.singleShot(0, …)` after
    `window.show()`: `MainWindow.load_paths(paths)` runs the plan, calls the same
    helpers the dialogs call, then reports `problems`.
 
-Steps 1–3 are pure (no Qt, no `MainWindow`) and live in `src/utils/cli_args.py`;
+Steps 1–4 are pure (no Qt, no `MainWindow`) and live in `src/utils/cli_args.py`;
 only step 4 touches the GUI.
 
 ## 5. Integration points
@@ -146,6 +156,12 @@ only step 4 touches the GUI.
 - **Missing paths** land in `problems` and not in `files`; an empty folder is
   reported too; a plan of nothing but missing paths yields empty `folder`/`files`.
 - **Nested folders are not walked** (a subdirectory contributes nothing).
+- **Wildcards** expand to their matches in case-insensitive order and plan as a
+  file list; `?` matches one character; an unmatched pattern is reported as
+  *no files match this pattern* rather than *not found*; a real file named
+  `shot[1].nef` wins over character-class interpretation; a pattern matching
+  one folder takes the single-folder rule and several folders expand in a list;
+  `**` recurses while a single `*` stays at one level.
 
 `tests/test_cli_startup.py` (GUI, offscreen, mirrors `test_tether_watcher.py`'s
 `MainWindow()` usage):

--- a/spec/cli-file-args.md
+++ b/spec/cli-file-args.md
@@ -1,0 +1,160 @@
+# Command-line File / Folder Arguments
+
+## 1. Goals / Non-goals
+
+### Goals
+- `freeccr [PATH ...]` opens the app with those images already importing, so a
+  roll can be opened from a shell, a script, or a file manager's "Open With"
+  without walking the Open Files / Open Folder dialogs.
+- Accept **files**, **folders**, or a mix, in any number:
+  - `freeccr /rolls/roll-07` — one folder: identical to **Open Folder**.
+  - `freeccr a.nef b.nef c.nef` — a file list: identical to **Open Files**.
+  - `freeccr /rolls/a /rolls/b *.nef` — several paths: every folder is expanded
+    to its supported images and the whole thing loads as one file list.
+- Reuse the existing import paths exactly — Unicode validation, 3-way-merge
+  validation, catalog restore, the loading dialog, and the failure report all
+  behave as they do for the dialogs. The CLI is a new *entry point*, not a new
+  loader.
+- `--help` / `-h` prints usage and exits; `--version` / `-V` prints the version
+  and exits. Neither starts a GUI.
+- Qt's own switches (`-platform offscreen`, `-style Fusion`, …) keep working and
+  are never mistaken for paths.
+
+### Non-goals
+- No batch/headless mode: the arguments only seed an import, they do not export,
+  convert, or otherwise script the app. Every argument-driven action ends in the
+  normal GUI with images loaded.
+- No recursive folder walk. A folder contributes the images *directly inside*
+  it, matching Open Folder.
+- No OS integration in this change — no `CFBundleDocumentTypes`, no Windows file
+  association, no `QFileOpenEvent` handler, no drag-and-drop. macOS delivers
+  double-clicked documents via `QFileOpenEvent`, **not** argv, so associating
+  file types is a separate piece of work that can build on `load_paths()`.
+- No new persisted setting.
+
+## 2. UX / interaction
+
+```
+Usage: freeccr [OPTIONS] [PATH ...]
+
+  PATH   image files and/or folders to open at startup.
+         One folder alone loads like Open Folder; anything else loads as a
+         file list, with each folder expanded to the images inside it.
+
+Options:
+  -h, --help      show this message and exit
+  -V, --version   show the version and exit
+
+Qt options (-platform, -style, …) are also accepted.
+```
+
+- The window appears first, then the import starts on the next event-loop turn,
+  so the user sees the app (and the loading dialog on top of it) rather than a
+  frozen splash. Startup with no arguments is byte-for-byte unchanged.
+- Paths that do not exist are collected and reported in **one** warning box
+  ("Nothing to open"), listing at most 5 with an "… and N more" tail, matching
+  the Unicode-warning style already used by `open_files`. The box goes up
+  **after** the good paths are dispatched — it is modal, and one mistyped
+  argument must not hold up the rest of the import. If *every* argument is
+  missing, the app still opens — empty — with that warning.
+- A folder argument holding no supported images contributes nothing and is
+  reported in the same box as "no supported images".
+- An explicitly named file is passed through **whatever its extension** (the
+  Open Files dialog has an "All Files" filter, so the CLI is no stricter); files
+  found by expanding a folder are filtered to the supported extension set. An
+  unopenable file then surfaces through the existing post-load failure report.
+- 3-way merge mode applies exactly as in the dialogs: the resulting file list is
+  validated up front (all RAW, a multiple of 3, FreeCCR-baked merge TIFFs
+  exempt) and a rejection shows the same warning and loads nothing.
+
+## 3. Data model
+
+No persistent state. One transient value object:
+
+```python
+OpenPlan(folder: str | None,      # set only for the single-folder case
+         files: list[str],        # ordered, de-duplicated
+         problems: list[str])     # human-readable, one per bad argument
+```
+
+Exactly one of `folder` / `files` is non-empty; both may be empty (nothing
+loadable), in which case only `problems` is reported.
+
+`files/last_open_dir` (QSettings) is updated by the shared import helpers just
+as a dialog import would, so the next dialog opens where the CLI pointed.
+
+## 4. Processing
+
+1. **Strip Qt switches.** Drop any argument starting with `-`, and additionally
+   drop the *value* token following a Qt option known to take one
+   (`-platform`, `-platformpluginpath`, `-plugin`, `-style`, `-stylesheet`,
+   `-session`, `-graphicssystem`, `-display`, `-geometry`, `-qwindowgeometry`,
+   `-qwindowtitle`, `-qwindowicon`, and their `--` spellings). `-opt=value`
+   carries its value inline and consumes nothing. `--` ends option processing:
+   everything after it is a path, even a leading-dash one.
+2. **Classify** each remaining argument: existing directory, existing file, or
+   missing.
+3. **Plan.** One argument, a directory ⇒ `folder=` that path. Otherwise expand
+   every directory (non-recursive, `SUPPORTED_EXTS`, sorted case-insensitively
+   by name) and concatenate with the named files in argument order,
+   de-duplicated by normalised absolute path, first occurrence winning.
+4. **Dispatch** on the GUI thread via `QTimer.singleShot(0, …)` after
+   `window.show()`: `MainWindow.load_paths(paths)` runs the plan, calls the same
+   helpers the dialogs call, then reports `problems`.
+
+Steps 1–3 are pure (no Qt, no `MainWindow`) and live in `src/utils/cli_args.py`;
+only step 4 touches the GUI.
+
+## 5. Integration points
+
+- `src/utils/cli_args.py` **(new)** — `USAGE`, `wants_help`, `wants_version`,
+  `strip_qt_options`, `expand_folder`, `plan_open`. `expand_folder` imports
+  `core.tether_watcher.SUPPORTED_EXTS` lazily (and accepts an injected predicate)
+  so the module stays importable without Qt.
+- `src/main.py` — handle `--help` / `--version` before `QApplication` is built;
+  after `window.show()`, schedule `window.load_paths(paths)` when there are
+  arguments. Nothing else in startup moves.
+- `src/ui/main_window.py`:
+  - `_launch_loader(files=None, folder=None, force_no_merge=False)` — the loader
+    thread boilerplate, generalised from (and replacing) `_launch_file_loader`
+    so the folder import stops duplicating it.
+  - `_import_file_list(files)` / `_import_folder(folder)` — the post-dialog tail
+    of `open_files` / `open_folder` (Unicode validation and warning, merge
+    validation, `last_open_dir`, loader launch), now callable without a dialog.
+  - `open_files` / `open_folder` — reduced to `save_catalog()` + dialog + helper.
+    `save_catalog()` stays *before* the dialog so a cancelled dialog still
+    persists pending edits.
+  - `load_paths(paths)` **(new, public)** — `save_catalog()`, `plan_open`,
+    `_import_folder` or `_import_file_list`, then report problems. This is the seam any
+    later "Open With" / drag-and-drop support hangs off.
+
+## 6. Test plan
+
+`tests/test_cli_args.py` (pure, no `MainWindow`):
+
+- **Qt switch stripping**: `-platform offscreen` consumes its value;
+  `--platform=offscreen` consumes nothing extra; a bare `-style` at the end does
+  not eat past the list; `-stylesheet dark.qss` does not leak a real file into
+  the paths; `--` passes a following `-weird-name.nef` through as a path.
+- **Single folder** ⇒ `folder` set, `files` empty.
+- **Single file / several files** ⇒ `files` in argument order, `folder` None.
+- **Mixed** file + folder ⇒ folder expanded, order preserved, `folder` None.
+- **Expansion filters** to supported extensions (a `.txt` in the folder is
+  skipped) and sorts case-insensitively; an explicitly named `.txt` is kept.
+- **De-duplication**: the same file named twice, and a file also reachable
+  through a named folder, appears once.
+- **Missing paths** land in `problems` and not in `files`; an empty folder is
+  reported too; a plan of nothing but missing paths yields empty `folder`/`files`.
+- **Nested folders are not walked** (a subdirectory contributes nothing).
+
+`tests/test_cli_startup.py` (GUI, offscreen, mirrors `test_tether_watcher.py`'s
+`MainWindow()` usage):
+
+- `load_paths([folder])` calls `_import_folder` with that folder;
+  `load_paths([f1, f2])` calls `_import_file_list` with both (loader stubbed).
+- `load_paths([missing])` loads nothing and reports one warning; a missing path
+  next to a good one still launches the load *before* the (modal) report.
+- With 3-way merge mode on, `load_paths` of two RAWs is rejected by the existing
+  merge validation and launches no loader.
+- `open_files` / `open_folder` still drive the same helpers (dialog stubbed), so
+  the refactor is behaviour-preserving.

--- a/spec/cli-file-args.md
+++ b/spec/cli-file-args.md
@@ -80,8 +80,12 @@ OpenPlan(folder: str | None,      # set only for the single-folder case
 Exactly one of `folder` / `files` is non-empty; both may be empty (nothing
 loadable), in which case only `problems` is reported.
 
-`files/last_open_dir` (QSettings) is updated by the shared import helpers just
-as a dialog import would, so the next dialog opens where the CLI pointed.
+`files/last_open_dir` (QSettings) is written by the **dialogs only**, never by a
+command-line import. It records where the user *browsed*, and CLI paths are not
+browsing: they arrive from a shell, are frequently relative, and
+`os.path.dirname("a.nef")` is `""` — so letting the shared helpers write it
+would silently wipe the setting and drop both dialogs back to the process cwd.
+`freeccr .` would likewise persist a literal `"."`.
 
 ## 4. Processing
 
@@ -130,7 +134,8 @@ only step 4 touches the GUI.
     so the folder import stops duplicating it.
   - `_import_file_list(files)` / `_import_folder(folder)` — the post-dialog tail
     of `open_files` / `open_folder` (Unicode validation and warning, merge
-    validation, `last_open_dir`, loader launch), now callable without a dialog.
+    validation, loader launch), now callable without a dialog. They deliberately
+    do NOT write `last_open_dir` — that stays in the dialog halves.
   - `open_files` / `open_folder` — reduced to `save_catalog()` + dialog + helper.
     `save_catalog()` stays *before* the dialog so a cancelled dialog still
     persists pending edits.

--- a/spec/cli-file-args.md
+++ b/spec/cli-file-args.md
@@ -51,8 +51,11 @@ Qt options (-platform, -style, …) are also accepted.
 - The window appears first, then the import starts on the next event-loop turn,
   so the user sees the app (and the loading dialog on top of it) rather than a
   frozen splash. Startup with no arguments is byte-for-byte unchanged.
-- Paths that do not exist are collected and reported in **one** warning box
-  ("Nothing to open"), listing at most 5 with an "… and N more" tail, matching
+- Paths that do not exist are collected and reported in **one** warning box,
+  titled "Nothing to open" only when nothing was importable and "Some paths
+  could not be opened" when an import is running behind it (the box goes up
+  after the dispatch, so the first title would contradict the load the user can
+  see starting). It lists at most 5 with an "… and N more" tail, matching
   the Unicode-warning style already used by `open_files`. The box goes up
   **after** the good paths are dispatched — it is modal, and one mistyped
   argument must not hold up the rest of the import. If *every* argument is

--- a/src/main.py
+++ b/src/main.py
@@ -58,8 +58,23 @@ except Exception as _e:  # noqa: BLE001
 
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
+from PySide6.QtCore import QTimer
 
 def main():
+    # Command-line file/folder arguments (spec/cli-file-args.md). --help and
+    # --version answer and exit before any Qt object exists; the remaining
+    # positional paths seed the startup import further down. Qt's own switches
+    # stay in sys.argv for QApplication to consume.
+    from utils import cli_args
+    if cli_args.wants_help(sys.argv[1:]):
+        print(cli_args.USAGE)
+        return
+    if cli_args.wants_version(sys.argv[1:]):
+        from version import VERSION
+        print(f"FreeCCR {VERSION}")
+        return
+    startup_paths = cli_args.strip_qt_options(sys.argv[1:])
+
     from ui.main_window import MainWindow
 
     app = QApplication(sys.argv)
@@ -76,6 +91,11 @@ def main():
 
     apply_windows_dark_titlebar(window)  # dark native title bar (Win10/11)
     window.show()
+    if startup_paths:
+        # Queued, not called inline: the import puts a modal-ish loading dialog
+        # up and pumps events, so the window must be shown and the event loop
+        # running first — otherwise the user stares at an unpainted frame.
+        QTimer.singleShot(0, lambda: window.load_paths(startup_paths))
     sys.exit(app.exec())
 
 if __name__ == "__main__":

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1212,14 +1212,18 @@ class MainWindow(QMainWindow):
             "Images (*.dng *.tif *.tiff *.arw *.nef *.cr2 *.cr3 *.raf *.png *.jpg *.jpeg *.rw2 *.3fr *.fff);;All Files (*)"
         )
         if files:
+            # Remember where the user BROWSED to (survives restarts). Set here
+            # rather than in _import_file_list so a command-line import never
+            # moves it: those paths come from a shell, are often relative, and
+            # `os.path.dirname("a.nef")` is "" — which would silently wipe the
+            # setting and drop both dialogs back to the process cwd.
+            self._settings.setValue("files/last_open_dir", os.path.dirname(files[0]))
             self._import_file_list(files)
 
     def _import_file_list(self, files):
         """Replace the current batch with `files`: Unicode validation, 3-way
         merge validation, then the loader. The post-dialog tail of open_files,
         shared with the command-line import (spec/cli-file-args.md)."""
-        # Remember where the user browses to (survives restarts)
-        self._settings.setValue("files/last_open_dir", os.path.dirname(files[0]))
         # Validate and normalize Unicode paths
         valid_files = []
         invalid_files = []
@@ -1274,14 +1278,15 @@ class MainWindow(QMainWindow):
             start_dir
         )
         if folder:
+            # Dialog-only, like open_files above: `freeccr .` would otherwise
+            # persist the literal "." as the browse location.
+            self._settings.setValue("files/last_open_dir", folder)
             self._import_folder(folder)
 
     def _import_folder(self, folder):
         """Replace the current batch with every supported image in `folder`.
         The post-dialog tail of open_folder, shared with the command-line
         import (spec/cli-file-args.md)."""
-        # Remember where the user browses to (survives restarts)
-        self._settings.setValue("files/last_open_dir", folder)
         # Validate and normalize Unicode path
         normalized_folder = normalize_unicode_path(folder)
         if not validate_unicode_path(normalized_folder):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1003,9 +1003,10 @@ class MainWindow(QMainWindow):
             licenses_text = "No license files found."
         return licenses_text
 
-    def _launch_file_loader(self, files, force_no_merge=False):
-        """Start the async image loader for a file list. Shared by Open Files and
-        the merge-replace reload (force_no_merge loads the generated TIFFs as
+    def _launch_loader(self, files=None, folder=None, force_no_merge=False):
+        """Start the async image loader for a file list OR a folder (exactly one).
+        Shared by Open Files, Open Folder, the command-line import, and the
+        merge-replace reload (force_no_merge loads the generated TIFFs as
         normal images even while 3-way merge is on)."""
         self._stop_loader_if_running()
         # New batch = new roll: the combo returns to "Default"
@@ -1013,7 +1014,7 @@ class MainWindow(QMainWindow):
         self.sliders_panel.reset_film_stock_combo()
         self.thumbnail_list.show_loading_dialog()
         self._loader_thread = QThread()
-        self._loader_worker = ImageLoaderWorker(files=files,
+        self._loader_worker = ImageLoaderWorker(folder=folder, files=files,
                                                 force_no_merge=force_no_merge)
         self._loader_worker.moveToThread(self._loader_thread)
         self._loader_thread.started.connect(self._loader_worker.run)
@@ -1150,7 +1151,7 @@ class MainWindow(QMainWindow):
 
         if tiffs:
             # Reload from the generated TIFFs as normal negatives (merge bypassed).
-            self._launch_file_loader(tiffs, force_no_merge=True)
+            self._launch_loader(files=tiffs, force_no_merge=True)
             self.sliders_panel.set_temporary_hint(
                 f"Replaced {len(tiffs)} frame(s) with linear TIFFs; "
                 f"deleted {len(deleted)} original(s).", duration=5000)
@@ -1211,51 +1212,57 @@ class MainWindow(QMainWindow):
             "Images (*.dng *.tif *.tiff *.arw *.nef *.cr2 *.cr3 *.raf *.png *.jpg *.jpeg *.rw2 *.3fr *.fff);;All Files (*)"
         )
         if files:
-            # Remember where the user browses to (survives restarts)
-            self._settings.setValue("files/last_open_dir", os.path.dirname(files[0]))
-            # Validate and normalize Unicode paths
-            valid_files = []
-            invalid_files = []
-            
-            for file_path in files:
-                normalized_path = normalize_unicode_path(file_path)
-                if validate_unicode_path(normalized_path):
-                    valid_files.append(normalized_path)
-                else:
-                    invalid_files.append(file_path)
-            
-            if invalid_files:
-                invalid_list = '\n'.join(invalid_files[:5])  # Show first 5 invalid files
-                if len(invalid_files) > 5:
-                    invalid_list += f'\n... and {len(invalid_files) - 5} more files'
-                QMessageBox.warning(
-                    self,
-                    "Unicode Path Warning",
-                    f"Some files have paths that may not be processed correctly due to Unicode characters:\n\n{invalid_list}\n\nThese files will be skipped. Please consider moving these files to paths with simpler names."
-                )
-            
-            if valid_files:
-                # 3-way RGB merge: validate the selection up front (multiple of
-                # 3, all RAW) so the user gets immediate feedback before any load.
-                # FreeCCR-baked merge TIFFs are excluded — they re-open as normal
-                # images even in merge mode. See spec/merge-linear-tiff-replace.md.
-                if ccr_backend.rgb_merge_mode:
-                    from core import ccr_merge
-                    to_merge = [p for p in valid_files
-                                if not ccr_merge.is_freeccr_merge_tiff(p)]
-                    if to_merge:
-                        ok, err = ccr_merge.validate_merge_inputs(
-                            ccr_merge.sort_for_merge(to_merge))
-                        if not ok:
-                            QMessageBox.warning(self, "3-way RGB merge", err)
-                            return
-                self._launch_file_loader(valid_files)
-            elif files:  # If there were files selected but all were invalid
-                QMessageBox.critical(
-                    self,
-                    "No Valid Files",
-                    "None of the selected files could be processed due to Unicode character issues in their paths. Please rename the files or move them to simpler paths."
-                )
+            self._import_file_list(files)
+
+    def _import_file_list(self, files):
+        """Replace the current batch with `files`: Unicode validation, 3-way
+        merge validation, then the loader. The post-dialog tail of open_files,
+        shared with the command-line import (spec/cli-file-args.md)."""
+        # Remember where the user browses to (survives restarts)
+        self._settings.setValue("files/last_open_dir", os.path.dirname(files[0]))
+        # Validate and normalize Unicode paths
+        valid_files = []
+        invalid_files = []
+
+        for file_path in files:
+            normalized_path = normalize_unicode_path(file_path)
+            if validate_unicode_path(normalized_path):
+                valid_files.append(normalized_path)
+            else:
+                invalid_files.append(file_path)
+
+        if invalid_files:
+            invalid_list = '\n'.join(invalid_files[:5])  # Show first 5 invalid files
+            if len(invalid_files) > 5:
+                invalid_list += f'\n... and {len(invalid_files) - 5} more files'
+            QMessageBox.warning(
+                self,
+                "Unicode Path Warning",
+                f"Some files have paths that may not be processed correctly due to Unicode characters:\n\n{invalid_list}\n\nThese files will be skipped. Please consider moving these files to paths with simpler names."
+            )
+
+        if valid_files:
+            # 3-way RGB merge: validate the selection up front (multiple of
+            # 3, all RAW) so the user gets immediate feedback before any load.
+            # FreeCCR-baked merge TIFFs are excluded — they re-open as normal
+            # images even in merge mode. See spec/merge-linear-tiff-replace.md.
+            if ccr_backend.rgb_merge_mode:
+                from core import ccr_merge
+                to_merge = [p for p in valid_files
+                            if not ccr_merge.is_freeccr_merge_tiff(p)]
+                if to_merge:
+                    ok, err = ccr_merge.validate_merge_inputs(
+                        ccr_merge.sort_for_merge(to_merge))
+                    if not ok:
+                        QMessageBox.warning(self, "3-way RGB merge", err)
+                        return
+            self._launch_loader(files=valid_files)
+        else:  # There were files, but all of them were invalid
+            QMessageBox.critical(
+                self,
+                "No Valid Files",
+                "None of the selected files could be processed due to Unicode character issues in their paths. Please rename the files or move them to simpler paths."
+            )
 
     def open_folder(self):
         # Loading a new batch replaces the current one — persist its edits first
@@ -1267,32 +1274,49 @@ class MainWindow(QMainWindow):
             start_dir
         )
         if folder:
-            # Remember where the user browses to (survives restarts)
-            self._settings.setValue("files/last_open_dir", folder)
-            # Validate and normalize Unicode path
-            normalized_folder = normalize_unicode_path(folder)
-            if not validate_unicode_path(normalized_folder):
-                QMessageBox.warning(
-                    self,
-                    "Unicode Path Warning",
-                    f"The selected folder path contains characters that may cause issues:\n\n{folder}\n\nPlease consider using a folder with a simpler path name."
-                )
-                return
-                
-            self._stop_loader_if_running()
-            # New batch = new roll: the combo returns to "Default"
-            # (the backend loader clears its copy too).
-            self.sliders_panel.reset_film_stock_combo()
-            self.thumbnail_list.show_loading_dialog()
-            self._loader_thread = QThread()
-            self._loader_worker = ImageLoaderWorker(normalized_folder)
-            self._loader_worker.moveToThread(self._loader_thread)
-            self._loader_thread.started.connect(self._loader_worker.run)
-            self._loader_worker.finished.connect(self._loader_thread.quit)
-            self._loader_worker.finished.connect(self._loader_worker.deleteLater)
-            self._loader_thread.finished.connect(self._cleanup_loader)
-            self._loader_worker.finished.connect(self.thumbnail_list.load_thumbnails)
-            self._loader_thread.start()
+            self._import_folder(folder)
+
+    def _import_folder(self, folder):
+        """Replace the current batch with every supported image in `folder`.
+        The post-dialog tail of open_folder, shared with the command-line
+        import (spec/cli-file-args.md)."""
+        # Remember where the user browses to (survives restarts)
+        self._settings.setValue("files/last_open_dir", folder)
+        # Validate and normalize Unicode path
+        normalized_folder = normalize_unicode_path(folder)
+        if not validate_unicode_path(normalized_folder):
+            QMessageBox.warning(
+                self,
+                "Unicode Path Warning",
+                f"The selected folder path contains characters that may cause issues:\n\n{folder}\n\nPlease consider using a folder with a simpler path name."
+            )
+            return
+
+        self._launch_loader(folder=normalized_folder)
+
+    def load_paths(self, paths):
+        """Open the files and/or folders named on the command line. The public
+        seam for argument-driven imports (and any later Open With / drag-and-
+        drop support): it plans the paths, reports the ones that contribute
+        nothing, then hands off to the same importers the dialogs use.
+        See spec/cli-file-args.md."""
+        from utils.cli_args import plan_open
+        # Loading a new batch replaces the current one — persist its edits first
+        ccr_backend.save_catalog()
+        plan = plan_open(paths)
+        # Start the import BEFORE reporting bad arguments: the report is modal,
+        # and one mistyped path must not hold up the paths that were fine.
+        if plan.folder:
+            self._import_folder(plan.folder)
+        elif plan.files:
+            self._import_file_list(plan.files)
+        if plan.problems:
+            shown = '\n'.join(plan.problems[:5])
+            if len(plan.problems) > 5:
+                shown += f'\n... and {len(plan.problems) - 5} more'
+            QMessageBox.warning(
+                self, "Nothing to open",
+                f"These command-line paths could not be opened:\n\n{shown}")
 
     # --- Tethering (watch-folder capture) ---------------------------------
     def toggle_tethering(self):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1319,8 +1319,15 @@ class MainWindow(QMainWindow):
             shown = '\n'.join(plan.problems[:5])
             if len(plan.problems) > 5:
                 shown += f'\n... and {len(plan.problems) - 5} more'
+            # An import may well be running behind this box (the dispatch
+            # above deliberately goes first), so only say "Nothing to open"
+            # when nothing actually opened — otherwise the title
+            # contradicts the load the user can see starting.
+            imported = bool(plan.folder or plan.files)
             QMessageBox.warning(
-                self, "Nothing to open",
+                self,
+                "Some paths could not be opened" if imported
+                else "Nothing to open",
                 f"These command-line paths could not be opened:\n\n{shown}")
 
     # --- Tethering (watch-folder capture) ---------------------------------

--- a/src/utils/cli_args.py
+++ b/src/utils/cli_args.py
@@ -1,0 +1,162 @@
+"""
+Command-line file / folder arguments.
+
+`freeccr [PATH ...]` seeds the startup import with files, folders, or a mix, so
+a roll can be opened from a shell or a script without walking the Open Files /
+Open Folder dialogs. This module is the PURE half — argument parsing, folder
+expansion and planning, no Qt and no MainWindow — so the whole decision is
+unit-testable; `MainWindow.load_paths` performs the plan. See
+spec/cli-file-args.md.
+"""
+import os
+from typing import Callable, List, NamedTuple, Optional, Sequence
+
+USAGE = """Usage: freeccr [OPTIONS] [PATH ...]
+
+  PATH   image files and/or folders to open at startup.
+         One folder alone loads like Open Folder; anything else loads as a
+         file list, with each folder expanded to the images inside it.
+
+Options:
+  -h, --help      show this message and exit
+  -V, --version   show the version and exit
+
+Qt options (-platform, -style, ...) are also accepted."""
+
+HELP_FLAGS = frozenset({"-h", "--help"})
+VERSION_FLAGS = frozenset({"-V", "--version"})
+
+# Qt/QApplication switches that take a SEPARATE value token. The value must be
+# skipped too, or `-stylesheet dark.qss` would offer dark.qss as an image to
+# open. Listed without the leading dash; both the `-opt` and `--opt` spellings
+# are recognised. An inline `-opt=value` carries its value and consumes nothing.
+# Value-LESS switches (-reverse, -widgetcount, -nograb, ...) are not listed:
+# they consume nothing, and listing one would make it swallow a real path.
+QT_VALUE_OPTIONS = frozenset({
+    "platform", "platformpluginpath", "platformtheme", "plugin", "style",
+    "stylesheet", "session", "graphicssystem", "display", "geometry",
+    "qwindowgeometry", "qwindowtitle", "qwindowicon", "qmljsdebugger",
+    "title", "name", "visual", "ncols", "cmap", "font", "fn",
+})
+
+
+class OpenPlan(NamedTuple):
+    """What a set of command-line paths should open.
+
+    folder:   set ONLY for the single-folder case (loads like Open Folder).
+    files:    ordered, de-duplicated file list (folders already expanded).
+    problems: one human-readable line per argument that contributed nothing.
+
+    At most one of folder/files is non-empty; both are empty when nothing
+    loadable was named (problems then says why).
+    """
+    folder: Optional[str]
+    files: List[str]
+    problems: List[str]
+
+
+def wants_help(argv: Sequence[str]) -> bool:
+    return any(a in HELP_FLAGS for a in _before_ddash(argv))
+
+
+def wants_version(argv: Sequence[str]) -> bool:
+    return any(a in VERSION_FLAGS for a in _before_ddash(argv))
+
+
+def _before_ddash(argv: Sequence[str]) -> List[str]:
+    """The arguments up to a bare `--` (after it, everything is a path)."""
+    out: List[str] = []
+    for a in argv:
+        if a == "--":
+            break
+        out.append(a)
+    return out
+
+
+def strip_qt_options(argv: Sequence[str]) -> List[str]:
+    """Return the positional (path) arguments of `argv`, dropping option
+    switches and the value token of any Qt option known to take one. A bare
+    `--` ends option processing: everything after it is a path, even one that
+    starts with a dash."""
+    paths: List[str] = []
+    skip_next = False
+    literal = False
+    for arg in argv:
+        if literal:
+            paths.append(arg)
+            continue
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--":
+            literal = True
+            continue
+        if arg.startswith("-") and arg != "-":
+            name = arg.lstrip("-").split("=", 1)[0].lower()
+            # An inline `-opt=value` already carries its value; a separate one
+            # is the NEXT token and must not be read as a path.
+            skip_next = "=" not in arg and name in QT_VALUE_OPTIONS
+            continue
+        paths.append(arg)
+    return paths
+
+
+def expand_folder(folder: str,
+                  is_supported: Optional[Callable[[str], bool]] = None
+                  ) -> List[str]:
+    """The supported images directly inside `folder`, sorted case-insensitively
+    by name. NOT recursive — a folder argument contributes what Open Folder
+    would see. `is_supported` defaults to the app's shared extension test
+    (imported lazily so this module needs no Qt); an unreadable folder yields
+    an empty list."""
+    supported = is_supported
+    if supported is None:
+        from core.tether_watcher import is_supported as supported
+    try:
+        names = [e.name for e in os.scandir(folder) if e.is_file()]
+    except OSError:
+        return []
+    names.sort(key=lambda n: (n.lower(), n))
+    return [os.path.join(folder, n) for n in names if supported(n)]
+
+
+def plan_open(args: Sequence[str],
+              is_supported: Optional[Callable[[str], bool]] = None) -> OpenPlan:
+    """Turn already-stripped path arguments into an OpenPlan.
+
+    One argument naming a folder loads as a folder (Open Folder). Anything else
+    becomes one file list: each folder is expanded to the images inside it and
+    concatenated with the named files IN ARGUMENT ORDER, de-duplicated by
+    normalised absolute path (first occurrence wins). A named file is kept
+    whatever its extension — the Open Files dialog has an All Files filter, so
+    the CLI is no stricter — while folder-expanded files are filtered.
+    Arguments that contribute nothing are reported, never silently dropped."""
+    args = [a for a in args if a]
+    problems: List[str] = []
+    if not args:
+        return OpenPlan(None, [], problems)
+
+    if len(args) == 1 and os.path.isdir(args[0]):
+        return OpenPlan(args[0], [], problems)
+
+    files: List[str] = []
+    seen = set()
+
+    def _add(path: str) -> None:
+        key = os.path.normcase(os.path.normpath(os.path.abspath(path)))
+        if key not in seen:
+            seen.add(key)
+            files.append(path)
+
+    for arg in args:
+        if os.path.isdir(arg):
+            found = expand_folder(arg, is_supported)
+            if not found:
+                problems.append(f"{arg} — no supported images in this folder")
+            for path in found:
+                _add(path)
+        elif os.path.isfile(arg):
+            _add(arg)
+        else:
+            problems.append(f"{arg} — not found")
+    return OpenPlan(None, files, problems)

--- a/src/utils/cli_args.py
+++ b/src/utils/cli_args.py
@@ -1,13 +1,14 @@
 """
 Command-line file / folder arguments.
 
-`freeccr [PATH ...]` seeds the startup import with files, folders, or a mix, so
-a roll can be opened from a shell or a script without walking the Open Files /
-Open Folder dialogs. This module is the PURE half — argument parsing, folder
-expansion and planning, no Qt and no MainWindow — so the whole decision is
-unit-testable; `MainWindow.load_paths` performs the plan. See
-spec/cli-file-args.md.
+`freeccr [PATH ...]` seeds the startup import with files, folders, wildcard
+patterns, or a mix, so a roll can be opened from a shell or a script without
+walking the Open Files / Open Folder dialogs. This module is the PURE half —
+argument parsing, glob and folder expansion, planning, no Qt and no MainWindow
+— so the whole decision is unit-testable; `MainWindow.load_paths` performs the
+plan. See spec/cli-file-args.md.
 """
+import glob
 import os
 from typing import Callable, List, NamedTuple, Optional, Sequence
 
@@ -16,12 +17,20 @@ USAGE = """Usage: freeccr [OPTIONS] [PATH ...]
   PATH   image files and/or folders to open at startup.
          One folder alone loads like Open Folder; anything else loads as a
          file list, with each folder expanded to the images inside it.
+         Wildcards (*.tif, roll-?.nef) are expanded by FreeCCR itself, so
+         they work in cmd.exe and PowerShell as well as in a Unix shell.
 
 Options:
   -h, --help      show this message and exit
   -V, --version   show the version and exit
 
 Qt options (-platform, -style, ...) are also accepted."""
+
+# Characters that make an argument a wildcard pattern rather than a literal
+# path. `[` is included because glob honours character classes, but an argument
+# naming a real file always wins over pattern interpretation (see expand_globs),
+# so a photo literally called `shot[1].tif` still opens.
+WILDCARD_CHARS = "*?["
 
 HELP_FLAGS = frozenset({"-h", "--help"})
 VERSION_FLAGS = frozenset({"-V", "--version"})
@@ -101,6 +110,37 @@ def strip_qt_options(argv: Sequence[str]) -> List[str]:
     return paths
 
 
+def _has_wildcard(arg: str) -> bool:
+    return any(ch in arg for ch in WILDCARD_CHARS)
+
+
+def expand_globs(args: Sequence[str]) -> List[str]:
+    """Expand wildcard arguments (`*.tif`, `roll-?.nef`, `**/*.dng`) in place,
+    each to its matches sorted case-insensitively.
+
+    Unix shells expand these before the program starts; cmd.exe and PowerShell
+    hand the pattern over untouched, so `freeccr *.tif` used to reach us as the
+    literal string and be reported as not found. Doing it here makes both hosts
+    behave the same. It stays a no-op under a Unix shell: a pattern the shell
+    matched arrives already expanded, and one it could not match is passed
+    through literally and matches nothing here either.
+
+    An argument naming an existing path is never treated as a pattern, so a
+    file called `shot[1].tif` opens as itself. A pattern matching nothing is
+    passed through unchanged for plan_open to report."""
+    out: List[str] = []
+    for arg in args:
+        if not _has_wildcard(arg) or os.path.exists(arg):
+            out.append(arg)
+            continue
+        # recursive=True only gives `**` its meaning; other patterns are
+        # unaffected, and `**` is a depth the user asked for explicitly.
+        matches = glob.glob(arg, recursive=True)
+        matches.sort(key=lambda pth: (pth.lower(), pth))
+        out.extend(matches or [arg])
+    return out
+
+
 def expand_folder(folder: str,
                   is_supported: Optional[Callable[[str], bool]] = None
                   ) -> List[str]:
@@ -130,8 +170,12 @@ def plan_open(args: Sequence[str],
     normalised absolute path (first occurrence wins). A named file is kept
     whatever its extension — the Open Files dialog has an All Files filter, so
     the CLI is no stricter — while folder-expanded files are filtered.
-    Arguments that contribute nothing are reported, never silently dropped."""
-    args = [a for a in args if a]
+    Arguments that contribute nothing are reported, never silently dropped.
+
+    Wildcard arguments are expanded first (see expand_globs), so a pattern
+    behaves exactly like the paths it matches — including the single-folder
+    rule, which a pattern matching one folder therefore takes."""
+    args = expand_globs([a for a in args if a])
     problems: List[str] = []
     if not args:
         return OpenPlan(None, [], problems)
@@ -157,6 +201,8 @@ def plan_open(args: Sequence[str],
                 _add(path)
         elif os.path.isfile(arg):
             _add(arg)
+        elif _has_wildcard(arg):
+            problems.append(f"{arg} — no files match this pattern")
         else:
             problems.append(f"{arg} — not found")
     return OpenPlan(None, files, problems)

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -11,8 +11,9 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from utils.cli_args import (OpenPlan, expand_folder, plan_open,  # noqa: E402
-                            strip_qt_options, wants_help, wants_version)
+from utils.cli_args import (OpenPlan, expand_folder, expand_globs,  # noqa: E402
+                            plan_open, strip_qt_options, wants_help,
+                            wants_version)
 
 # Stand-in for core.tether_watcher.is_supported (same rule, no Qt import).
 SUPPORTED = {".nef", ".dng", ".tif", ".jpg"}
@@ -154,6 +155,82 @@ def test_expansion_is_not_recursive(tmp_path):
 
 def test_unreadable_folder_expands_to_nothing(tmp_path):
     assert expand_folder(str(tmp_path / "does-not-exist"), _supported) == []
+
+
+# --- wildcard expansion --------------------------------------------------
+# Unix shells expand these before argv reaches us; cmd.exe and PowerShell do
+# not, so FreeCCR expands them itself and both hosts behave alike.
+
+def test_star_pattern_expands_to_its_matches_sorted(tmp_path):
+    _touch(tmp_path, "B.nef", "a.nef", "c.jpg")
+    got = expand_globs([str(tmp_path / "*.nef")])
+    assert got == [str(tmp_path / "a.nef"), str(tmp_path / "B.nef")]
+
+
+def test_question_mark_pattern_matches_one_character(tmp_path):
+    _touch(tmp_path, "roll-1.nef", "roll-12.nef")
+    got = expand_globs([str(tmp_path / "roll-?.nef")])
+    assert got == [str(tmp_path / "roll-1.nef")]
+
+
+def test_pattern_plans_as_a_file_list(tmp_path):
+    a, b = _touch(tmp_path, "a.nef", "b.nef")
+    plan = plan_open([str(tmp_path / "*.nef")], _supported)
+    assert plan.folder is None and plan.files == [a, b]
+    assert plan.problems == []
+
+
+def test_pattern_and_named_file_keep_argument_order_and_dedupe(tmp_path):
+    a, b = _touch(tmp_path, "a.nef", "b.nef")
+    plan = plan_open([b, str(tmp_path / "*.nef")], _supported)
+    # The named file comes first; the pattern re-offers it and it collapses.
+    assert plan.files == [b, a]
+
+
+def test_unmatched_pattern_is_reported_as_a_pattern(tmp_path):
+    plan = plan_open([str(tmp_path / "*.nef")], _supported)
+    assert plan.files == []
+    assert len(plan.problems) == 1
+    assert "no files match this pattern" in plan.problems[0]
+
+
+def test_a_real_file_named_like_a_pattern_wins(tmp_path):
+    # glob would read `shot[1].nef` as a character class; the file exists, so
+    # it must open as itself.
+    real, = _touch(tmp_path, "shot[1].nef")
+    assert expand_globs([real]) == [real]
+    assert plan_open([real], _supported).files == [real]
+
+
+def test_pattern_matching_one_folder_takes_the_single_folder_rule(tmp_path):
+    d = tmp_path / "roll-1"
+    d.mkdir()
+    _touch(d, "a.nef")
+    plan = plan_open([str(tmp_path / "roll-*")], _supported)
+    assert plan == OpenPlan(str(d), [], [])
+
+
+def test_pattern_matching_folders_expands_each_in_a_list(tmp_path):
+    for name in ("roll-1", "roll-2"):
+        (tmp_path / name).mkdir()
+    one, = _touch(tmp_path / "roll-1", "a.nef")
+    two, = _touch(tmp_path / "roll-2", "b.nef")
+    plan = plan_open([str(tmp_path / "roll-*")], _supported)
+    assert plan.folder is None and plan.files == [one, two]
+
+
+def test_double_star_recurses_only_when_asked(tmp_path):
+    (tmp_path / "sub").mkdir()
+    deep, = _touch(tmp_path / "sub", "deep.nef")
+    top, = _touch(tmp_path, "top.nef")
+    assert expand_globs([str(tmp_path / "**" / "*.nef")]) == [deep, top]
+    # A single star stays at one level.
+    assert expand_globs([str(tmp_path / "*.nef")]) == [top]
+
+
+def test_non_wildcard_arguments_pass_through_untouched():
+    args = ["/a/b.nef", "relative.nef", "-"]
+    assert expand_globs(args) == args
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,160 @@
+"""
+Command-line file/folder argument parsing (spec/cli-file-args.md §6).
+
+Pure tests: no Qt, no MainWindow. The supported-extension predicate is injected
+so the plan can be exercised without importing the app's Qt-bound modules.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from utils.cli_args import (OpenPlan, expand_folder, plan_open,  # noqa: E402
+                            strip_qt_options, wants_help, wants_version)
+
+# Stand-in for core.tether_watcher.is_supported (same rule, no Qt import).
+SUPPORTED = {".nef", ".dng", ".tif", ".jpg"}
+
+
+def _supported(name):
+    return os.path.splitext(name)[1].lower() in SUPPORTED
+
+
+def _touch(folder, *names):
+    made = []
+    for n in names:
+        p = os.path.join(str(folder), n)
+        with open(p, "wb") as f:
+            f.write(b"x")
+        made.append(p)
+    return made
+
+
+# --- option stripping ----------------------------------------------------
+
+def test_qt_option_with_separate_value_consumes_it():
+    assert strip_qt_options(["-platform", "offscreen", "a.nef"]) == ["a.nef"]
+
+
+def test_inline_qt_option_value_consumes_nothing_extra():
+    assert strip_qt_options(["--platform=offscreen", "a.nef"]) == ["a.nef"]
+
+
+def test_stylesheet_value_is_not_offered_as_a_path():
+    assert strip_qt_options(["-stylesheet", "dark.qss", "a.nef"]) == ["a.nef"]
+
+
+def test_trailing_value_option_does_not_read_past_the_list():
+    assert strip_qt_options(["a.nef", "-style"]) == ["a.nef"]
+
+
+def test_valueless_switch_does_not_swallow_the_next_path():
+    # -reverse / -widgetcount take no value; the path after them must survive.
+    assert strip_qt_options(["-reverse", "a.nef"]) == ["a.nef"]
+    assert strip_qt_options(["-widgetcount", "a.nef", "b.nef"]) == ["a.nef",
+                                                                    "b.nef"]
+
+
+def test_double_dash_passes_a_dashed_path_through():
+    assert strip_qt_options(["--", "-odd-name.nef"]) == ["-odd-name.nef"]
+
+
+def test_help_and_version_flags_detected_before_double_dash_only():
+    assert wants_help(["--help"]) and wants_help(["-h", "a.nef"])
+    assert wants_version(["-V"]) and wants_version(["--version"])
+    assert not wants_help(["a.nef"])
+    # After `--` they are paths, not flags.
+    assert not wants_help(["--", "--help"])
+    assert not wants_version(["--", "--version"])
+
+
+# --- planning ------------------------------------------------------------
+
+def test_single_folder_loads_as_a_folder(tmp_path):
+    d = tmp_path / "roll"
+    d.mkdir()
+    _touch(d, "a.nef")
+    plan = plan_open([str(d)], _supported)
+    assert plan == OpenPlan(str(d), [], [])
+
+
+def test_single_file_and_file_list_keep_argument_order(tmp_path):
+    a, b = _touch(tmp_path, "b.nef", "a.nef")
+    assert plan_open([a], _supported).files == [a]
+    plan = plan_open([a, b], _supported)
+    assert plan.folder is None and plan.files == [a, b]
+
+
+def test_mixed_file_and_folder_expands_the_folder_in_place(tmp_path):
+    d = tmp_path / "roll"
+    d.mkdir()
+    inner = _touch(d, "B.nef", "a.nef")
+    named, = _touch(tmp_path, "loose.nef")
+    plan = plan_open([named, str(d)], _supported)
+    assert plan.folder is None
+    # Case-insensitive name sort inside the folder: a.nef before B.nef.
+    assert plan.files == [named, inner[1], inner[0]]
+
+
+def test_folder_expansion_filters_unsupported_but_named_files_are_kept(tmp_path):
+    d = tmp_path / "roll"
+    d.mkdir()
+    _touch(d, "notes.txt")
+    keep, = _touch(d, "keep.nef")
+    txt, = _touch(tmp_path, "readme.txt")
+    plan = plan_open([str(d), txt], _supported)
+    assert plan.files == [keep, txt]
+
+
+def test_duplicates_collapse_across_arguments(tmp_path):
+    d = tmp_path / "roll"
+    d.mkdir()
+    inside, = _touch(d, "a.nef")
+    plan = plan_open([inside, str(d), inside], _supported)
+    assert plan.files == [inside]
+
+
+def test_missing_paths_are_reported_not_loaded(tmp_path):
+    good, = _touch(tmp_path, "a.nef")
+    missing = str(tmp_path / "gone.nef")
+    plan = plan_open([good, missing], _supported)
+    assert plan.files == [good]
+    assert len(plan.problems) == 1 and "gone.nef" in plan.problems[0]
+
+
+def test_all_missing_yields_an_empty_plan(tmp_path):
+    plan = plan_open([str(tmp_path / "x.nef"), str(tmp_path / "y.nef")],
+                     _supported)
+    assert plan.folder is None and plan.files == []
+    assert len(plan.problems) == 2
+
+
+def test_empty_folder_in_a_list_is_reported(tmp_path):
+    d = tmp_path / "empty"
+    d.mkdir()
+    good, = _touch(tmp_path, "a.nef")
+    plan = plan_open([good, str(d)], _supported)
+    assert plan.files == [good]
+    assert len(plan.problems) == 1 and "no supported images" in plan.problems[0]
+
+
+def test_no_arguments_is_an_empty_plan():
+    assert plan_open([], _supported) == OpenPlan(None, [], [])
+
+
+def test_expansion_is_not_recursive(tmp_path):
+    d = tmp_path / "roll"
+    (d / "sub").mkdir(parents=True)
+    _touch(d / "sub", "deep.nef")
+    top, = _touch(d, "top.nef")
+    assert expand_folder(str(d), _supported) == [top]
+
+
+def test_unreadable_folder_expands_to_nothing(tmp_path):
+    assert expand_folder(str(tmp_path / "does-not-exist"), _supported) == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_cli_startup.py
+++ b/tests/test_cli_startup.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""MainWindow.load_paths — the command-line import seam (spec/cli-file-args.md §6).
+
+The loader itself is stubbed everywhere: these tests assert WHICH importer runs
+with WHICH paths (and that warnings replace a load when nothing is openable),
+not that images decode. Dialog stubs prove the refactor left Open Files / Open
+Folder driving the same helpers.
+"""
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import pytest  # noqa: E402
+from PySide6.QtWidgets import QApplication, QFileDialog, QMessageBox  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv[:1])
+
+from core.ccr_backend import ccr_backend  # noqa: E402
+
+
+@pytest.fixture
+def win(monkeypatch):
+    """A MainWindow whose loader and message boxes are stubbed out. Yields
+    (window, launched, warnings): `launched` records every _launch_loader call
+    as {"files": ..., "folder": ...}; `warnings` records message-box titles."""
+    from ui.main_window import MainWindow
+    ccr_backend.images.clear()
+    ccr_backend.file_paths.clear()
+    ccr_backend.rgb_merge_mode = False
+
+    w = MainWindow()
+    launched = []
+    warnings = []
+    monkeypatch.setattr(
+        type(w), "_launch_loader",
+        lambda self, files=None, folder=None, force_no_merge=False:
+            launched.append({"files": files, "folder": folder}))
+    monkeypatch.setattr(QMessageBox, "warning",
+                        staticmethod(lambda *a, **k: warnings.append(a[1])))
+    monkeypatch.setattr(QMessageBox, "critical",
+                        staticmethod(lambda *a, **k: warnings.append(a[1])))
+    # save_catalog() would rewrite the user's real catalog during a test run.
+    monkeypatch.setattr(ccr_backend, "save_catalog", lambda *a, **k: None)
+    yield w, launched, warnings
+    ccr_backend.rgb_merge_mode = False
+
+
+def _touch(folder, *names):
+    made = []
+    for n in names:
+        p = os.path.join(str(folder), n)
+        with open(p, "wb") as f:
+            f.write(b"x")
+        made.append(p)
+    return made
+
+
+def test_single_folder_argument_imports_the_folder(win, tmp_path):
+    w, launched, warnings = win
+    d = tmp_path / "roll"
+    d.mkdir()
+    _touch(d, "a.nef")
+    w.load_paths([str(d)])
+    assert launched == [{"files": None, "folder": str(d)}]
+    assert warnings == []
+
+
+def test_file_arguments_import_as_a_file_list(win, tmp_path):
+    w, launched, warnings = win
+    a, b = _touch(tmp_path, "a.nef", "b.nef")
+    w.load_paths([a, b])
+    assert len(launched) == 1
+    assert launched[0]["folder"] is None
+    assert launched[0]["files"] == [a, b]
+    assert warnings == []
+
+
+def test_folder_in_a_list_is_expanded_to_its_images(win, tmp_path):
+    w, launched, warnings = win
+    d = tmp_path / "roll"
+    d.mkdir()
+    inside, = _touch(d, "inside.nef")
+    _touch(d, "notes.txt")            # unsupported: not imported
+    loose, = _touch(tmp_path, "loose.nef")
+    w.load_paths([loose, str(d)])
+    assert launched[0]["files"] == [loose, inside]
+    assert launched[0]["folder"] is None
+
+
+def test_missing_path_warns_and_loads_nothing(win, tmp_path):
+    w, launched, warnings = win
+    w.load_paths([str(tmp_path / "gone.nef")])
+    assert launched == []
+    assert warnings == ["Nothing to open"]
+
+
+def test_missing_path_alongside_a_real_one_still_loads_the_real_one(win, tmp_path,
+                                                                    monkeypatch):
+    w, launched, warnings = win
+    good, = _touch(tmp_path, "a.nef")
+    # The report is modal, so it must come AFTER the good paths are underway:
+    # record how much had launched by the time the box went up.
+    at_warn = []
+    monkeypatch.setattr(QMessageBox, "warning",
+                        staticmethod(lambda *a, **k: (warnings.append(a[1]),
+                                                      at_warn.append(len(launched)))))
+    w.load_paths([good, str(tmp_path / "gone.nef")])
+    assert launched[0]["files"] == [good]
+    assert warnings == ["Nothing to open"]
+    assert at_warn == [1]          # the load had already started
+
+
+def test_merge_mode_rejects_a_non_triplet_from_the_command_line(win, tmp_path):
+    w, launched, warnings = win
+    ccr_backend.rgb_merge_mode = True
+    a, b = _touch(tmp_path, "a.nef", "b.nef")   # 2 files: not a multiple of 3
+    w.load_paths([a, b])
+    assert launched == []
+    assert warnings == ["3-way RGB merge"]
+
+
+def test_merge_mode_accepts_a_triplet_from_the_command_line(win, tmp_path):
+    w, launched, warnings = win
+    ccr_backend.rgb_merge_mode = True
+    files = _touch(tmp_path, "r.nef", "g.nef", "b.nef")
+    w.load_paths(files)
+    assert len(launched) == 1 and launched[0]["files"] == files
+    assert warnings == []
+
+
+def test_open_files_dialog_still_drives_the_shared_importer(win, tmp_path,
+                                                            monkeypatch):
+    w, launched, warnings = win
+    a, = _touch(tmp_path, "a.nef")
+    monkeypatch.setattr(QFileDialog, "getOpenFileNames",
+                        staticmethod(lambda *a_, **k: ([a], "")))
+    w.open_files()
+    assert launched == [{"files": [a], "folder": None}]
+
+
+def test_open_folder_dialog_still_drives_the_shared_importer(win, tmp_path,
+                                                             monkeypatch):
+    w, launched, warnings = win
+    d = tmp_path / "roll"
+    d.mkdir()
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory",
+                        staticmethod(lambda *a_, **k: str(d)))
+    w.open_folder()
+    assert launched == [{"files": None, "folder": str(d)}]
+
+
+def test_cancelled_dialogs_load_nothing(win, monkeypatch):
+    w, launched, warnings = win
+    monkeypatch.setattr(QFileDialog, "getOpenFileNames",
+                        staticmethod(lambda *a_, **k: ([], "")))
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory",
+                        staticmethod(lambda *a_, **k: ""))
+    w.open_files()
+    w.open_folder()
+    assert launched == [] and warnings == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_cli_startup.py
+++ b/tests/test_cli_startup.py
@@ -30,9 +30,15 @@ def win(monkeypatch):
     from ui.main_window import MainWindow
     ccr_backend.images.clear()
     ccr_backend.file_paths.clear()
-    ccr_backend.rgb_merge_mode = False
+    saved_merge_mode = ccr_backend.rgb_merge_mode
 
     w = MainWindow()
+    # AFTER construction, not before: MainWindow.__init__ restores
+    # rgb_merge_mode from the user's persisted QSettings
+    # ("import/rgb_merge_mode"), so resetting first is undone by the very next
+    # line. On a machine with 3-way merge enabled that put every file-list
+    # import into merge validation instead of the loader.
+    ccr_backend.rgb_merge_mode = False
     launched = []
     warnings = []
     monkeypatch.setattr(
@@ -46,7 +52,9 @@ def win(monkeypatch):
     # save_catalog() would rewrite the user's real catalog during a test run.
     monkeypatch.setattr(ccr_backend, "save_catalog", lambda *a, **k: None)
     yield w, launched, warnings
-    ccr_backend.rgb_merge_mode = False
+    # Restore, don't force: this is a global singleton, and pinning it to False
+    # would leak a non-default into whatever module runs next in a full run.
+    ccr_backend.rgb_merge_mode = saved_merge_mode
 
 
 def _touch(folder, *names):
@@ -112,6 +120,75 @@ def test_missing_path_alongside_a_real_one_still_loads_the_real_one(win, tmp_pat
     assert launched[0]["files"] == [good]
     assert warnings == ["Nothing to open"]
     assert at_warn == [1]          # the load had already started
+
+
+def _browse_dir(w):
+    return w._settings.value("files/last_open_dir", "", type=str)
+
+
+def test_command_line_import_does_not_move_the_browse_location(win, tmp_path):
+    """last_open_dir records where the user BROWSED, so a command-line import
+    must leave it alone. Shell paths are often relative and
+    os.path.dirname("a.nef") is "", which would wipe the setting and drop both
+    dialogs back to the process cwd."""
+    w, launched, _warnings = win
+    saved = _browse_dir(w)
+    try:
+        w._settings.setValue("files/last_open_dir", "/previously/browsed")
+        a, = _touch(tmp_path, "a.nef")
+        w.load_paths([a])
+        assert launched                       # the import really did run
+        assert _browse_dir(w) == "/previously/browsed"
+    finally:
+        w._settings.setValue("files/last_open_dir", saved)
+
+
+def test_command_line_folder_import_does_not_move_it_either(win, tmp_path):
+    """The folder half of the same rule — `freeccr .` must not persist "."."""
+    w, launched, _warnings = win
+    saved = _browse_dir(w)
+    try:
+        w._settings.setValue("files/last_open_dir", "/previously/browsed")
+        d = tmp_path / "roll"
+        d.mkdir()
+        _touch(d, "a.nef")
+        w.load_paths([str(d)])
+        assert launched
+        assert _browse_dir(w) == "/previously/browsed"
+    finally:
+        w._settings.setValue("files/last_open_dir", saved)
+
+
+def test_open_files_dialog_still_records_the_browse_location(win, tmp_path,
+                                                             monkeypatch):
+    """...and the dialog still does record it — the fix moved the write, it did
+    not remove the feature."""
+    w, _launched, _warnings = win
+    saved = _browse_dir(w)
+    try:
+        a, = _touch(tmp_path, "a.nef")
+        monkeypatch.setattr(QFileDialog, "getOpenFileNames",
+                            staticmethod(lambda *a_, **k: ([a], "")))
+        w.open_files()
+        assert _browse_dir(w) == os.path.dirname(a)
+    finally:
+        w._settings.setValue("files/last_open_dir", saved)
+
+
+def test_open_folder_dialog_still_records_the_browse_location(win, tmp_path,
+                                                              monkeypatch):
+    w, _launched, _warnings = win
+    saved = _browse_dir(w)
+    try:
+        d = tmp_path / "roll"
+        d.mkdir()
+        _touch(d, "a.nef")
+        monkeypatch.setattr(QFileDialog, "getExistingDirectory",
+                            staticmethod(lambda *a_, **k: str(d)))
+        w.open_folder()
+        assert _browse_dir(w) == str(d)
+    finally:
+        w._settings.setValue("files/last_open_dir", saved)
 
 
 def test_merge_mode_rejects_a_non_triplet_from_the_command_line(win, tmp_path):

--- a/tests/test_cli_startup.py
+++ b/tests/test_cli_startup.py
@@ -118,8 +118,18 @@ def test_missing_path_alongside_a_real_one_still_loads_the_real_one(win, tmp_pat
                                                       at_warn.append(len(launched)))))
     w.load_paths([good, str(tmp_path / "gone.nef")])
     assert launched[0]["files"] == [good]
-    assert warnings == ["Nothing to open"]
+    # ...and the box must not claim nothing opened while that load runs.
+    assert warnings == ["Some paths could not be opened"]
     assert at_warn == [1]          # the load had already started
+
+
+def test_all_paths_bad_still_says_nothing_to_open(win, tmp_path):
+    """The other half of the title rule: when nothing was importable,
+    "Nothing to open" is exactly right."""
+    w, launched, warnings = win
+    w.load_paths([str(tmp_path / "gone.nef"), str(tmp_path / "x.nef")])
+    assert launched == []
+    assert warnings == ["Nothing to open"]
 
 
 def _browse_dir(w):


### PR DESCRIPTION
Closes #126.

`freeccr [PATH ...]` seeds the startup import with files, folders, wildcard patterns, or a mix, so a roll can be opened from a shell or a script without walking the Open Files / Open Folder dialogs.

```bash
freeccr /rolls/roll-07          # open a whole folder
freeccr a.nef b.nef c.nef       # open specific frames
freeccr "/rolls/roll-07/*.tif"  # open everything matching
freeccr --help                  # usage, then exit
```

A single folder loads like **Open Folder**; anything else loads as a file list, with each folder expanded to the images inside it (non-recursive, supported extensions, de-duplicated by normalised absolute path). `--help` / `--version` answer and exit before Qt starts, so they work headless. Qt's own switches (`-platform`, `-style`, `-stylesheet …`) are never mistaken for paths, and `--` ends option processing so a leading-dash filename can still be opened.

### A new entry point, not a new loader

The post-dialog tails of `open_files` / `open_folder` became `_import_file_list` / `_import_folder`, so Unicode validation, 3-way-merge validation, catalog restore and the failure report behave exactly as they do for the dialogs. `_launch_file_loader` generalises to `_launch_loader(files=, folder=)`, which drops the loader-thread boilerplate `open_folder` had duplicated.

Bad arguments are reported in one box **after** the good paths are dispatched — the box is modal, and one typo must not hold up the rest of the import.

### Wildcards are expanded by FreeCCR itself

Unix shells expand `*.tif` before `argv` reaches the program; cmd.exe and PowerShell hand the pattern over untouched. Left to the shell, the most natural way to open a roll would fail on Windows with `*.tif — not found`. `plan_open` therefore expands patterns itself, on every platform rather than branching on `sys.platform` — under a Unix shell it is a no-op, since a pattern the shell matched arrives already expanded and one it could not match matches nothing here either, so the same code path is exercised in development as on Windows.

Three details this turns on:

- An argument naming an existing path is never read as a pattern, or `glob`'s character classes would swallow a photo literally called `shot[1].tif`.
- Matches are sorted case-insensitively with `expand_folder`'s key, since raw `glob` order is filesystem-dependent.
- Expansion happens *before* the planning rules, so a pattern behaves exactly like the paths it matched — `roll-*` hitting one directory takes the single-folder rule, same as naming that directory.

An unmatched pattern reports `no files match this pattern` rather than the misleading `not found`.

### Scope

This is the CLI half of #126. It does not add OS integration — no `CFBundleDocumentTypes`, no Windows file associations — so "Open With → FreeCCR" from digiKam or Photo Supreme is not wired up by this PR. `MainWindow.load_paths` is deliberately the public seam those would call, and drag-and-drop after them.

### Testing

`tests/test_cli_args.py` (38 pure tests, no Qt) covers option stripping, planning, folder expansion, de-duplication, problem reporting and wildcard expansion. `tests/test_cli_startup.py` (offscreen GUI) covers the dispatch path end to end.

Full suite via `tests/run_tests.py`: **1131 passed, 1 failed, 4 skipped**. The one failure, `test_export_naming.py::TestUniquifyInBatch::test_case_insensitive`, reproduces unchanged on `main` and is unrelated to this branch.

Verified in the real app on macOS: no arguments, a single 217 MB TIFF, a mixed folder (42 images — 12 `.tif`, 12 `.tiff`, 12 `.jpg`, 6 `.rw2`, sidecars correctly ignored), and a quoted pattern the shell could not expand — which is what a Windows shell would send — loading its 12 matching TIFFs with no problems reported.

See `spec/cli-file-args.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThPxS9DgcCWVv9YwoLMoQs
